### PR TITLE
Update all docs to reflect TypeScript-first architecture and dungeon …

### DIFF
--- a/.agent/architecture.md
+++ b/.agent/architecture.md
@@ -2,11 +2,11 @@
 
 ## Layers
 
-The codebase is organized into four layers with strict dependency rules.
+TypeScript in `src/` is the single source of truth, compiled to `dist/` via tsc + esbuild.
 
 ```
                 ┌──────────┐    ┌──────────┐
-                │  core/   │    │  game/   │
+                │ src/cli/ │    │src/game/ │
                 │ (Node.js │    │ (Browser │
                 │   CLI)   │    │ Canvas)  │
                 └────┬─────┘    └────┬─────┘
@@ -14,80 +14,128 @@ The codebase is organized into four layers with strict dependency rules.
            ┌─────────┼───────────────┼─────────┐
            │         ▼               ▼         │
            │    ┌────────────────────────┐     │
-           │    │     ecosystem/         │     │
-           │    │  (Shared game content) │     │
+           │    │   src/agentguard/      │     │
+           │    │  (Governance runtime)  │     │
            │    └────────────────────────┘     │
            │                                   │
            │    ┌────────────────────────┐     │
-           │    │      domain/           │     │
+           │    │     src/domain/        │     │
            │    │  (Pure domain logic)   │     │
+           │    └────────────────────────┘     │
+           │                                   │
+           │    ┌────────────────────────┐     │
+           │    │     src/core/          │     │
+           │    │  (Shared logic)        │     │
+           │    └────────────────────────┘     │
+           │                                   │
+           │    ┌────────────────────────┐     │
+           │    │  ecosystem/data/       │     │
+           │    │  (Game content JSON)   │     │
            │    └────────────────────────┘     │
            └───────────────────────────────────┘
 ```
 
-### domain/ — Pure Domain Logic
+### src/domain/ — Pure Domain Logic
 
 Environment-agnostic. No DOM APIs, no Node.js-specific APIs. All functions are pure and deterministic when RNG is injected. Contains:
 
-- `events.js` — Canonical event schema (45 event kinds) and factory
-- `event-bus.js` — Universal pub/sub (works in Node.js and browser)
-- `battle.js` — Deterministic battle engine with passive abilities
-- `encounters.js` — Encounter trigger logic with rarity-weighted selection
-- `evolution.js` — Progression condition checking
-- `hash.js` — Deterministic string hashing (DJB2)
-- `ingestion/` — Multi-stage error normalization pipeline
+- `events.ts` — Canonical event schema (45+ event kinds) and factory
+- `event-bus.ts` — Universal pub/sub (works in Node.js and browser)
+- `battle.ts` — Deterministic battle engine with passive abilities, combo, healing
+- `encounters.ts` — Encounter trigger logic with rarity-weighted selection
+- `evolution.ts` — Progression condition checking
+- `ingestion/` — Multi-stage error normalization pipeline (8 files)
+- `execution/` — Execution event log with causal chains
+- `invariants.ts`, `policy.ts`, `reference-monitor.ts` — Governance primitives
 
-### core/ — CLI Companion (Node.js)
+### src/core/ — Shared Logic
 
-Node.js runtime code. Depends on domain/ and ecosystem/. Contains:
+Used by both CLI and game. Contains:
 
-- `error-parser.js` — 40+ regex patterns across 6+ languages
-- `stacktrace-parser.js` — Stack trace analysis
-- `bug-event.js` — BugEvent type definition and severity mapping
-- `matcher.js` — Error-to-creature matching
-- `cli/` — Terminal UI, encounter logic, Claude Code hook, WebSocket sync
+- `event-bus.ts` — Typed EventBus
+- `error-parser.ts` — 40+ regex patterns across 6+ languages
+- `stacktrace-parser.ts` — Stack trace analysis
+- `bug-event.ts` — BugEvent type definition and severity mapping
+- `matcher.ts` — Error-to-creature matching
+- `sources/` — Event source adapters (watch, scan, claude-hook)
 
-### game/ — Browser Roguelike (Client-Side)
+### src/cli/ — CLI Companion (Node.js)
 
-Browser-only code using Canvas 2D and Web Audio API. Depends on domain/ and ecosystem/. Contains:
+Commander-based CLI with 20 subcommands. Depends on domain/, core/, meta/. Contains:
 
-- `engine/` — State machine, input, renderer, transitions
-- `world/` — Map, player, encounter triggers
-- `battle/` — UI-connected battle system (delegates to domain/battle.js)
+- `bin.ts` — Entry point (agentguard + bugmon binaries)
+- `commands/` — 20 subcommands (watch, scan, play, demo, replay, etc.)
+- `renderer.ts` — Terminal renderer (ANSI)
+- `sync-server.ts` — WebSocket sync server
+
+### src/game/ — Browser Roguelike (Client-Side)
+
+Browser-only code using Canvas 2D and Web Audio API. Zero runtime dependencies. Contains:
+
+- `dungeon/` — Idle auto-dungeon runner (primary game mode)
+  - `runner.ts` — Auto-run logic, encounter resolution, phase machine
+  - `dungeon.ts` — Procedural floor generation (rooms, corridors, loot)
+  - `loot.ts` — Gold, boosts, localStorage persistence
+  - `dungeon-renderer.ts` — Premium renderer (parallax, glassmorphic HUD)
+- `theme.ts` — Design system (OLED palette, gold accents, glassmorphism)
+- `engine/` — State machine, input, renderer, effects, transitions
+- `battle/` — UI-connected battle system (delegates to domain/battle.ts)
+- `world/` — Map, player, encounter triggers (exploration mode)
 - `evolution/` — Progression UI and dev activity tracking
 - `audio/` — Synthesized sound effects (no audio files)
 - `sprites/` — Procedural and static pixel art
 - `sync/` — Save system (localStorage) and WebSocket client
 
-### ecosystem/ — Shared Game Content
+### src/agentguard/ — Governance Runtime
 
-Consumed by both core/ and game/. Contains:
+Deterministic governance for AI coding agents. Contains:
 
-- `data/` — JSON source of truth + inlined JS modules (monsters, moves, types, evolutions, map)
-- `bugdex.js` — Bug Grimoire system
-- `bosses.js` — Boss encounter definitions
-- `storage.js` — Persistence abstraction (localStorage or filesystem)
-- `sync-protocol.js` — WebSocket message constants
+- `core/aab.ts` — Action Authorization Boundary
+- `core/engine.ts` — Runtime Assurance Engine
+- `policies/evaluator.ts` — Policy evaluation
+- `policies/loader.ts` — Policy loading from JSON
+- `invariants/checker.ts` — Invariant checking
+- `invariants/definitions.ts` — Built-in invariant definitions
+- `evidence/pack.ts` — Evidence pack generation
+- `monitor.ts` — Closed-loop governance monitor
+
+### Additional Layers
+
+- `src/meta/` — Metadata (bugdex.ts, bosses.ts)
+- `src/orchestration/` — Multi-agent pipeline orchestration
+- `src/protocol/` — Sync protocol definitions
+- `src/content/` — Game content validation
+- `src/watchers/` — Environment watchers (console, test, build)
+- `src/ai/` — AI integration interface
+
+### ecosystem/data/ — Game Content
+
+Consumed by both CLI and game. Contains:
+
+- `*.json` — Source of truth (monsters, moves, types, evolutions, map)
+- `*.js` — Inlined JS modules (generated by `npm run sync-data`)
 
 ## Dependency Rules
 
-1. **domain/ depends on nothing** — it is the pure foundation
-2. **ecosystem/ depends on nothing** — it is shared data
-3. **core/ depends on domain/ and ecosystem/** — never on game/
-4. **game/ depends on domain/ and ecosystem/** — never on core/
-5. **No circular dependencies** between any layers
-6. **No cross-environment code** — domain/ must not use DOM or Node.js APIs
+1. **src/domain/ depends on nothing** — it is the pure foundation
+2. **src/core/ depends on domain/** — shared logic layer
+3. **src/agentguard/ depends on domain/** — governance layer
+4. **src/cli/ depends on domain/, core/, meta/** — never on game/
+5. **src/game/ depends on domain/, core/, meta/** — never on cli/
+6. **ecosystem/data/ depends on nothing** — pure data
+7. **No circular dependencies** between any layers
+8. **No cross-environment code** — domain/ must not use DOM or Node.js APIs
 
 ## Module System
 
-All source uses ES6 `import`/`export`. No CommonJS. No bundler required. Browser loads `game/game.js` as a `<script type="module">`.
+All source uses ES6 `import`/`export` with TypeScript. `verbatimModuleSyntax: true` — use `import type` for type-only imports. Browser loads `dist/game/game.js` as a `<script type="module">`.
 
 ## Data Flow
 
 ```
 Event Sources (stderr, tests, CI, agent actions)
-    → domain/ingestion/ (parse → fingerprint → classify → map)
-    → Canonical Event (domain/events.js schema)
-    → EventBus (domain/event-bus.js)
-    → Subscribers (BugMon renderers, Grimoire, stats, AgentGuard audit)
+    → src/domain/ingestion/ (parse → fingerprint → classify → map)
+    → Canonical Event (src/domain/events.ts schema)
+    → EventBus (src/core/event-bus.ts)
+    → Subscribers (Dungeon Runner, Terminal Renderer, Grimoire, Stats, AgentGuard)
 ```

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -30,7 +30,7 @@ For the full integration model, see [docs/unified-architecture.md](docs/unified-
          ┌─────────────────────────────────────────────────────┐
          │              Event Normalization Pipeline            │
          │  source → parse → normalize → classify → dedupe     │
-         │  Implementation: domain/ingestion/                   │
+         │  Implementation: src/domain/ingestion/              │
          └──────────────────────┬──────────────────────────────┘
                                 │
                    ┌────────────────────────┐
@@ -57,6 +57,7 @@ For the full integration model, see [docs/unified-architecture.md](docs/unified-
               │    Subscribers       │
               │  Terminal renderer   │
               │  Browser renderer    │
+              │  Dungeon runner      │
               │  Bug Grimoire        │
               │  Stats engine        │
               │  Replay engine       │
@@ -65,251 +66,207 @@ For the full integration model, see [docs/unified-architecture.md](docs/unified-
 
 ## Project Structure
 
-The codebase follows a **layered architecture** with five top-level directories plus supporting infrastructure:
+TypeScript in `src/` is the **single source of truth**. It compiles to `dist/` via `tsc` (individual modules) + `esbuild` (CLI and game bundles).
 
 ```
-BugMon/
-├── index.html              Entry point - canvas, touch controls, loads game.js
-├── simulate.js             Battle simulator CLI (Node.js)
-├── package.json            npm scripts (simulate, serve, build, test)
+AgentGuard/
+├── index.html              # Entry point (canvas, inline CSS, touch controls)
+├── package.json            # npm scripts, deps, build config
 │
-├── core/                   CLI companion & shared logic (Node.js)
-│   ├── matcher.js          Error → BugMon enemy matching logic
-│   ├── error-parser.js     Error message parser (40+ patterns, 6+ languages)
-│   ├── stacktrace-parser.js Stack trace analysis
-│   ├── bug-event.js        Bug event definitions and severity mapping
-│   ├── sources/            Event source adapters (watch, scan, claude-hook)
-│   └── cli/                CLI tool (bugmon command)
-│       ├── bin.js           Entry point (bugmon command)
-│       ├── adapter.js       CLI watch adapter (event source)
-│       ├── auto-walk.js     Auto-walk feature
-│       ├── boss-battle.js   Boss battle interactive encounter
-│       ├── catch.js         Combat resolution mechanic
-│       ├── claude-hook.js   Claude Code PostToolUse hook (error encounters)
-│       ├── claude-init.js   Claude Code integration setup
-│       ├── colors.js        Shared ANSI color constants
-│       ├── contribute.js    Contribution prompt
-│       ├── demo.js          Demo encounter launcher
-│       ├── encounter.js     CLI encounter logic
-│       ├── init.js          Git hooks installer for progression tracking
-│       ├── renderer.js      Terminal renderer (ANSI)
-│       ├── resolve.js       Bug resolve/XP mechanic
-│       ├── args.js          Lightweight CLI argument parser (zero deps)
-│       ├── scan.js          Error scanning feature
-│       ├── sync-server.js   WebSocket sync server (zero deps)
-│       └── bugmon-legacy.js Legacy CLI version
+├── src/                    # TypeScript source (single source of truth)
+│   ├── agentguard/         # Governance runtime (deterministic RTA)
+│   │   ├── core/           # AAB + RTA engine
+│   │   ├── policies/       # Policy evaluation + loading
+│   │   ├── invariants/     # Invariant checking + definitions
+│   │   ├── evidence/       # Evidence pack generation
+│   │   └── monitor.ts      # Closed-loop governance monitor
+│   ├── cli/                # CLI interface (agentguard command)
+│   │   ├── bin.ts          # Entry point (agentguard + bugmon binaries)
+│   │   ├── index.ts        # CLI exports
+│   │   └── commands/       # 20 subcommands (watch, scan, play, etc.)
+│   ├── core/               # Shared logic (EventBus, parsing, matching)
+│   │   ├── event-bus.ts    # Universal typed EventBus
+│   │   ├── error-parser.ts # Error message parser (40+ patterns)
+│   │   ├── matcher.ts      # Error → BugMon enemy matching
+│   │   ├── types.ts        # Shared type definitions
+│   │   └── sources/        # Event source adapters (watch, scan, claude-hook)
+│   ├── domain/             # Pure domain logic (no DOM, no Node.js APIs)
+│   │   ├── battle.ts       # Pure battle engine (deterministic with injected RNG)
+│   │   ├── encounters.ts   # Encounter logic with rarity weights
+│   │   ├── evolution.ts    # Progression condition checking
+│   │   ├── events.ts       # Canonical domain event definitions
+│   │   ├── dev-event.ts    # Developer signal event types
+│   │   ├── event-bus.ts    # Domain event bus
+│   │   ├── event-store.ts  # Event persistence interface
+│   │   ├── ingestion/      # Error normalization pipeline (8 files)
+│   │   ├── execution/      # Execution adapters
+│   │   ├── invariants.ts   # Governance invariant definitions
+│   │   ├── policy.ts       # Policy evaluation logic
+│   │   ├── reference-monitor.ts  # Governance reference monitor
+│   │   ├── contracts.ts    # Module contract registry
+│   │   ├── shapes.ts       # Runtime shape definitions
+│   │   └── ...             # rng, hash, correlation, projections, etc.
+│   ├── game/               # BugMon browser game (client-side, zero deps)
+│   │   ├── game.ts         # Game entry point (auto-init, data loading)
+│   │   ├── theme.ts        # Design system (OLED palette, gold accents, glassmorphism)
+│   │   ├── engine/         # Core framework (state, input, renderer, events, effects)
+│   │   ├── dungeon/        # Idle dungeon runner (primary game mode)
+│   │   │   ├── runner.ts   # Auto-run logic, phase machine, encounter resolution
+│   │   │   ├── dungeon.ts  # Procedural floor generation (rooms, corridors, loot)
+│   │   │   ├── loot.ts     # Gold, boosts, run persistence (localStorage)
+│   │   │   └── dungeon-renderer.ts  # Premium renderer (parallax, glassmorphic HUD)
+│   │   ├── battle/         # Turn-based battle engine
+│   │   ├── world/          # Map, player, encounters (exploration mode)
+│   │   ├── evolution/      # Dev-activity progression (tracker, animation)
+│   │   ├── audio/          # Sound synthesis (Web Audio API)
+│   │   ├── sync/           # Save/sync (localStorage, WebSocket)
+│   │   └── sprites/        # Pixel art (procedural gen + PNG sprites)
+│   ├── meta/               # Metadata systems (bugdex, bosses)
+│   ├── orchestration/      # Multi-agent pipeline orchestration
+│   ├── protocol/           # Sync protocol definitions
+│   ├── content/            # Game content validation (bugdex-spec)
+│   ├── watchers/           # Environment watchers (console, test, build)
+│   └── ai/                 # AI integration interface
 │
-├── game/                   Browser roguelike (client-side)
-│   ├── game.js             Game loop, data loading, orchestration
-│   ├── engine/             Core engine (framework-level)
-│   │   ├── state.js        Game state machine
-│   │   ├── events.js       Event bus for decoupled communication
-│   │   ├── input.js        Keyboard + touch input
-│   │   ├── renderer.js     All Canvas drawing functions
-│   │   ├── transition.js   Battle transition animation
-│   │   └── title.js        Title screen (ASCII logo, starfield, menu)
-│   ├── world/              Dungeon / exploration
-│   │   ├── map.js          Map data loading, tile queries, collision
-│   │   ├── player.js       Player position, movement
-│   │   └── encounters.js   Wild encounter checks (10% in tall grass)
-│   ├── battle/             Battle systems
-│   │   ├── battle-core.js  Pure battle engine (no UI/audio — testable)
-│   │   ├── battleEngine.js Battle UI controller
-│   │   └── damage.js       Damage formula
-│   ├── evolution/          Progression system
-│   │   ├── evolution.js    Checks conditions, triggers progressions
-│   │   ├── tracker.js      Dev activity tracker (localStorage + .events.json)
-│   │   └── animation.js    Progression visual sequence
-│   ├── audio/              Sound effects (Web Audio API, no files)
-│   │   └── sound.js        Synthesized sound effects
-│   ├── sync/               Save/sync system
-│   │   ├── save.js         Browser-side save/load (localStorage)
-│   │   └── client.js       Client-side sync (WebSocket to CLI)
-│   └── sprites/            Pixel art sprites
-│       ├── sprites.js      Image loader with preload and fallback
-│       ├── monsterGen.js   Procedural sprite generation
-│       ├── tiles.js        Procedural tile texture generation
-│       └── *.png           Battle sprites (64x64) and player sprites (32x32)
+├── dist/                   # Compiled output (tsc + esbuild)
+│   ├── cli/                # Bundled CLI (esbuild)
+│   ├── game/               # Bundled game + sprites (esbuild)
+│   ├── core/               # Individual modules (tsc)
+│   ├── domain/             # Individual modules (tsc)
+│   ├── agentguard/         # Individual modules (tsc)
+│   └── ecosystem/          # Individual modules (tsc)
 │
-├── ecosystem/              Game content & metagame systems
-│   ├── data/               All game data (JSON source + JS modules)
-│   │   ├── monsters.json   31 BugMon enemy definitions
-│   │   ├── monsters.js     Inlined JS module
-│   │   ├── moves.json      72 move definitions
-│   │   ├── moves.js        Inlined JS module
-│   │   ├── types.json      7 types + effectiveness chart
-│   │   ├── types.js        Inlined JS module
-│   │   ├── evolutions.json Progression chains with dev-activity triggers
-│   │   ├── evolutions.js   Inlined JS module
-│   │   ├── map.json        Tile grid for the dungeon
-│   │   └── mapData.js      Inlined JS module
-│   ├── bugdex.js           Bug Grimoire system
-│   ├── bugdex-spec.js      Grimoire specification
-│   ├── bosses.js           Boss encounter definitions and triggers
-│   ├── storage.js          Shared storage utilities
-│   └── sync-protocol.js    Shared WebSocket sync protocol constants
+├── ecosystem/data/         # Game content (JSON source + inlined JS modules)
+│   ├── monsters.json       # 34 BugMon enemy definitions
+│   ├── moves.json          # 76 move definitions
+│   ├── types.json          # 7 types + effectiveness chart
+│   ├── evolutions.json     # Progression chains
+│   ├── map.json            # 15x10 tile grid
+│   └── *.js                # Inlined JS modules (generated by sync-data)
 │
-├── domain/                 Pure domain logic (no DOM, no Node.js-specific APIs)
-│   ├── battle.js           Pure battle engine (deterministic with injected RNG)
-│   ├── encounters.js       Pure encounter logic (rarity weights, trigger checks)
-│   ├── event-bus.js        Universal EventBus (works in Node.js and browser)
-│   ├── events.js           Canonical domain event definitions
-│   ├── event-store.js      Event persistence interface
-│   ├── evolution.js        Pure progression engine (no localStorage)
-│   ├── source-registry.js  Event source plugin registry
-│   ├── actions.js          Action definitions
-│   ├── invariants.js       Invariant definitions
-│   ├── policy.js           Policy evaluation logic
-│   ├── reference-monitor.js Reference monitor for governance
-│   ├── run-history.js      Run history tracking
-│   ├── run-session.js      Run session management
-│   ├── combo.js            Combo system logic
-│   ├── hash.js             Hashing utilities
-│   ├── contracts.js        Module contract registry
-│   ├── shapes.js           Runtime shape definitions
-│   ├── ingestion/          Error ingestion pipeline
-│   │   ├── pipeline.js     Orchestrates: parse → fingerprint → classify → map
-│   │   ├── parser.js       Error message parsing
-│   │   ├── fingerprint.js  Error deduplication via stable fingerprinting
-│   │   ├── classifier.js   Parsed error → BugEvent classification
-│   │   ├── species-mapper.js BugEvent → BugMon species mapping
-│   │   └── invariant-mapper.js Invariant violation → event mapping
-│   ├── pipeline/           Multi-agent pipeline orchestration
-│   │   ├── index.js        Pipeline entry point
-│   │   ├── orchestrator.js Pipeline orchestrator
-│   │   ├── stages.js       Pipeline stage definitions
-│   │   └── roles.js        Pipeline role definitions
-│   └── execution/          Execution adapters
-│       └── adapters.js     Execution environment adapters
+├── policy/                 # Policy configuration (JSON)
+│   ├── action_rules.json   # Agent action validation rules
+│   └── capabilities.json   # Agent capability boundaries
 │
-├── agentguard/             Governance runtime (deterministic RTA)
-│   ├── monitor.js          Closed-loop feedback (escalation, violation tracking)
-│   ├── core/               Core governance engine
-│   │   ├── aab.js          Action Authorization Boundary
-│   │   └── engine.js       Runtime Assurance (RTA) engine
-│   ├── policies/           Policy evaluation
-│   │   ├── evaluator.js    Policy compliance checking
-│   │   └── loader.js       Policy loader from JSON
-│   ├── invariants/         Invariant verification
-│   │   ├── checker.js      Runtime invariant checker
-│   │   └── definitions.js  Invariant registry
-│   └── evidence/           Audit trail
-│       └── pack.js         Evidence collection & reporting
+├── simulation/             # Headless battle simulation
+│   ├── cli.js              # CLI entry (--battles, --compare flags)
+│   ├── simulator.js        # Round-robin matchup orchestrator
+│   ├── headlessBattle.js   # Headless battle runner
+│   ├── strategies.js       # AI battle strategies
+│   ├── report.js           # Statistical report generation
+│   └── rng.js              # Seeded RNG for reproducible sims
 │
-├── policy/                 Policy configuration (JSON)
-│   ├── action_rules.json   Capability rules per agent action
-│   └── capabilities.json   Available action categories
+├── tests/                  # Test suite (77 JS + 16 TS test files)
+│   ├── run.js              # Custom test runner (JS tests import from dist/)
+│   ├── *.test.js           # JavaScript tests
+│   └── ts/                 # TypeScript tests (run via vitest)
 │
-├── runtime/                Event tracing & replay
-│   ├── events/             Event log storage
-│   └── replay/             Replay data
+├── scripts/                # Build tooling
+│   ├── build.js            # Single-file builder (esbuild + terser)
+│   ├── dev-server.js       # Zero-dep dev server with live reload
+│   ├── sync-data.js        # JSON → JS module converter
+│   └── check-contracts.js  # Module contract validation
 │
-├── src/                    TypeScript refactoring (in progress)
-│   ├── cli/                Commander-based CLI (index.ts, commands/)
-│   ├── core/               Typed core (types.ts, event-bus.ts, bug-engine.ts)
-│   ├── game/               Game engine modules (engine.ts, renderer.ts, loop.ts)
-│   ├── watchers/           Environment watchers (console, test, build)
-│   └── ai/                 AI integration interface
-│
-├── simulation/             Headless battle simulation
-│   ├── cli.js              CLI entry point (seeded RNG)
-│   ├── simulator.js        Battle simulator engine
-│   ├── headlessBattle.js   Headless battle runner
-│   ├── strategies.js       AI battle strategies
-│   ├── report.js           Simulation report generator
-│   └── rng.js              Seeded random number generator
-│
-├── tests/                  Test suite (77 JS + 4 TS test files)
-│   ├── run.js              Test runner
-│   └── *.test.js           Tests covering all modules
-│
-├── scripts/                Build tooling
-│   ├── build.js            Single-file builder (esbuild + terser → dist/index.html)
-│   ├── dev-server.js       Zero-dependency dev server with live reload
-│   ├── sync-data.js        JSON → JS module converter
-│   └── prune-merged-branches.sh  Git branch cleanup
-│
-├── docs/                   System documentation
-│   ├── unified-architecture.md  AgentGuard + BugMon integration
-│   ├── agentguard.md       Governance runtime specification
-│   ├── event-model.md      Canonical event schema
-│   ├── bug-event-pipeline.md Signal normalization pipeline
-│   ├── roguelike-design.md Debugging-as-roguelike mechanics
-│   ├── plugin-api.md       Extension points
-│   ├── sequence-diagrams.md System flow diagrams
-│   ├── product-positioning.md What this is and isn't
-│   └── current-priorities.md Active development phase
-│
-├── hooks/                  Git hooks for dev activity tracking
-│   ├── post-commit         Increments commit counter
-│   └── post-merge          Increments merge counter
-│
-└── .github/
-    ├── workflows/          CI/CD automation
-    ├── scripts/            Validation and generation scripts
-    └── ISSUE_TEMPLATE/     Community submission forms
+├── spec/                   # Artifact-first development specs
+├── docs/                   # System documentation
+├── hooks/                  # Git hooks for dev activity tracking
+└── .github/                # CI/CD workflows and issue templates
 ```
 
 ## Layered Architecture
 
 ```
 ┌─────────────────────────────────────────────────────────┐
-│  index.html / simulate.js        (entry points)        │
+│  src/cli/                Commander-based CLI (Node.js)   │
+│  ├── commands/*           20 subcommands                 │
+│  ├── renderer.ts          Terminal rendering (ANSI)      │
+│  └── sync-server.ts       WebSocket sync server          │
 ├─────────────────────────────────────────────────────────┤
-│  core/                     CLI companion & shared logic  │
-│  ├── cli/*                 Terminal UI, watch adapter    │
-│  ├── sources/*             Event source adapters         │
-│  ├── matcher.js            Error → enemy matching        │
-│  └── error-parser.js       Error parsing (40+ patterns)  │
+│  src/game/                Browser roguelike (client-side) │
+│  ├── dungeon/*            Idle dungeon runner (primary)   │
+│  ├── engine/*             State, input, rendering, FX     │
+│  ├── battle/*             Turn-based combat engine        │
+│  ├── world/*              Tile-based exploration          │
+│  ├── evolution/*          Dev-activity progression        │
+│  ├── audio/*              Synthesized sound effects       │
+│  ├── sync/*               Save/load + CLI sync            │
+│  └── sprites/*            Sprite loading + generation     │
 ├─────────────────────────────────────────────────────────┤
-│  game/                     Browser roguelike             │
-│  ├── engine/*              State, input, rendering       │
-│  ├── battle/*              Combat engine + damage calc   │
-│  ├── world/*               Dungeon, player, encounters   │
-│  ├── evolution/*           Dev-activity progression      │
-│  ├── audio/*               Synthesized sound effects     │
-│  ├── sync/*                Save/load + CLI sync          │
-│  └── sprites/*             Sprite loading + generation   │
+│  src/agentguard/          Governance runtime (RTA)        │
+│  ├── core/*               AAB + RTA engine                │
+│  ├── policies/*           Policy evaluation + loading     │
+│  ├── invariants/*         Invariant checking              │
+│  ├── evidence/*           Evidence pack generation        │
+│  └── monitor.ts           Closed-loop feedback            │
 ├─────────────────────────────────────────────────────────┤
-│  agentguard/               Governance runtime (RTA)      │
-│  ├── core/*                AAB + RTA engine              │
-│  ├── policies/*            Policy evaluation + loading   │
-│  ├── invariants/*          Invariant checking            │
-│  ├── evidence/*            Evidence pack generation      │
-│  └── monitor.js            Closed-loop feedback          │
+│  src/domain/              Pure domain logic (no deps)     │
+│  ├── battle.ts            Pure battle engine              │
+│  ├── encounters.ts        Encounter logic                 │
+│  ├── evolution.ts         Progression engine              │
+│  ├── events.ts            Domain event definitions        │
+│  ├── event-bus.ts         Universal EventBus              │
+│  ├── source-registry.ts   Event source plugin registry    │
+│  ├── ingestion/*          Error ingestion pipeline        │
+│  └── execution/*          Execution adapters              │
 ├─────────────────────────────────────────────────────────┤
-│  domain/                   Pure domain logic (no deps)   │
-│  ├── battle.js             Pure battle engine            │
-│  ├── encounters.js         Encounter logic               │
-│  ├── evolution.js          Progression engine            │
-│  ├── event-bus.js          Universal EventBus            │
-│  ├── events.js             Domain event definitions      │
-│  ├── source-registry.js    Event source plugin registry  │
-│  ├── ingestion/*           Error ingestion pipeline      │
-│  └── pipeline/*            Multi-agent orchestration     │
+│  src/core/                Shared logic (CLI + browser)    │
+│  ├── event-bus.ts         Typed EventBus                  │
+│  ├── error-parser.ts      Error parsing (40+ patterns)    │
+│  ├── matcher.ts           Error → enemy matching          │
+│  └── sources/*            Event source adapters            │
 ├─────────────────────────────────────────────────────────┤
-│  ecosystem/                Game content & metagame        │
-│  ├── data/*.json           Source data (monsters, moves)  │
-│  ├── data/*.js             Inlined JS modules            │
-│  ├── bugdex.js             Bug Grimoire                  │
-│  └── bosses.js             Boss definitions              │
+│  src/meta/                Metadata (bugdex, bosses)       │
+│  src/orchestration/       Multi-agent pipeline            │
+│  src/protocol/            Sync protocol definitions       │
+│  src/content/             Game content validation         │
+│  src/watchers/            Environment watchers            │
 ├─────────────────────────────────────────────────────────┤
-│  src/ (TypeScript)         In-progress TS refactoring    │
-│  ├── cli/*                 Commander-based CLI           │
-│  ├── core/*                Typed EventBus, BugEngine     │
-│  ├── game/*                Game engine modules           │
-│  └── watchers/*            Environment watchers          │
+│  ecosystem/data/          Game content (JSON + JS)        │
+│  ├── *.json               Source data (monsters, moves)   │
+│  └── *.js                 Inlined JS modules              │
 └─────────────────────────────────────────────────────────┘
 ```
 
 **Key separation:**
-- **core/** — Node.js code for the CLI. Parses errors, matches them to enemies, renders to terminal. Includes `sources/` for event source adapters. Runs in Node.js only.
-- **game/** — Browser roguelike. Engine, battle, dungeon, progression, audio, sprites. Runs in the browser only.
-- **agentguard/** — Governance runtime implementing the Runtime Assurance Architecture. Evaluates agent actions against policies and invariants. Produces canonical governance events.
-- **domain/** — Pure domain logic with no DOM or Node.js-specific APIs. Battle engine, encounter logic, progression engine, event bus, error ingestion pipeline, multi-agent pipeline orchestration, governance primitives, and source registry. All functions are pure and deterministic (when RNG is injected). Consumed by both core/ and game/.
-- **ecosystem/** — Shared game content (JSON data, Bug Grimoire, bosses). Consumed by both core/ and game/.
+- **src/cli/** — Node.js CLI (`agentguard` command). Parses errors, matches them to enemies, renders to terminal. Includes event source adapters. Runs in Node.js only.
+- **src/game/** — Browser roguelike. Idle dungeon runner, battle engine, exploration, progression, audio, sprites. Runs in the browser only. Zero runtime dependencies.
+- **src/agentguard/** — Governance runtime implementing the Runtime Assurance Architecture. Evaluates agent actions against policies and invariants. Produces canonical governance events.
+- **src/domain/** — Pure domain logic with no DOM or Node.js-specific APIs. Battle engine, encounter logic, progression engine, event bus, error ingestion pipeline, governance primitives, and source registry. All functions are pure and deterministic (when RNG is injected). Consumed by both cli/ and game/.
+- **src/core/** — Shared logic used by both CLI and game. EventBus, error parsing, matching, event source adapters.
+- **ecosystem/data/** — Shared game content (JSON data). Consumed by both cli/ and game/.
 
-**Invariant:** `core/` and `game/` have no cross-imports. Both consume from `ecosystem/` and `domain/`.
+**Invariant:** `src/cli/` and `src/game/` have no cross-imports. Both consume from `src/domain/`, `src/core/`, and `ecosystem/data/`.
+
+## Idle Dungeon Runner
+
+The browser game's primary mode is an **idle auto-dungeon runner** (`src/game/dungeon/`). The character automatically runs through procedural dungeon floors:
+
+- **Auto-run**: Dev character moves through rooms, corridors, and treasure
+- **Minor enemies**: Auto-resolve inline with floating damage numbers
+- **Bosses**: Pause for player input (simple turn-based fight)
+- **Treasure**: Auto-collects gold, boosts, and power-ups
+- **Floors**: Procedurally generated with increasing difficulty
+- **Persistence**: Gold, run stats, and boosts persist via localStorage
+
+### Design System
+
+The game uses a premium dark aesthetic (`src/game/theme.ts`):
+- **OLED palette**: Deep darks (#050510 → #0A0E27 → #151B38)
+- **Gold accents**: Treasure, highlights, premium feel (#F59E0B)
+- **Glassmorphic panels**: Semi-transparent HUD elements with subtle borders
+- **Cyan/purple action accents**: Combat effects and abilities
+- **DM Sans typography**: Clean, modern font
+- **Parallax scrolling**: Multi-layer depth in dungeon corridors
+
+### Runner Phases
+
+```
+running → encounter (auto-battle) → collecting (treasure) → floor_clear → next floor
+                                                              ↓
+                                                          boss (manual)
+                                                              ↓
+                                                          run_over (death stats)
+```
 
 ## AgentGuard Governance Pipeline
 
@@ -336,9 +293,9 @@ BugMon implements a roguelike with hybrid idle/active encounters. See [docs/rogu
 
 **Run lifecycle:** Session start → event monitoring → encounter generation → idle/active combat → run end
 
-**Idle mode:** Minor enemies (severity 1-2) auto-resolve in background. Developer sees notification log.
+**Idle mode (dungeon runner):** The character auto-runs through procedural floors. Minor enemies (severity 1-2) are defeated inline with floating combat text. The developer watches or codes while the game plays itself.
 
-**Active mode:** Bosses and elites (severity 3+) interrupt and require player input.
+**Active mode:** Bosses and elites (severity 3+) pause the runner and require player input for turn-based combat.
 
 **Bug Grimoire:** Permanent compendium of defeated enemy types. Records encounter history, error patterns, and fix strategies.
 
@@ -350,42 +307,40 @@ The pipeline transforms raw signals into canonical events. See [docs/bug-event-p
 source → parse → normalize → classify → dedupe → persist → emit
 ```
 
-Implementation: `domain/ingestion/` with supporting modules in `core/`.
+Implementation: `src/domain/ingestion/` with supporting modules in `src/core/`.
 
 ## Module Dependency Graph
 
 ```
-game/game.js (entry point, browser)
-├── game/engine/events.js        (no deps — event bus)
-├── game/engine/state.js         ← game/engine/events.js
-├── game/engine/input.js         ← game/audio/sound.js
-├── game/engine/renderer.js      ← game/sprites/sprites.js, game/sprites/monsterGen.js
-├── game/engine/transition.js    ← game/audio/sound.js
-├── game/engine/title.js         ← game/engine/input.js, game/engine/state.js, game/audio/sound.js
-├── game/world/map.js            (no deps)
-├── game/world/player.js         ← game/engine/input.js, game/world/map.js, game/audio/sound.js
-├── game/world/encounters.js     ← game/audio/sound.js
-├── game/battle/damage.js        (no deps — pure math)
-├── game/battle/battleEngine.js  ← game/battle/damage.js, game/engine/input.js, game/engine/state.js,
-│                                   game/engine/events.js, game/world/player.js, game/audio/sound.js
-├── game/evolution/tracker.js    (localStorage + .events.json)
-├── game/evolution/evolution.js  ← game/evolution/tracker.js
-├── game/evolution/animation.js  ← game/engine/renderer.js, game/audio/sound.js
-├── game/sync/save.js            (localStorage persistence)
-├── game/audio/sound.js          (no deps, Web Audio API)
-├── game/sprites/sprites.js      (no deps, image loader)
-├── game/sprites/monsterGen.js   (no deps, procedural sprite gen)
-├── game/sprites/tiles.js        (no deps, procedural tile gen)
-├── ecosystem/data/monsters.js   (inlined data module)
-├── ecosystem/data/moves.js      (inlined data module)
-├── ecosystem/data/types.js      (inlined data module)
+src/game/game.ts (entry point, browser)
+├── src/game/theme.ts           (design system tokens, no deps)
+├── src/game/dungeon/runner.ts  ← theme, dungeon, loot, audio
+├── src/game/dungeon/dungeon.ts ← theme (procedural floor gen)
+├── src/game/dungeon/loot.ts    (localStorage persistence)
+├── src/game/dungeon/dungeon-renderer.ts ← theme, runner state
+├── src/game/engine/state.ts    ← engine/events
+├── src/game/engine/input.ts    ← audio/sound
+├── src/game/engine/game-renderer.ts ← sprites, theme
+├── src/game/engine/effects.ts  ← theme (battle visual effects)
+├── src/game/battle/battle-engine.ts ← domain/battle, engine, audio
+├── src/game/world/map.ts       (no deps)
+├── src/game/world/player.ts    ← input, map, audio
+├── src/game/world/encounters.ts ← audio
+├── src/game/evolution/tracker.ts (localStorage)
+├── src/game/audio/sound.ts     (no deps, Web Audio API)
+├── src/game/sprites/sprites.ts (no deps, image loader)
+├── src/game/sprites/monster-gen.ts (procedural sprite gen)
+├── src/game/sprites/tiles.ts   (procedural tile gen)
+├── ecosystem/data/monsters.js  (inlined data module)
+├── ecosystem/data/moves.js     (inlined data module)
+├── ecosystem/data/types.js     (inlined data module)
 └── ecosystem/data/evolutions.js (inlined data module)
 
-core/cli/bin.js (entry point, Node.js CLI)
-├── core/error-parser.js         ← error parsing
-├── core/stacktrace-parser.js    ← stack trace analysis
-├── core/matcher.js              ← error → enemy matching
-└── core/cli/*                   ← CLI subsystems
+src/cli/bin.ts (entry point, Node.js CLI)
+├── src/core/error-parser.ts    ← error parsing
+├── src/core/matcher.ts         ← error → enemy matching
+├── src/cli/commands/*          ← CLI subcommands
+└── src/domain/*                ← pure domain logic
 ```
 
 ## Game State Machine
@@ -395,23 +350,19 @@ core/cli/bin.js (entry point, Node.js CLI)
 │  TITLE  │───────────────>│ EXPLORE │────────────>│ BATTLE_TRANSITION │──────>│ BATTLE  │
 │         │                │         │<────────────│  (flash + fade)   │       │         │
 └─────────┘                └─────────┘  win/run    └──────────────────┘       └─────────┘
-                                │                        ~860ms
-                                │
-                           progression trigger
-                                │
-                                v
-                           ┌──────────┐
-                           │ EVOLVING │  (4-phase animation)
-                           └──────────┘
+     │                          │
+     │  dungeon mode            │ progression trigger
+     ▼                          ▼
+┌──────────┐              ┌──────────┐
+│ DUNGEON  │              │ EVOLVING │  (4-phase animation)
+│ RUNNER   │              └──────────┘
+│ (idle)   │
+└──────────┘
 ```
 
-States: `TITLE`, `EXPLORE`, `BATTLE_TRANSITION`, `BATTLE`, `EVOLVING`, `MENU`
+States: `TITLE`, `EXPLORE`, `BATTLE_TRANSITION`, `BATTLE`, `EVOLVING`, `MENU`, `DUNGEON_RUNNER`
 
 ## Battle System
-
-Two battle APIs coexist in `game/battle/battle-core.js`:
-1. **Original API** (`executeTurn`, `simulateBattle`) — used by `simulate.js` and `battleEngine.js`
-2. **Spec-based API** (`resolveTurn`, `createPureBattleState`) — fully immutable, PP tracking, accuracy
 
 ### Turn Resolution
 1. Compare speeds — faster combatant goes first (ties: player)
@@ -427,7 +378,7 @@ Two battle APIs coexist in `game/battle/battle-core.js`:
 
 ### Boss Encounters
 
-Bosses spawn from systemic failures via threshold triggers defined in `ecosystem/bosses.js`:
+Bosses spawn from systemic failures via threshold triggers:
 
 | Boss | Trigger | Threshold |
 |------|---------|-----------|
@@ -484,21 +435,16 @@ The system supports five extension categories. See [docs/plugin-api.md](docs/plu
 4. **Policy packs** — AgentGuard governance rule sets
 5. **Replay processors** — event stream analysis and transformation
 
-## Event Replay
-
-Events are immutable and ordered. A stored event stream can be replayed to reconstruct any past session. Given the same events and RNG seed, replay produces identical encounters.
-
-See [docs/sequence-diagrams.md](docs/sequence-diagrams.md) for replay flow diagrams.
-
 ## Build System
 
 ```bash
+npm run build:ts       # Compile TypeScript (tsc + esbuild → dist/)
 npm run build          # Full build with inline sprites
 npm run build:tiny     # Build without sprites (smallest)
 npm run budget         # Check size budget compliance
 ```
 
-Pipeline: esbuild (minification, dead code elimination) → terser (3-pass compression) → single HTML file with inlined CSS and JS.
+Pipeline: TypeScript → tsc (individual modules) + esbuild (bundles) → terser (compression) → single HTML file with inlined CSS and JS.
 
 ## Size Budget
 
@@ -512,20 +458,21 @@ Subsystem caps (raw bytes): engine (7.5 KB), rendering (15.5 KB), battle (14.5 K
 ## Testing
 
 ```bash
-npm test               # Run JS tests (77 test files)
-npm run ts:test        # Run TypeScript tests (4 test files, vitest)
+npm test               # Run JS tests (77 test files, import from dist/)
+npm run ts:test        # Run TypeScript tests (16 test files, vitest)
 npm run test:coverage  # Run with coverage (c8, 50% threshold)
 npm run simulate -- --all --runs 100   # Balance analysis
 ```
 
-81 test files (77 JS + 4 TS) covering: battle, damage, encounters, evolution, ingestion pipeline, event bus, game loop, input, map, renderer, save, simulation, sprites, sync, governance (AAB, RTA, invariants, monitor), and more.
+93 test files (77 JS + 16 TS) covering: battle, damage, encounters, evolution, ingestion pipeline, event bus, game loop, input, map, renderer, save, simulation, sprites, sync, governance (AAB, RTA, invariants, monitor), and more.
 
 ## Architectural Invariants
 
-1. **Layer boundaries are strict.** `core/` must not import from `game/`. `game/` must not import from `core/`.
-2. **`battle-core.js` must stay pure.** Zero UI, audio, or DOM dependencies.
+1. **Layer boundaries are strict.** `src/cli/` must not import from `src/game/`. `src/game/` must not import from `src/cli/`.
+2. **Battle engine must stay pure.** Zero UI, audio, or DOM dependencies in `src/domain/battle.ts`.
 3. **JSON is the source of truth.** `.js` data modules are generated artifacts.
 4. **Contributed enemies require no code changes.** New BugMon are added entirely through JSON edits.
 5. **Zero runtime dependencies in browser game.** No npm packages in shipped browser code. CLI has runtime deps (`chokidar`, `commander`, `pino`).
 6. **Deterministic battle engine.** Same inputs + same RNG seed = same outputs.
 7. **Universal EventBus.** Works identically in Node.js and browser.
+8. **TypeScript is the source of truth.** All source lives in `src/`, compiled to `dist/` via tsc + esbuild.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,9 +55,15 @@ BugMon/
 │   │   └── sources/        # Event source adapters
 │   ├── game/               # Browser roguelike (client-side)
 │   │   ├── game.ts         # Game entry point (auto-init, data loading)
-│   │   ├── engine/         # Core framework (state, input, renderer, events)
-│   │   ├── world/          # Dungeon (map, player, encounters)
-│   │   ├── battle/         # Combat (battle-engine, damage, battle-core)
+│   │   ├── theme.ts        # Design system (OLED palette, gold accents, glassmorphism)
+│   │   ├── engine/         # Core framework (state, input, renderer, events, effects)
+│   │   ├── dungeon/        # Idle dungeon runner (primary game mode)
+│   │   │   ├── runner.ts   # Auto-run logic, encounter resolution
+│   │   │   ├── dungeon.ts  # Procedural floor generation
+│   │   │   ├── loot.ts     # Gold, boosts, localStorage persistence
+│   │   │   └── dungeon-renderer.ts  # Premium renderer (parallax, glassmorphic HUD)
+│   │   ├── world/          # Exploration mode (map, player, encounters)
+│   │   ├── battle/         # Combat (battle-engine)
 │   │   ├── evolution/      # Progression (tracker, animation)
 │   │   ├── audio/          # Sound synthesis (Web Audio API)
 │   │   ├── sync/           # Save/sync (localStorage, WebSocket)
@@ -71,9 +77,12 @@ BugMon/
 │   │   ├── contracts.ts    # Module contract registry
 │   │   ├── shapes.ts       # Runtime shape definitions
 │   │   ├── ingestion/      # Error ingestion pipeline
-│   │   └── pipeline/       # Multi-agent pipeline orchestration
+│   │   └── execution/      # Execution adapters + event log
 │   ├── agentguard/         # Governance runtime (RTA)
-│   ├── ecosystem/          # Game content modules (bugdex, bosses, storage)
+│   ├── meta/               # Metadata systems (bugdex, bosses)
+│   ├── orchestration/      # Multi-agent pipeline orchestration
+│   ├── protocol/           # Sync protocol definitions
+│   ├── content/            # Game content validation
 │   ├── watchers/           # Environment watchers (console, test, build)
 │   └── ai/                 # AI integration interface
 │
@@ -190,16 +199,25 @@ The platform uses a dual-layer naming strategy:
 ### Layered Architecture
 All source lives in `src/`, compiled to `dist/`. The codebase is organized into layers:
 - **src/core/** — Shared logic (EventBus, error parsing, bug events). Used by CLI and game.
-- **src/cli/** — Commander-based CLI companion tool. Runs in Node.js only.
-- **src/game/** — Browser roguelike (engine, battle, dungeon, progression, audio, sprites). Runs in the browser only.
+- **src/cli/** — Commander-based CLI companion tool (20 subcommands). Runs in Node.js only.
+- **src/game/** — Browser roguelike with idle dungeon runner (primary mode), exploration, battle, progression, audio, sprites. Runs in the browser only. Zero runtime deps.
+- **src/game/dungeon/** — Idle auto-dungeon runner. Dev character runs through procedural floors, auto-resolves minor enemies, pauses for boss fights.
+- **src/game/theme.ts** — Design system tokens (OLED palette, gold accents, glassmorphism, typography).
 - **ecosystem/data/** — Game content (JSON source of truth + inlined JS modules). Consumed by both CLI and game.
 - **src/domain/** — Pure domain logic with no DOM or Node.js-specific APIs. Battle engine, encounter logic, progression engine, event definitions, ingestion pipeline, governance primitives. All functions are pure and deterministic (when RNG is injected).
 - **src/agentguard/** — Governance runtime implementing the Runtime Assurance Architecture. Evaluates agent actions against policies and invariants.
+- **src/meta/** — Metadata systems (bugdex compendium, boss definitions).
+- **src/orchestration/** — Multi-agent pipeline orchestration (orchestrator, stages, roles).
+- **src/protocol/** — Sync protocol definitions (storage, sync protocol constants).
+- **src/content/** — Game content validation (bugdex-spec).
+- **src/watchers/** — Environment watchers (console, test, build).
 
 ### Roguelike Model
 - Coding sessions are dungeon **runs**
-- Minor enemies (severity 1-2) **auto-resolve** in idle mode
-- Bosses (severity 3+) require **active engagement**
+- Primary mode: **idle dungeon runner** — dev character auto-runs through procedural floors
+- Minor enemies (severity 1-2) **auto-resolve** inline with floating combat text
+- Bosses (severity 3+) **pause the runner** for active engagement
+- Gold and loot persist across runs via localStorage
 - **Bug Grimoire** records defeated enemy types (not a collection game)
 
 ### Domain Layer & Ingestion Pipeline
@@ -212,7 +230,8 @@ The `src/domain/` layer provides environment-agnostic logic:
 - **`src/domain/evolution.ts`** — Progression condition checking (takes event counts as input, no storage dependency)
 - **`src/domain/source-registry.ts`** — Event source plugin registry
 - **`src/domain/ingestion/`** — Multi-stage pipeline: raw stderr → parsed errors → fingerprinted → classified → mapped to BugMon species
-- **`src/domain/pipeline/`** — Multi-agent pipeline orchestration (orchestrator, stages, roles)
+- **`src/domain/execution/`** — Execution event log with causal chains
+- **`src/orchestration/`** — Multi-agent pipeline orchestration (orchestrator, stages, roles)
 - **`src/domain/invariants.ts`**, **`src/domain/policy.ts`**, **`src/domain/reference-monitor.ts`** — Governance primitives consumed by agentguard/
 
 ### Build & Module System

--- a/CONSTRAINTS.md
+++ b/CONSTRAINTS.md
@@ -5,7 +5,7 @@ Total bundle must remain under 32 KB gzipped. Target: 16 KB.
 ## Rules
 
 - No runtime dependencies in browser game; CLI deps must be minimal (`chokidar`, `commander`, `pino`)
-- Vanilla JavaScript for production game code; TypeScript refactoring in progress in `src/`
+- TypeScript in `src/` is the single source of truth, compiled to `dist/` via tsc + esbuild
 - Canvas API for rendering
 - Web Audio API for sound (no audio files)
 - Functions over classes

--- a/LIGHTWEIGHT.md
+++ b/LIGHTWEIGHT.md
@@ -2,7 +2,7 @@
 
 **How small can a game be?**
 
-BugMon is a complete monster-taming RPG — 31 creatures, 72 moves, 7 types, evolution chains, turn-based battles, tile-based exploration, synthesized audio, mobile touch controls — and the whole thing fits in a single HTML file.
+BugMon is a complete monster-taming RPG — 34 creatures, 76 moves, 7 types, evolution chains, turn-based battles, an idle dungeon runner, synthesized audio, mobile touch controls — and the whole thing fits in a single HTML file.
 
 No npm. No webpack. No React. No Babel. No transpiler. No bundler. No framework. No polyfills. No node_modules.
 
@@ -45,7 +45,7 @@ Build it yourself: `node scripts/build.js`
 | Average website hero image | ~200-500 KB |
 | `create-react-app` node_modules | ~300,000 KB |
 
-BugMon has 31 monsters, 72 moves, 7 types, evolution chains, procedural terrain, synthesized audio, a full battle system, and mobile controls. Still smaller than jQuery.
+BugMon has 34 monsters, 76 moves, 7 types, evolution chains, an idle dungeon runner, procedural terrain, synthesized audio, a full battle system, and mobile controls. Still smaller than jQuery.
 
 `node_modules` for dev tooling: esbuild + terser only. Zero browser runtime dependencies. CLI tool has minimal deps (`chokidar`, `commander`, `pino`).
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ See [Plugin API](docs/plugin-api.md) for the full extension guide.
 - **Bug Grimoire** — compendium of every enemy type defeated, with encounter history
 - **Dev-activity progression** — commits, PRs, and bug fixes drive level-ups via git hooks
 - **34 named enemies** across 7 types — community-contributed creatures with sprites and lore
-- **Hybrid idle/active** — minor enemies auto-resolve, bosses demand engagement
+- **Idle dungeon runner** — dev character auto-runs through procedural floors, minor enemies auto-resolve
+- **Premium dark aesthetic** — OLED palette, gold accents, glassmorphic HUD, parallax scrolling
 - Turn-based combat with speed priority, type effectiveness, critical hits, and passive abilities
 - Synthesized sound effects (Web Audio API — zero audio files)
 - **Zero browser runtime dependencies** — vanilla JS, HTML5 Canvas, no framework
@@ -206,9 +207,17 @@ npx agentguard claude-init
 
 ## Browser Game
 
-The BugMon browser companion provides a visual roguelike experience — explore a tile-based dungeon, battle enemies, and track your Grimoire progress. It syncs with the CLI in real time via WebSocket.
+The BugMon browser game features an **idle dungeon runner** — your dev character automatically runs through procedural dungeon floors, defeating minor enemies inline and pausing for boss fights. Gold, loot, and progression persist across runs.
 
-**[Play Now](https://jpleva91.github.io/BugMon/)** — the entire game fits in a single 12 KB file (gzipped, smaller than jQuery).
+**[Play Now](https://jpleva91.github.io/BugMon/)** — the entire game fits in a single file (gzipped, smaller than jQuery).
+
+### Visual Design
+
+- Premium dark aesthetic (OLED palette + gold accents)
+- Glassmorphic HUD with floor progress, HP, gold counter
+- Dev character with hoodie + laptop sprite
+- Parallax scrolling dungeon corridors
+- Floating combat text and XP gains
 
 ### Controls
 
@@ -255,22 +264,26 @@ AgentGuard/
 │   ├── agentguard/         # Governance runtime (deterministic RTA)
 │   │   ├── core/           # AAB + RTA engine
 │   │   ├── policies/       # Policy evaluation + loading
-│   │   ├── invariants/     # Invariant checking
+│   │   ├── invariants/     # Invariant checking + definitions
 │   │   └── evidence/       # Evidence pack generation
 │   ├── cli/                # CLI interface (agentguard command)
-│   │   └── commands/       # Subcommands (watch, scan, play, etc.)
+│   │   └── commands/       # 20 subcommands (watch, scan, play, etc.)
 │   ├── core/               # Shared logic (EventBus, parsing, matching)
 │   ├── domain/             # Pure domain logic (no DOM, no Node.js APIs)
 │   │   ├── ingestion/      # Error normalization pipeline
-│   │   └── pipeline/       # Multi-agent pipeline orchestration
+│   │   └── execution/      # Execution adapters + event log
 │   ├── game/               # BugMon browser game (client-side)
-│   │   ├── engine/         # State machine, input, rendering
+│   │   ├── dungeon/        # Idle dungeon runner (primary game mode)
+│   │   ├── engine/         # State machine, input, rendering, effects
 │   │   ├── battle/         # Turn-based battle engine
-│   │   ├── world/          # Map, player, encounters
+│   │   ├── world/          # Map, player, encounters (exploration mode)
 │   │   ├── evolution/      # Dev-activity progression
 │   │   ├── audio/          # Synthesized sounds (Web Audio API)
 │   │   └── sprites/        # Sprites + procedural generation
-│   ├── ecosystem/          # Game content & metagame
+│   ├── meta/               # Metadata (bugdex, bosses)
+│   ├── orchestration/      # Multi-agent pipeline orchestration
+│   ├── protocol/           # Sync protocol definitions
+│   ├── content/            # Game content validation
 │   └── watchers/           # Environment watchers
 ├── dist/                   # Compiled output (tsc + esbuild)
 ├── ecosystem/data/         # Game content (JSON + JS modules)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,11 +23,11 @@ AgentGuard evaluates governance
     ↓
 BugMon generates encounters
     ↓
-minor enemies auto-resolve (idle)
-bosses require engagement (active)
+dungeon runner auto-resolves minor enemies (idle)
+bosses pause for engagement (active)
     ↓
 Bug Grimoire records defeated enemy types
-XP accumulates across runs
+gold + XP accumulate across runs
     ↑                              |
     └──────────────────────────────┘
 ```
@@ -51,7 +51,7 @@ Establish the conceptual architecture, documentation, and event model that conne
 - [x] Rewritten README, ARCHITECTURE, ROADMAP
 - [x] Updated CLAUDE.md
 
-## Phase 1 — Canonical Event Model
+## Phase 1 — Canonical Event Model `COMPLETE`
 
 > **Theme:** Formalize the event spine
 
@@ -66,80 +66,81 @@ Extend the existing event system (`src/domain/events.ts`, `src/core/event-bus.ts
 - [x] Event store interface (persist, query, replay)
 - [x] Tests for all event types and lifecycle
 
-## Phase 2 — AgentGuard Governance Runtime `CURRENT`
+## Phase 2 — AgentGuard Governance Runtime `MOSTLY COMPLETE`
 
 > **Theme:** Deterministic agent governance
 
 Build the governance runtime that evaluates agent actions against policies and invariants.
 
-- [x] Action Authorization Boundary (AAB) implementation (`agentguard/core/aab.js`)
+- [x] Action Authorization Boundary (AAB) implementation (`src/agentguard/core/aab.ts`)
 - [x] Policy definition format (JSON) (`policy/action_rules.json`, `policy/capabilities.json`)
-- [x] Policy loader and parser (`agentguard/policies/loader.js`)
-- [x] Deterministic policy evaluator (`agentguard/policies/evaluator.js`)
-- [x] Invariant monitoring engine (`agentguard/invariants/checker.js`)
-- [x] Built-in invariants (`agentguard/invariants/definitions.js`)
+- [x] Policy loader and parser (`src/agentguard/policies/loader.ts`)
+- [x] Deterministic policy evaluator (`src/agentguard/policies/evaluator.ts`)
+- [x] Invariant monitoring engine (`src/agentguard/invariants/checker.ts`)
+- [x] Built-in invariants (`src/agentguard/invariants/definitions.ts`)
 - [ ] Blast radius computation
-- [x] Evidence pack generation and persistence (`agentguard/evidence/pack.js`)
-- [ ] CLI governance commands (`bugmon guard`, `bugmon audit`)
-- [x] Governance event emission into canonical event model (via `domain/events.js`)
+- [x] Evidence pack generation and persistence (`src/agentguard/evidence/pack.ts`)
+- [ ] CLI governance commands (`agentguard guard`, `agentguard audit`)
+- [x] Governance event emission into canonical event model (via `src/domain/events.ts`)
 - [ ] Integration with Claude Code hook (governance events from agent actions)
 
-## Phase 3 — BugMon Terminal Roguelike MVP
+## Phase 3 — BugMon Browser Dungeon Runner `COMPLETE`
 
 > **Theme:** Coding sessions become dungeon runs
 
-Implement the roguelike run engine with hybrid idle/active encounters in the terminal.
+Implement the roguelike dungeon runner with hybrid idle/active encounters in the browser.
 
-- [ ] Run engine (session-scoped gameplay lifecycle)
-- [ ] Idle mode: auto-resolve minor enemies (severity 1-2) in background
-- [ ] Active mode: interrupt for bosses and elites (severity 3+)
-- [ ] Configurable idle/active threshold
-- [ ] Encounter difficulty scaling based on session context
-- [ ] Session escalation (unresolved errors compound difficulty)
-- [ ] Stability collapse detection (run death from cascading failures)
-- [ ] Run summary and scoring at session end
-- [ ] Governance boss encounters from AgentGuard events
-- [ ] Bug Grimoire terminal display (enemy compendium)
-- [ ] Run statistics (encounters, defeats, score, duration)
+- [x] Idle dungeon runner (auto-run through procedural floors)
+- [x] Auto-resolve minor enemies (severity 1-2) inline with floating combat text
+- [x] Boss encounters pause for player input (severity 3+)
+- [x] Procedural floor generation (rooms, corridors, treasure, exits)
+- [x] Premium dark aesthetic (OLED + gold/cyan accents, glassmorphic HUD)
+- [x] Dev character with hoodie + laptop sprite and running animation
+- [x] Gold and loot persistence via localStorage
+- [x] Floor progression with increasing difficulty
+- [x] Parallax scrolling dungeon renderer
+- [x] Sound effects for combat, treasure, and floor transitions
 
-## Phase 4 — Event Persistence + Replay
+## Phase 4 — Event Persistence + Replay `PARTIALLY COMPLETE`
 
 > **Theme:** Every session is replayable
 
 Implement durable event storage and deterministic replay.
 
-- [ ] File-based event store (`.bugmon/events/`)
-- [ ] Event stream serialization format
-- [ ] Session metadata (run ID, RNG seed, timestamps)
-- [ ] Replay engine: feed stored event stream through encounter generator
+- [x] File-based event store (`src/domain/event-store.ts`)
+- [x] Event stream serialization (NDJSON)
+- [x] Session metadata (run ID, RNG seed, timestamps)
+- [x] Execution event log (`src/domain/execution/`)
+- [x] CLI replay command (`agentguard replay`)
 - [ ] Deterministic replay with seeded RNG
 - [ ] Replay comparator (verify original vs replayed outcomes)
-- [ ] CLI replay command (`bugmon replay <run-id>`)
 - [ ] Event export/import for sharing sessions
 
-## Phase 5 — Bug Grimoire + Progression
+## Phase 5 — Bug Grimoire + Progression `PARTIALLY COMPLETE`
 
 > **Theme:** Meta-progression across runs
 
 Build the persistent progression system that spans coding sessions.
 
-- [ ] Bug Grimoire: enemy compendium with defeat history, error patterns, fix strategies
+- [x] Bug Grimoire: enemy compendium with defeat history (`src/meta/bugdex.ts`)
+- [x] XP and leveling
+- [x] Dev-activity progression via git hooks (commits, PRs, bug fixes)
+- [x] Evolution chains with activity-based triggers
+- [x] Gold economy (dungeon runner loot)
 - [ ] Grimoire completion tracking and unlock rewards
 - [ ] Achievement system (first boss, perfect run, 100% Grimoire, etc.)
 - [ ] Lifetime statistics aggregation
 - [ ] Developer level with title progression
 - [ ] Difficulty scaling based on developer level
-- [ ] Idle combat effectiveness scaling with level
-- [ ] Dev-activity progression via git hooks (commits, PRs, bug fixes)
 - [ ] Session leaderboard (best scores, fastest boss defeats)
 
-## Phase 6 — Plugin Ecosystem
+## Phase 6 — Plugin Ecosystem `CURRENT`
 
 > **Theme:** Extensible by design
 
 Formalize the plugin system for third-party extensions.
 
-- [ ] Event source plugin interface
+- [x] Event source plugin interface (`src/domain/source-registry.ts`)
 - [ ] Content pack loading system (community enemies, moves, bosses)
 - [ ] Renderer plugin interface
 - [ ] Policy pack loading system
@@ -148,20 +149,22 @@ Formalize the plugin system for third-party extensions.
 - [ ] Plugin registry / discovery mechanism
 - [ ] Language-specific content packs (Python BugMon, Go BugMon, Rust BugMon)
 
-## Phase 7 — Browser / Mobile Renderers
+## Phase 7 — Terminal Roguelike MVP
 
-> **Theme:** Enhanced visual experience
+> **Theme:** Terminal-native dungeon experience
 
-Upgrade the browser game to a roguelike dungeon renderer.
+Bring the dungeon runner experience to the terminal CLI.
 
-- [ ] Roguelike dungeon renderer (procedural floor layouts)
-- [ ] Run-based browser gameplay (session → run mapping)
-- [ ] Idle encounter log in browser UI
-- [ ] Active encounter battle screen
-- [ ] Bug Grimoire browser UI
-- [ ] Mobile-optimized responsive renderer
-- [ ] CLI ↔ browser sync for run state
-- [ ] Sound effects for idle/active transitions
+- [ ] Run engine in terminal (session-scoped gameplay lifecycle)
+- [ ] Idle mode: auto-resolve minor enemies in background with ANSI output
+- [ ] Active mode: interrupt for bosses and elites
+- [ ] Configurable idle/active threshold
+- [ ] Encounter difficulty scaling based on session context
+- [ ] Session escalation (unresolved errors compound difficulty)
+- [ ] Run summary and scoring at session end
+- [ ] Governance boss encounters from AgentGuard events
+- [ ] Bug Grimoire terminal display
+- [ ] Run statistics (encounters, defeats, score, duration)
 
 ## Phase 8 — Editor Integrations
 
@@ -267,39 +270,30 @@ Every feature must fit within the byte budget:
 
 Run `npm run budget` to check compliance.
 
-## Cross-Cutting: TypeScript Migration `IN PROGRESS`
+## TypeScript Migration `COMPLETE`
 
-> **Theme:** Incremental migration to TypeScript
+> **Theme:** TypeScript as single source of truth
 
-A parallel TypeScript implementation exists in `src/` (see `src/README.md` for architecture). This is an incremental migration — the JavaScript implementation remains the production system.
+TypeScript in `src/` is now the **single source of truth** for all system code. The migration from JavaScript to TypeScript is complete.
 
 **Current state:**
-- `src/` directory with 48 TypeScript files across `cli/`, `core/`, `game/`, `domain/`, `agentguard/`, `ecosystem/`, `watchers/`, `ai/`
+- `src/` directory with 134 TypeScript files across `cli/`, `core/`, `game/`, `domain/`, `agentguard/`, `meta/`, `orchestration/`, `protocol/`, `content/`, `watchers/`, `ai/`
 - `tsconfig.json` — strict mode, ES2022 target, rootDir: `src/`, outDir: `dist/`
-- `vitest.config.ts` — test runner for TypeScript tests
+- `vitest.config.ts` — test runner for TypeScript tests (16 test files)
 - `esbuild.config.ts` — builds CLI and game bundles from TS sources
-- 16 TypeScript tests in `tests/ts/` (run via `npm run ts:test`)
-- Runtime dependencies introduced for CLI: `chokidar`, `commander`, `pino`
+- Runtime dependencies for CLI: `chokidar`, `commander`, `pino`
+- Browser game remains zero-dependency
 
-**Commands:**
+**Build pipeline:**
+- `npm run build:ts` — Build TypeScript (tsc + esbuild → dist/)
 - `npm run ts:check` — Type-check (tsc --noEmit)
 - `npm run ts:test` — Run TS tests (vitest)
-- `npm run build:ts` — Build TS (tsc + esbuild)
 
-**Known issues:**
-- Runtime deps (`chokidar`, `commander`, `pino`) are only used by TS code in `src/`, not by the JS CLI
-- `src/game/engine/events.ts` duplicates `src/core/event-bus.ts` — consolidate during migration
-
-**Remaining work:**
-- [ ] Migrate remaining `core/` modules to TypeScript
-- [ ] Migrate `domain/` modules to TypeScript
-- [ ] Migrate `agentguard/` modules to TypeScript
-- [ ] Consolidate `game/engine/events.js` with `domain/event-bus.js`
-- [ ] Integrate TS CLI as primary CLI entry point
-- [ ] Unify JS and TS test suites
-- [ ] Update build pipeline to produce TS-based bundles
+**Key architectural addition (latest):**
+- Idle dungeon runner (`src/game/dungeon/`) — 4 files, ~1,400 lines
+- Premium dark design system (`src/game/theme.ts`) — OLED palette, gold accents, glassmorphism
+- Battle visual effects (`src/game/engine/effects.ts`)
 
 ## Legend
 
-- **Effort:** `[S]` = hours | `[M]` = 1-2 days | `[L]` = 3+ days
-- **Status:** `CURRENT` | `PLANNED` | `IDEA`
+- **Status:** `COMPLETE` | `MOSTLY COMPLETE` | `PARTIALLY COMPLETE` | `CURRENT` | `PLANNED`

--- a/docs/current-priorities.md
+++ b/docs/current-priorities.md
@@ -1,95 +1,129 @@
 # Current Priorities
 
-## Active Phase: Phase 0 — Architecture Clarity
+## Active Phase: Phase 6 — Plugin Ecosystem
 
-The system is in its architectural definition phase. Documentation and conceptual architecture are being established to define the unified AgentGuard + BugMon platform.
+The system has completed its core architecture (Phases 0-3) and is now focused on extensibility. The governance runtime, canonical event model, and browser dungeon runner are all operational.
 
 ## What Is Implemented
 
 The following systems are built and operational:
 
 ### Event Pipeline
-- Error parser with 40+ patterns across JS, TS, Python, Go, Rust, Java (`core/error-parser.js`)
-- Stack trace parser for 6+ frame formats (`core/stacktrace-parser.js`)
-- Stable fingerprinting for event deduplication (`domain/ingestion/fingerprint.js`)
-- Event classification with severity mapping (`core/bug-event.js`)
-- Pipeline orchestration (`domain/ingestion/pipeline.js`)
-- Universal EventBus (`domain/event-bus.js`)
-- Canonical event definitions (`domain/events.js`)
+- Error parser with 40+ patterns across JS, TS, Python, Go, Rust, Java (`src/core/error-parser.ts`)
+- Stack trace parser for 6+ frame formats (`src/core/stacktrace-parser.ts`)
+- Stable fingerprinting for event deduplication (`src/domain/ingestion/fingerprint.ts`)
+- Event classification with severity mapping (`src/core/bug-event.ts`)
+- Pipeline orchestration (`src/domain/ingestion/pipeline.ts`)
+- Universal EventBus (`src/domain/event-bus.ts`, `src/core/event-bus.ts`)
+- Canonical event definitions (`src/domain/events.ts`)
+- Developer signal event types (`src/domain/dev-event.ts`)
+- Event store interface (`src/domain/event-store.ts`)
+- Execution event log with causal chains (`src/domain/execution/`)
 
 ### Battle Engine
-- Pure deterministic battle engine with injected RNG (`domain/battle.js`)
+- Pure deterministic battle engine with injected RNG (`src/domain/battle.ts`)
 - Damage formula with type effectiveness and critical hits
 - Passive abilities (RandomFailure, NonDeterministic)
 - Healing moves
 - Combat system with turn-based battles
 - Battle simulation framework with seeded RNG (`simulation/`)
+- Combo system (`src/domain/combo.ts`)
+- Action definitions (`src/domain/actions.ts`)
+- Battle strategies (`src/domain/strategies.ts`)
 
 ### BugMon Roster
-- 31 BugMon across 7 types (frontend, backend, devops, testing, architecture, security, ai)
-- 72 moves
+- 34 BugMon across 7 types (frontend, backend, devops, testing, architecture, security, ai)
+- 76 moves
 - 7x7 type effectiveness chart
 - 7 evolution chains with 10 evolved forms
 - Rarity system (common, uncommon, legendary, evolved)
 - Error pattern matching for species selection
 
-### Terminal Renderer
-- ANSI-colored encounter display with type-specific ASCII art (`core/cli/renderer.js`)
-- HP bar visualization
-- Bug Grimoire display with completion tracking
-- Stats display with XP progress
-- Boss battle interactive encounter (`core/cli/boss-battle.js`)
+### Governance Runtime (AgentGuard)
+- Action Authorization Boundary (`src/agentguard/core/aab.ts`)
+- Runtime Assurance Engine (`src/agentguard/core/engine.ts`)
+- Policy evaluator (`src/agentguard/policies/evaluator.ts`)
+- Policy loader (`src/agentguard/policies/loader.ts`)
+- Invariant checker (`src/agentguard/invariants/checker.ts`)
+- Invariant definitions (`src/agentguard/invariants/definitions.ts`)
+- Evidence pack generation (`src/agentguard/evidence/pack.ts`)
+- Closed-loop governance monitor (`src/agentguard/monitor.ts`)
+- Policy configuration (`policy/action_rules.json`, `policy/capabilities.json`)
 
-### Browser Game
-- Full RPG with tile-based exploration, random encounters, turn-based battles
+### CLI (Commander-based)
+- 20 subcommands: watch, scan, demo, simulate, resolve, replay, trace, status, score, run-summary, auto-walk, boss-battle, catch, encounter, init, claude-hook, claude-init, contribute, adapter, demo-runner
+- Terminal renderer with ANSI colors (`src/cli/renderer.ts`)
+- WebSocket sync server (`src/cli/sync-server.ts`)
+- Session persistence (`src/cli/session-store.ts`)
+- Event source adapters: watch, scan, claude-hook (`src/core/sources/`)
+
+### Browser Game (Idle Dungeon Runner)
+- Idle auto-dungeon runner as primary game mode (`src/game/dungeon/runner.ts`)
+- Procedural floor generation with rooms, corridors, and loot (`src/game/dungeon/dungeon.ts`)
+- Premium dark design system with OLED palette and gold accents (`src/game/theme.ts`)
+- Glassmorphic HUD with floor progress, HP, gold counter, event log
+- Dev character with hoodie + laptop sprite and running animation
+- Parallax scrolling dungeon renderer (`src/game/dungeon/dungeon-renderer.ts`)
+- Gold and loot persistence via localStorage (`src/game/dungeon/loot.ts`)
+- Auto-resolve minor enemies inline, manual boss fights
+- Classic exploration mode (tile-based dungeon, random encounters)
 - Canvas 2D rendering with procedural tile textures
+- Battle visual effects (`src/game/engine/effects.ts`)
 - Synthesized audio (Web Audio API, no audio files)
 - Mobile touch controls
 - Save/load with auto-save
 - CLI-to-browser sync via WebSocket
 
 ### Progression
-- Bug Grimoire collection tracking (`ecosystem/bugdex.js`)
-- Dev-activity evolution system with git hook tracking (`game/evolution/`)
+- Bug Grimoire collection tracking (`src/meta/bugdex.ts`)
+- Dev-activity evolution system with git hook tracking (`src/game/evolution/`)
 - XP and leveling
-- Boss encounter system with threshold triggers (`ecosystem/bosses.js`)
+- Boss encounter system with threshold triggers (`src/meta/bosses.ts`)
+- Gold economy (dungeon loot, boosts)
+
+### Multi-Agent Pipeline
+- Pipeline orchestrator (`src/orchestration/orchestrator.ts`)
+- Stage definitions (`src/orchestration/stages.ts`)
+- Agent role definitions (`src/orchestration/roles.ts`)
 
 ### Infrastructure
-- 81 test files (77 JS + 4 TS) covering all modules
+- 134 TypeScript source files (single source of truth)
+- 93 test files (77 JS + 16 TS) covering all modules
 - Size budget enforcement (10 KB target, 17 KB cap gzipped)
 - CI workflows (deploy, validate, size check, CodeQL, publish, release)
 - Community submission workflow with automated validation
 - Zero browser runtime dependencies; CLI uses `chokidar`, `commander`, `pino`
+- Module contract registry (`src/domain/contracts.ts`)
+- Runtime shape validation (`src/domain/shapes.ts`)
 
 ## What Is Next
 
-### Phase 1 — Canonical Event Model ~~(complete)~~
-- ~~Extend `domain/events.js` with the full event type taxonomy (governance events, session events)~~ (done)
-- ~~Implement formal event schema validation~~ (done)
-- ~~Add governance event types: `InvariantViolation`, `UnauthorizedAction`, `PolicyDenied`, `BlastRadiusExceeded`, `MergeGuardFailure`~~ (done)
-- ~~Add developer signal event types: `FileSaved`, `TestCompleted`, `BuildCompleted`, `CommitCreated`, `CodeReviewed`, `DeployCompleted`, `LintCompleted`~~ (done)
-- ~~Event factory with fingerprint generation~~ (done)
-- ~~Event store interface with in-memory implementation~~ (done)
-- ~~Tests for all event types and lifecycle~~ (done)
+### Phase 6 — Plugin Ecosystem (Current)
+- Content pack loading system (community enemies, moves, bosses)
+- Renderer plugin interface
+- Policy pack loading system
+- Replay processor interface
+- Plugin validation and sandboxing
 
-### Phase 2 — AgentGuard Governance Runtime
-- Action Authorization Boundary (AAB) implementation
-- Policy definition format and loader
-- Invariant monitoring engine
-- Blast radius computation
-- Evidence pack generation
-- CLI governance commands
+### Phase 7 — Terminal Roguelike MVP
+- Bring the dungeon runner experience to the terminal
+- Idle mode with ANSI output
+- Active mode for bosses and elites
 
-### Phase 3 — BugMon Terminal Roguelike MVP
-- Run engine (session-scoped gameplay)
-- Encounter difficulty scaling based on session context
-- Stability collapse detection
-- Run summary and scoring
-- Governance boss encounters from AgentGuard events
+### Phase 8 — Editor Integrations
+- VS Code extension (sidebar webview)
+- JetBrains plugin
+- Claude Code deep integration
+
+## Resolved Questions
+
+1. **Event persistence format** — NDJSON files in `runtime/events/`
+2. **Policy definition language** — JSON (`policy/*.json`)
+3. **TypeScript migration** — Complete. `src/` is the single source of truth, compiled to `dist/`
+4. **Game mode** — Idle dungeon runner as primary mode, with exploration as secondary
 
 ## Open Questions
 
-1. **Event persistence format** — file-based (`.bugmon/events/`) vs SQLite vs plain JSON files
-2. **Policy definition language** — YAML vs JSON vs JavaScript
-3. **Replay granularity** — full event streams vs checkpoint-based snapshots
-4. **Cross-session evolution** — how dev-activity evolution interacts with run-scoped progression
+1. **Content pack format** — how to package and distribute community content packs
+2. **Plugin sandboxing** — how to safely load third-party plugins
+3. **Terminal dungeon renderer** — how to replicate the visual dungeon experience in ANSI

--- a/docs/roguelike-design.md
+++ b/docs/roguelike-design.md
@@ -107,7 +107,7 @@ Selection priority:
 2. **Type fallback** — no keyword match, but error type maps to a BugMon type (e.g., `null-reference` → backend type).
 3. **Random fallback** — no match at all; select from available roster.
 
-Implementation: `core/matcher.js`
+Implementation: `src/core/matcher.ts`
 
 ### Difficulty Scaling
 
@@ -126,7 +126,7 @@ hp = baseHP + (severity - 1) * 2
 
 ### Boss Escalation
 
-Bosses spawn from systemic failures, not individual errors. The existing boss system (`ecosystem/bosses.js`) defines threshold-based triggers:
+Bosses spawn from systemic failures, not individual errors. The boss system (`src/meta/bosses.ts`) defines threshold-based triggers:
 
 | Boss | Trigger | Threshold |
 |------|---------|-----------|
@@ -214,9 +214,54 @@ Use cases:
 - Sharing memorable runs with other developers
 - Regression testing of the encounter system
 
-## Terminal-First UX
+## Browser Dungeon Runner (Primary Mode)
 
-The primary BugMon interface is the terminal. The roguelike runs alongside the developer's existing workflow.
+The primary BugMon interface is the **idle dungeon runner** in the browser. The dev character runs automatically through procedural dungeon floors while the developer codes.
+
+### Runner Phases
+
+```
+running → encounter (auto-battle) → collecting (treasure) → floor_clear → next floor
+                                                              ↓
+                                                          boss (manual fight)
+                                                              ↓
+                                                          run_over (death stats)
+```
+
+### Visual Design
+
+The dungeon runner uses a premium dark aesthetic:
+- **OLED palette**: Deep darks (#050510 → #0A0E27 → #151B38)
+- **Gold accents**: Treasure, highlights, premium feel
+- **Glassmorphic HUD**: Floor progress, HP bar, gold counter, event log
+- **Parallax scrolling**: Multi-layer depth in dungeon corridors
+- **Floating combat text**: Damage numbers, XP gains, loot pickups
+- **Dev character**: Hoodie + laptop sprite with running animation
+
+### Encounter Resolution
+
+- **Minor enemies** (severity 1-2): Auto-resolve inline. The character runs through them, showing floating damage numbers and XP gains. No interruption.
+- **Bosses** (severity 3+): The runner pauses. A simple turn-based combat interface appears. The developer must engage.
+- **Treasure**: Auto-collects gold and boosts. Floating "+5g" text.
+
+### Floor Progression
+
+Each floor is procedurally generated:
+- Rooms connected by corridors
+- Random enemy placements scaled by floor depth
+- Treasure chests with gold and boosts
+- Boss room at the end of every Nth floor
+- Floor difficulty increases as the developer progresses
+
+### Persistence
+
+- Gold persists across runs via localStorage
+- Run history tracked (floors cleared, enemies defeated, gold earned)
+- Boosts collected during a run reset on death
+
+## Terminal UX
+
+The terminal provides a text-based interface for the CLI:
 
 ```
 ┌─────────────────────────────────────────────────────┐
@@ -237,13 +282,7 @@ The primary BugMon interface is the terminal. The roguelike runs alongside the d
 └─────────────────────────────────────────────────────┘
 ```
 
-The terminal renderer displays:
-- Current run status (run number, current "floor", developer level)
-- Encounter details (BugMon name, HP, error message, source location)
-- Battle options
-- Session statistics
-
-Browser and mobile renderers provide enhanced visual experiences but are not required. The terminal is the canonical interface.
+The browser dungeon runner is the recommended experience; the terminal renderer provides a fallback for CLI-only workflows.
 
 ## Design Rationale
 

--- a/docs/unified-architecture.md
+++ b/docs/unified-architecture.md
@@ -31,7 +31,7 @@ Neither system exists in isolation. AgentGuard produces governance events. BugMo
          │                                                     │
          │  source → parse → normalize → classify → dedupe     │
          │                                                     │
-         │  Implementation: domain/ingestion/                   │
+         │  Implementation: src/domain/ingestion/               │
          └──────────────────────┬──────────────────────────────┘
                                 │
                                 ▼
@@ -164,27 +164,33 @@ The shared layer provides the canonical event model and infrastructure used by b
 
 | Component | Description | Path |
 |-----------|-------------|------|
-| Event schema | Canonical event structure | `domain/events.js` |
-| EventBus | Universal pub/sub | `domain/event-bus.js` |
-| Fingerprinting | Stable event deduplication | `domain/ingestion/fingerprint.js` |
-| Pipeline | Event normalization | `domain/ingestion/pipeline.js` |
-| Replay engine | Event stream replay (planned) | — |
+| Event schema | Canonical event structure | `src/domain/events.ts` |
+| EventBus | Universal pub/sub | `src/core/event-bus.ts`, `src/domain/event-bus.ts` |
+| Fingerprinting | Stable event deduplication | `src/domain/ingestion/fingerprint.ts` |
+| Pipeline | Event normalization | `src/domain/ingestion/pipeline.ts` |
+| Event store | Event persistence | `src/domain/event-store.ts` |
+| Execution log | Causal chain tracking | `src/domain/execution/` |
 
 ## Current Implementation Mapping
 
-The existing codebase maps to the unified architecture as follows:
+The codebase maps to the unified architecture as follows:
 
 | Unified Layer | Current Directory | Description |
 |--------------|-------------------|-------------|
-| Shared / Events | `domain/` | Pure domain logic, event bus, ingestion pipeline |
-| BugMon / Battle Engine | `game/battle/` + `domain/battle.js` | Battle system |
-| BugMon / Terminal Renderer | `core/cli/renderer.js`, `core/cli/encounter.js` | ANSI terminal UI |
-| BugMon / Browser Renderer | `game/` (engine, world, sprites, audio) | Canvas 2D browser game |
-| BugMon / Grimoire | `ecosystem/bugdex.js` | Enemy compendium tracking |
-| BugMon / Stats | `game/evolution/tracker.js` | Dev activity tracking |
+| Shared / Events | `src/domain/` | Pure domain logic, event bus, ingestion pipeline |
+| Shared / Core | `src/core/` | EventBus, error parsing, matching |
+| BugMon / Battle Engine | `src/game/battle/` + `src/domain/battle.ts` | Battle system |
+| BugMon / Dungeon Runner | `src/game/dungeon/` | Idle auto-dungeon (primary game mode) |
+| BugMon / Design System | `src/game/theme.ts` | Premium dark aesthetic, tokens |
+| BugMon / Terminal Renderer | `src/cli/renderer.ts` | ANSI terminal UI |
+| BugMon / Browser Renderer | `src/game/` (engine, world, sprites, audio) | Canvas 2D browser game |
+| BugMon / Grimoire | `src/meta/bugdex.ts` | Enemy compendium tracking |
+| BugMon / Stats | `src/game/evolution/tracker.ts` | Dev activity tracking |
 | Shared / Data | `ecosystem/data/` | Game content (JSON + JS modules) |
-| AgentGuard / Action Interception | `core/cli/claude-hook.js` | Claude Code hook (prototype) |
-| BugMon / Boss System | `ecosystem/bosses.js` | Boss trigger definitions |
+| AgentGuard / Governance | `src/agentguard/` | AAB, policies, invariants, evidence |
+| AgentGuard / Action Interception | `src/core/sources/claude-hook-source.ts` | Claude Code hook |
+| BugMon / Boss System | `src/meta/bosses.ts` | Boss trigger definitions |
+| Orchestration | `src/orchestration/` | Multi-agent pipeline |
 
 ## Target Directory Structure
 

--- a/spec/architecture.md
+++ b/spec/architecture.md
@@ -1,68 +1,106 @@
 # Architecture Specification
 
-## Four-Layer Model
+## Layered Model
 
 ```
 ┌─────────────────────────────────────────┐
-│ core/    (Node.js only)                 │
-│   CLI companion, error parsing, hooks   │
+│ src/cli/    (Node.js only)             │
+│   CLI companion, commands, renderer    │
 └────────────────┬────────────────────────┘
                  │ imports ↓
 ┌────────────────┴────────────────────────┐
-│ domain/  (Environment-agnostic)         │
+│ src/agentguard/  (Governance runtime)  │
+│   AAB, policies, invariants, evidence  │
+└────────────────┬────────────────────────┘
+                 │ imports ↓
+┌────────────────┴────────────────────────┐
+│ src/domain/  (Environment-agnostic)    │
 │   Pure logic: events, battle, encounters│
-│   ingestion pipeline, evolution engine  │
+│   ingestion pipeline, evolution engine │
 └────────────────┬────────────────────────┘
                  │ imports ↓
 ┌────────────────┴────────────────────────┐
-│ ecosystem/  (Shared content)            │
-│   JSON data, Grimoire, bosses, storage  │
+│ src/core/  (Shared logic)              │
+│   EventBus, error parsing, matching    │
 └────────────────┬────────────────────────┘
                  │ imports ↓
 ┌────────────────┴────────────────────────┐
-│ game/    (Browser only)                 │
-│   Canvas rendering, audio, UI, sprites  │
+│ src/game/    (Browser only)            │
+│   Dungeon runner, battle, exploration  │
+│   Canvas rendering, audio, sprites     │
 └─────────────────────────────────────────┘
+```
+
+### Additional Layers
+
+```
+src/meta/           Metadata systems (bugdex, bosses)
+src/orchestration/  Multi-agent pipeline orchestration
+src/protocol/       Sync protocol definitions
+src/content/        Game content validation
+src/watchers/       Environment watchers (console, test, build)
+src/ai/             AI integration interface
 ```
 
 ## Dependency Rules
 
-- **domain/** has zero external dependencies. No DOM APIs, no Node.js-specific APIs.
-- **core/** depends on domain/ and ecosystem/. Never imports from game/.
-- **game/** depends on domain/ and ecosystem/. Never imports from core/.
-- **ecosystem/** depends on domain/ only. Never imports from core/ or game/.
+- **src/domain/** has zero external dependencies. No DOM APIs, no Node.js-specific APIs.
+- **src/core/** depends on domain/. Never imports from game/ or cli/.
+- **src/cli/** depends on domain/, core/, and meta/. Never imports from game/.
+- **src/game/** depends on domain/, core/, and meta/. Never imports from cli/.
+- **src/agentguard/** depends on domain/ only. Never imports from cli/ or game/.
+- **src/meta/** depends on domain/ and ecosystem/data/. Never imports from cli/ or game/.
+- **ecosystem/data/** has zero dependencies. Pure data.
 
 ## Key Subsystems
 
-### Ingestion Pipeline (`domain/ingestion/`)
+### Ingestion Pipeline (`src/domain/ingestion/`)
 
-Five-stage pipeline converting raw errors into game entities:
+Multi-stage pipeline converting raw errors into game entities:
 
 1. **Parse** — Regex matching against 40+ error patterns across 6+ languages
 2. **Fingerprint** — Stable hash for deduplication (same error = same fingerprint)
 3. **Classify** — Map error type to severity (1-5 scale) and BugEvent
 4. **Create Event** — Wrap in canonical event envelope with ID + fingerprint
 5. **Map to Species** — BugEvent → BugMon monster species
+6. **Map Invariants** — Invariant violations → governance events
 
-### Battle Engine (`domain/battle.js`)
+### Battle Engine (`src/domain/battle.ts`)
 
-Pure, deterministic combat with injected RNG. Supports passive abilities, healing, and type effectiveness.
+Pure, deterministic combat with injected RNG. Supports passive abilities, healing, combo system, and type effectiveness.
 
-### Event System (`domain/events.js`, `domain/event-bus.js`)
+### Event System (`src/domain/events.ts`, `src/core/event-bus.ts`)
 
-Canonical event kinds: `ERROR_OBSERVED`, `MOVE_USED`, `EVOLUTION_TRIGGERED`, etc. EventBus provides pub/sub that works in both Node.js and browser.
+Canonical event kinds: `ERROR_OBSERVED`, `MOVE_USED`, `EVOLUTION_TRIGGERED`, governance events, developer signal events, session events. EventBus provides typed pub/sub that works in both Node.js and browser.
 
-### Game State Machine (`game/engine/state.js`)
+### Governance Runtime (`src/agentguard/`)
 
-States: `TITLE → EXPLORE → BATTLE_TRANSITION → BATTLE → EVOLVING → MENU`
+Action Authorization Boundary (AAB) evaluates agent actions against declared policies. Invariant checker monitors system constraints. Evidence packs provide full audit trails.
+
+### Idle Dungeon Runner (`src/game/dungeon/`)
+
+Auto-run through procedural floors. Dev character moves automatically, defeating minor enemies inline and pausing for boss fights. Gold and loot persist across runs.
+
+### Design System (`src/game/theme.ts`)
+
+Premium dark aesthetic with OLED palette, gold accents, glassmorphic panels, and DM Sans typography. Provides all color tokens, spacing constants, and animation timing.
+
+### Game State Machine (`src/game/engine/state.ts`)
+
+States: `TITLE → EXPLORE → BATTLE_TRANSITION → BATTLE → EVOLVING → MENU → DUNGEON_RUNNER`
 
 ## Data Flow
 
 ```
 External Source → Ingestion Pipeline → Canonical Event → EventBus
-                                                           ├→ Game (spawn enemy)
-                                                           └→ AgentGuard (check policy)
+                                                           ├→ Game (spawn enemy / dungeon encounter)
+                                                           ├→ AgentGuard (check policy)
+                                                           └→ Event Store (persist)
 ```
+
+## Build System
+
+TypeScript source compiles via `tsc` (individual modules for tests/imports) + `esbuild` (bundles for CLI and browser game). Browser loads `dist/game/game.js` as a module.
 
 ## Size Budget
 

--- a/src/README.md
+++ b/src/README.md
@@ -1,106 +1,81 @@
-# BugMon TypeScript System
+# AgentGuard / BugMon TypeScript System
 
-A lightweight CLI system that detects software bugs and converts them into roguelike game encounters.
+TypeScript source — the single source of truth for the AgentGuard platform.
 
 ## Architecture
 
-BugMon follows a strict event-driven architecture. Every module communicates through a strongly typed event bus — no direct coupling between systems.
+The system follows a layered architecture with strict dependency rules. All modules communicate through typed event buses and pure domain logic.
 
 ```
-┌─────────────┐     ┌───────────┐     ┌────────────┐     ┌─────────────┐
-│   Watchers   │────▶│ Event Bus │────▶│ Bug Engine  │────▶│ Game Engine  │
-│ (detection)  │     │ (backbone)│     │ (lifecycle) │     │ (encounters) │
-└─────────────┘     └───────────┘     └────────────┘     └─────────────┘
-  console              BugDetected       MonsterSpawned      battle
-  test                 BugResolved       MonsterDefeated     victory
-  build                PlayerDamage      BugAnalyzed         defeat
+┌─────────────┐     ┌───────────┐     ┌──────────────┐     ┌─────────────────┐
+│   Sources    │────▶│ Ingestion │────▶│ Canonical    │────▶│ Subscribers     │
+│ (detection)  │     │ Pipeline  │     │ Event Model  │     │ (renderers)     │
+└─────────────┘     └───────────┘     └──────────────┘     └─────────────────┘
+  stderr              parse             EventBus            Dungeon Runner
+  test output         fingerprint       Event Store         Terminal Renderer
+  agent actions       classify          AgentGuard          Bug Grimoire
+  CI systems          dedupe                                Stats Engine
 ```
 
-## Event Flow
+## Layers
 
-1. **Watchers** observe the development environment (console errors, test failures, build errors)
-2. Watchers emit `BugDetected` events on the **Event Bus**
-3. The **Bug Engine** receives events, registers bugs, and emits `MonsterSpawned`
-4. The **Game Engine** receives monster events and manages encounters
-5. When bugs are resolved, `MonsterDefeated` is emitted with XP rewards
+| Layer | Path | Purpose |
+|-------|------|---------|
+| **CLI** | `src/cli/` | Commander-based CLI (20 subcommands). Node.js only. |
+| **Game** | `src/game/` | Browser roguelike with idle dungeon runner. Zero deps. |
+| **Dungeon** | `src/game/dungeon/` | Idle auto-dungeon runner (primary game mode) |
+| **Theme** | `src/game/theme.ts` | Design system (OLED palette, gold, glassmorphism) |
+| **AgentGuard** | `src/agentguard/` | Governance runtime (AAB, policies, invariants) |
+| **Domain** | `src/domain/` | Pure domain logic (battle, events, ingestion). No DOM/Node APIs. |
+| **Core** | `src/core/` | Shared logic (EventBus, error parsing, matching) |
+| **Meta** | `src/meta/` | Metadata (bugdex compendium, boss definitions) |
+| **Orchestration** | `src/orchestration/` | Multi-agent pipeline orchestration |
+| **Protocol** | `src/protocol/` | Sync protocol definitions |
+| **Content** | `src/content/` | Game content validation |
+| **Watchers** | `src/watchers/` | Environment watchers (console, test, build) |
+| **AI** | `src/ai/` | AI integration interface |
 
-## Module Responsibilities
+## Key Modules
 
 | Module | Path | Purpose |
 |--------|------|---------|
-| **Types** | `src/core/types.ts` | All shared type definitions |
 | **EventBus** | `src/core/event-bus.ts` | Strongly typed pub/sub backbone |
-| **BugRegistry** | `src/core/bug-registry.ts` | In-memory bug storage |
-| **BugEngine** | `src/core/bug-engine.ts` | Bug lifecycle management |
-| **ConsoleWatcher** | `src/watchers/console-watcher.ts` | Runtime error detection |
-| **TestWatcher** | `src/watchers/test-watcher.ts` | Test failure detection |
-| **BuildWatcher** | `src/watchers/build-watcher.ts` | Build error detection |
-| **GameEngine** | `src/game/engine.ts` | Game state machine & combat |
-| **Renderer** | `src/game/renderer.ts` | HTML5 Canvas 2D rendering |
-| **GameLoop** | `src/game/loop.ts` | requestAnimationFrame loop |
-| **AI Interface** | `src/ai/bug-analysis-interface.ts` | Provider-agnostic AI contracts |
-| **CLI** | `src/cli/index.ts` | Commander-based CLI entry point |
+| **ErrorParser** | `src/core/error-parser.ts` | 40+ error patterns across 6+ languages |
+| **Matcher** | `src/core/matcher.ts` | Error → BugMon enemy matching |
+| **Battle** | `src/domain/battle.ts` | Pure deterministic battle engine |
+| **Events** | `src/domain/events.ts` | Canonical event definitions |
+| **Ingestion** | `src/domain/ingestion/` | Error normalization pipeline |
+| **Runner** | `src/game/dungeon/runner.ts` | Idle dungeon runner logic |
+| **DungeonGen** | `src/game/dungeon/dungeon.ts` | Procedural floor generation |
+| **Theme** | `src/game/theme.ts` | Design system tokens |
+| **AAB** | `src/agentguard/core/aab.ts` | Action Authorization Boundary |
+| **CLI** | `src/cli/bin.ts` | CLI entry point |
 
 ## Getting Started
 
 ```bash
-# Install dependencies
-pnpm install
+# Build TypeScript
+npm run build:ts
 
 # Type check
-pnpm run ts:check
+npm run ts:check
 
-# Run tests
-pnpm run ts:test
+# Run TypeScript tests
+npm run ts:test
 
-# CLI commands
-pnpm exec tsx src/cli/index.ts watch        # Start watchers
-pnpm exec tsx src/cli/index.ts demo         # Run demo encounter
-pnpm exec tsx src/cli/index.ts status       # Show status
-```
+# Start dev server
+npm run serve
+# Open http://localhost:8000
 
-## Extension Points
-
-### Custom Watchers
-
-Implement the `Watcher` interface from `src/core/types.ts`:
-
-```typescript
-import type { Watcher, EventMap } from './core/types';
-import type { EventBus } from './core/event-bus';
-
-class MyWatcher implements Watcher {
-  constructor(private eventBus: EventBus<EventMap>) {}
-
-  start() {
-    // Observe your source, emit BugDetected events
-    this.eventBus.emit('BugDetected', { bug: { ... } });
-  }
-
-  stop() { /* cleanup */ }
-}
-```
-
-### AI Analyzers
-
-Implement the `BugAnalyzer` interface:
-
-```typescript
-import type { BugAnalyzer, BugEvent, BugAnalysis } from './core/types';
-
-class MyAIAnalyzer implements BugAnalyzer {
-  async analyzeBug(bug: BugEvent): Promise<BugAnalysis> {
-    // Call your AI provider
-    return { suggestedFix: '...', confidence: 0.9, category: '...', relatedPatterns: [] };
-  }
-}
+# Run CLI
+npm run dev
 ```
 
 ## Design Principles
 
 - **Deterministic**: All core logic is pure and deterministic (RNG injected)
-- **No global state**: All state lives in class instances, wired at startup
-- **Dependency injection**: Constructors accept dependencies, never import singletons
-- **Small functions**: Each function does one thing
+- **Layered**: Strict dependency rules — no cross-imports between cli/ and game/
+- **Zero browser deps**: Browser game has no runtime dependencies
 - **Strong typing**: Full TypeScript strict mode, discriminated unions for events
-- **AI-friendly**: Explicit contracts, small modules, predictable patterns
+- **Data-driven**: Game content in JSON, engine reads data, never hardcodes
+- **Event-driven**: Canonical event model connects all subsystems


### PR DESCRIPTION
…runner

Documentation was significantly outdated — still referencing JavaScript-first structure, missing the idle dungeon runner, design system, and new layers (meta/, orchestration/, protocol/, content/). Updated 12 files across ARCHITECTURE, ROADMAP, CLAUDE.md, README, specs, and supporting docs.