### PR TITLE
Add governed action kernel with adapters, CLI, and docs overhaul

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,30 +2,37 @@
 
 ## Project Overview
 
-**AgentGuard** is a deterministic runtime guardrails platform for AI-assisted software systems. It uses a dual-layer naming strategy:
+**AgentGuard** is a **governed action runtime for AI coding agents**. It intercepts agent tool calls, enforces policies and invariants, executes authorized actions via adapters, and emits lifecycle events. The Action is the primary unit of computation.
 
-- **AgentGuard** (platform layer) — The serious infrastructure. Deterministic governance runtime for AI coding agents. Evaluates agent actions against declared policies and invariants. Produces canonical events when violations occur.
-- **BugMon** (UX layer) — The gamified interface. Consumes canonical events (developer errors, CI failures, governance violations) and renders them as interactive roguelike encounters. Coding sessions are dungeon runs. Bugs are enemies. CI failures are bosses. BugMon is a *mode* within AgentGuard, not the platform itself.
+- **AgentGuard** (active focus) — The governed action kernel. Intercepts agent tool calls (Claude Code hooks), evaluates against policies and invariants, executes via adapters, emits canonical events. CLI commands: `guard`, `inspect`, `events`.
+- **BugMon** (deprioritized) — A gamified visualization mode that can consume governance events as roguelike encounters. Functional but not under active development.
 
-The system has one architectural spine: the **canonical event model**. All system activity becomes events. AgentGuard produces governance events. BugMon mode consumes all events as gameplay.
+The system has one architectural spine: the **canonical event model**. All system activity becomes events. The kernel produces governance events. Subscribers (TUI renderer, JSONL sink, CLI inspect) consume them.
 
 **Key characteristics:**
-- Hybrid idle/active roguelike — minor enemies auto-resolve, bosses demand engagement
-- Bug Grimoire instead of collection — compendium of defeated enemy types
-- 100% client-side browser game with zero runtime dependencies
-- TypeScript source (`src/`), compiled to `dist/` via tsc + esbuild. HTML5 Canvas 2D, Web Audio API
-- CLI has runtime dependencies (`chokidar`, `commander`, `pino`); browser game remains zero-dep
+- Governed action kernel: propose → normalize → evaluate → execute → emit
+- 6 built-in invariants (secret exposure, protected branches, blast radius, test-before-push, no force push, lockfile integrity)
+- YAML/JSON policy format with pattern matching, scopes, and branch conditions
+- Escalation tracking: NORMAL → ELEVATED → HIGH → LOCKDOWN
+- JSONL event persistence for audit trail and replay
+- Claude Code adapter for PreToolUse/PostToolUse hooks
+- TypeScript source (`src/`), compiled to `dist/` via tsc + esbuild
+- CLI has runtime dependencies (`chokidar`, `commander`, `pino`)
 - Build tooling: tsc + esbuild + terser + vitest (dev dependencies only)
-- Deployed to GitHub Pages
-- Community enemy submissions via GitHub Issues + automated validation
-- Layered architecture: `src/core/` (shared logic), `src/cli/` (CLI), `src/game/` (browser), `src/domain/` (pure logic), `src/agentguard/` (governance), `ecosystem/data/` (game content)
+- Layered architecture: `src/agentguard/` (kernel + governance), `src/domain/` (pure logic), `src/core/` (shared), `src/cli/` (CLI), `src/game/` (browser, deprioritized), `ecosystem/data/` (game content, deprioritized)
 
 ## Quick Start
 
-Build first, then start the dev server:
-
 ```bash
 npm run build:ts     # Compile TypeScript → dist/
+
+# Governance runtime
+echo '{"tool":"Bash","command":"git push origin main"}' | npx agentguard guard --dry-run
+npx agentguard guard --policy agentguard.yaml   # Start runtime with policy
+npx agentguard inspect --last                   # Inspect most recent run
+npx agentguard events --last                    # Show raw event stream
+
+# BugMon mode (deprioritized)
 npm run serve        # Runs scripts/dev-server.js (zero deps, live reload)
 # Then open http://localhost:8000
 ```
@@ -55,15 +62,9 @@ BugMon/
 │   │   └── sources/        # Event source adapters
 │   ├── game/               # Browser roguelike (client-side)
 │   │   ├── game.ts         # Game entry point (auto-init, data loading)
-│   │   ├── theme.ts        # Design system (OLED palette, gold accents, glassmorphism)
-│   │   ├── engine/         # Core framework (state, input, renderer, events, effects)
-│   │   ├── dungeon/        # Idle dungeon runner (primary game mode)
-│   │   │   ├── runner.ts   # Auto-run logic, encounter resolution
-│   │   │   ├── dungeon.ts  # Procedural floor generation
-│   │   │   ├── loot.ts     # Gold, boosts, localStorage persistence
-│   │   │   └── dungeon-renderer.ts  # Premium renderer (parallax, glassmorphic HUD)
-│   │   ├── world/          # Exploration mode (map, player, encounters)
-│   │   ├── battle/         # Combat (battle-engine)
+│   │   ├── engine/         # Core framework (state, input, renderer, events)
+│   │   ├── world/          # Dungeon (map, player, encounters)
+│   │   ├── battle/         # Combat (battle-engine, damage, battle-core)
 │   │   ├── evolution/      # Progression (tracker, animation)
 │   │   ├── audio/          # Sound synthesis (Web Audio API)
 │   │   ├── sync/           # Save/sync (localStorage, WebSocket)
@@ -77,12 +78,18 @@ BugMon/
 │   │   ├── contracts.ts    # Module contract registry
 │   │   ├── shapes.ts       # Runtime shape definitions
 │   │   ├── ingestion/      # Error ingestion pipeline
-│   │   └── execution/      # Execution adapters + event log
-│   ├── agentguard/         # Governance runtime (RTA)
-│   ├── meta/               # Metadata systems (bugdex, bosses)
-│   ├── orchestration/      # Multi-agent pipeline orchestration
-│   ├── protocol/           # Sync protocol definitions
-│   ├── content/            # Game content validation
+│   │   └── pipeline/       # Multi-agent pipeline orchestration
+│   ├── agentguard/         # Governance runtime (ACTIVE FOCUS)
+│   │   ├── kernel.ts       # Governed action kernel (orchestrator)
+│   │   ├── monitor.ts      # Runtime monitor (escalation tracking)
+│   │   ├── core/           # AAB + RTA engine
+│   │   ├── policies/       # Policy evaluator + JSON/YAML loaders
+│   │   ├── invariants/     # Invariant checker + 6 defaults
+│   │   ├── evidence/       # Evidence pack generation
+│   │   ├── adapters/       # Execution adapters (file, shell, git, claude-code)
+│   │   ├── renderers/      # TUI renderer (terminal action stream)
+│   │   └── sinks/          # JSONL event persistence
+│   ├── ecosystem/          # Game content modules (deprioritized)
 │   ├── watchers/           # Environment watchers (console, test, build)
 │   └── ai/                 # AI integration interface
 │
@@ -131,108 +138,83 @@ BugMon/
 ## Development Commands
 
 ```bash
-# Serve locally
-npm run serve
+# TypeScript build (required before running tests or CLI)
+npm run build:ts           # Build TypeScript (tsc + esbuild → dist/)
+npm run ts:check           # Type-check TypeScript (tsc --noEmit)
 
 # Run tests
-npm test
-
-# Run battle simulation (random matchup, verbose)
-npm run simulate
-
-# Specific matchup
-npm run simulate -- NullPointer Deadlock
-
-# Statistical analysis
-npm run simulate -- NullPointer Deadlock --runs 1000
-
-# Full roster round-robin
-npm run simulate -- --all
-
-# Quick statistical analysis (1,000 battles)
-npm run simulate:quick
-
-# Full roster balance check (50,000 battles)
-npm run simulate:full
-
-# Compare before/after balance changes
-npm run simulate:compare
-
-# Build single-file distribution
-npm run build            # Full build with inline sprites
-npm run build:tiny       # Build without sprites (smallest)
-npm run build:debug      # Build with sourcemaps
-npm run budget           # Check size budget compliance
-
-# Sync JSON data → JS modules
-npm run sync-data
+npm test                   # Run JS tests (1085 tests)
+npm run ts:test            # Run TypeScript tests (345 tests, vitest)
+npm run ts:test:watch      # Run TypeScript tests in watch mode
+npm run test:coverage      # Run with coverage (c8, 50% line threshold)
 
 # Code quality
-npm run contracts:check  # Verify module contracts
 npm run lint             # Run ESLint
 npm run lint:fix         # Run ESLint with auto-fix
 npm run format           # Check formatting (Prettier)
 npm run format:fix       # Fix formatting (Prettier)
-npm run test:coverage    # Run tests with coverage (c8, 50% line threshold)
+npm run contracts:check  # Verify module contracts
 
 # Run AgentGuard CLI
 npm run dev
 
-# TypeScript build (required before running JS tests or serving)
-npm run build:ts           # Build TypeScript (tsc + esbuild → dist/)
-npm run ts:check           # Type-check TypeScript (tsc --noEmit)
-npm run ts:test            # Run TypeScript tests (vitest)
-npm run ts:test:watch      # Run TypeScript tests in watch mode
+# BugMon game (deprioritized)
+npm run serve            # Dev server for browser game
+npm run simulate         # Battle simulation
+npm run build            # Full build with inline sprites
+npm run sync-data        # Sync JSON data → JS modules
+npm run budget           # Check size budget compliance
 ```
 
 ## Architecture & Key Patterns
 
-### Dual-Layer Naming
-The platform uses a dual-layer naming strategy:
-- **AgentGuard** (platform) — serious infrastructure name for governance, policies, events
-- **BugMon** (mode) — fun viral UX layer for the gamified debugging interface
-- CLI binary is `agentguard` (with `bugmon` as backward-compatible alias)
-- `agentguard watch`, `agentguard scan`, `agentguard guard` = infrastructure commands
-- `agentguard play`, `agentguard demo` = BugMon mode commands
-- See `docs/unified-architecture.md` for the full integration model
+### Governed Action Kernel (Primary)
+The kernel loop is the core of AgentGuard. Every agent action passes through it:
+1. Agent proposes action (Claude Code tool call → `RawAgentAction`)
+2. AAB normalizes intent (tool → action type, detect git/destructive commands)
+3. Policy evaluator matches rules (deny/allow with scopes, branches, limits)
+4. Invariant checker verifies system state (6 defaults)
+5. If allowed: execute via adapter (file/shell/git handlers)
+6. Emit lifecycle events: `ACTION_REQUESTED` → `ACTION_ALLOWED/DENIED` → `ACTION_EXECUTED/FAILED`
+7. Sink all events to JSONL for audit trail
+
+Key files: `agentguard/kernel.ts`, `agentguard/core/aab.ts`, `agentguard/core/engine.ts`, `agentguard/monitor.ts`
+See `docs/unified-architecture.md` for the full model.
 
 ### Layered Architecture
 All source lives in `src/`, compiled to `dist/`. The codebase is organized into layers:
-- **src/core/** — Shared logic (EventBus, error parsing, bug events). Used by CLI and game.
-- **src/cli/** — Commander-based CLI companion tool (20 subcommands). Runs in Node.js only.
-- **src/game/** — Browser roguelike with idle dungeon runner (primary mode), exploration, battle, progression, audio, sprites. Runs in the browser only. Zero runtime deps.
-- **src/game/dungeon/** — Idle auto-dungeon runner. Dev character runs through procedural floors, auto-resolves minor enemies, pauses for boss fights.
-- **src/game/theme.ts** — Design system tokens (OLED palette, gold accents, glassmorphism, typography).
-- **ecosystem/data/** — Game content (JSON source of truth + inlined JS modules). Consumed by both CLI and game.
-- **src/domain/** — Pure domain logic with no DOM or Node.js-specific APIs. Battle engine, encounter logic, progression engine, event definitions, ingestion pipeline, governance primitives. All functions are pure and deterministic (when RNG is injected).
-- **src/agentguard/** — Governance runtime implementing the Runtime Assurance Architecture. Evaluates agent actions against policies and invariants.
-- **src/meta/** — Metadata systems (bugdex compendium, boss definitions).
-- **src/orchestration/** — Multi-agent pipeline orchestration (orchestrator, stages, roles).
-- **src/protocol/** — Sync protocol definitions (storage, sync protocol constants).
-- **src/content/** — Game content validation (bugdex-spec).
-- **src/watchers/** — Environment watchers (console, test, build).
+- **src/agentguard/** — Governed action kernel, policies, invariants, adapters, renderers, sinks. **Active focus.**
+- **src/domain/** — Pure domain logic with no DOM or Node.js-specific APIs. Actions, events, reference monitor, adapter registry, governance primitives. All functions are pure and deterministic.
+- **src/core/** — Shared logic (EventBus, types, error parsing). Used by all layers.
+- **src/cli/** — CLI entry point and commands. Runs in Node.js only.
+- **src/game/** — Browser roguelike. **Deprioritized.** Runs in the browser only.
+- **ecosystem/data/** — Game content. **Deprioritized.** JSON source of truth + inlined JS modules.
 
-### Roguelike Model
-- Coding sessions are dungeon **runs**
-- Primary mode: **idle dungeon runner** — dev character auto-runs through procedural floors
-- Minor enemies (severity 1-2) **auto-resolve** inline with floating combat text
-- Bosses (severity 3+) **pause the runner** for active engagement
-- Gold and loot persist across runs via localStorage
-- **Bug Grimoire** records defeated enemy types (not a collection game)
+### CLI Commands
+- `agentguard guard` — Start the governed action runtime (policy + invariant enforcement)
+- `agentguard guard --policy <file>` — Use a specific policy file (YAML or JSON)
+- `agentguard guard --dry-run` — Evaluate without executing actions
+- `agentguard inspect [runId]` — Show action graph for a run
+- `agentguard events [runId]` — Show raw event stream for a run
+- `agentguard watch -- <cmd>` — Monitor a command for errors
+- `agentguard play` / `agentguard demo` — BugMon mode (deprioritized)
 
-### Domain Layer & Ingestion Pipeline
+### Domain Layer
 The `src/domain/` layer provides environment-agnostic logic:
-- **`src/domain/events.ts`** — Canonical event kinds (e.g., `ERROR_OBSERVED`, `MOVE_USED`, `EVOLUTION_TRIGGERED`)
-- **`src/core/event-bus.ts`** — Generic typed EventBus that works in both Node.js and browser
+- **`src/domain/actions.ts`** — 23 canonical action types across 8 classes
+- **`src/domain/events.ts`** — 50+ canonical event kinds, factory, validation
+- **`src/domain/reference-monitor.ts`** — Action authorization with decision trail
+- **`src/domain/execution/adapters.ts`** — Adapter registry (action class → handler mapping)
+- **`src/core/event-bus.ts`** — Generic typed EventBus
 - **`src/domain/event-store.ts`** — Event persistence interface
-- **`src/domain/battle.ts`** — Pure battle engine with passive abilities, healing, and damage calculation
-- **`src/domain/encounters.ts`** — Encounter trigger checks with rarity-weighted enemy selection
-- **`src/domain/evolution.ts`** — Progression condition checking (takes event counts as input, no storage dependency)
-- **`src/domain/source-registry.ts`** — Event source plugin registry
-- **`src/domain/ingestion/`** — Multi-stage pipeline: raw stderr → parsed errors → fingerprinted → classified → mapped to BugMon species
-- **`src/domain/execution/`** — Execution event log with causal chains
-- **`src/orchestration/`** — Multi-agent pipeline orchestration (orchestrator, stages, roles)
-- **`src/domain/invariants.ts`**, **`src/domain/policy.ts`**, **`src/domain/reference-monitor.ts`** — Governance primitives consumed by agentguard/
+- **`src/domain/ingestion/`** — Error ingestion pipeline
+- **`src/domain/pipeline/`** — Multi-agent pipeline orchestration
+
+### BugMon Game Layer (Deprioritized)
+The game layer remains functional but is not under active development:
+- Battle engine, encounters, progression (`domain/battle.ts`, `domain/encounters.ts`)
+- Browser game: Canvas 2D, synthesized audio, sprites (`game/`)
+- Game content: 31 BugMon, 72 moves, 7 evolution chains (`ecosystem/data/`)
 
 ### Build & Module System
 TypeScript source compiles via `tsc` (individual modules for tests/imports) + `esbuild` (bundles for CLI and browser game). Browser loads `dist/game/game.js` as a module via `<script type="module">`.
@@ -240,7 +222,7 @@ TypeScript source compiles via `tsc` (individual modules for tests/imports) + `e
 ### Data as Inlined JS Modules
 Game data lives in `ecosystem/data/` as both JSON (source of truth) and JS modules (imported by the game). To regenerate JS modules from JSON: `npm run sync-data`
 
-### Battle System
+### Battle System (Deprioritized)
 Turn order: faster combatant goes first (ties: player wins). Damage formula:
 ```
 damage = (power + attack - floor(defense / 2) + random(1-3)) * typeMultiplier
@@ -329,7 +311,7 @@ Key files:
 - Domain layer modules must remain pure — no DOM, no Node.js APIs
 - Specs are living documents — update them when implementations evolve
 
-## Data Formats
+## Data Formats (BugMon — Deprioritized)
 
 ### monsters.json
 ```json
@@ -358,7 +340,7 @@ Key files:
     "description": "Make 10 commits" }] }
 ```
 
-## Size Budget
+## Size Budget (BugMon — Deprioritized)
 
 - **Main bundle**: 10 KB target / 17 KB cap (gzipped, built with `--no-sprites`)
 - **Subsystem caps** (raw bytes): engine (7.5 KB), rendering (15.5 KB), battle (14.5 KB), data (13.2 KB), game-logic (19.5 KB), infrastructure (7 KB)
@@ -366,10 +348,9 @@ Key files:
 ## Testing
 
 ```bash
-npm test                               # Run JS tests (77 test files, import from dist/)
-npm run ts:test                        # Run TypeScript tests (16 test files, vitest)
+npm test                               # Run JS tests (1085 tests, import from dist/)
+npm run ts:test                        # Run TypeScript tests (345 tests, vitest)
 npm run test:coverage                  # Run with coverage (c8, 50% line threshold)
-npm run simulate -- --all --runs 100   # Round-robin roster balance analysis
 ```
 
 ## CI/CD & Automation
@@ -397,7 +378,7 @@ Community members can submit new BugMon enemies and moves via GitHub Issues usin
 
 Submissions are validated automatically by `.github/scripts/validate-submission.cjs`, previewed with `.github/scripts/battle-preview.cjs`, and generated into data entries by `.github/scripts/generate-bugmon.cjs`.
 
-## When Adding New Content
+## When Adding New Content (BugMon — Deprioritized)
 
 ### New BugMon Enemy
 1. Add entry to `ecosystem/data/monsters.json` following existing schema

--- a/README.md
+++ b/README.md
@@ -1,388 +1,236 @@
 # AgentGuard
 
-**Deterministic runtime guardrails for AI-assisted software systems.**
+**Governed action runtime for AI coding agents.**
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 [![npm](https://img.shields.io/badge/npm-agentguard-cb3837.svg)](https://www.npmjs.com/package/agentguard)
-[![Play BugMon](https://img.shields.io/badge/BugMon-Play%20Now-orange.svg)](https://jpleva91.github.io/BugMon/)
-[![Size](https://img.shields.io/badge/gzipped-12_KB-brightgreen.svg)](LIGHTWEIGHT.md)
-[![Dependencies](https://img.shields.io/badge/browser_deps-0-brightgreen.svg)](LIGHTWEIGHT.md)
 
 ---
 
-AgentGuard is an execution safety and observability platform for AI-assisted development. It monitors agent actions against declared policies and invariants, producing canonical events when violations occur.
-
-**[BugMon](https://jpleva91.github.io/BugMon/)** is the gamified interface that visualizes system failures as monsters you battle while coding.
+AgentGuard intercepts AI agent tool calls, enforces policies and invariants, and emits lifecycle events. Every action passes through a deterministic kernel that decides allow or deny before execution.
 
 ```
-error detected  -->  policy evaluated  -->  event emitted  -->  monster spawns  -->  fix bug  -->  victory
+agent proposes action  →  policy evaluated  →  invariants checked  →  allow/deny  →  execute  →  events emitted
 ```
-
-<p align="center">
-  <img src="game/sprites/nullpointer.png" width="64" alt="NullPointer">
-  <img src="game/sprites/racecondition.png" width="64" alt="RaceCondition">
-  <img src="game/sprites/memoryleak.png" width="64" alt="MemoryLeak">
-  <img src="game/sprites/deadlock.png" width="64" alt="Deadlock">
-</p>
 
 ## Quick Start
 
 ```bash
-# Watch a command — errors become events
-npx agentguard watch -- npm test
+# Pipe an action into the kernel
+echo '{"tool":"Bash","command":"git push origin main"}' | npx agentguard guard --dry-run
 
-# Launch BugMon mode — gamified debugging
-npx agentguard play
+# Start the runtime with a policy file
+npx agentguard guard --policy agentguard.yaml
 
-# No install. No config. No dependencies.
+# Inspect the last run
+npx agentguard inspect --last
 ```
 
 ## How It Works
 
-AgentGuard has two layers:
+AgentGuard evaluates every agent action through a **governed action kernel**:
 
-### Layer 1: Runtime Guardrails (Infrastructure)
+1. **Normalize** — Claude Code tool calls (Bash, Write, Edit, Read) are mapped to canonical action types (shell.exec, file.write, file.read)
+2. **Evaluate** — policies match against the action (deny git.push to main, deny destructive commands, enforce scope limits)
+3. **Check invariants** — 6 built-in safety checks run on every action
+4. **Execute** — if allowed, the action runs via adapters (file, shell, git handlers)
+5. **Emit events** — full lifecycle events sunk to JSONL for audit trail
 
-AgentGuard evaluates AI agent actions against deterministic policies and invariants. When violations occur, it produces canonical events — structured, typed, auditable records of what happened.
-
-```bash
-agentguard watch -- npm run dev      # Monitor for errors and violations
-agentguard scan ./src                # Scan files for bugs (eslint/tsc)
-agentguard replay --last             # Replay a session timeline
-```
-
-### Layer 2: BugMon Mode (Gamified Interface)
-
-BugMon consumes canonical events and renders them as roguelike encounters. Coding sessions are dungeon runs. Errors are enemies. CI failures are bosses.
-
-```bash
-agentguard play                      # Launch BugMon mode
-agentguard watch --cache -- npm test  # Interactive: battle & cache BugMon!
-agentguard dex                       # View your Bug Grimoire
-```
-
-### Examples
+### Example Output
 
 ```
-  Watching test output...
+  AgentGuard Runtime Active
+  policy: agentguard.yaml | invariants: 6 active
 
-  ⚠ Error detected
-  Spawned: NullPointer Beetle (Lv.3)
-
-  [idle] NullPointer defeated         +15 XP     TypeError
-  [idle] TypeCoercion defeated        +10 XP     lint warning
-  [idle] ImportError defeated         +15 XP     module not found
-
-  ⚠ BOSS: CI Dragon appeared!                    CIFailure
-  ████████████████████████████░░  HP: 500/500    severity: 4
-  Pipeline failed: deploy job exited with code 1
-  .github/workflows/deploy.yml
-  [1] Fight  [2] Run
+  ✓ file.write src/auth/service.ts
+  ✓ shell.exec npm test
+  ✗ git.push main → DENIED (protect-main)
+  ⚠ invariant violated: protected-branch
 ```
 
-## Plugin Architecture
+## Policy Format
 
-AgentGuard uses a **SourceRegistry** to manage where signals come from. Any tool, service, or workflow that produces error output can be a source.
+Policies are YAML or JSON files that declare what agents can and cannot do:
 
-### Built-in Sources
+```yaml
+id: project-policy
+name: Project Policy
+severity: 4
+rules:
+  - action: git.push
+    effect: deny
+    branches: [main, master]
+    reason: Protected branch
 
-| Source | Description |
-|--------|-------------|
-| `watch` | Wraps a child process, captures stderr errors |
-| `scan` | Runs linters/compilers (eslint, tsc), captures output |
-| `claude-hook` | Captures errors from Claude Code sessions |
+  - action: git.force-push
+    effect: deny
+    reason: Force push not allowed
 
-### Write a Custom Source
+  - action: file.write
+    effect: deny
+    target: .env
+    reason: No secrets modification
 
-```javascript
-import { SourceRegistry } from './domain/source-registry.js';
-import { EventBus } from './domain/event-bus.js';
-import { ingest } from './domain/ingestion/pipeline.js';
-
-const registry = new SourceRegistry({ eventBus: new EventBus(), ingest });
-
-registry.register({
-  name: 'my-ci-watcher',
-  start(onRawSignal) {
-    // Feed raw error text into the pipeline
-    onRawSignal('TypeError: Cannot read properties of undefined');
-  },
-  stop() {},
-});
-
-registry.start();
+  - action: file.read
+    effect: allow
+    reason: Reading is always safe
 ```
 
-Any raw text fed to `onRawSignal` goes through the ingestion pipeline (parse, fingerprint, classify) and becomes a canonical event on the EventBus.
+Drop an `agentguard.yaml` in your repo root — the CLI picks it up automatically.
 
-See [Plugin API](docs/plugin-api.md) for the full extension guide.
+## Built-in Invariants
 
-## Features
+6 safety invariants run on every action evaluation:
 
-### AgentGuard (Governance Runtime)
-- **Deterministic policy evaluation** — declare what agents can and cannot do
-- **Invariant monitoring** — system-wide constraints that must never be violated
-- **Action Authorization Boundary** — central gatekeeper for all agent actions
-- **Evidence packs** — full audit trail for every decision
-- **Escalation levels** — normal, elevated, high, lockdown
-- **Canonical event model** — 40+ structured event types
+| Invariant | Severity | Description |
+|-----------|----------|-------------|
+| **no-secret-exposure** | 5 (critical) | Blocks access to .env, credentials, .pem, .key files |
+| **protected-branch** | 4 (high) | Prevents direct push to main/master |
+| **no-force-push** | 4 (high) | Forbids force push |
+| **blast-radius-limit** | 3 (medium) | Enforces file modification limit (default 20) |
+| **test-before-push** | 3 (medium) | Requires tests pass before push |
+| **lockfile-integrity** | 2 (low) | Ensures package.json changes sync with lockfiles |
 
-### BugMon Mode (Gamified Interface)
-- **40+ error patterns** — JavaScript, TypeScript, Python, Go, Rust, Java, ESLint, CI output
-- **Bug Grimoire** — compendium of every enemy type defeated, with encounter history
-- **Dev-activity progression** — commits, PRs, and bug fixes drive level-ups via git hooks
-- **34 named enemies** across 7 types — community-contributed creatures with sprites and lore
-- **Idle dungeon runner** — dev character auto-runs through procedural floors, minor enemies auto-resolve
-- **Premium dark aesthetic** — OLED palette, gold accents, glassmorphic HUD, parallax scrolling
-- Turn-based combat with speed priority, type effectiveness, critical hits, and passive abilities
-- Synthesized sound effects (Web Audio API — zero audio files)
-- **Zero browser runtime dependencies** — vanilla JS, HTML5 Canvas, no framework
+## Escalation
 
-## The Roguelike Model
+AgentGuard tracks cumulative denials and violations. Repeated bad behavior escalates:
 
-Coding sessions are **runs**. Errors are **enemies**. CI failures are **bosses**.
-
-| Software Development | Roguelike Mechanic |
-|---------------------|-------------------|
-| Coding session | Run |
-| Lint warning | Weak enemy (idle) |
-| Type error | Minor enemy (idle) |
-| Test failure | Strong enemy (active) |
-| CI failure | Boss (active) |
-| Bug fix | Enemy defeated |
-| Policy violation | Elite boss |
-
-Minor enemies auto-resolve while you code. Boss encounters interrupt your session and require active input. Governance violations from AgentGuard spawn elite bosses. The **Bug Grimoire** records every enemy type you've defeated.
-
-See [docs/roguelike-design.md](docs/roguelike-design.md) for the full design.
+| Level | Trigger | Effect |
+|-------|---------|--------|
+| **NORMAL** | Default state | Actions evaluated normally |
+| **ELEVATED** | Denials ≥ half threshold | Warning state |
+| **HIGH** | Denials or violations ≥ threshold | Heightened scrutiny |
+| **LOCKDOWN** | Denials or violations ≥ 2× threshold | All actions denied until human intervention |
 
 ## CLI
 
 ```bash
-# === AgentGuard Core ===
-npx agentguard watch -- npm run dev       # Monitor errors in real time
-npx agentguard watch -- tsc --watch       # Watch TypeScript compilation
-npx agentguard scan                       # Scan for bugs (eslint/tsc)
-npx agentguard replay --last              # Replay last session
+# === Governance ===
+agentguard guard                          # Start governed action runtime
+agentguard guard --policy <file>          # Use a specific policy file (YAML/JSON)
+agentguard guard --dry-run                # Evaluate without executing actions
+agentguard inspect [runId]                # Show action graph for a run
+agentguard inspect --last                 # Inspect most recent run
+agentguard events [runId]                 # Show raw event stream for a run
 
-# === BugMon Mode ===
-npx agentguard play                       # Launch BugMon mode
-npx agentguard watch --cache -- npm test  # Interactive battle mode
-npx agentguard dex                        # View your Bug Grimoire
-npx agentguard stats                      # Bug hunter level and XP
-npx agentguard party                      # View your BugMon party
+# === Monitoring ===
+agentguard watch -- <command>             # Monitor a command for errors
+agentguard scan [path]                    # Scan files for bugs (eslint/tsc)
+agentguard replay --last                  # Replay a session timeline
 
 # === Tools ===
-npx agentguard sync                       # Sync CLI <-> browser game
-npx agentguard init                       # Install git hooks
-npx agentguard claude-init                # Set up Claude Code integration
+agentguard init                           # Install git hooks
+agentguard claude-init                    # Set up Claude Code integration
+agentguard help                           # Show all commands
 ```
 
 Install globally: `npm i -g agentguard`
 
-The `bugmon` binary is also available as an alias for backwards compatibility.
-
-## Governance Integration
-
-AgentGuard's governance runtime evaluates agent actions against declared policies and invariants. Violations produce canonical events that BugMon renders as elite boss encounters.
-
-```
-  ⚠ GOVERNANCE: Invariant Titan appeared!         InvariantViolation
-  ██████████████████████████████  HP: 600/600    severity: 5
-  Agent modified production schema outside scope
-  src/database/schema.sql
-  [1] Fight  [2] Run
-```
-
-See [docs/agentguard.md](docs/agentguard.md) for the governance runtime specification.
-
 ## Claude Code Integration
 
-Using [Claude Code](https://docs.anthropic.com/en/docs/claude-code)? AgentGuard hooks into your sessions — errors trigger encounters automatically.
+AgentGuard hooks into [Claude Code](https://docs.anthropic.com/en/docs/claude-code) sessions via PreToolUse/PostToolUse hooks. Every tool call is normalized into a canonical action and evaluated by the kernel.
 
 ```bash
-npx agentguard claude-init
+npx agentguard claude-init    # Set up Claude Code hooks
 ```
 
-## Browser Game
+Tool call mapping:
 
-The BugMon browser game features an **idle dungeon runner** — your dev character automatically runs through procedural dungeon floors, defeating minor enemies inline and pausing for boss fights. Gold, loot, and progression persist across runs.
+| Claude Code Tool | AgentGuard Action |
+|-----------------|-------------------|
+| Write | file.write |
+| Edit | file.write |
+| Read | file.read |
+| Bash | shell.exec (or git.push, git.commit if git command detected) |
+| Glob | file.read |
+| Grep | file.read |
 
-**[Play Now](https://jpleva91.github.io/BugMon/)** — the entire game fits in a single file (gzipped, smaller than jQuery).
+## Event Trail
 
-### Visual Design
+Every action proposal, decision, and execution is recorded as JSONL:
 
-- Premium dark aesthetic (OLED palette + gold accents)
-- Glassmorphic HUD with floor progress, HP, gold counter
-- Dev character with hoodie + laptop sprite
-- Parallax scrolling dungeon corridors
-- Floating combat text and XP gains
+```
+.agentguard/events/<runId>.jsonl
+```
 
-### Controls
+Inspect with:
 
-| Action | Keyboard | Mobile |
-|--------|----------|--------|
-| Move | Arrow keys | D-pad |
-| Confirm | Enter | A button |
-| Back | Escape | B button |
+```bash
+agentguard inspect --last     # Action summary + event stream
+agentguard events --last      # Raw JSONL to stdout (pipe to jq, etc.)
+```
 
 ## Architecture
 
 ```
-┌────────────────────────────────────────────────────────────┐
-│                    AgentGuard Platform                        │
-├────────────────────────────────────────────────────────────┤
-│                                                              │
-│   ┌──────────────────────────────────────────────────┐     │
-│   │              Governance Runtime                    │     │
-│   │   policies │ invariants │ AAB │ evidence packs    │     │
-│   └──────────────────────┬───────────────────────────┘     │
-│                           │ canonical events                 │
-│   ┌──────────────────────┴───────────────────────────┐     │
-│   │              Event Sources (plugins)               │     │
-│   │   stderr │ test output │ linter │ CI │ custom     │     │
-│   └──────────────────────┬───────────────────────────┘     │
-│                           │                                  │
-│            ┌──────────────┼──────────────┐                  │
-│            ▼              ▼              ▼                  │
-│     ┌───────────┐ ┌──────────┐ ┌──────────┐              │
-│     │ Terminal  │ │ BugMon   │ │  Bug     │              │
-│     │ Renderer  │ │ Browser  │ │ Grimoire │              │
-│     │           │ │ Game     │ │          │              │
-│     │ CLI mode  │ │ play mode│ │ history  │              │
-│     └───────────┘ └──────────┘ └──────────┘              │
-│                                                              │
-└────────────────────────────────────────────────────────────┘
+Claude Code Tool Call
+    │
+    ▼
+┌─────────────────────────────────────────┐
+│         Governed Action Kernel           │
+│                                         │
+│  1. Normalize (AAB)                     │
+│  2. Policy evaluation                   │
+│  3. Invariant checking                  │
+│  4. Evidence pack generation            │
+│  5. Execute via adapter                 │
+│  6. Emit lifecycle events               │
+│  7. Escalation tracking                 │
+└────────────┬────────────────────────────┘
+             │
+     ┌───────┼───────┐
+     ▼       ▼       ▼
+  TUI     JSONL   EventBus
+ render    sink    pub/sub
 ```
 
 ### Repository Structure
 
 ```
-AgentGuard/
-├── src/                    # TypeScript source (single source of truth)
-│   ├── agentguard/         # Governance runtime (deterministic RTA)
-│   │   ├── core/           # AAB + RTA engine
-│   │   ├── policies/       # Policy evaluation + loading
-│   │   ├── invariants/     # Invariant checking + definitions
-│   │   └── evidence/       # Evidence pack generation
-│   ├── cli/                # CLI interface (agentguard command)
-│   │   └── commands/       # 20 subcommands (watch, scan, play, etc.)
-│   ├── core/               # Shared logic (EventBus, parsing, matching)
-│   ├── domain/             # Pure domain logic (no DOM, no Node.js APIs)
-│   │   ├── ingestion/      # Error normalization pipeline
-│   │   └── execution/      # Execution adapters + event log
-│   ├── game/               # BugMon browser game (client-side)
-│   │   ├── dungeon/        # Idle dungeon runner (primary game mode)
-│   │   ├── engine/         # State machine, input, rendering, effects
-│   │   ├── battle/         # Turn-based battle engine
-│   │   ├── world/          # Map, player, encounters (exploration mode)
-│   │   ├── evolution/      # Dev-activity progression
-│   │   ├── audio/          # Synthesized sounds (Web Audio API)
-│   │   └── sprites/        # Sprites + procedural generation
-│   ├── meta/               # Metadata (bugdex, bosses)
-│   ├── orchestration/      # Multi-agent pipeline orchestration
-│   ├── protocol/           # Sync protocol definitions
-│   ├── content/            # Game content validation
-│   └── watchers/           # Environment watchers
-├── dist/                   # Compiled output (tsc + esbuild)
-├── ecosystem/data/         # Game content (JSON + JS modules)
-├── policy/                 # Policy configuration (JSON)
-├── simulation/             # Headless battle simulation
-├── tests/                  # Test suite (77 JS + 16 TS)
-└── docs/                   # System documentation
+src/
+├── agentguard/             # Governance runtime (active focus)
+│   ├── kernel.ts           # Governed action kernel
+│   ├── monitor.ts          # Escalation tracking
+│   ├── core/               # AAB + RTA engine
+│   ├── policies/           # Policy evaluator + JSON/YAML loaders
+│   ├── invariants/         # Invariant checker + 6 defaults
+│   ├── evidence/           # Evidence pack generation
+│   ├── adapters/           # Execution adapters (file, shell, git, claude-code)
+│   ├── renderers/          # TUI renderer
+│   └── sinks/              # JSONL event persistence
+├── domain/                 # Pure domain logic (no DOM, no Node.js APIs)
+│   ├── actions.ts          # 23 canonical action types
+│   ├── events.ts           # 50+ event kinds
+│   ├── reference-monitor.ts
+│   └── execution/          # Adapter registry
+├── core/                   # Shared infrastructure (EventBus, types)
+├── cli/                    # CLI entry point + commands
+└── game/                   # BugMon browser game (deprioritized)
 ```
-
-## Type System
-
-7 types with effectiveness matchups:
-
-| | Front | Back | DevOps | Test | Arch | Sec | AI |
-|---|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
-| **Frontend** | -- | **1.5x** | 1x | **1.5x** | 0.5x | 1x | 0.5x |
-| **Backend** | 0.5x | -- | **1.5x** | 1x | **1.5x** | 0.5x | 1x |
-| **DevOps** | 1x | 0.5x | -- | **1.5x** | 1x | **1.5x** | 0.5x |
-| **Testing** | 0.5x | 1x | 0.5x | -- | **1.5x** | 1x | **1.5x** |
-| **Architecture** | **1.5x** | 0.5x | 1x | 0.5x | -- | **1.5x** | 1x |
-| **Security** | 1x | **1.5x** | 0.5x | 1x | 0.5x | -- | **1.5x** |
-| **AI** | **1.5x** | 1x | **1.5x** | 0.5x | 1x | 0.5x | -- |
-
-## Add a BugMon Enemy
-
-BugMon is data-driven. Add a new enemy by editing a single JSON file — no code changes needed:
-
-```json
-{
-  "id": 32,
-  "name": "YourBugName",
-  "type": "frontend",
-  "hp": 30, "attack": 7, "defense": 5, "speed": 6,
-  "moves": ["layoutshift", "zindexwar"],
-  "color": "#3498db",
-  "sprite": "yourbugname"
-}
-```
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide.
-
-## Contribute a BugMon
-
-No coding required! Submit your own BugMon enemy in 4 steps:
-
-1. [Open a new BugMon submission](../../issues/new?template=new-bugmon.yml)
-2. Fill out the form with your BugMon's name, type, stats, and moves
-3. A bot will validate your submission and show a battle preview
-4. Once approved by a maintainer, your BugMon joins the game!
 
 ## Run Locally
 
 ```bash
-git clone https://github.com/jpleva91/BugMon.git
-cd BugMon
-npm run build:ts     # Compile TypeScript
-npm run serve        # Start dev server
-# Open http://localhost:8000
-```
-
-### Development Commands
-
-```bash
-npm test                               # Run test suite
-npm run simulate                       # Random battle matchup
-npm run simulate -- --all --runs 100   # Full roster balance analysis
-npm run build                          # Build single-file dist (~12 KB gzipped)
-npm run budget                         # Check size budget compliance
-npm run dev                            # Run AgentGuard CLI
-npm run lint                           # Run ESLint
-npm run format                         # Check formatting (Prettier)
+git clone https://github.com/jpleva91/agent-guard.git
+cd agent-guard
+npm install
+npm run build:ts        # Compile TypeScript → dist/
+npm run ts:test         # Run 345 TypeScript tests
+npm test                # Run 1085 JavaScript tests
 ```
 
 ## Documentation
 
 | Document | Description |
 |----------|-------------|
-| [Architecture](ARCHITECTURE.md) | Technical architecture and system design |
-| [AgentGuard](docs/agentguard.md) | Governance runtime specification |
-| [Unified Architecture](docs/unified-architecture.md) | How AgentGuard and BugMon integrate |
-| [Plugin API](docs/plugin-api.md) | Event sources, content packs, renderers |
-| [Roguelike Design](docs/roguelike-design.md) | BugMon mode mechanics |
-| [Event Model](docs/event-model.md) | Canonical event schema and lifecycle |
-| [Bug Event Pipeline](docs/bug-event-pipeline.md) | Signal normalization pipeline |
-| [Agent-Native SDLC](docs/agent-sdlc-architecture.md) | Formal architecture brief |
+| [AgentGuard Spec](docs/agentguard.md) | Governance runtime specification |
+| [Architecture](docs/unified-architecture.md) | Governed action kernel model |
+| [Priorities](docs/current-priorities.md) | Current roadmap and next steps |
 | [Product Positioning](docs/product-positioning.md) | What this is and isn't |
-| [Sequence Diagrams](docs/sequence-diagrams.md) | System flow diagrams |
-| [Roadmap](ROADMAP.md) | Phased development plan |
+| [Event Model](docs/event-model.md) | Canonical event schema |
+| [Plugin API](docs/plugin-api.md) | Event sources and extension points |
 | [Contributing](CONTRIBUTING.md) | How to contribute |
-| [Lightweight Manifesto](LIGHTWEIGHT.md) | Zero-dependency philosophy |
-
-## Tech Stack
-
-- TypeScript (source of truth in `src/`, compiled to `dist/` via tsc + esbuild)
-- HTML5 Canvas 2D
-- Web Audio API (synthesized sounds)
-- Zero browser runtime dependencies; CLI uses `chokidar`, `commander`, `pino`
-- Dev tooling: esbuild + terser (build), vitest (TS tests), custom test runner (JS tests)
-- CI: GitHub Actions (deploy, validate, size check, CodeQL)
 
 ## License
 

--- a/docs/agentguard.md
+++ b/docs/agentguard.md
@@ -192,36 +192,80 @@ Event Store + EventBus
 
 6. **Separation from AI.** AgentGuard does not use AI for evaluation. It is a deterministic runtime. AI agents are the subjects being governed, not the governance mechanism.
 
-## Current Implementation Status
+## Implementation Status
 
-AgentGuard is in the specification phase. The following existing components provide the foundation:
+AgentGuard is **implemented and operational**. The governed action kernel connects all governance infrastructure into a working runtime.
 
-| Concept | Existing Foundation | Path |
-|---------|-------------------|------|
-| Event emission | EventBus | `domain/event-bus.js` |
-| Event types | Events constant (to be extended with governance types) | `domain/events.js` |
-| Action interception | Claude Code PostToolUse hook | `core/cli/claude-hook.js` |
-| Error classification | BugEvent severity mapping | `core/bug-event.js` |
-| Boss triggers | Threshold-based escalation | `ecosystem/bosses.js` |
+### Kernel Loop (Core)
+| Component | File | Status |
+|-----------|------|--------|
+| Governed action kernel | `agentguard/kernel.ts` | Complete |
+| AAB (normalization) | `agentguard/core/aab.ts` | Complete |
+| RTA decision engine | `agentguard/core/engine.ts` | Complete |
+| Runtime monitor (escalation) | `agentguard/monitor.ts` | Complete |
 
-## Target Directory Structure
+### Policy Engine
+| Component | File | Status |
+|-----------|------|--------|
+| Policy evaluator | `agentguard/policies/evaluator.ts` | Complete |
+| JSON policy loader | `agentguard/policies/loader.ts` | Complete |
+| YAML policy loader | `agentguard/policies/yaml-loader.ts` | Complete |
+
+### Safety Infrastructure
+| Component | File | Status |
+|-----------|------|--------|
+| Invariant checker | `agentguard/invariants/checker.ts` | Complete |
+| 6 default invariants | `agentguard/invariants/definitions.ts` | Complete |
+| Evidence pack generation | `agentguard/evidence/pack.ts` | Complete |
+
+### Execution Adapters
+| Component | File | Status |
+|-----------|------|--------|
+| File adapter (read/write/delete) | `agentguard/adapters/file.ts` | Complete |
+| Shell adapter (exec with timeout) | `agentguard/adapters/shell.ts` | Complete |
+| Git adapter (commit/push/branch) | `agentguard/adapters/git.ts` | Complete |
+| Adapter registry | `agentguard/adapters/registry.ts` | Complete |
+| Claude Code adapter | `agentguard/adapters/claude-code.ts` | Complete |
+
+### Observability
+| Component | File | Status |
+|-----------|------|--------|
+| JSONL event sink | `agentguard/sinks/jsonl.ts` | Complete |
+| TUI renderer | `agentguard/renderers/tui.ts` | Complete |
+
+### CLI Commands
+| Component | File | Status |
+|-----------|------|--------|
+| `agentguard guard` | `cli/commands/guard.ts` | Complete |
+| `agentguard inspect` | `cli/commands/inspect.ts` | Complete |
+| `agentguard events` | `cli/commands/inspect.ts` | Complete |
+
+### Directory Structure
 
 ```
 agentguard/
-├── core/          # Runtime engine
-│   ├── aab.js     # Action Authorization Boundary
-│   └── runtime.js # Main governance loop
-├── policies/      # Policy definitions and evaluation
-│   ├── loader.js  # Policy file parser
-│   ├── eval.js    # Deterministic policy evaluator
-│   └── default.yaml  # Default policy set
-├── invariants/    # Invariant definitions and monitoring
-│   ├── checker.js # Invariant evaluation engine
-│   └── system.js  # Built-in system invariants
-├── evidence/      # Evidence pack generation
-│   ├── pack.js    # Evidence pack builder
-│   └── store.js   # Evidence persistence
-└── cli/           # CLI integration
-    ├── guard.js   # CLI command for governance mode
-    └── report.js  # Governance audit report
+├── kernel.ts              # Governed action kernel (orchestrator)
+├── monitor.ts             # Runtime monitor (escalation tracking)
+├── core/
+│   ├── aab.ts             # Action Authorization Boundary
+│   └── engine.ts          # RTA decision engine
+├── policies/
+│   ├── evaluator.ts       # Policy rule matching
+│   ├── loader.ts          # JSON policy loader
+│   └── yaml-loader.ts     # YAML policy loader
+├── invariants/
+│   ├── checker.ts         # Invariant evaluation engine
+│   └── definitions.ts     # 6 default invariants
+├── evidence/
+│   └── pack.ts            # Evidence pack builder
+├── adapters/
+│   ├── file.ts            # File operations (fs)
+│   ├── shell.ts           # Shell execution (child_process)
+│   ├── git.ts             # Git operations
+│   ├── registry.ts        # Adapter wiring
+│   └── claude-code.ts     # Claude Code hook adapter
+├── renderers/
+│   └── tui.ts             # Terminal action stream
+└── sinks/
+    └── jsonl.ts           # JSONL event persistence
 ```

--- a/docs/current-priorities.md
+++ b/docs/current-priorities.md
@@ -1,129 +1,94 @@
 # Current Priorities
 
-## Active Phase: Phase 6 — Plugin Ecosystem
+## Active Phase: Governed Action Kernel
 
-The system has completed its core architecture (Phases 0-3) and is now focused on extensibility. The governance runtime, canonical event model, and browser dungeon runner are all operational.
+AgentGuard is a **governed action runtime for AI agents**. The kernel loop intercepts agent tool calls, enforces policies and invariants, executes via adapters, and emits lifecycle events. This is the core value proposition.
+
+The BugMon game layer (roguelike encounters, browser game, battle engine) is **deprioritized**. It remains functional but is not the focus of active development. Future work may revisit it as an optional visualization mode.
 
 ## What Is Implemented
 
-The following systems are built and operational:
+### Governed Action Kernel (NEW — Active Focus)
+- **Kernel loop** — orchestrates AAB → policy → invariants → execute → events (`agentguard/kernel.ts`)
+- **Execution adapters** — file, shell, git handlers (`agentguard/adapters/`)
+- **Claude Code adapter** — normalizes PreToolUse/PostToolUse into kernel actions (`agentguard/adapters/claude-code.ts`)
+- **YAML policy loader** — simple YAML policy format, zero external deps (`agentguard/policies/yaml-loader.ts`)
+- **JSONL event sink** — persists events to `.agentguard/events/<runId>.jsonl` (`agentguard/sinks/jsonl.ts`)
+- **Terminal renderer** — real-time action stream, action graph, event display (`agentguard/renderers/tui.ts`)
+- **CLI commands** — `agentguard guard`, `agentguard inspect`, `agentguard events` (`cli/commands/guard.ts`, `cli/commands/inspect.ts`)
+
+### Governance Infrastructure
+- **Action Authorization Boundary (AAB)** — normalizes tool calls, detects git/destructive actions (`agentguard/core/aab.ts`)
+- **RTA decision engine** — combines AAB + policy evaluation + invariant checking + evidence packs (`agentguard/core/engine.ts`)
+- **Policy evaluator** — pattern matching, scope rules, wildcard support (`agentguard/policies/evaluator.ts`)
+- **Policy loader** — JSON policy validation and loading (`agentguard/policies/loader.ts`)
+- **Invariant checker** — 6 default invariants (secret exposure, protected branch, blast radius, etc.) (`agentguard/invariants/`)
+- **Evidence pack generation** — structured audit records for every governance decision (`agentguard/evidence/pack.ts`)
+- **Runtime monitor** — escalation tracking (NORMAL → ELEVATED → HIGH → LOCKDOWN) (`agentguard/monitor.ts`)
+- **Canonical Action schema** — 23 action types across 8 classes (`domain/actions.ts`)
+- **Reference monitor** — action authorization with decision trail (`domain/reference-monitor.ts`)
+- **Adapter registry** — action class → handler mapping with authorization guard (`domain/execution/adapters.ts`)
+
+### Canonical Event Model
+- 50+ event kinds covering governance, battle, progression, pipeline, developer signals (`domain/events.ts`, `core/types.ts`)
+- EventBus — generic typed pub/sub (`core/event-bus.ts`)
+- Event store — in-memory persistence with query/replay (`domain/event-store.ts`)
+- Event factory with fingerprinting (`domain/events.ts`)
 
 ### Event Pipeline
-- Error parser with 40+ patterns across JS, TS, Python, Go, Rust, Java (`src/core/error-parser.ts`)
-- Stack trace parser for 6+ frame formats (`src/core/stacktrace-parser.ts`)
-- Stable fingerprinting for event deduplication (`src/domain/ingestion/fingerprint.ts`)
-- Event classification with severity mapping (`src/core/bug-event.ts`)
-- Pipeline orchestration (`src/domain/ingestion/pipeline.ts`)
-- Universal EventBus (`src/domain/event-bus.ts`, `src/core/event-bus.ts`)
-- Canonical event definitions (`src/domain/events.ts`)
-- Developer signal event types (`src/domain/dev-event.ts`)
-- Event store interface (`src/domain/event-store.ts`)
-- Execution event log with causal chains (`src/domain/execution/`)
-
-### Battle Engine
-- Pure deterministic battle engine with injected RNG (`src/domain/battle.ts`)
-- Damage formula with type effectiveness and critical hits
-- Passive abilities (RandomFailure, NonDeterministic)
-- Healing moves
-- Combat system with turn-based battles
-- Battle simulation framework with seeded RNG (`simulation/`)
-- Combo system (`src/domain/combo.ts`)
-- Action definitions (`src/domain/actions.ts`)
-- Battle strategies (`src/domain/strategies.ts`)
-
-### BugMon Roster
-- 34 BugMon across 7 types (frontend, backend, devops, testing, architecture, security, ai)
-- 76 moves
-- 7x7 type effectiveness chart
-- 7 evolution chains with 10 evolved forms
-- Rarity system (common, uncommon, legendary, evolved)
-- Error pattern matching for species selection
-
-### Governance Runtime (AgentGuard)
-- Action Authorization Boundary (`src/agentguard/core/aab.ts`)
-- Runtime Assurance Engine (`src/agentguard/core/engine.ts`)
-- Policy evaluator (`src/agentguard/policies/evaluator.ts`)
-- Policy loader (`src/agentguard/policies/loader.ts`)
-- Invariant checker (`src/agentguard/invariants/checker.ts`)
-- Invariant definitions (`src/agentguard/invariants/definitions.ts`)
-- Evidence pack generation (`src/agentguard/evidence/pack.ts`)
-- Closed-loop governance monitor (`src/agentguard/monitor.ts`)
-- Policy configuration (`policy/action_rules.json`, `policy/capabilities.json`)
-
-### CLI (Commander-based)
-- 20 subcommands: watch, scan, demo, simulate, resolve, replay, trace, status, score, run-summary, auto-walk, boss-battle, catch, encounter, init, claude-hook, claude-init, contribute, adapter, demo-runner
-- Terminal renderer with ANSI colors (`src/cli/renderer.ts`)
-- WebSocket sync server (`src/cli/sync-server.ts`)
-- Session persistence (`src/cli/session-store.ts`)
-- Event source adapters: watch, scan, claude-hook (`src/core/sources/`)
-
-### Browser Game (Idle Dungeon Runner)
-- Idle auto-dungeon runner as primary game mode (`src/game/dungeon/runner.ts`)
-- Procedural floor generation with rooms, corridors, and loot (`src/game/dungeon/dungeon.ts`)
-- Premium dark design system with OLED palette and gold accents (`src/game/theme.ts`)
-- Glassmorphic HUD with floor progress, HP, gold counter, event log
-- Dev character with hoodie + laptop sprite and running animation
-- Parallax scrolling dungeon renderer (`src/game/dungeon/dungeon-renderer.ts`)
-- Gold and loot persistence via localStorage (`src/game/dungeon/loot.ts`)
-- Auto-resolve minor enemies inline, manual boss fights
-- Classic exploration mode (tile-based dungeon, random encounters)
-- Canvas 2D rendering with procedural tile textures
-- Battle visual effects (`src/game/engine/effects.ts`)
-- Synthesized audio (Web Audio API, no audio files)
-- Mobile touch controls
-- Save/load with auto-save
-- CLI-to-browser sync via WebSocket
-
-### Progression
-- Bug Grimoire collection tracking (`src/meta/bugdex.ts`)
-- Dev-activity evolution system with git hook tracking (`src/game/evolution/`)
-- XP and leveling
-- Boss encounter system with threshold triggers (`src/meta/bosses.ts`)
-- Gold economy (dungeon loot, boosts)
-
-### Multi-Agent Pipeline
-- Pipeline orchestrator (`src/orchestration/orchestrator.ts`)
-- Stage definitions (`src/orchestration/stages.ts`)
-- Agent role definitions (`src/orchestration/roles.ts`)
+- Error parser with 40+ patterns across JS, TS, Python, Go, Rust, Java (`core/error-parser.ts`)
+- Stack trace parser for 6+ frame formats (`core/stacktrace-parser.ts`)
+- Stable fingerprinting for deduplication (`domain/ingestion/`)
+- Pipeline orchestration (`domain/ingestion/pipeline.ts`)
 
 ### Infrastructure
-- 134 TypeScript source files (single source of truth)
-- 93 test files (77 JS + 16 TS) covering all modules
-- Size budget enforcement (10 KB target, 17 KB cap gzipped)
+- 345+ TypeScript tests (vitest) + 1085 JavaScript tests
+- TypeScript build: tsc + esbuild → dist/
 - CI workflows (deploy, validate, size check, CodeQL, publish, release)
-- Community submission workflow with automated validation
-- Zero browser runtime dependencies; CLI uses `chokidar`, `commander`, `pino`
-- Module contract registry (`src/domain/contracts.ts`)
-- Runtime shape validation (`src/domain/shapes.ts`)
+- ESLint + Prettier enforced
+- Size budget enforcement
+
+### BugMon Game Layer (DEPRIORITIZED)
+- Battle engine with type effectiveness, passives, healing (`domain/battle.ts`)
+- 31 BugMon across 7 types, 72 moves, 7 evolution chains (`ecosystem/data/`)
+- Browser game: Canvas 2D, synthesized audio, mobile touch controls (`game/`)
+- Terminal renderer for encounters (`cli/renderer.ts`)
+- Bug Grimoire, progression, XP system (`ecosystem/`)
+- Battle simulation framework (`simulation/`)
 
 ## What Is Next
 
-### Phase 6 — Plugin Ecosystem (Current)
-- Content pack loading system (community enemies, moves, bosses)
-- Renderer plugin interface
-- Policy pack loading system
-- Replay processor interface
-- Plugin validation and sandboxing
+### Phase 1 — Kernel Hardening (Current)
+- Integration testing: end-to-end Claude Code hook → kernel → decisions
+- Demo script that simulates the "killer demo" scenario
+- Error handling improvements for edge cases in adapters
+- Documentation: README update with governance-first quickstart
 
-### Phase 7 — Terminal Roguelike MVP
-- Bring the dungeon runner experience to the terminal
-- Idle mode with ANSI output
-- Active mode for bosses and elites
+### Phase 2 — Policy Ecosystem
+- Policy templates for common scenarios (strict, permissive, CI-only)
+- Policy composition (multiple policy files merged)
+- Policy validation CLI (`agentguard policy validate <file>`)
+- Community policy repository
 
-### Phase 8 — Editor Integrations
-- VS Code extension (sidebar webview)
-- JetBrains plugin
-- Claude Code deep integration
+### Phase 3 — Agent Integration
+- Deep Claude Code integration via hooks (auto-install, configuration)
+- Session-aware context (track what files were modified, test results)
+- Multi-agent support (different policies per agent identity)
 
-## Resolved Questions
+### Phase 4 — Observability
+- Run comparison and diff (`agentguard diff <run1> <run2>`)
+- Aggregate statistics across runs
+- Risk scoring per agent run
+- Failure clustering
 
-1. **Event persistence format** — NDJSON files in `runtime/events/`
-2. **Policy definition language** — JSON (`policy/*.json`)
-3. **TypeScript migration** — Complete. `src/` is the single source of truth, compiled to `dist/`
-4. **Game mode** — Idle dungeon runner as primary mode, with exploration as secondary
+### Future — BugMon Revival (Not Scheduled)
+- Governance events → boss encounters
+- Browser game integration with kernel events
+- Run engine connecting game sessions to governance runs
 
 ## Open Questions
 
-1. **Content pack format** — how to package and distribute community content packs
-2. **Plugin sandboxing** — how to safely load third-party plugins
-3. **Terminal dungeon renderer** — how to replicate the visual dungeon experience in ANSI
+1. **Policy distribution** — how do users share and discover policies? npm packages? GitHub repos?
+2. **Multi-agent identity** — how does the kernel distinguish between different agents in a session?
+3. **Session context** — how much system state should the kernel track automatically (test results, modified files)?
+4. **Remote mode** — should the kernel support a server mode for CI/CD integration?

--- a/docs/product-positioning.md
+++ b/docs/product-positioning.md
@@ -2,70 +2,77 @@
 
 ## What This Is
 
-**BugMon** is a developer experience platform that turns debugging into gameplay. It consumes developer signals — errors, CI failures, lint warnings, governance violations — and transforms them into interactive encounters. Coding sessions become dungeon runs. Bugs become enemies. CI failures become bosses.
+**AgentGuard** is a governed action runtime for AI coding agents. It intercepts agent tool calls, enforces policies and invariants, executes authorized actions, and emits lifecycle events. Every agent action passes through a deterministic kernel that decides allow/deny before execution.
 
-BugMon integrates with **AgentGuard**, a deterministic governance runtime for AI coding agents. AgentGuard evaluates agent actions against policies and invariants, producing canonical events when violations occur. These events feed into BugMon as elite boss encounters.
+AgentGuard answers one question: **"Should this AI agent be allowed to do this?"**
 
-Together, they form a system where all development activity flows through a single event model and surfaces as engaging, trackable gameplay.
+The first integration target is **Claude Code** via its hook system (PreToolUse/PostToolUse). The architecture supports any agent framework that can normalize tool calls into the canonical action format.
+
+### Optional: BugMon Mode (Deprioritized)
+
+BugMon is a gamified visualization mode that consumes AgentGuard events and renders them as roguelike encounters. It is functional but not under active development. The governance kernel is the primary focus.
 
 ## What This Is Not
 
-### Not just a game
+### Not monitoring or observability
 
-BugMon encounters are generated from real system failures. The error pipeline detects 40+ error patterns across 6+ languages. The encounter difficulty scales with actual error severity. The battle system maps to real debugging activity. There is no scripted content — every encounter comes from a real event.
+AgentGuard is not Sentry, Datadog, or a logging tool. It is an **active runtime** that intercepts and gates actions before they happen. It blocks destructive commands. It denies pushes to protected branches. It enforces blast radius limits. Monitoring happens as a side effect of enforcement, not as the goal.
 
-### Not an observability platform
+### Not AI-based safety
 
-The system does not replace Sentry, Datadog, or PagerDuty. It operates at the developer workstation level — intercepting local errors, CI output, and agent actions during coding sessions. It is a development-time tool, not a production monitoring system.
+AgentGuard does not use AI to evaluate agent actions. Policy evaluation is deterministic: pattern matching, scope checking, invariant verification. Same action + same policy = same decision. No heuristics, no inference, no probabilistic decisions.
 
-### Not a testing framework
+### Not a sandbox or VM
 
-BugMon does not run tests or lint code. It observes the output of tools that do and translates failures into gameplay events. It works alongside existing tooling, not instead of it.
+AgentGuard operates at the application layer, not the OS layer. It doesn't intercept syscalls or run agents in containers. It works by integrating with agent tool-use interfaces (Claude Code hooks, future framework adapters) to evaluate actions before they execute.
 
 ## Why This Architecture
 
-The **SourceRegistry** plugin system and canonical event model solve a real problem: developer telemetry is fragmented across dozens of tools (linters, test runners, CI systems, error trackers). By normalizing all signals through a single pipeline:
+The **governed action kernel** pattern solves a real problem: AI coding agents can execute arbitrary tool calls — file writes, shell commands, git operations — with no systematic policy enforcement. AgentGuard provides:
 
-1. **Any error source** can feed into BugMon — just register a source that calls `onRawSignal(rawText)`
-2. **Every encounter** is generated from real errors through the same parse-fingerprint-classify pipeline
-3. **Developers** get a single, engaging view of their session's health through the roguelike metaphor
-4. **Plugin authors** get clean extension points (new event sources, new renderers, new content packs)
+1. **Policy enforcement** — declare what agents can and cannot do in YAML/JSON. The kernel enforces it deterministically.
+2. **Invariant safety** — 6 built-in invariants (no secret exposure, protected branches, blast radius limits, test-before-push, no force push, lockfile integrity) catch safety violations.
+3. **Escalation** — repeated denials or violations escalate from NORMAL → ELEVATED → HIGH → LOCKDOWN (all actions blocked until human intervention).
+4. **Audit trail** — every action proposal, decision, and execution is recorded as JSONL events. Fully inspectable and replayable.
+5. **Extensibility** — custom policies, custom invariants, custom adapters for new agent frameworks.
 
 ## Who This Is For
 
-### Primary: Developers who want engaging feedback on their errors
+### Primary: Developers using AI coding agents
 
-Any developer who runs tests, builds, or lints. BugMon adds a layer of engagement to debugging — every error becomes a challenge to defeat, and every fix earns progress.
+Developers who use Claude Code, Copilot, Cursor, or similar AI assistants and want guardrails on what the agent can do. "Let the agent write code, but don't let it push to main or delete production files."
 
-### Secondary: Developers using AI coding agents
+### Secondary: Teams with AI agent governance requirements
 
-Developers who use AI assistants (Claude Code, Copilot, Cursor, etc.) get automatic encounter generation from agent errors. Combined with AgentGuard governance, the system provides both visibility and guardrails.
+Organizations that need audit trails and policy enforcement for AI-assisted development. Compliance, security, and risk management.
 
-### Tertiary: Teams that enjoy gamified tooling
+### Tertiary: Agent framework builders
 
-Developers who appreciate terminal toys and gamification of development activity. BugMon turns the tedium of debugging into a persistent, trackable game.
+Developers building agent systems who want a reusable governance layer. AgentGuard's canonical action model and policy engine can be integrated into any agent framework.
 
 ## How Developers Discover This
 
-1. **CLI** — `npx bugmon demo` or `npx bugmon watch -- npm run dev`. Zero install, immediate encounter.
-2. **Claude Code** — `npx bugmon claude-init` hooks into Claude Code sessions. Errors trigger encounters automatically.
-3. **Browser** — Play on GitHub Pages for the full RPG experience. Syncs with CLI via WebSocket.
-4. **Community** — Add a BugMon creature in 2 minutes with a JSON edit. No code changes needed.
+1. **Claude Code integration** — `agentguard guard --policy agentguard.yaml` starts the runtime. Agent actions are evaluated in real-time.
+2. **CLI** — pipe actions into `agentguard guard` to see allow/deny decisions.
+3. **npm** — `npm install -g agentguard` for the CLI.
+4. **Policy files** — drop an `agentguard.yaml` in your repo to define agent boundaries.
 
 ## Competitive Position
 
-| Category | Existing Tools | BugMon |
-|----------|---------------|--------|
-| Error detection | Sentry, Datadog | Development-time, not production. Local errors, not deployed services. |
-| Developer gamification | GitHub achievements, WakaTime | Roguelike model with real error-driven encounters, not time tracking. |
-| AI agent governance | No standard tool | AgentGuard integration: deterministic runtime with policy evaluation. |
-| Terminal toys | sl, cmatrix, pokemon-cli | Functional system integrated into dev workflow, not novelty-only. |
+| Category | Existing Tools | AgentGuard |
+|----------|---------------|------------|
+| AI agent governance | No standard tool | Deterministic runtime with policy evaluation, invariant checking, escalation |
+| Policy enforcement | Ad-hoc rules in prompts | Declarative YAML/JSON policies with pattern matching and scope rules |
+| Agent audit trails | Manual logging | Automatic JSONL event streams with full action lifecycle |
+| Agent safety | Prompt engineering | Runtime enforcement: block destructive commands, protect branches, enforce blast radius |
 
 ## Technical Differentiators
 
-- **Zero runtime dependencies** — vanilla JavaScript, no framework, no build required for development
-- **12 KB gzipped** — entire browser game fits in a single file smaller than jQuery
-- **Plugin architecture** — SourceRegistry lets anyone add new bug sources with 3 functions
-- **Terminal-first** — primary interface is the terminal, not a web dashboard
-- **Community-driven content** — new BugMon creatures submitted via GitHub Issues with automated validation
-- **Canonical event model** — every signal becomes a structured event that can be replayed, analyzed, or rendered
+- **Deterministic kernel** — no AI, no heuristics, no probabilistic decisions
+- **6 built-in invariants** — secret exposure, protected branches, blast radius, test-before-push, no force push, lockfile integrity
+- **Escalation system** — NORMAL → ELEVATED → HIGH → LOCKDOWN with automatic de-escalation
+- **Evidence packs** — structured audit records for every governance decision
+- **YAML policies** — simple, declarative, version-controllable
+- **Claude Code integration** — first-class support via hooks
+- **JSONL event sink** — every action, decision, and execution recorded for replay
+- **TypeScript** — type-safe governance infrastructure with 345+ tests

--- a/docs/unified-architecture.md
+++ b/docs/unified-architecture.md
@@ -1,16 +1,12 @@
-# Unified Architecture — AgentGuard + BugMon
+# Unified Architecture — AgentGuard
 
-This document describes how AgentGuard and BugMon connect through the canonical event model to form a single coherent system.
+This document describes the architecture of AgentGuard as a governed action runtime for AI agents, with the BugMon game layer as a deprioritized optional mode.
 
 ## Architectural Thesis
 
-The system has one architectural spine: the **canonical event model**.
+AgentGuard is a **governed action runtime**. The Action is the primary unit of computation. Every agent tool call passes through the kernel loop, which enforces policies and invariants before execution.
 
-All system activity becomes events. Events feed two systems:
-- **AgentGuard** enforces deterministic execution constraints on AI coding agents.
-- **BugMon** visualizes events through a roguelike gameplay loop.
-
-Neither system exists in isolation. AgentGuard produces governance events. BugMon consumes all events — developer signals and governance violations alike — and turns them into interactive encounters.
+The system has one architectural spine: the **canonical event model**. All system activity becomes events. The kernel produces governance events. Subscribers (TUI renderer, JSONL sink, and optionally BugMon) consume them.
 
 ## System Model
 
@@ -18,217 +14,156 @@ Neither system exists in isolation. AgentGuard produces governance events. BugMo
 ┌──────────────────────────────────────────────────────────────────┐
 │                        Event Sources                             │
 │                                                                  │
-│  Developer Signals          Agent Actions        CI Systems      │
-│  ├── stderr                 ├── file_write       ├── pipeline    │
-│  ├── test output            ├── git_commit       ├── build       │
-│  ├── linter output          ├── git_push         └── deploy      │
-│  └── runtime crashes        └── config_change                    │
+│  Claude Code Hooks        Agent Tool Calls      CI Systems       │
+│  ├── PreToolUse           ├── file.write        ├── pipeline     │
+│  ├── PostToolUse          ├── git.commit         ├── build       │
+│  └── (future hooks)       ├── git.push          └── deploy      │
+│                           └── shell.exec                         │
 └──────────────────┬───────────────────┬───────────────┬───────────┘
                    │                   │               │
                    ▼                   ▼               ▼
          ┌─────────────────────────────────────────────────────┐
-         │              Event Normalization Pipeline            │
+         │              Claude Code Adapter                     │
          │                                                     │
-         │  source → parse → normalize → classify → dedupe     │
-         │                                                     │
-         │  Implementation: src/domain/ingestion/               │
+         │  Normalize tool calls → RawAgentAction              │
+         │  Implementation: agentguard/adapters/claude-code.ts │
          └──────────────────────┬──────────────────────────────┘
                                 │
                                 ▼
-                   ┌────────────────────────┐
-                   │  Canonical Event Model  │
-                   │                        │
-                   │  { id, fingerprint,    │
-                   │    type, severity,     │
-                   │    source, file,       │
-                   │    metadata,           │
-                   │    timestamp,          │
-                   │    resolved }          │
-                   └───────────┬────────────┘
-                               │
-              ┌────────────────┼────────────────┐
-              │                │                │
-              ▼                ▼                ▼
-    ┌─────────────┐  ┌─────────────┐  ┌─────────────┐
-    │ AgentGuard   │  │ Event Store  │  │  EventBus   │
-    │              │  │              │  │             │
-    │ Policy eval  │  │ Persistence  │  │ Pub/sub     │
-    │ Invariants   │  │ Replay       │  │ Broadcast   │
-    │ AAB          │  │ History      │  │             │
-    └──────┬───────┘  └──────────────┘  └──────┬──────┘
-           │                                    │
-           │ governance events                  │ all events
-           │                                    │
-           ▼                                    ▼
-    ┌──────────────────────────────────────────────────────┐
-    │                    Subscribers                        │
-    │                                                      │
-    │  BugMon Terminal    BugMon Browser    Bug Grimoire          │
-    │  Renderer           Renderer          Collector       │
-    │                                                      │
-    │  Stats Engine       Replay Engine     Editor          │
-    │                                       Integration     │
-    └──────────────────────────────────────────────────────┘
+         ┌─────────────────────────────────────────────────────┐
+         │              Governed Action Kernel                  │
+         │                                                     │
+         │  1. ACTION_REQUESTED event                          │
+         │  2. AAB normalizes intent                           │
+         │  3. Policy evaluation (match → allow/deny)          │
+         │  4. Invariant checking (6 default invariants)       │
+         │  5. Evidence pack generation                        │
+         │  6. If allowed: execute via adapter                 │
+         │  7. ACTION_ALLOWED/DENIED + ACTION_EXECUTED/FAILED  │
+         │  8. Escalation tracking (monitor)                   │
+         │                                                     │
+         │  Implementation: agentguard/kernel.ts               │
+         └──────────────────────┬──────────────────────────────┘
+                                │
+               ┌────────────────┼────────────────┐
+               │                │                │
+               ▼                ▼                ▼
+     ┌─────────────┐  ┌─────────────┐  ┌─────────────┐
+     │ TUI Renderer │  │ JSONL Sink   │  │  EventBus   │
+     │              │  │              │  │             │
+     │ Terminal     │  │ .agentguard/ │  │ Pub/sub     │
+     │ action       │  │ events/      │  │ broadcast   │
+     │ stream       │  │ <runId>.jsonl│  │             │
+     └──────────────┘  └──────────────┘  └──────┬──────┘
+                                                │
+                                                ▼
+                                    ┌───────────────────┐
+                                    │   Subscribers      │
+                                    │                   │
+                                    │  CLI inspect      │
+                                    │  CLI events       │
+                                    │  (future: BugMon) │
+                                    └───────────────────┘
 ```
 
-## Data Flow
-
-### Flow 1: Developer Error → BugMon Encounter
+## Kernel Loop Detail
 
 ```
-Developer writes code with a bug
-    → Test runner outputs TypeError to stderr
-    → CLI watch adapter captures stderr
-    → Pipeline: parse → normalize → classify → dedupe
-    → Canonical event created (type: TypeError, severity: 2)
-    → Event persisted to store
-    → EventBus emits ERROR_OBSERVED
-    → BugMon encounter generator creates NullPointer enemy
-    → Terminal renderer shows encounter
-    → Developer fixes bug
-    → Event marked resolved
-    → BugMon records victory in Grimoire, awards XP
-```
-
-### Flow 2: Agent Violation → Governance Boss
-
-```
-AI agent attempts to modify production config
-    → AgentGuard AAB intercepts action
-    → Scope resolver: file outside authorized scope
-    → Policy evaluator: DENY
-    → Invariant checker: production-scope-guard violated
-    → Evidence pack generated
-    → Canonical event created (type: InvariantViolation, severity: 5)
-    → Event persisted to store
-    → EventBus emits INVARIANT_VIOLATION
-    → BugMon encounter generator creates elite governance boss
-    → Terminal renderer shows boss encounter
-    → Agent adjusts behavior
-    → Event remains in audit trail
-```
-
-### Flow 3: CI Failure → Boss Escalation
-
-```
-CI pipeline fails on push
-    → CI webhook delivers failure event
-    → Pipeline: parse CI output → classify → dedupe
-    → Canonical event created (type: CIFailure, severity: 4)
-    → Boss trigger system checks threshold (ecosystem/bosses.js)
-    → CI Dragon boss spawned
-    → Event persisted to store
-    → EventBus emits BOSS_TRIGGERED
-    → BugMon shows boss encounter with elevated difficulty
-    → Developer fixes pipeline
-    → Event marked resolved
-    → Boss defeated, large XP reward
+Agent proposes action (RawAgentAction)
+    │
+    ▼ emit ACTION_REQUESTED
+    │
+    ▼ AAB.normalizeIntent() → NormalizedIntent
+    │   ├── Map tool name to action type (Write → file.write, Bash → shell.exec)
+    │   ├── Detect git commands in shell (git push → git.push)
+    │   └── Flag destructive commands (rm -rf, chmod 777, etc.)
+    │
+    ▼ Engine.evaluate() → EngineDecision
+    │   ├── Policy evaluator: match rules, check deny/allow
+    │   ├── Invariant checker: 6 defaults + custom invariants
+    │   └── Evidence pack: structured audit record
+    │
+    ▼ Monitor.process() → MonitorDecision
+    │   ├── Track escalation level (NORMAL → ELEVATED → HIGH → LOCKDOWN)
+    │   └── LOCKDOWN = all actions denied until human intervention
+    │
+    ├── If DENIED:
+    │   ├── emit ACTION_DENIED
+    │   ├── sink events to JSONL
+    │   └── return { allowed: false, intervention }
+    │
+    └── If ALLOWED:
+        ├── emit ACTION_ALLOWED
+        ├── Execute via adapter registry (file/shell/git handlers)
+        ├── emit ACTION_EXECUTED or ACTION_FAILED
+        ├── sink events to JSONL
+        └── return { allowed: true, executed: true/false, execution result }
 ```
 
 ## Layer Responsibilities
 
-### AgentGuard Layer
+### Kernel Layer (Active Focus)
 
-AgentGuard is the **governance producer**. It does not render UI, track progression, or manage game state.
+The kernel is the **governance producer and action executor**. It is the core of the system.
+
+| Component | File | Responsibility |
+|-----------|------|----------------|
+| Kernel loop | `agentguard/kernel.ts` | Orchestrate propose → evaluate → execute → emit |
+| AAB | `agentguard/core/aab.ts` | Normalize tool calls, detect destructive commands |
+| Engine | `agentguard/core/engine.ts` | Policy + invariant evaluation, intervention selection |
+| Monitor | `agentguard/monitor.ts` | Escalation tracking, lockdown enforcement |
+| Policy evaluator | `agentguard/policies/evaluator.ts` | Rule matching with wildcards and scopes |
+| Policy loader | `agentguard/policies/loader.ts` | JSON policy validation |
+| YAML loader | `agentguard/policies/yaml-loader.ts` | YAML policy parsing |
+| Invariant checker | `agentguard/invariants/checker.ts` | System state invariant verification |
+| Evidence packs | `agentguard/evidence/pack.ts` | Audit trail generation |
+| File adapter | `agentguard/adapters/file.ts` | Read/write/delete/move files |
+| Shell adapter | `agentguard/adapters/shell.ts` | Execute shell commands with timeout |
+| Git adapter | `agentguard/adapters/git.ts` | Git operations with validation |
+| Claude Code adapter | `agentguard/adapters/claude-code.ts` | Hook payload normalization |
+| TUI renderer | `agentguard/renderers/tui.ts` | Terminal action stream display |
+| JSONL sink | `agentguard/sinks/jsonl.ts` | Event persistence |
+
+### Domain Layer (Shared)
+
+Pure domain logic with no environment dependencies.
+
+| Component | File | Responsibility |
+|-----------|------|----------------|
+| Canonical actions | `domain/actions.ts` | 23 action types, 8 classes |
+| Canonical events | `domain/events.ts` | 50+ event kinds, factory, validation |
+| Reference monitor | `domain/reference-monitor.ts` | Action authorization with decision trail |
+| Adapter registry | `domain/execution/adapters.ts` | Action class → handler mapping |
+| Event store | `domain/event-store.ts` | In-memory event persistence |
+
+### CLI Layer
+
+| Component | File | Responsibility |
+|-----------|------|----------------|
+| `agentguard guard` | `cli/commands/guard.ts` | Start governed action runtime |
+| `agentguard inspect` | `cli/commands/inspect.ts` | Show action graph for a run |
+| `agentguard events` | `cli/commands/inspect.ts` | Show raw event stream for a run |
+
+### BugMon Layer (Deprioritized)
+
+BugMon is the **event consumer and game layer**. It remains functional but is not under active development.
 
 | Responsibility | Description |
-|---------------|-------------|
-| Action interception | Intercept agent actions before execution |
-| Policy evaluation | Evaluate actions against declared policies |
-| Invariant monitoring | Verify system invariants hold |
-| Blast radius computation | Assess scope of impact |
-| Evidence generation | Record evaluation details for audit |
-| Event emission | Produce governance events into the canonical model |
-
-See [AgentGuard specification](agentguard.md).
-
-### BugMon Layer
-
-BugMon is the **event consumer and interaction layer**. It does not evaluate policies, authorize actions, or enforce constraints.
-
-| Responsibility | Description |
-|---------------|-------------|
-| Event consumption | Subscribe to all canonical events |
+|----------------|-------------|
+| Event consumption | Subscribe to canonical events |
 | Encounter generation | Map events to BugMon creatures |
 | Battle engine | Turn-based combat system |
-| Run management | Session-scoped roguelike run lifecycle |
-| Progression tracking | XP, levels, Bug Grimoire, achievements |
-| Rendering | Terminal, browser, and mobile UIs |
-| Replay | Reconstruct past sessions from event streams |
-
-See [Roguelike Design](roguelike-design.md).
-
-### Shared Layer
-
-The shared layer provides the canonical event model and infrastructure used by both systems.
-
-| Component | Description | Path |
-|-----------|-------------|------|
-| Event schema | Canonical event structure | `src/domain/events.ts` |
-| EventBus | Universal pub/sub | `src/core/event-bus.ts`, `src/domain/event-bus.ts` |
-| Fingerprinting | Stable event deduplication | `src/domain/ingestion/fingerprint.ts` |
-| Pipeline | Event normalization | `src/domain/ingestion/pipeline.ts` |
-| Event store | Event persistence | `src/domain/event-store.ts` |
-| Execution log | Causal chain tracking | `src/domain/execution/` |
-
-## Current Implementation Mapping
-
-The codebase maps to the unified architecture as follows:
-
-| Unified Layer | Current Directory | Description |
-|--------------|-------------------|-------------|
-| Shared / Events | `src/domain/` | Pure domain logic, event bus, ingestion pipeline |
-| Shared / Core | `src/core/` | EventBus, error parsing, matching |
-| BugMon / Battle Engine | `src/game/battle/` + `src/domain/battle.ts` | Battle system |
-| BugMon / Dungeon Runner | `src/game/dungeon/` | Idle auto-dungeon (primary game mode) |
-| BugMon / Design System | `src/game/theme.ts` | Premium dark aesthetic, tokens |
-| BugMon / Terminal Renderer | `src/cli/renderer.ts` | ANSI terminal UI |
-| BugMon / Browser Renderer | `src/game/` (engine, world, sprites, audio) | Canvas 2D browser game |
-| BugMon / Grimoire | `src/meta/bugdex.ts` | Enemy compendium tracking |
-| BugMon / Stats | `src/game/evolution/tracker.ts` | Dev activity tracking |
-| Shared / Data | `ecosystem/data/` | Game content (JSON + JS modules) |
-| AgentGuard / Governance | `src/agentguard/` | AAB, policies, invariants, evidence |
-| AgentGuard / Action Interception | `src/core/sources/claude-hook-source.ts` | Claude Code hook |
-| BugMon / Boss System | `src/meta/bosses.ts` | Boss trigger definitions |
-| Orchestration | `src/orchestration/` | Multi-agent pipeline |
-
-## Target Directory Structure
-
-```
-agentguard/                    ← Governance runtime
-├── core/                      Runtime engine (AAB, evaluation loop)
-├── policies/                  Policy definitions and evaluation
-├── invariants/                Invariant definitions and monitoring
-├── evidence/                  Evidence pack generation and storage
-└── cli/                       CLI governance commands
-
-bugmon/                        ← Roguelike game layer
-├── core/                      Run engine, encounter generation
-├── battle-engine/             Turn-based combat (from domain/battle.js)
-├── grimoire/                  Enemy compendium and progression
-├── stats/                     Statistics and meta-progression
-└── renderers/
-    ├── terminal/              ANSI terminal renderer (from core/cli/)
-    ├── browser/               Canvas 2D game (from game/)
-    └── mobile/                Mobile-optimized renderer
-
-shared/                        ← Canonical event model
-├── events/                    Event schema and definitions
-├── schemas/                   Data format schemas
-├── fingerprints/              Deduplication logic
-└── replay/                    Event stream replay engine
-```
-
-This restructuring is a future target. The current layered architecture (`core/`, `game/`, `ecosystem/`, `domain/`) continues to function and is not moved in this phase.
+| Progression tracking | XP, levels, Bug Grimoire |
+| Rendering | Terminal + browser game UIs |
 
 ## Integration Guarantees
 
-1. **Single event schema.** AgentGuard and BugMon both produce and consume events conforming to the same canonical schema. No translation layer needed.
+1. **Single event schema.** The kernel and all consumers use the same canonical event format.
 
-2. **Unidirectional governance flow.** AgentGuard produces governance events. BugMon consumes them. BugMon never influences governance decisions.
+2. **Kernel as single mediation point.** All agent actions pass through the kernel. No bypass.
 
-3. **Independent operation.** BugMon works without AgentGuard (developer signal events only). AgentGuard works without BugMon (governance enforcement only, no game layer). Together, they form the complete system.
+3. **Independent operation.** The kernel works without BugMon. BugMon works without the kernel (consuming developer signal events only). They connect through the canonical event model.
 
-4. **Shared event store.** Both systems write to and read from the same event store. This enables cross-cutting queries (e.g., "show all events from this session, both developer errors and governance violations").
+4. **Deterministic evaluation.** Same action + same policy + same state = same decision. No inference, no heuristics.
 
-5. **Zero coupling between renderers.** Terminal, browser, and mobile renderers are independent subscribers. Adding a new renderer requires no changes to AgentGuard, the event model, or other renderers.
+5. **Observable.** Every decision produces events. Every event is sunk to JSONL. Every run is inspectable.

--- a/spec/architecture.md
+++ b/spec/architecture.md
@@ -1,108 +1,121 @@
 # Architecture Specification
 
-## Layered Model
+## Governed Action Kernel Model
 
 ```
 ┌─────────────────────────────────────────┐
-│ src/cli/    (Node.js only)             │
-│   CLI companion, commands, renderer    │
+│ agentguard/  (Governance Runtime)      │
+│   Kernel loop, policies, invariants,   │
+│   adapters, renderers, sinks           │
 └────────────────┬────────────────────────┘
                  │ imports ↓
 ┌────────────────┴────────────────────────┐
-│ src/agentguard/  (Governance runtime)  │
-│   AAB, policies, invariants, evidence  │
+│ domain/  (Environment-agnostic)        │
+│   Actions, events, reference monitor,  │
+│   adapter registry, battle, encounters │
 └────────────────┬────────────────────────┘
                  │ imports ↓
 ┌────────────────┴────────────────────────┐
-│ src/domain/  (Environment-agnostic)    │
-│   Pure logic: events, battle, encounters│
-│   ingestion pipeline, evolution engine │
+│ core/  (Shared infrastructure)         │
+│   EventBus, types, error parsing       │
 └────────────────┬────────────────────────┘
                  │ imports ↓
 ┌────────────────┴────────────────────────┐
-│ src/core/  (Shared logic)              │
-│   EventBus, error parsing, matching    │
-└────────────────┬────────────────────────┘
-                 │ imports ↓
-┌────────────────┴────────────────────────┐
-│ src/game/    (Browser only)            │
-│   Dungeon runner, battle, exploration  │
-│   Canvas rendering, audio, sprites     │
+│ cli/  (Node.js CLI)                    │
+│   guard, inspect, events, watch, scan  │
 └─────────────────────────────────────────┘
-```
 
-### Additional Layers
-
-```
-src/meta/           Metadata systems (bugdex, bosses)
-src/orchestration/  Multi-agent pipeline orchestration
-src/protocol/       Sync protocol definitions
-src/content/        Game content validation
-src/watchers/       Environment watchers (console, test, build)
-src/ai/             AI integration interface
+Deprioritized:
+┌─────────────────────────────────────────┐
+│ game/  (Browser only — not active)     │
+│   Canvas rendering, audio, UI, sprites │
+├─────────────────────────────────────────┤
+│ ecosystem/  (Game content — not active)│
+│   JSON data, Grimoire, bosses, storage │
+└─────────────────────────────────────────┘
 ```
 
 ## Dependency Rules
 
-- **src/domain/** has zero external dependencies. No DOM APIs, no Node.js-specific APIs.
-- **src/core/** depends on domain/. Never imports from game/ or cli/.
-- **src/cli/** depends on domain/, core/, and meta/. Never imports from game/.
-- **src/game/** depends on domain/, core/, and meta/. Never imports from cli/.
-- **src/agentguard/** depends on domain/ only. Never imports from cli/ or game/.
-- **src/meta/** depends on domain/ and ecosystem/data/. Never imports from cli/ or game/.
-- **ecosystem/data/** has zero dependencies. Pure data.
+- **domain/** has zero external dependencies. No DOM APIs, no Node.js-specific APIs.
+- **agentguard/** depends on domain/ and core/. Node.js APIs allowed (fs, child_process).
+- **cli/** depends on agentguard/, domain/, and core/.
+- **core/** depends on domain/ only.
+- **game/** and **ecosystem/** are deprioritized. They depend on domain/ and core/ but nothing depends on them in the governance flow.
 
 ## Key Subsystems
 
-### Ingestion Pipeline (`src/domain/ingestion/`)
+### Governed Action Kernel (`agentguard/kernel.ts`)
 
-Multi-stage pipeline converting raw errors into game entities:
+The orchestrator that connects all governance infrastructure:
 
-1. **Parse** — Regex matching against 40+ error patterns across 6+ languages
-2. **Fingerprint** — Stable hash for deduplication (same error = same fingerprint)
-3. **Classify** — Map error type to severity (1-5 scale) and BugEvent
-4. **Create Event** — Wrap in canonical event envelope with ID + fingerprint
-5. **Map to Species** — BugEvent → BugMon monster species
-6. **Map Invariants** — Invariant violations → governance events
+```
+propose(rawAction) →
+  1. ACTION_REQUESTED event
+  2. Monitor evaluates (AAB → policy → invariants → evidence)
+  3. If denied: ACTION_DENIED + evidence pack + intervention
+  4. If allowed: ACTION_ALLOWED → execute via adapter → ACTION_EXECUTED/FAILED
+  5. Sink all events to JSONL
+  → KernelResult { allowed, executed, decision, execution, events, runId }
+```
 
-### Battle Engine (`src/domain/battle.ts`)
+### Action Authorization Boundary (`agentguard/core/aab.ts`)
 
-Pure, deterministic combat with injected RNG. Supports passive abilities, healing, combo system, and type effectiveness.
+Normalizes raw tool calls into structured intents:
+- Maps tool names to action types (Write → file.write, Bash → shell.exec)
+- Detects git commands in shell (git push → git.push)
+- Flags destructive commands (rm -rf, chmod 777, dd if=, DROP DATABASE)
+- Computes blast radius from policy limits
 
-### Event System (`src/domain/events.ts`, `src/core/event-bus.ts`)
+### Policy Engine (`agentguard/policies/`)
 
-Canonical event kinds: `ERROR_OBSERVED`, `MOVE_USED`, `EVOLUTION_TRIGGERED`, governance events, developer signal events, session events. EventBus provides typed pub/sub that works in both Node.js and browser.
+Declarative policy evaluation:
+- JSON and YAML policy formats
+- Pattern matching: exact, wildcard (`*`), prefix (`git.*`)
+- Scope matching: exact, prefix, suffix (`*.env`)
+- Branch conditions, file limits, test requirements
+- Two-pass evaluation: deny rules first (highest severity), then allow rules, default allow
 
-### Governance Runtime (`src/agentguard/`)
+### Invariant Checker (`agentguard/invariants/`)
 
-Action Authorization Boundary (AAB) evaluates agent actions against declared policies. Invariant checker monitors system constraints. Evidence packs provide full audit trails.
+6 default system invariants:
+1. **no-secret-exposure** (sev 5) — blocks .env, credentials, .pem, .key, secret, token files
+2. **protected-branch** (sev 4) — prevents direct push to main/master
+3. **blast-radius-limit** (sev 3) — enforces file modification limit (default 20)
+4. **test-before-push** (sev 3) — requires tests pass before push
+5. **no-force-push** (sev 4) — forbids force push
+6. **lockfile-integrity** (sev 2) — ensures package.json changes sync with lockfiles
 
-### Idle Dungeon Runner (`src/game/dungeon/`)
+### Execution Adapters (`agentguard/adapters/`)
 
-Auto-run through procedural floors. Dev character moves automatically, defeating minor enemies inline and pausing for boss fights. Gold and loot persist across runs.
+Action handlers registered by class:
+- **file** — fs.readFile, fs.writeFile, fs.unlink, fs.rename
+- **shell** — child_process.exec with timeout (30s default, 1MB buffer)
+- **git** — git commit, push, branch, checkout, merge (validated shell wrappers)
+- **claude-code** — normalizes PreToolUse/PostToolUse hook payloads
 
-### Design System (`src/game/theme.ts`)
+### Escalation System (`agentguard/monitor.ts`)
 
-Premium dark aesthetic with OLED palette, gold accents, glassmorphic panels, and DM Sans typography. Provides all color tokens, spacing constants, and animation timing.
+Tracks cumulative denials and violations:
+- NORMAL (0) — default state
+- ELEVATED (1) — denials >= ceil(threshold/2)
+- HIGH (2) — denials >= threshold OR violations >= threshold
+- LOCKDOWN (3) — denials >= 2×threshold OR violations >= 2×threshold → all actions denied
 
-### Game State Machine (`src/game/engine/state.ts`)
+### Event System (`domain/events.ts`, `core/event-bus.ts`)
 
-States: `TITLE → EXPLORE → BATTLE_TRANSITION → BATTLE → EVOLVING → MENU → DUNGEON_RUNNER`
+50+ canonical event kinds. EventBus provides typed pub/sub. Event factory with auto-generated IDs and fingerprints.
 
 ## Data Flow
 
 ```
-External Source → Ingestion Pipeline → Canonical Event → EventBus
-                                                           ├→ Game (spawn enemy / dungeon encounter)
-                                                           ├→ AgentGuard (check policy)
-                                                           └→ Event Store (persist)
+Claude Code Tool Call → Claude Code Adapter → Kernel → AAB → Policy → Invariants
+                                                │                        │
+                                                ├── Evidence Pack ◄──────┘
+                                                │
+                                                ├── Adapter (execute) → Result
+                                                │
+                                                ├── TUI Renderer → Terminal
+                                                │
+                                                └── JSONL Sink → .agentguard/events/
 ```
-
-## Build System
-
-TypeScript source compiles via `tsc` (individual modules for tests/imports) + `esbuild` (bundles for CLI and browser game). Browser loads `dist/game/game.js` as a module.
-
-## Size Budget
-
-- Main bundle: 10 KB target / 17 KB cap (gzipped, no sprites)
-- Subsystem caps enforced per module group

--- a/spec/system.md
+++ b/spec/system.md
@@ -1,84 +1,80 @@
 # System Specification
 
-BugMon is a roguelike developer telemetry game. It monitors software bugs and converts them into interactive encounters. AgentGuard provides deterministic governance for AI coding agents. Together they form a unified platform where all system activity flows through the canonical event model.
+AgentGuard is a **governed action runtime for AI coding agents**. It intercepts agent tool calls, enforces policies and invariants, executes authorized actions via adapters, and emits lifecycle events. The Action is the primary unit of computation.
 
-## Core Event Flow
+BugMon is a deprioritized game layer that can consume governance events as roguelike encounters. It remains functional but is not under active development.
+
+## Core Flow: Governed Action Kernel
 
 ```
-watcher detects failure (stderr, CI output, agent action)
+Agent proposes tool call (e.g., Claude Code Bash, Write, Edit)
 ↓
-ingestion pipeline: parse → fingerprint → classify → map
+Claude Code adapter normalizes → RawAgentAction
 ↓
-canonical event emitted (e.g., ERROR_OBSERVED)
+Kernel loop:
+  1. Emit ACTION_REQUESTED
+  2. AAB normalizes intent (tool → action type, detect git/destructive)
+  3. Policy evaluator matches rules (allow/deny with scope, branches, limits)
+  4. Invariant checker verifies system state (6 defaults)
+  5. Evidence pack generated if violation
+  6. Monitor tracks escalation (NORMAL → ELEVATED → HIGH → LOCKDOWN)
 ↓
-game engine spawns BugMon enemy
+If DENIED → emit ACTION_DENIED, return with reason + intervention
+If ALLOWED → execute via adapter → emit ACTION_EXECUTED or ACTION_FAILED
 ↓
-developer fixes the bug
-↓
-BugMon enemy defeated → recorded in Bug Grimoire
+All events sunk to JSONL (.agentguard/events/<runId>.jsonl)
 ```
-
-## Gameplay Model
-
-- Coding sessions are dungeon **runs**
-- Bugs are **enemies** with stats derived from error severity
-- CI failures are **bosses** requiring active engagement
-- Minor errors (severity 1-2) **auto-resolve** in idle mode
-- Severe errors (severity 3+) require **player interaction**
-- The Bug Grimoire records defeated enemy types (compendium, not collection)
 
 ## Two-Layer System
 
-| Layer | Role | Produces |
-|-------|------|----------|
-| **AgentGuard** | Governance runtime — evaluates agent actions against policies | Policy violation events |
-| **BugMon** | Roguelike game — renders events as interactive encounters | Gameplay state |
+| Layer | Role | Status |
+|-------|------|--------|
+| **AgentGuard** | Governed action runtime — kernel loop, policies, invariants, adapters | Active focus |
+| **BugMon** | Roguelike game — renders events as encounters | Deprioritized |
 
 Both layers share the **canonical event model** as their architectural spine.
 
 ## System Boundaries
 
-### AgentGuard (Governance Runtime)
-- **Input**: Agent actions (file edits, shell commands, API calls)
-- **Output**: Canonical governance events (`PolicyDenied`, `InvariantViolation`, `BlastRadiusExceeded`)
-- **Constraint**: Deterministic evaluation — same action + same policy = same result
+### AgentGuard (Governance Runtime — Active)
+- **Input**: Agent tool calls (file edits, shell commands, git operations)
+- **Processing**: Kernel loop — normalize → evaluate → execute → emit
+- **Output**: Allow/deny decisions, execution results, canonical events, JSONL audit trail
+- **Constraint**: Deterministic evaluation — same action + same policy + same state = same result
 
-### BugMon (Roguelike Game)
-- **Input**: Canonical events (developer signals, governance violations, CI results)
+### Domain Layer (Pure Logic)
+- **Input**: Events, actions, policies, system state
+- **Output**: Decisions, event objects, validation results
+- **Constraint**: No DOM, no Node.js-specific APIs, deterministic when RNG is injected
+
+### BugMon (Game Layer — Deprioritized)
+- **Input**: Canonical events (developer signals, governance violations)
 - **Output**: Interactive encounters, Bug Grimoire entries, session scores
 - **Constraint**: Hybrid idle/active — minor enemies auto-resolve, bosses demand engagement
 
-### Domain Layer (Pure Logic)
-- **Input**: Events, game data, injected RNG
-- **Output**: Battle results, encounter triggers, progression checks
-- **Constraint**: No DOM, no Node.js-specific APIs, deterministic when RNG is injected
-
 ## Invariants
 
-1. All system activity flows through the canonical event model
-2. Domain logic has zero environment dependencies
-3. Zero browser runtime dependencies — CLI has minimal runtime deps (`chokidar`, `commander`, `pino`)
-4. Browser game is 100% client-side
-5. All audio is synthesized at runtime (no audio files)
-6. Size budget: 10 KB target / 17 KB cap (gzipped main bundle)
+1. All agent actions pass through the kernel loop (no bypass)
+2. Policy evaluation is deterministic (no inference, no heuristics)
+3. Domain logic has zero environment dependencies
+4. Every governance decision produces events sunk to JSONL
+5. Escalation tracks cumulative denials/violations and locks down at threshold
+6. Evidence packs provide structured audit trail for every violation
 
 ## Event Taxonomy
 
 | Category | Examples | Producer | Consumer |
 |----------|----------|----------|----------|
-| Ingestion | `ErrorObserved`, `BugClassified` | Error watchers | Battle engine |
-| Battle | `ENCOUNTER_STARTED`, `MOVE_USED`, `DAMAGE_DEALT` | Battle engine | UI renderers |
-| Progression | `ActivityRecorded`, `EvolutionTriggered` | Dev activity tracker | Progression engine |
-| Session | `RunStarted`, `RunEnded`, `CheckpointReached` | Run engine | Scoring, save system |
-| Governance | `PolicyDenied`, `UnauthorizedAction`, `InvariantViolation` | AgentGuard | Boss encounters |
-| Reference Monitor | `ActionRequested`, `ActionAllowed`, `ActionDenied`, `ActionExecuted` | Agent Action Boundary | Audit trail, governance |
-| Developer Signals | `FileSaved`, `TestCompleted`, `CommitCreated` | Git hooks, watchers | Encounter triggers |
+| Action Lifecycle | `ActionRequested`, `ActionAllowed`, `ActionDenied`, `ActionExecuted`, `ActionFailed` | Kernel | TUI, JSONL sink, inspect CLI |
+| Governance | `PolicyDenied`, `UnauthorizedAction`, `InvariantViolation`, `BlastRadiusExceeded` | Engine/AAB | Kernel, monitor, evidence |
+| Evidence | `EvidencePackGenerated` | Evidence pack | JSONL sink |
+| Ingestion | `ErrorObserved`, `BugClassified` | Error watchers | (BugMon) |
+| Developer Signals | `FileSaved`, `TestCompleted`, `CommitCreated` | Git hooks, watchers | Kernel context |
 
 ## Technical Constraints
 
-- 100% client-side browser game, zero browser runtime dependencies
-- Vanilla JavaScript (ES6 modules), HTML5 Canvas 2D, Web Audio API; TypeScript refactoring in progress (`src/`)
-- All audio synthesized at runtime (no audio files)
-- Build: esbuild + terser (dev dependencies only)
-- Deployed to GitHub Pages
+- TypeScript source (`src/`), compiled to `dist/` via tsc + esbuild
+- CLI runtime dependencies: `chokidar`, `commander`, `pino`
 - ESLint + Prettier enforced
+- Node.js >= 18 required
+- 345+ TypeScript tests (vitest) + 1085 JavaScript tests

--- a/src/agentguard/adapters/claude-code.ts
+++ b/src/agentguard/adapters/claude-code.ts
@@ -1,0 +1,113 @@
+// Claude Code adapter — normalizes Claude Code hook payloads into kernel actions.
+// Handles PreToolUse and PostToolUse hook events.
+
+import type { RawAgentAction } from '../core/aab.js';
+import type { Kernel, KernelResult } from '../kernel.js';
+
+export interface ClaudeCodeToolUse {
+  tool_name: string;
+  tool_input?: Record<string, unknown>;
+  tool_output?: Record<string, unknown>;
+}
+
+export interface ClaudeCodeHookPayload {
+  hook: 'PreToolUse' | 'PostToolUse';
+  tool_name: string;
+  tool_input?: Record<string, unknown>;
+  tool_output?: Record<string, unknown>;
+}
+
+export function normalizeClaudeCodeAction(payload: ClaudeCodeHookPayload): RawAgentAction {
+  const input = payload.tool_input || {};
+
+  switch (payload.tool_name) {
+    case 'Write':
+      return {
+        tool: 'Write',
+        file: input.file_path as string | undefined,
+        content: input.content as string | undefined,
+        agent: 'claude-code',
+        metadata: { hook: payload.hook },
+      };
+
+    case 'Edit':
+      return {
+        tool: 'Edit',
+        file: input.file_path as string | undefined,
+        content: input.new_string as string | undefined,
+        agent: 'claude-code',
+        metadata: {
+          hook: payload.hook,
+          old_string: input.old_string,
+        },
+      };
+
+    case 'Read':
+      return {
+        tool: 'Read',
+        file: input.file_path as string | undefined,
+        agent: 'claude-code',
+        metadata: { hook: payload.hook },
+      };
+
+    case 'Bash': {
+      const command = input.command as string | undefined;
+      return {
+        tool: 'Bash',
+        command,
+        target: command?.slice(0, 100),
+        agent: 'claude-code',
+        metadata: {
+          hook: payload.hook,
+          timeout: input.timeout,
+          description: input.description,
+        },
+      };
+    }
+
+    case 'Glob':
+      return {
+        tool: 'Glob',
+        target: input.pattern as string | undefined,
+        agent: 'claude-code',
+        metadata: { hook: payload.hook, path: input.path },
+      };
+
+    case 'Grep':
+      return {
+        tool: 'Grep',
+        target: input.pattern as string | undefined,
+        agent: 'claude-code',
+        metadata: { hook: payload.hook, path: input.path },
+      };
+
+    default:
+      return {
+        tool: payload.tool_name,
+        agent: 'claude-code',
+        metadata: { hook: payload.hook, input },
+      };
+  }
+}
+
+export async function processClaudeCodeHook(
+  kernel: Kernel,
+  payload: ClaudeCodeHookPayload,
+  systemContext: Record<string, unknown> = {}
+): Promise<KernelResult> {
+  const rawAction = normalizeClaudeCodeAction(payload);
+  return kernel.propose(rawAction, systemContext);
+}
+
+export function formatHookResponse(result: KernelResult): string {
+  if (!result.allowed) {
+    const reason = result.decision.decision.reason;
+    const violations = result.decision.violations;
+    const parts = [`DENIED: ${reason}`];
+    if (violations.length > 0) {
+      parts.push(`Violations: ${violations.map((v) => v.name).join(', ')}`);
+    }
+    return JSON.stringify({ error: parts.join(' | ') });
+  }
+  return '';
+}

--- a/src/agentguard/adapters/file.ts
+++ b/src/agentguard/adapters/file.ts
@@ -1,0 +1,42 @@
+// File operation adapter — executes file.read, file.write, file.delete actions.
+// Node.js adapter. Uses fs APIs.
+
+import { readFile, writeFile, unlink, rename } from 'node:fs/promises';
+import type { CanonicalAction } from '../../core/types.js';
+
+export async function fileAdapter(action: CanonicalAction): Promise<unknown> {
+  const target = action.target;
+
+  switch (action.type) {
+    case 'file.read': {
+      const content = await readFile(target, 'utf8');
+      return { path: target, size: content.length };
+    }
+
+    case 'file.write': {
+      const content = (action as Record<string, unknown>).content as string | undefined;
+      if (content === undefined) {
+        throw new Error('file.write requires content');
+      }
+      await writeFile(target, content, 'utf8');
+      return { path: target, written: content.length };
+    }
+
+    case 'file.delete': {
+      await unlink(target);
+      return { path: target, deleted: true };
+    }
+
+    case 'file.move': {
+      const destination = (action as Record<string, unknown>).destination as string | undefined;
+      if (!destination) {
+        throw new Error('file.move requires destination');
+      }
+      await rename(target, destination);
+      return { from: target, to: destination };
+    }
+
+    default:
+      throw new Error(`Unsupported file action: ${action.type}`);
+  }
+}

--- a/src/agentguard/adapters/git.ts
+++ b/src/agentguard/adapters/git.ts
@@ -1,0 +1,75 @@
+// Git operation adapter — executes git.commit, git.push, etc.
+// Node.js adapter. Wraps shell execution with git-specific validation.
+
+import { exec } from 'node:child_process';
+import type { CanonicalAction } from '../../core/types.js';
+
+const GIT_TIMEOUT = 30_000;
+
+function execGit(command: string, cwd?: string): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    exec(command, { timeout: GIT_TIMEOUT, cwd }, (error, stdout, stderr) => {
+      if (error) {
+        reject(new Error(`Git command failed: ${stderr || error.message}`));
+        return;
+      }
+      resolve({ stdout: stdout.toString(), stderr: stderr.toString() });
+    });
+  });
+}
+
+export async function gitAdapter(action: CanonicalAction): Promise<unknown> {
+  const cwd = (action as Record<string, unknown>).cwd as string | undefined;
+
+  switch (action.type) {
+    case 'git.commit': {
+      const message =
+        (action as Record<string, unknown>).message as string | undefined;
+      if (!message) {
+        throw new Error('git.commit requires a message');
+      }
+      const result = await execGit(`git commit -m "${message.replace(/"/g, '\\"')}"`, cwd);
+      return { committed: true, output: result.stdout.trim() };
+    }
+
+    case 'git.push': {
+      const branch = action.target || 'HEAD';
+      const remote =
+        ((action as Record<string, unknown>).remote as string | undefined) || 'origin';
+      const result = await execGit(`git push ${remote} ${branch}`, cwd);
+      return { pushed: true, branch, remote, output: result.stdout.trim() };
+    }
+
+    case 'git.diff': {
+      const result = await execGit('git diff', cwd);
+      return { diff: result.stdout };
+    }
+
+    case 'git.branch.create': {
+      const branch = action.target;
+      const result = await execGit(`git checkout -b ${branch}`, cwd);
+      return { created: true, branch, output: result.stdout.trim() };
+    }
+
+    case 'git.branch.delete': {
+      const branch = action.target;
+      const result = await execGit(`git branch -d ${branch}`, cwd);
+      return { deleted: true, branch, output: result.stdout.trim() };
+    }
+
+    case 'git.checkout': {
+      const branch = action.target;
+      const result = await execGit(`git checkout ${branch}`, cwd);
+      return { checkedOut: true, branch, output: result.stdout.trim() };
+    }
+
+    case 'git.merge': {
+      const branch = action.target;
+      const result = await execGit(`git merge ${branch}`, cwd);
+      return { merged: true, branch, output: result.stdout.trim() };
+    }
+
+    default:
+      throw new Error(`Unsupported git action: ${action.type}`);
+  }
+}

--- a/src/agentguard/adapters/registry.ts
+++ b/src/agentguard/adapters/registry.ts
@@ -1,0 +1,20 @@
+// Adapter registry — connects action classes to execution handlers.
+// Node.js module. Registers file, shell, and git adapters.
+
+import { createAdapterRegistry, createDryRunRegistry } from '../../domain/execution/adapters.js';
+import type { AdapterRegistry } from '../../core/types.js';
+import { fileAdapter } from './file.js';
+import { shellAdapter } from './shell.js';
+import { gitAdapter } from './git.js';
+
+export function createLiveRegistry(): AdapterRegistry {
+  const registry = createAdapterRegistry();
+
+  registry.register('file', fileAdapter);
+  registry.register('shell', shellAdapter);
+  registry.register('git', gitAdapter);
+
+  return registry;
+}
+
+export { createDryRunRegistry };

--- a/src/agentguard/adapters/shell.ts
+++ b/src/agentguard/adapters/shell.ts
@@ -1,0 +1,40 @@
+// Shell execution adapter — executes shell.exec actions.
+// Node.js adapter. Uses child_process.
+
+import { exec } from 'node:child_process';
+import type { CanonicalAction } from '../../core/types.js';
+
+const DEFAULT_TIMEOUT = 30_000;
+const MAX_BUFFER = 1024 * 1024; // 1MB
+
+export interface ShellResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export async function shellAdapter(action: CanonicalAction): Promise<ShellResult> {
+  const command = (action as Record<string, unknown>).command as string | undefined;
+  if (!command) {
+    throw new Error('shell.exec requires a command');
+  }
+
+  const timeout =
+    ((action as Record<string, unknown>).timeout as number | undefined) || DEFAULT_TIMEOUT;
+  const cwd = (action as Record<string, unknown>).cwd as string | undefined;
+
+  return new Promise((resolve, reject) => {
+    exec(command, { timeout, maxBuffer: MAX_BUFFER, cwd }, (error, stdout, stderr) => {
+      if (error && error.killed) {
+        reject(new Error(`Command timed out after ${timeout}ms: ${command}`));
+        return;
+      }
+
+      resolve({
+        stdout: stdout.toString(),
+        stderr: stderr.toString(),
+        exitCode: error ? error.code ?? 1 : 0,
+      });
+    });
+  });
+}

--- a/src/agentguard/kernel.ts
+++ b/src/agentguard/kernel.ts
@@ -1,0 +1,256 @@
+// Governed Action Kernel — the core orchestrator.
+// Connects monitor (AAB + policy + invariants) with execution adapters.
+// Emits full action lifecycle events: REQUESTED → ALLOWED/DENIED → EXECUTED/FAILED.
+
+import type { DomainEvent, CanonicalAction } from '../core/types.js';
+import { createMonitor } from './monitor.js';
+import type { MonitorConfig, MonitorDecision } from './monitor.js';
+import type { RawAgentAction } from './core/aab.js';
+import { createAction, getActionClass } from '../domain/actions.js';
+import { createAdapterRegistry } from '../domain/execution/adapters.js';
+import type { AdapterRegistry, ExecutionResult, DecisionRecord } from '../core/types.js';
+import {
+  createEvent,
+  ACTION_REQUESTED,
+  ACTION_ALLOWED,
+  ACTION_DENIED,
+  ACTION_EXECUTED,
+  ACTION_FAILED,
+} from '../domain/events.js';
+import { simpleHash } from '../domain/hash.js';
+
+export interface KernelResult {
+  allowed: boolean;
+  executed: boolean;
+  decision: MonitorDecision;
+  execution: ExecutionResult | null;
+  action: CanonicalAction | null;
+  events: DomainEvent[];
+  runId: string;
+}
+
+export interface EventSink {
+  write(event: DomainEvent): void;
+  flush?(): void;
+}
+
+export interface KernelConfig extends MonitorConfig {
+  runId?: string;
+  sinks?: EventSink[];
+  adapters?: AdapterRegistry;
+  dryRun?: boolean;
+}
+
+export interface Kernel {
+  propose(
+    rawAction: RawAgentAction,
+    systemContext?: Record<string, unknown>
+  ): Promise<KernelResult>;
+  getRunId(): string;
+  getActionLog(): KernelResult[];
+  getEventCount(): number;
+  shutdown(): void;
+}
+
+function generateRunId(): string {
+  return `run_${Date.now()}_${simpleHash(Math.random().toString())}`;
+}
+
+export function createKernel(config: KernelConfig = {}): Kernel {
+  const runId = config.runId || generateRunId();
+  const sinks: EventSink[] = config.sinks || [];
+  const adapters = config.adapters || createAdapterRegistry();
+  const dryRun = config.dryRun ?? false;
+  const actionLog: KernelResult[] = [];
+  let eventCount = 0;
+
+  const monitor = createMonitor({
+    policyDefs: config.policyDefs,
+    invariants: config.invariants,
+    denialThreshold: config.denialThreshold,
+    violationThreshold: config.violationThreshold,
+    windowSize: config.windowSize,
+  });
+
+  function sinkEvent(event: DomainEvent): void {
+    eventCount++;
+    for (const sink of sinks) {
+      sink.write(event);
+    }
+  }
+
+  function sinkEvents(events: DomainEvent[]): void {
+    for (const event of events) {
+      sinkEvent(event);
+    }
+  }
+
+  return {
+    propose: async (rawAction, systemContext = {}) => {
+      const allEvents: DomainEvent[] = [];
+
+      // 1. Emit ACTION_REQUESTED
+      const requestedEvent = createEvent(ACTION_REQUESTED, {
+        actionType: rawAction.tool || 'unknown',
+        target: rawAction.file || rawAction.target || '',
+        justification: (rawAction.metadata?.justification as string) || 'agent action',
+        actionId: undefined,
+        agentId: rawAction.agent || 'unknown',
+        metadata: { runId, command: rawAction.command },
+      });
+      allEvents.push(requestedEvent);
+
+      // 2. Evaluate via monitor (AAB → policy → invariants → evidence)
+      const decision = monitor.process(rawAction, systemContext);
+
+      // 3. Create canonical action object for execution
+      let action: CanonicalAction | null = null;
+      try {
+        const actionType = decision.intent.action;
+        const target = decision.intent.target;
+        if (actionType !== 'unknown') {
+          action = createAction(actionType, target, 'kernel-proposed', {
+            command: rawAction.command,
+            agent: rawAction.agent,
+            runId,
+          });
+        }
+      } catch {
+        // Action creation may fail for unknown types — continue with null
+      }
+
+      // 4. Emit decision events from monitor
+      sinkEvents(decision.events);
+
+      if (!decision.allowed) {
+        // 5a. DENIED — emit denial event
+        const deniedEvent = createEvent(ACTION_DENIED, {
+          actionType: decision.intent.action,
+          target: decision.intent.target,
+          reason: decision.decision.reason,
+          actionId: action?.id,
+          policyHash: decision.decision.matchedPolicy?.id,
+          metadata: {
+            runId,
+            intervention: decision.intervention,
+            violations: decision.violations,
+          },
+        });
+        allEvents.push(deniedEvent);
+        sinkEvents(allEvents);
+
+        const result: KernelResult = {
+          allowed: false,
+          executed: false,
+          decision,
+          execution: null,
+          action,
+          events: allEvents,
+          runId,
+        };
+        actionLog.push(result);
+        return result;
+      }
+
+      // 5b. ALLOWED — emit allowed event
+      const allowedEvent = createEvent(ACTION_ALLOWED, {
+        actionType: decision.intent.action,
+        target: decision.intent.target,
+        capability: decision.decision.matchedPolicy?.id || 'default-allow',
+        actionId: action?.id,
+        reason: decision.decision.reason,
+        metadata: { runId },
+      });
+      allEvents.push(allowedEvent);
+
+      // 6. Execute via adapter (unless dry-run)
+      let execution: ExecutionResult | null = null;
+      if (!dryRun && action) {
+        const actionClass = getActionClass(action.type);
+        if (actionClass && adapters.has(actionClass)) {
+          const decisionRecord: DecisionRecord = {
+            actionId: action.id,
+            decision: 'allow',
+            reason: decision.decision.reason,
+            timestamp: Date.now(),
+            policyHash: decision.decision.matchedPolicy?.id || 'none',
+          };
+
+          const startTime = Date.now();
+          try {
+            execution = await adapters.execute(action, decisionRecord);
+            const duration = Date.now() - startTime;
+
+            if (execution.success) {
+              // 7a. Execution succeeded
+              const executedEvent = createEvent(ACTION_EXECUTED, {
+                actionType: action.type,
+                target: action.target,
+                result: 'success',
+                actionId: action.id,
+                duration,
+                metadata: { runId },
+              });
+              allEvents.push(executedEvent);
+            } else {
+              // 7b. Execution failed
+              const failedEvent = createEvent(ACTION_FAILED, {
+                actionType: action.type,
+                target: action.target,
+                error: execution.error || 'Unknown execution error',
+                actionId: action.id,
+                duration,
+                metadata: { runId },
+              });
+              allEvents.push(failedEvent);
+            }
+          } catch (err) {
+            const duration = Date.now() - startTime;
+            execution = { success: false, error: (err as Error).message };
+            const failedEvent = createEvent(ACTION_FAILED, {
+              actionType: action.type,
+              target: action.target,
+              error: (err as Error).message,
+              actionId: action.id,
+              duration,
+              metadata: { runId },
+            });
+            allEvents.push(failedEvent);
+          }
+        }
+      }
+
+      sinkEvents(allEvents);
+
+      const result: KernelResult = {
+        allowed: true,
+        executed: execution !== null,
+        decision,
+        execution,
+        action,
+        events: allEvents,
+        runId,
+      };
+      actionLog.push(result);
+      return result;
+    },
+
+    getRunId() {
+      return runId;
+    },
+
+    getActionLog() {
+      return [...actionLog];
+    },
+
+    getEventCount() {
+      return eventCount;
+    },
+
+    shutdown() {
+      for (const sink of sinks) {
+        if (sink.flush) sink.flush();
+      }
+    },
+  };
+}

--- a/src/agentguard/policies/yaml-loader.ts
+++ b/src/agentguard/policies/yaml-loader.ts
@@ -1,0 +1,236 @@
+// YAML policy loader — parses simple YAML policy files into LoadedPolicy format.
+// Supports the subset of YAML needed for AgentGuard policy definitions.
+// No external dependencies — minimal line-based parser for constrained format.
+
+import type { PolicyRule, LoadedPolicy } from './evaluator.js';
+
+interface YamlPolicyDef {
+  id?: string;
+  name?: string;
+  description?: string;
+  severity?: number;
+  rules?: YamlRule[];
+}
+
+interface YamlRule {
+  action?: string;
+  effect?: string;
+  target?: string;
+  branches?: string[];
+  reason?: string;
+  limit?: number;
+  requireTests?: boolean;
+}
+
+function trimQuotes(s: string): string {
+  if ((s.startsWith('"') && s.endsWith('"')) || (s.startsWith("'") && s.endsWith("'"))) {
+    return s.slice(1, -1);
+  }
+  return s;
+}
+
+function parseValue(raw: string): string | number | boolean {
+  const s = raw.trim();
+  if (s === 'true') return true;
+  if (s === 'false') return false;
+  if (s === 'null' || s === '~') return '';
+  if (/^-?\d+$/.test(s)) return parseInt(s, 10);
+  if (/^-?\d+\.\d+$/.test(s)) return parseFloat(s);
+  return trimQuotes(s);
+}
+
+function parseInlineArray(raw: string): string[] {
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith('[') || !trimmed.endsWith(']')) return [];
+  const inner = trimmed.slice(1, -1);
+  return inner
+    .split(',')
+    .map((s) => trimQuotes(s.trim()))
+    .filter((s) => s.length > 0);
+}
+
+function indentLevel(line: string): number {
+  const match = line.match(/^(\s*)/);
+  return match ? match[1].length : 0;
+}
+
+export function parseYamlPolicy(yaml: string): YamlPolicyDef {
+  const lines = yaml.split('\n');
+  const result: YamlPolicyDef = {};
+  const rules: YamlRule[] = [];
+  let currentRule: YamlRule | null = null;
+  let inRules = false;
+  let inBranches = false;
+
+  for (const rawLine of lines) {
+    const line = rawLine.replace(/\r$/, '');
+
+    // Skip blank lines and comments
+    if (!line.trim() || line.trim().startsWith('#')) continue;
+
+    const indent = indentLevel(line);
+    const trimmed = line.trim();
+
+    // Top-level keys (indent 0)
+    if (indent === 0) {
+      inRules = false;
+      inBranches = false;
+      if (currentRule) {
+        rules.push(currentRule);
+        currentRule = null;
+      }
+
+      const colonIdx = trimmed.indexOf(':');
+      if (colonIdx === -1) continue;
+
+      const key = trimmed.slice(0, colonIdx).trim();
+      const val = trimmed.slice(colonIdx + 1).trim();
+
+      switch (key) {
+        case 'id':
+          result.id = trimQuotes(val);
+          break;
+        case 'name':
+          result.name = trimQuotes(val);
+          break;
+        case 'description':
+          result.description = trimQuotes(val);
+          break;
+        case 'severity':
+          result.severity = parseInt(val, 10);
+          break;
+        case 'rules':
+          inRules = true;
+          break;
+      }
+      continue;
+    }
+
+    // Inside rules array
+    if (inRules) {
+      // New rule entry (- action: ...)
+      if (trimmed.startsWith('- ')) {
+        if (currentRule) rules.push(currentRule);
+        currentRule = {};
+        inBranches = false;
+
+        const rest = trimmed.slice(2).trim();
+        const colonIdx = rest.indexOf(':');
+        if (colonIdx !== -1) {
+          const key = rest.slice(0, colonIdx).trim();
+          const val = rest.slice(colonIdx + 1).trim();
+          applyRuleField(currentRule, key, val);
+        }
+        continue;
+      }
+
+      // Continuation of branches array
+      if (inBranches && trimmed.startsWith('- ') && currentRule) {
+        currentRule.branches = currentRule.branches || [];
+        currentRule.branches.push(trimQuotes(trimmed.slice(2).trim()));
+        continue;
+      }
+
+      // Rule property
+      if (currentRule) {
+        inBranches = false;
+        const colonIdx = trimmed.indexOf(':');
+        if (colonIdx !== -1) {
+          const key = trimmed.slice(0, colonIdx).trim();
+          const val = trimmed.slice(colonIdx + 1).trim();
+
+          if (key === 'branches' && !val) {
+            inBranches = true;
+            currentRule.branches = [];
+            continue;
+          }
+
+          applyRuleField(currentRule, key, val);
+        }
+      }
+    }
+  }
+
+  if (currentRule) rules.push(currentRule);
+  if (rules.length > 0) result.rules = rules;
+
+  return result;
+}
+
+function applyRuleField(rule: YamlRule, key: string, val: string): void {
+  switch (key) {
+    case 'action':
+      rule.action = trimQuotes(val);
+      break;
+    case 'effect':
+      rule.effect = trimQuotes(val);
+      break;
+    case 'target':
+      rule.target = trimQuotes(val);
+      break;
+    case 'reason':
+      rule.reason = trimQuotes(val);
+      break;
+    case 'limit': {
+      const n = parseValue(val);
+      if (typeof n === 'number') rule.limit = n;
+      break;
+    }
+    case 'requireTests':
+      rule.requireTests = val === 'true';
+      break;
+    case 'branches': {
+      const arr = parseInlineArray(val);
+      if (arr.length > 0) rule.branches = arr;
+      break;
+    }
+  }
+}
+
+function convertRule(yamlRule: YamlRule): PolicyRule {
+  const conditions: PolicyRule['conditions'] = {};
+  let hasConditions = false;
+
+  if (yamlRule.target) {
+    conditions.scope = [yamlRule.target];
+    hasConditions = true;
+  }
+
+  if (yamlRule.branches) {
+    conditions.branches = yamlRule.branches;
+    hasConditions = true;
+  }
+
+  if (yamlRule.limit !== undefined) {
+    conditions.limit = yamlRule.limit;
+    hasConditions = true;
+  }
+
+  if (yamlRule.requireTests !== undefined) {
+    conditions.requireTests = yamlRule.requireTests;
+    hasConditions = true;
+  }
+
+  return {
+    action: yamlRule.action || '*',
+    effect: (yamlRule.effect as 'allow' | 'deny') || 'deny',
+    conditions: hasConditions ? conditions : undefined,
+    reason: yamlRule.reason,
+  };
+}
+
+export function loadYamlPolicy(yaml: string, defaultId?: string): LoadedPolicy {
+  const def = parseYamlPolicy(yaml);
+
+  return {
+    id: def.id || defaultId || 'yaml-policy',
+    name: def.name || 'YAML Policy',
+    description: def.description,
+    rules: (def.rules || []).map(convertRule),
+    severity: def.severity ?? 3,
+  };
+}
+
+export function loadYamlPolicies(yaml: string): LoadedPolicy[] {
+  return [loadYamlPolicy(yaml)];
+}

--- a/src/agentguard/renderers/tui.ts
+++ b/src/agentguard/renderers/tui.ts
@@ -1,0 +1,170 @@
+// Terminal UI renderer — real-time action stream display.
+// Node.js module. Writes ANSI-colored output to stderr.
+
+import type { KernelResult } from '../kernel.js';
+import type { MonitorDecision } from '../monitor.js';
+
+const ANSI = {
+  reset: '\x1b[0m',
+  bold: '\x1b[1m',
+  dim: '\x1b[2m',
+  red: '\x1b[31m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  blue: '\x1b[34m',
+  magenta: '\x1b[35m',
+  cyan: '\x1b[36m',
+  gray: '\x1b[90m',
+};
+
+const ICONS = {
+  allowed: '\u2713',  // ✓
+  denied: '\u2717',   // ✗
+  warning: '\u26A0',  // ⚠
+  arrow: '\u2192',    // →
+  bullet: '\u2022',   // •
+};
+
+export interface TuiConfig {
+  policyName?: string;
+  invariantCount?: number;
+  verbose?: boolean;
+}
+
+export function renderBanner(config: TuiConfig): string {
+  const lines: string[] = [];
+  lines.push('');
+  lines.push(`  ${ANSI.bold}${ANSI.cyan}AgentGuard Runtime Active${ANSI.reset}`);
+
+  const parts: string[] = [];
+  if (config.policyName) {
+    parts.push(`policy: ${ANSI.bold}${config.policyName}${ANSI.reset}`);
+  }
+  if (config.invariantCount !== undefined) {
+    parts.push(`invariants: ${ANSI.bold}${config.invariantCount}${ANSI.reset} active`);
+  }
+  if (parts.length > 0) {
+    lines.push(`  ${ANSI.dim}${parts.join(' | ')}${ANSI.reset}`);
+  }
+
+  lines.push('');
+  return lines.join('\n');
+}
+
+export function renderAction(result: KernelResult, verbose?: boolean): string {
+  const intent = result.decision.intent;
+  const action = intent.action;
+  const target = intent.target;
+
+  if (result.allowed) {
+    const exec = result.executed ? '' : ` ${ANSI.dim}(dry-run)${ANSI.reset}`;
+    return `  ${ANSI.green}${ICONS.allowed}${ANSI.reset} ${action} ${ANSI.dim}${target}${ANSI.reset}${exec}`;
+  }
+
+  const reason = result.decision.decision.reason;
+  const policy = result.decision.decision.matchedPolicy;
+  const policyTag = policy ? ` (${policy.id})` : '';
+
+  const lines: string[] = [];
+  lines.push(
+    `  ${ANSI.red}${ICONS.denied}${ANSI.reset} ${action} ${target} ${ANSI.red}${ICONS.arrow} DENIED${ANSI.reset}${ANSI.dim}${policyTag}${ANSI.reset}`
+  );
+
+  if (verbose && reason) {
+    lines.push(`    ${ANSI.dim}${reason}${ANSI.reset}`);
+  }
+
+  return lines.join('\n');
+}
+
+export function renderViolations(result: KernelResult): string {
+  const violations = result.decision.violations;
+  if (violations.length === 0) return '';
+
+  const lines: string[] = [];
+  for (const v of violations) {
+    lines.push(
+      `  ${ANSI.yellow}${ICONS.warning}${ANSI.reset} invariant violated: ${ANSI.bold}${v.name}${ANSI.reset}`
+    );
+  }
+  return lines.join('\n');
+}
+
+export function renderMonitorStatus(decision: MonitorDecision): string {
+  const m = decision.monitor;
+  const level = ['NORMAL', 'ELEVATED', 'HIGH', 'LOCKDOWN'][m.escalationLevel];
+
+  const levelColor =
+    m.escalationLevel === 0
+      ? ANSI.green
+      : m.escalationLevel === 1
+        ? ANSI.yellow
+        : m.escalationLevel === 2
+          ? ANSI.red
+          : ANSI.bold + ANSI.red;
+
+  return `  ${ANSI.dim}[${levelColor}${level}${ANSI.reset}${ANSI.dim}] evals:${m.totalEvaluations} denied:${m.totalDenials} violations:${m.totalViolations}${ANSI.reset}`;
+}
+
+export function renderKernelResult(result: KernelResult, verbose?: boolean): string {
+  const lines: string[] = [];
+  lines.push(renderAction(result, verbose));
+
+  const violationText = renderViolations(result);
+  if (violationText) lines.push(violationText);
+
+  return lines.join('\n');
+}
+
+export function renderActionGraph(results: KernelResult[]): string {
+  const lines: string[] = [];
+  lines.push('');
+  lines.push(`  ${ANSI.bold}Action Graph${ANSI.reset} ${ANSI.dim}(${results.length} actions)${ANSI.reset}`);
+  lines.push(`  ${ANSI.dim}${'─'.repeat(50)}${ANSI.reset}`);
+
+  for (let i = 0; i < results.length; i++) {
+    const r = results[i];
+    const intent = r.decision.intent;
+    const num = `${i + 1}.`.padStart(4);
+    const icon = r.allowed ? `${ANSI.green}${ICONS.allowed}${ANSI.reset}` : `${ANSI.red}${ICONS.denied}${ANSI.reset}`;
+    const status = r.allowed
+      ? r.executed
+        ? `${ANSI.green}EXECUTED${ANSI.reset}`
+        : `${ANSI.dim}ALLOWED${ANSI.reset}`
+      : `${ANSI.red}DENIED${ANSI.reset}`;
+
+    lines.push(`  ${num} ${icon} ${intent.action} ${ANSI.dim}${intent.target}${ANSI.reset} ${ANSI.gray}[${status}${ANSI.gray}]${ANSI.reset}`);
+
+    if (!r.allowed) {
+      lines.push(`       ${ANSI.dim}${r.decision.decision.reason}${ANSI.reset}`);
+    }
+
+    for (const v of r.decision.violations) {
+      lines.push(`       ${ANSI.yellow}${ICONS.warning} ${v.name}${ANSI.reset}`);
+    }
+  }
+
+  lines.push('');
+  return lines.join('\n');
+}
+
+export function renderEventStream(events: Array<{ kind: string; timestamp: number; [key: string]: unknown }>): string {
+  const lines: string[] = [];
+  lines.push('');
+  lines.push(`  ${ANSI.bold}Event Stream${ANSI.reset} ${ANSI.dim}(${events.length} events)${ANSI.reset}`);
+  lines.push(`  ${ANSI.dim}${'─'.repeat(50)}${ANSI.reset}`);
+
+  for (const event of events) {
+    const time = new Date(event.timestamp).toISOString().slice(11, 23);
+    const kindColor = event.kind.includes('Denied') || event.kind.includes('Violation')
+      ? ANSI.red
+      : event.kind.includes('Allowed') || event.kind.includes('Executed')
+        ? ANSI.green
+        : ANSI.cyan;
+
+    lines.push(`  ${ANSI.dim}${time}${ANSI.reset} ${kindColor}${event.kind}${ANSI.reset}`);
+  }
+
+  lines.push('');
+  return lines.join('\n');
+}

--- a/src/agentguard/sinks/jsonl.ts
+++ b/src/agentguard/sinks/jsonl.ts
@@ -1,0 +1,58 @@
+// JSONL event sink — persists events to .agentguard/events/<runId>.jsonl.
+// Node.js module. Creates directories as needed.
+
+import { mkdirSync, appendFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { DomainEvent } from '../../core/types.js';
+import type { EventSink } from '../kernel.js';
+
+const DEFAULT_BASE_DIR = '.agentguard';
+const EVENTS_DIR = 'events';
+
+export interface JsonlSinkOptions {
+  baseDir?: string;
+  runId: string;
+}
+
+export function createJsonlSink(options: JsonlSinkOptions): EventSink {
+  const baseDir = options.baseDir || DEFAULT_BASE_DIR;
+  const eventsDir = join(baseDir, EVENTS_DIR);
+  const filePath = join(eventsDir, `${options.runId}.jsonl`);
+
+  let initialized = false;
+  const buffer: string[] = [];
+
+  function ensureDir(): void {
+    if (initialized) return;
+    try {
+      mkdirSync(eventsDir, { recursive: true });
+      initialized = true;
+    } catch {
+      // Directory may already exist
+      initialized = true;
+    }
+  }
+
+  return {
+    write(event: DomainEvent): void {
+      ensureDir();
+      const line = JSON.stringify(event) + '\n';
+      buffer.push(line);
+
+      // Write immediately for durability
+      try {
+        appendFileSync(filePath, line, 'utf8');
+      } catch {
+        // Swallow write errors — don't crash the kernel
+      }
+    },
+
+    flush(): void {
+      buffer.length = 0;
+    },
+  };
+}
+
+export function getEventFilePath(runId: string, baseDir?: string): string {
+  return join(baseDir || DEFAULT_BASE_DIR, EVENTS_DIR, `${runId}.jsonl`);
+}

--- a/src/cli/bin.ts
+++ b/src/cli/bin.ts
@@ -24,12 +24,52 @@ const wantsHelp = args.includes('--help') || args.includes('-h');
 // Detect whether invoked as `bugmon` or `agentguard`
 const binName = process.argv[1]?.endsWith('bugmon') ? 'bugmon' : 'agentguard';
 
-// TODO(roadmap): Phase 2 — Add 'agentguard guard' and 'agentguard audit' CLI governance commands
-// TODO(roadmap): Phase 4 — Add 'agentguard replay <run-id>' CLI replay command
 // TODO(roadmap): Phase 8 — Editor integrations (VS Code extension, JetBrains plugin, Claude Code deep integration)
 // TODO(roadmap): TS Migration — Integrate TS CLI as primary CLI entry point
 
 const COMMANDS: Record<string, CommandHelp> = {
+  // === AgentGuard Governance Commands ===
+  guard: {
+    name: `${binName} guard`,
+    description: 'Start the governed action runtime — enforce policies and invariants',
+    usage: `${binName} guard [flags]`,
+    flags: [
+      { flag: '--policy, -p <file>', description: 'Policy file (YAML or JSON)' },
+      { flag: '--dry-run', description: 'Evaluate without executing actions' },
+      { flag: '--verbose, -v', description: 'Show detailed output' },
+    ],
+    examples: [
+      `${binName} guard`,
+      `${binName} guard --policy agentguard.yaml`,
+      `${binName} guard --dry-run`,
+      `echo '{"tool":"Bash","command":"rm -rf /"}' | ${binName} guard`,
+    ],
+  },
+  inspect: {
+    name: `${binName} inspect`,
+    description: 'Inspect the action graph and events for a run',
+    usage: `${binName} inspect [runId]`,
+    flags: [
+      { flag: '--list', description: 'List all recorded runs' },
+      { flag: '--last', description: 'Inspect the most recent run' },
+    ],
+    examples: [
+      `${binName} inspect --list`,
+      `${binName} inspect --last`,
+      `${binName} inspect run_1234567890_abc`,
+    ],
+  },
+  events: {
+    name: `${binName} events`,
+    description: 'Show the raw event stream for a run',
+    usage: `${binName} events <runId>`,
+    flags: [],
+    examples: [
+      `${binName} events --last`,
+      `${binName} events run_1234567890_abc`,
+    ],
+  },
+
   // === AgentGuard Core Commands ===
   watch: {
     name: `${binName} watch`,
@@ -104,6 +144,43 @@ const COMMANDS: Record<string, CommandHelp> = {
 
 async function main() {
   switch (command) {
+    case 'guard': {
+      if (wantsHelp) {
+        console.log(formatHelp(COMMANDS.guard));
+        break;
+      }
+      const flags = args.slice(1);
+      const policyIdx = flags.findIndex((f) => f === '--policy' || f === '-p');
+      const policyFile = policyIdx !== -1 ? flags[policyIdx + 1] : undefined;
+      const dryRun = flags.includes('--dry-run');
+      const verbose = flags.includes('--verbose') || flags.includes('-v');
+
+      const { guard } = await import('./commands/guard.js');
+      const code = await guard(args.slice(1), { policy: policyFile, dryRun, verbose, stdin: true });
+      process.exit(code);
+      break;
+    }
+
+    case 'inspect': {
+      if (wantsHelp) {
+        console.log(formatHelp(COMMANDS.inspect));
+        break;
+      }
+      const { inspect } = await import('./commands/inspect.js');
+      await inspect(args.slice(1));
+      break;
+    }
+
+    case 'events': {
+      if (wantsHelp) {
+        console.log(formatHelp(COMMANDS.events));
+        break;
+      }
+      const { events } = await import('./commands/inspect.js');
+      await events(args.slice(1));
+      break;
+    }
+
     case 'watch': {
       if (wantsHelp) {
         console.log(formatHelp(COMMANDS.watch));
@@ -321,7 +398,13 @@ function printHelp(): void {
   console.log(`
   \x1b[1mAgentGuard\x1b[0m — Deterministic runtime guardrails for AI-assisted software systems
 
-  \x1b[1mGuard:\x1b[0m
+  \x1b[1mGovernance:\x1b[0m
+    ${binName} guard                          Start governed action runtime
+    ${binName} guard --policy <file>          Use a specific policy file (YAML/JSON)
+    ${binName} inspect [runId]                Inspect action graph for a run
+    ${binName} events [runId]                 Show raw event stream for a run
+
+  \x1b[1mMonitor:\x1b[0m
     ${binName} watch -- <command>             Monitor a command for errors and violations
     ${binName} watch --cache -- <command>     Interactive: battle & cache BugMon!
     ${binName} scan [path]                    Scan files for bugs (eslint/tsc)

--- a/src/cli/commands/guard.ts
+++ b/src/cli/commands/guard.ts
@@ -1,0 +1,153 @@
+// CLI command: agentguard guard — start the governed action runtime.
+// Reads stdin for action proposals (JSON), evaluates them, writes results to stdout.
+
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { createKernel } from '../../agentguard/kernel.js';
+import type { KernelConfig } from '../../agentguard/kernel.js';
+import { createLiveRegistry } from '../../agentguard/adapters/registry.js';
+import { createJsonlSink } from '../../agentguard/sinks/jsonl.js';
+import { loadYamlPolicy } from '../../agentguard/policies/yaml-loader.js';
+import { renderBanner, renderKernelResult, renderMonitorStatus } from '../../agentguard/renderers/tui.js';
+import type { RawAgentAction } from '../../agentguard/core/aab.js';
+
+export interface GuardOptions {
+  policy?: string;
+  dryRun?: boolean;
+  verbose?: boolean;
+  stdin?: boolean;
+}
+
+function loadPolicyFile(policyPath: string): unknown[] {
+  const absPath = resolve(policyPath);
+  if (!existsSync(absPath)) {
+    process.stderr.write(`  \x1b[31mError:\x1b[0m Policy file not found: ${absPath}\n`);
+    process.exit(1);
+  }
+
+  const content = readFileSync(absPath, 'utf8');
+
+  if (absPath.endsWith('.yaml') || absPath.endsWith('.yml')) {
+    const policy = loadYamlPolicy(content, policyPath);
+    return [{ id: policy.id, name: policy.name, rules: policy.rules, severity: policy.severity }];
+  }
+
+  try {
+    const parsed = JSON.parse(content) as unknown;
+    return Array.isArray(parsed) ? parsed : [parsed];
+  } catch {
+    process.stderr.write(`  \x1b[31mError:\x1b[0m Failed to parse policy file: ${absPath}\n`);
+    process.exit(1);
+  }
+}
+
+function findDefaultPolicy(): string | null {
+  const candidates = ['agentguard.yaml', 'agentguard.yml', 'agentguard.json', '.agentguard.yaml', '.agentguard.yml'];
+  for (const name of candidates) {
+    if (existsSync(name)) return name;
+  }
+  return null;
+}
+
+export async function guard(_args: string[], options: GuardOptions = {}): Promise<number> {
+  // Resolve policy
+  const policyPath = options.policy || findDefaultPolicy();
+  const policyDefs = policyPath ? loadPolicyFile(policyPath) : [];
+
+  // Build kernel config
+  const kernelConfig: KernelConfig = {
+    policyDefs,
+    dryRun: options.dryRun ?? false,
+    adapters: options.dryRun ? undefined : createLiveRegistry(),
+  };
+
+  const kernel = createKernel(kernelConfig);
+  const runId = kernel.getRunId();
+
+  // Add JSONL sink
+  const jsonlSink = createJsonlSink({ runId });
+  kernelConfig.sinks = [jsonlSink];
+
+  // Re-create kernel with sink (sinks are set at creation time)
+  const fullKernel = createKernel({
+    ...kernelConfig,
+    runId,
+    sinks: [jsonlSink],
+  });
+
+  // Render banner
+  const policyName = policyPath || 'default (no file)';
+  process.stderr.write(
+    renderBanner({
+      policyName,
+      invariantCount: 6,
+      verbose: options.verbose,
+    })
+  );
+  process.stderr.write(`  ${'\x1b[2m'}run: ${runId}${'\x1b[0m'}\n\n`);
+
+  if (options.stdin) {
+    // Read actions from stdin (one JSON per line)
+    return processStdin(fullKernel, options);
+  }
+
+  // Interactive mode: read from stdin line by line
+  process.stderr.write(`  ${'\x1b[2m'}Listening for actions on stdin (JSON per line)...${'\x1b[0m'}\n`);
+  process.stderr.write(`  ${'\x1b[2m'}Press Ctrl+C to stop.${'\x1b[0m'}\n\n`);
+
+  return processStdin(fullKernel, options);
+}
+
+async function processStdin(kernel: ReturnType<typeof createKernel>, options: GuardOptions): Promise<number> {
+  return new Promise((resolvePromise) => {
+    let buffer = '';
+
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', async (chunk: string) => {
+      buffer += chunk;
+      const lines = buffer.split('\n');
+      buffer = lines.pop() || '';
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+
+        try {
+          const rawAction = JSON.parse(trimmed) as RawAgentAction;
+          const result = await kernel.propose(rawAction);
+
+          // Render result to stderr
+          process.stderr.write(renderKernelResult(result, options.verbose) + '\n');
+          if (result.decision.violations.length > 0 || !result.allowed) {
+            process.stderr.write(renderMonitorStatus(result.decision) + '\n');
+          }
+
+          // Write machine-readable result to stdout
+          const output = {
+            allowed: result.allowed,
+            executed: result.executed,
+            action: result.decision.intent.action,
+            target: result.decision.intent.target,
+            reason: result.decision.decision.reason,
+            violations: result.decision.violations.map((v) => v.name),
+            runId: result.runId,
+          };
+          process.stdout.write(JSON.stringify(output) + '\n');
+        } catch (err) {
+          process.stderr.write(`  \x1b[31mError:\x1b[0m Invalid JSON input: ${(err as Error).message}\n`);
+        }
+      }
+    });
+
+    process.stdin.on('end', () => {
+      kernel.shutdown();
+      resolvePromise(0);
+    });
+
+    process.on('SIGINT', () => {
+      kernel.shutdown();
+      process.stderr.write('\n  \x1b[33mAgentGuard stopped.\x1b[0m\n\n');
+      resolvePromise(0);
+    });
+  });
+}

--- a/src/cli/commands/inspect.ts
+++ b/src/cli/commands/inspect.ts
@@ -1,0 +1,175 @@
+// CLI command: agentguard inspect — show action graph and events for a run.
+// Also handles: agentguard events <runId>
+
+import { readFileSync, existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { renderEventStream } from '../../agentguard/renderers/tui.js';
+import { getEventFilePath } from '../../agentguard/sinks/jsonl.js';
+import type { DomainEvent } from '../../core/types.js';
+
+const BASE_DIR = '.agentguard';
+const EVENTS_DIR = join(BASE_DIR, 'events');
+
+function loadEvents(runId: string): DomainEvent[] {
+  const filePath = getEventFilePath(runId);
+  if (!existsSync(filePath)) {
+    process.stderr.write(`  \x1b[31mError:\x1b[0m No events found for run: ${runId}\n`);
+    process.stderr.write(`  Expected file: ${filePath}\n`);
+    return [];
+  }
+
+  const content = readFileSync(filePath, 'utf8');
+  const events: DomainEvent[] = [];
+
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      events.push(JSON.parse(trimmed) as DomainEvent);
+    } catch {
+      // Skip malformed lines
+    }
+  }
+
+  return events;
+}
+
+function listRuns(): string[] {
+  if (!existsSync(EVENTS_DIR)) return [];
+  return readdirSync(EVENTS_DIR)
+    .filter((f) => f.endsWith('.jsonl'))
+    .map((f) => f.replace('.jsonl', ''))
+    .sort()
+    .reverse();
+}
+
+export async function inspect(args: string[]): Promise<void> {
+  const runId = args[0];
+
+  if (!runId || runId === '--list') {
+    const runs = listRuns();
+    if (runs.length === 0) {
+      process.stderr.write('\n  \x1b[2mNo runs recorded yet.\x1b[0m\n');
+      process.stderr.write('  Run \x1b[1magentguard guard\x1b[0m to start recording.\n\n');
+      return;
+    }
+
+    process.stderr.write('\n  \x1b[1mRecorded Runs\x1b[0m\n');
+    process.stderr.write(`  ${'\x1b[2m'}${'─'.repeat(50)}${'\x1b[0m'}\n`);
+    for (const id of runs.slice(0, 20)) {
+      const events = loadEvents(id);
+      process.stderr.write(`  ${id}  ${'\x1b[2m'}(${events.length} events)${'\x1b[0m'}\n`);
+    }
+    process.stderr.write('\n');
+    return;
+  }
+
+  // Check for --last flag
+  const targetRunId = runId === '--last' ? listRuns()[0] : runId;
+  if (!targetRunId) {
+    process.stderr.write('\n  \x1b[2mNo runs recorded yet.\x1b[0m\n\n');
+    return;
+  }
+
+  const events = loadEvents(targetRunId);
+  if (events.length === 0) return;
+
+  process.stderr.write(`\n  \x1b[1mRun:\x1b[0m ${targetRunId}\n`);
+
+  // Reconstruct action graph from events
+  const actionEvents = events.filter(
+    (e) =>
+      e.kind === 'ActionRequested' ||
+      e.kind === 'ActionAllowed' ||
+      e.kind === 'ActionDenied' ||
+      e.kind === 'ActionExecuted' ||
+      e.kind === 'ActionFailed'
+  );
+
+  if (actionEvents.length > 0) {
+    // Group by action sequence to show action graph
+    const actions: Array<{
+      action: string;
+      target: string;
+      allowed: boolean;
+      executed: boolean;
+      reason: string;
+      violations: string[];
+    }> = [];
+
+    for (const event of actionEvents) {
+      const rec = event as unknown as Record<string, unknown>;
+      if (event.kind === 'ActionAllowed') {
+        actions.push({
+          action: rec.actionType as string,
+          target: rec.target as string,
+          allowed: true,
+          executed: false,
+          reason: (rec.reason as string) || '',
+          violations: [],
+        });
+      } else if (event.kind === 'ActionDenied') {
+        const meta = rec.metadata as Record<string, unknown> | undefined;
+        const violations = (meta?.violations as Array<{ name: string }>) || [];
+        actions.push({
+          action: rec.actionType as string,
+          target: rec.target as string,
+          allowed: false,
+          executed: false,
+          reason: rec.reason as string,
+          violations: violations.map((v) => v.name),
+        });
+      } else if (event.kind === 'ActionExecuted') {
+        const last = actions[actions.length - 1];
+        if (last) last.executed = true;
+      }
+    }
+
+    // Simple action summary
+    process.stderr.write(`\n  \x1b[1mAction Summary\x1b[0m (${actions.length} actions)\n`);
+    process.stderr.write(`  ${'\x1b[2m'}${'─'.repeat(50)}${'\x1b[0m'}\n`);
+
+    for (let i = 0; i < actions.length; i++) {
+      const a = actions[i];
+      const num = `${i + 1}.`.padStart(4);
+      const icon = a.allowed ? '\x1b[32m\u2713\x1b[0m' : '\x1b[31m\u2717\x1b[0m';
+      const status = a.allowed
+        ? a.executed ? '\x1b[32mEXECUTED\x1b[0m' : '\x1b[2mALLOWED\x1b[0m'
+        : '\x1b[31mDENIED\x1b[0m';
+
+      process.stderr.write(`  ${num} ${icon} ${a.action} \x1b[2m${a.target}\x1b[0m \x1b[90m[${status}\x1b[90m]\x1b[0m\n`);
+      if (!a.allowed) {
+        process.stderr.write(`       \x1b[2m${a.reason}\x1b[0m\n`);
+      }
+      for (const v of a.violations) {
+        process.stderr.write(`       \x1b[33m\u26A0 ${v}\x1b[0m\n`);
+      }
+    }
+  }
+
+  // Show event stream
+  process.stderr.write(renderEventStream(events));
+}
+
+export async function events(args: string[]): Promise<void> {
+  const runId = args[0];
+
+  if (!runId) {
+    process.stderr.write('\n  Usage: agentguard events <runId>\n\n');
+    return;
+  }
+
+  const targetRunId = runId === '--last' ? listRuns()[0] : runId;
+  if (!targetRunId) {
+    process.stderr.write('\n  \x1b[2mNo runs recorded yet.\x1b[0m\n\n');
+    return;
+  }
+
+  const eventList = loadEvents(targetRunId);
+  if (eventList.length === 0) return;
+
+  // Raw event dump
+  for (const event of eventList) {
+    process.stdout.write(JSON.stringify(event) + '\n');
+  }
+}

--- a/tests/ts/claude-code-adapter.test.ts
+++ b/tests/ts/claude-code-adapter.test.ts
@@ -1,0 +1,157 @@
+// Tests for Claude Code adapter
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeClaudeCodeAction,
+  formatHookResponse,
+} from '../../src/agentguard/adapters/claude-code.js';
+import type { ClaudeCodeHookPayload } from '../../src/agentguard/adapters/claude-code.js';
+import { createKernel } from '../../src/agentguard/kernel.js';
+import { resetActionCounter } from '../../src/domain/actions.js';
+import { resetEventCounter } from '../../src/domain/events.js';
+import { beforeEach } from 'vitest';
+
+beforeEach(() => {
+  resetActionCounter();
+  resetEventCounter();
+});
+
+describe('normalizeClaudeCodeAction', () => {
+  it('normalizes Write tool', () => {
+    const payload: ClaudeCodeHookPayload = {
+      hook: 'PreToolUse',
+      tool_name: 'Write',
+      tool_input: { file_path: 'src/test.ts', content: 'hello' },
+    };
+    const action = normalizeClaudeCodeAction(payload);
+    expect(action.tool).toBe('Write');
+    expect(action.file).toBe('src/test.ts');
+    expect(action.agent).toBe('claude-code');
+  });
+
+  it('normalizes Edit tool', () => {
+    const payload: ClaudeCodeHookPayload = {
+      hook: 'PreToolUse',
+      tool_name: 'Edit',
+      tool_input: { file_path: 'src/test.ts', old_string: 'a', new_string: 'b' },
+    };
+    const action = normalizeClaudeCodeAction(payload);
+    expect(action.tool).toBe('Edit');
+    expect(action.file).toBe('src/test.ts');
+  });
+
+  it('normalizes Bash tool', () => {
+    const payload: ClaudeCodeHookPayload = {
+      hook: 'PreToolUse',
+      tool_name: 'Bash',
+      tool_input: { command: 'npm test' },
+    };
+    const action = normalizeClaudeCodeAction(payload);
+    expect(action.tool).toBe('Bash');
+    expect(action.command).toBe('npm test');
+  });
+
+  it('normalizes Bash with git push', () => {
+    const payload: ClaudeCodeHookPayload = {
+      hook: 'PreToolUse',
+      tool_name: 'Bash',
+      tool_input: { command: 'git push origin main' },
+    };
+    const action = normalizeClaudeCodeAction(payload);
+    expect(action.tool).toBe('Bash');
+    expect(action.command).toBe('git push origin main');
+  });
+
+  it('normalizes Read tool', () => {
+    const payload: ClaudeCodeHookPayload = {
+      hook: 'PreToolUse',
+      tool_name: 'Read',
+      tool_input: { file_path: 'README.md' },
+    };
+    const action = normalizeClaudeCodeAction(payload);
+    expect(action.tool).toBe('Read');
+    expect(action.file).toBe('README.md');
+  });
+
+  it('normalizes unknown tool gracefully', () => {
+    const payload: ClaudeCodeHookPayload = {
+      hook: 'PreToolUse',
+      tool_name: 'Agent',
+      tool_input: { prompt: 'do something' },
+    };
+    const action = normalizeClaudeCodeAction(payload);
+    expect(action.tool).toBe('Agent');
+    expect(action.agent).toBe('claude-code');
+  });
+});
+
+describe('Integration: Claude Code → Kernel', () => {
+  it('allows benign file read through kernel', async () => {
+    const kernel = createKernel({ dryRun: true });
+    const payload: ClaudeCodeHookPayload = {
+      hook: 'PreToolUse',
+      tool_name: 'Read',
+      tool_input: { file_path: 'src/index.ts' },
+    };
+    const rawAction = normalizeClaudeCodeAction(payload);
+    const result = await kernel.propose(rawAction);
+    expect(result.allowed).toBe(true);
+  });
+
+  it('denies destructive command through kernel', async () => {
+    const kernel = createKernel({ dryRun: true });
+    const payload: ClaudeCodeHookPayload = {
+      hook: 'PreToolUse',
+      tool_name: 'Bash',
+      tool_input: { command: 'rm -rf /' },
+    };
+    const rawAction = normalizeClaudeCodeAction(payload);
+    const result = await kernel.propose(rawAction);
+    expect(result.allowed).toBe(false);
+  });
+
+  it('denies git push to main with policy', async () => {
+    const kernel = createKernel({
+      dryRun: true,
+      policyDefs: [
+        {
+          id: 'protect-main',
+          name: 'Protect Main',
+          rules: [{ action: 'git.push', effect: 'deny', reason: 'Protected branch' }],
+          severity: 4,
+        },
+      ],
+    });
+    const payload: ClaudeCodeHookPayload = {
+      hook: 'PreToolUse',
+      tool_name: 'Bash',
+      tool_input: { command: 'git push origin main' },
+    };
+    const rawAction = normalizeClaudeCodeAction(payload);
+    const result = await kernel.propose(rawAction);
+    expect(result.allowed).toBe(false);
+  });
+});
+
+describe('formatHookResponse', () => {
+  it('returns empty string for allowed actions', async () => {
+    const kernel = createKernel({ dryRun: true });
+    const result = await kernel.propose({
+      tool: 'Read',
+      file: 'test.ts',
+      agent: 'test',
+    });
+    expect(formatHookResponse(result)).toBe('');
+  });
+
+  it('returns JSON error for denied actions', async () => {
+    const kernel = createKernel({ dryRun: true });
+    const result = await kernel.propose({
+      tool: 'Bash',
+      command: 'rm -rf /',
+      agent: 'test',
+    });
+    const response = formatHookResponse(result);
+    expect(response).toContain('DENIED');
+    expect(JSON.parse(response)).toHaveProperty('error');
+  });
+});

--- a/tests/ts/kernel.test.ts
+++ b/tests/ts/kernel.test.ts
@@ -1,0 +1,245 @@
+// Tests for the Governed Action Kernel
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createKernel } from '../../src/agentguard/kernel.js';
+import type { KernelConfig, EventSink } from '../../src/agentguard/kernel.js';
+import { createDryRunRegistry } from '../../src/domain/execution/adapters.js';
+import { resetActionCounter } from '../../src/domain/actions.js';
+import { resetEventCounter } from '../../src/domain/events.js';
+import type { DomainEvent } from '../../src/core/types.js';
+
+beforeEach(() => {
+  resetActionCounter();
+  resetEventCounter();
+});
+
+describe('Kernel', () => {
+  it('creates with a run ID', () => {
+    const kernel = createKernel();
+    expect(kernel.getRunId()).toMatch(/^run_/);
+  });
+
+  it('uses custom run ID', () => {
+    const kernel = createKernel({ runId: 'test-run-123' });
+    expect(kernel.getRunId()).toBe('test-run-123');
+  });
+
+  it('allows benign file read', async () => {
+    const kernel = createKernel({ dryRun: true });
+    const result = await kernel.propose({
+      tool: 'Read',
+      file: 'src/index.ts',
+      agent: 'test-agent',
+    });
+
+    expect(result.allowed).toBe(true);
+    expect(result.runId).toMatch(/^run_/);
+    expect(result.decision.intent.action).toBe('file.read');
+    expect(result.events.length).toBeGreaterThan(0);
+  });
+
+  it('denies destructive shell command', async () => {
+    const kernel = createKernel({ dryRun: true });
+    const result = await kernel.propose({
+      tool: 'Bash',
+      command: 'rm -rf /',
+      agent: 'test-agent',
+    });
+
+    expect(result.allowed).toBe(false);
+    expect(result.executed).toBe(false);
+    expect(result.decision.intent.destructive).toBe(true);
+  });
+
+  it('denies actions matching deny policy', async () => {
+    const kernel = createKernel({
+      dryRun: true,
+      policyDefs: [
+        {
+          id: 'protect-main',
+          name: 'Protect Main Branch',
+          rules: [
+            { action: 'git.push', effect: 'deny', reason: 'Protected branch' },
+          ],
+          severity: 4,
+        },
+      ],
+    });
+
+    const result = await kernel.propose({
+      tool: 'Bash',
+      command: 'git push origin main',
+      agent: 'test-agent',
+    });
+
+    expect(result.allowed).toBe(false);
+    expect(result.decision.decision.reason).toContain('Protected branch');
+  });
+
+  it('executes allowed actions via adapters', async () => {
+    const { registry, dryRun } = createDryRunRegistry();
+    const kernel = createKernel({ adapters: registry });
+
+    const result = await kernel.propose({
+      tool: 'Read',
+      file: 'test.txt',
+      agent: 'test-agent',
+    });
+
+    expect(result.allowed).toBe(true);
+    expect(result.executed).toBe(true);
+    expect(dryRun.getLog().length).toBe(1);
+    expect(dryRun.getLog()[0].type).toBe('file.read');
+  });
+
+  it('tracks action log', async () => {
+    const kernel = createKernel({ dryRun: true });
+
+    await kernel.propose({ tool: 'Read', file: 'a.ts', agent: 'test' });
+    await kernel.propose({ tool: 'Write', file: 'b.ts', agent: 'test' });
+    await kernel.propose({ tool: 'Bash', command: 'npm test', agent: 'test' });
+
+    expect(kernel.getActionLog().length).toBe(3);
+  });
+
+  it('emits ACTION_REQUESTED event', async () => {
+    const kernel = createKernel({ dryRun: true });
+    const result = await kernel.propose({
+      tool: 'Read',
+      file: 'test.ts',
+      agent: 'test',
+    });
+
+    const requestedEvents = result.events.filter((e) => e.kind === 'ActionRequested');
+    expect(requestedEvents.length).toBe(1);
+  });
+
+  it('emits ACTION_ALLOWED event for allowed actions', async () => {
+    const kernel = createKernel({ dryRun: true });
+    const result = await kernel.propose({
+      tool: 'Read',
+      file: 'test.ts',
+      agent: 'test',
+    });
+
+    const allowedEvents = result.events.filter((e) => e.kind === 'ActionAllowed');
+    expect(allowedEvents.length).toBe(1);
+  });
+
+  it('emits ACTION_DENIED event for denied actions', async () => {
+    const kernel = createKernel({ dryRun: true });
+    const result = await kernel.propose({
+      tool: 'Bash',
+      command: 'rm -rf /',
+      agent: 'test',
+    });
+
+    const deniedEvents = result.events.filter((e) => e.kind === 'ActionDenied');
+    expect(deniedEvents.length).toBe(1);
+  });
+
+  it('sinks events to configured sinks', async () => {
+    const sunkEvents: DomainEvent[] = [];
+    const testSink: EventSink = {
+      write(event) {
+        sunkEvents.push(event);
+      },
+    };
+
+    const kernel = createKernel({ dryRun: true, sinks: [testSink] });
+    await kernel.propose({ tool: 'Read', file: 'test.ts', agent: 'test' });
+
+    expect(sunkEvents.length).toBeGreaterThan(0);
+  });
+
+  it('shutdown flushes sinks', () => {
+    let flushed = false;
+    const testSink: EventSink = {
+      write() {},
+      flush() {
+        flushed = true;
+      },
+    };
+
+    const kernel = createKernel({ dryRun: true, sinks: [testSink] });
+    kernel.shutdown();
+    expect(flushed).toBe(true);
+  });
+
+  it('tracks event count', async () => {
+    const kernel = createKernel({ dryRun: true });
+    expect(kernel.getEventCount()).toBe(0);
+
+    await kernel.propose({ tool: 'Read', file: 'test.ts', agent: 'test' });
+    expect(kernel.getEventCount()).toBeGreaterThan(0);
+  });
+});
+
+describe('Kernel with policies', () => {
+  const strictPolicy: KernelConfig = {
+    dryRun: true,
+    policyDefs: [
+      {
+        id: 'no-push',
+        name: 'No Push',
+        rules: [
+          { action: 'git.push', effect: 'deny', reason: 'Pushing not allowed' },
+          { action: 'git.force-push', effect: 'deny', reason: 'Force push not allowed' },
+        ],
+        severity: 4,
+      },
+      {
+        id: 'safe-shell',
+        name: 'Safe Shell',
+        rules: [
+          {
+            action: 'shell.exec',
+            effect: 'deny',
+            conditions: { scope: ['*.env'] },
+            reason: 'No env file access',
+          },
+        ],
+        severity: 3,
+      },
+    ],
+  };
+
+  it('allows file reads under strict policy', async () => {
+    const kernel = createKernel(strictPolicy);
+    const result = await kernel.propose({
+      tool: 'Read',
+      file: 'src/index.ts',
+      agent: 'test',
+    });
+    expect(result.allowed).toBe(true);
+  });
+
+  it('denies git push under strict policy', async () => {
+    const kernel = createKernel(strictPolicy);
+    const result = await kernel.propose({
+      tool: 'Bash',
+      command: 'git push origin main',
+      agent: 'test',
+    });
+    expect(result.allowed).toBe(false);
+  });
+
+  it('denies git force push under strict policy', async () => {
+    const kernel = createKernel(strictPolicy);
+    const result = await kernel.propose({
+      tool: 'Bash',
+      command: 'git push --force origin main',
+      agent: 'test',
+    });
+    expect(result.allowed).toBe(false);
+  });
+
+  it('includes evidence pack on denial', async () => {
+    const kernel = createKernel(strictPolicy);
+    const result = await kernel.propose({
+      tool: 'Bash',
+      command: 'git push origin main',
+      agent: 'test',
+    });
+    expect(result.decision.evidencePack).not.toBeNull();
+  });
+});

--- a/tests/ts/yaml-loader.test.ts
+++ b/tests/ts/yaml-loader.test.ts
@@ -1,0 +1,157 @@
+// Tests for YAML policy loader
+import { describe, it, expect } from 'vitest';
+import { parseYamlPolicy, loadYamlPolicy } from '../../src/agentguard/policies/yaml-loader.js';
+
+describe('parseYamlPolicy', () => {
+  it('parses basic policy', () => {
+    const yaml = `
+id: protect-main
+name: Protect Main Branch
+severity: 4
+rules:
+  - action: git.push
+    effect: deny
+    reason: Protected branch
+`;
+    const result = parseYamlPolicy(yaml);
+    expect(result.id).toBe('protect-main');
+    expect(result.name).toBe('Protect Main Branch');
+    expect(result.severity).toBe(4);
+    expect(result.rules).toHaveLength(1);
+    expect(result.rules![0].action).toBe('git.push');
+    expect(result.rules![0].effect).toBe('deny');
+    expect(result.rules![0].reason).toBe('Protected branch');
+  });
+
+  it('parses multiple rules', () => {
+    const yaml = `
+id: strict
+name: Strict Policy
+rules:
+  - action: git.push
+    effect: deny
+    reason: No pushing
+  - action: git.force-push
+    effect: deny
+    reason: No force pushing
+  - action: file.read
+    effect: allow
+    reason: Reading is fine
+`;
+    const result = parseYamlPolicy(yaml);
+    expect(result.rules).toHaveLength(3);
+    expect(result.rules![0].effect).toBe('deny');
+    expect(result.rules![1].effect).toBe('deny');
+    expect(result.rules![2].effect).toBe('allow');
+  });
+
+  it('parses inline branches array', () => {
+    const yaml = `
+rules:
+  - action: git.push
+    effect: deny
+    branches: [main, master, production]
+`;
+    const result = parseYamlPolicy(yaml);
+    expect(result.rules![0].branches).toEqual(['main', 'master', 'production']);
+  });
+
+  it('parses target condition', () => {
+    const yaml = `
+rules:
+  - action: file.write
+    effect: deny
+    target: .env
+    reason: No env file writes
+`;
+    const result = parseYamlPolicy(yaml);
+    expect(result.rules![0].target).toBe('.env');
+  });
+
+  it('parses limit condition', () => {
+    const yaml = `
+rules:
+  - action: file.write
+    effect: deny
+    limit: 20
+`;
+    const result = parseYamlPolicy(yaml);
+    expect(result.rules![0].limit).toBe(20);
+  });
+
+  it('skips comments and blank lines', () => {
+    const yaml = `
+# This is a comment
+id: test
+
+# Another comment
+rules:
+  # Rule comment
+  - action: git.push
+    effect: deny
+`;
+    const result = parseYamlPolicy(yaml);
+    expect(result.id).toBe('test');
+    expect(result.rules).toHaveLength(1);
+  });
+
+  it('handles quoted values', () => {
+    const yaml = `
+id: "quoted-id"
+name: 'single-quoted'
+rules:
+  - action: "git.push"
+    effect: "deny"
+`;
+    const result = parseYamlPolicy(yaml);
+    expect(result.id).toBe('quoted-id');
+    expect(result.name).toBe('single-quoted');
+    expect(result.rules![0].action).toBe('git.push');
+  });
+});
+
+describe('loadYamlPolicy', () => {
+  it('converts to LoadedPolicy format', () => {
+    const yaml = `
+id: test-policy
+name: Test Policy
+severity: 3
+rules:
+  - action: git.push
+    effect: deny
+    reason: No pushing
+    target: main
+`;
+    const policy = loadYamlPolicy(yaml);
+    expect(policy.id).toBe('test-policy');
+    expect(policy.name).toBe('Test Policy');
+    expect(policy.severity).toBe(3);
+    expect(policy.rules).toHaveLength(1);
+    expect(policy.rules[0].action).toBe('git.push');
+    expect(policy.rules[0].effect).toBe('deny');
+    expect(policy.rules[0].conditions?.scope).toEqual(['main']);
+  });
+
+  it('uses defaults for missing fields', () => {
+    const yaml = `
+rules:
+  - action: git.push
+    effect: deny
+`;
+    const policy = loadYamlPolicy(yaml, 'fallback-id');
+    expect(policy.id).toBe('fallback-id');
+    expect(policy.name).toBe('YAML Policy');
+    expect(policy.severity).toBe(3);
+  });
+
+  it('converts branches to conditions', () => {
+    const yaml = `
+rules:
+  - action: git.push
+    effect: deny
+    branches: [main, master]
+`;
+    const policy = loadYamlPolicy(yaml);
+    expect(policy.rules[0].conditions?.branches).toEqual(['main', 'master']);
+  });
+});


### PR DESCRIPTION
Implement the governed action kernel that connects all existing governance infrastructure (AAB, policy engine, invariant checker, evidence packs, monitor) into a working runtime. Agent tool calls are intercepted, evaluated against policies and invariants, executed via adapters, and recorded as JSONL events.

New files (11):
- agentguard/kernel.ts — kernel loop orchestrator
- agentguard/adapters/ — file, shell, git, claude-code, registry
- agentguard/policies/yaml-loader.ts — YAML policy format
- agentguard/renderers/tui.ts — terminal action stream
- agentguard/sinks/jsonl.ts — JSONL event persistence
- cli/commands/guard.ts — agentguard guard command
- cli/commands/inspect.ts — agentguard inspect/events commands

Tests (38 new): kernel lifecycle, Claude Code adapter, YAML loader.
Docs (8 files): repositioned as governed action runtime, BugMon deprioritized.