### PR TITLE
Add developer experience polish: demo, default policy, examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ runtime/events/*
 runtime/replay/*
 !runtime/events/.gitkeep
 !runtime/replay/.gitkeep
+.agentguard/

--- a/README.md
+++ b/README.md
@@ -16,6 +16,34 @@ agent proposes action  →  policy evaluated  →  invariants checked  →  allo
 
 ## Quick Start
 
+**30 seconds to see it work:**
+
+```bash
+git clone https://github.com/jpleva91/agent-guard.git
+cd agent-guard
+npm install && npm run build:ts
+npm run demo:guard
+```
+
+Expected output:
+
+```
+  AgentGuard Runtime Active
+  policy: Demo Safety Policy | invariants: 6 active
+
+  ✓ file.read src/auth/service.ts (dry-run)
+  ✓ file.write src/auth/service.ts (dry-run)
+  ✓ shell.exec npm test (dry-run)
+  ✗ git.push main → DENIED (demo-policy)
+    Protected branch — use a PR
+  ✗ file.write .env → DENIED (demo-policy)
+    Secrets files must not be modified
+
+  3 allowed, 2 denied, 15 events emitted
+```
+
+**Try it on your own repo:**
+
 ```bash
 # Pipe an action into the kernel
 echo '{"tool":"Bash","command":"git push origin main"}' | npx agentguard guard --dry-run

--- a/agentguard.yaml
+++ b/agentguard.yaml
@@ -1,0 +1,35 @@
+# Default AgentGuard policy — baseline guardrails for AI coding agents.
+# Drop this file in your repo root. The CLI picks it up automatically.
+
+id: default-policy
+name: Default Safety Policy
+description: Baseline guardrails for AI coding agents
+severity: 4
+
+rules:
+  - action: git.push
+    effect: deny
+    branches: [main, master]
+    reason: Direct push to protected branch
+
+  - action: git.force-push
+    effect: deny
+    reason: Force push rewrites shared history
+
+  - action: file.write
+    effect: deny
+    target: .env
+    reason: Secrets files must not be modified
+
+  - action: shell.exec
+    effect: deny
+    target: rm -rf
+    reason: Destructive shell commands blocked
+
+  - action: file.read
+    effect: allow
+    reason: Reading is always safe
+
+  - action: file.write
+    effect: allow
+    reason: File writes allowed by default

--- a/examples/basic-policy.yaml
+++ b/examples/basic-policy.yaml
@@ -1,0 +1,48 @@
+# Example AgentGuard policy — annotated to show all rule features.
+#
+# Place as `agentguard.yaml` in your repo root for automatic discovery,
+# or pass explicitly: `agentguard guard --policy examples/basic-policy.yaml`
+
+# Policy metadata
+id: example-policy
+name: Example Safety Policy
+description: Annotated policy showing all rule features
+severity: 4
+
+rules:
+  # --- Deny rules (evaluated first, block matching actions) ---
+
+  # Block pushes to protected branches
+  - action: git.push
+    effect: deny
+    branches: [main, master, release]
+    reason: Protected branches require PR review
+
+  # Block force-push everywhere
+  - action: git.force-push
+    effect: deny
+    reason: Force push rewrites shared history
+
+  # Protect secrets files from writes
+  - action: file.write
+    effect: deny
+    target: .env
+    reason: Secrets must not be modified by agents
+
+  # Block destructive shell commands
+  - action: shell.exec
+    effect: deny
+    target: rm -rf
+    reason: Destructive commands blocked
+
+  # --- Allow rules (permit matching actions) ---
+
+  # Reading is always safe
+  - action: file.read
+    effect: allow
+    reason: Reading is always safe
+
+  # File writes allowed by default (deny rules above take precedence)
+  - action: file.write
+    effect: allow
+    reason: File writes allowed by default

--- a/examples/claude-code-hook.js
+++ b/examples/claude-code-hook.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+// Example: Wire AgentGuard into Claude Code as a PreToolUse hook.
+//
+// In your .claude/settings.json:
+//   "hooks": {
+//     "PreToolUse": [{ "command": "node examples/claude-code-hook.js" }]
+//   }
+//
+// The hook reads the tool call from stdin, evaluates it through the kernel,
+// and exits non-zero to block denied actions.
+
+import { createKernel } from '../dist/agentguard/kernel.js';
+import { normalizeClaudeCodeAction } from '../dist/agentguard/adapters/claude-code.js';
+import { loadYamlPolicy } from '../dist/agentguard/policies/yaml-loader.js';
+import { readFileSync, existsSync } from 'node:fs';
+
+// Load policy from repo root (auto-discovered by the guard command too)
+const policyPath = 'agentguard.yaml';
+const policyDefs = existsSync(policyPath)
+  ? [loadYamlPolicy(readFileSync(policyPath, 'utf8'))]
+  : [];
+
+const kernel = createKernel({ dryRun: true, policyDefs });
+
+// Read hook payload from stdin
+let input = '';
+for await (const chunk of process.stdin) {
+  input += chunk;
+}
+
+const payload = JSON.parse(input);
+const rawAction = normalizeClaudeCodeAction({
+  hook: 'PreToolUse',
+  tool_name: payload.tool_name,
+  tool_input: payload.tool_input,
+});
+
+const result = await kernel.propose(rawAction);
+
+if (!result.allowed) {
+  const reason = result.decision.decision.reason;
+  console.error(`AgentGuard DENIED: ${reason}`);
+  process.exit(1);
+}

--- a/examples/evaluate-action.js
+++ b/examples/evaluate-action.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+// Minimal example: create a kernel and evaluate one action.
+// Run: node examples/evaluate-action.js (after npm run build:ts)
+
+import { createKernel } from '../dist/agentguard/kernel.js';
+import { loadYamlPolicy } from '../dist/agentguard/policies/yaml-loader.js';
+import { readFileSync } from 'node:fs';
+
+const policy = loadYamlPolicy(readFileSync('agentguard.yaml', 'utf8'));
+const kernel = createKernel({ dryRun: true, policyDefs: [policy] });
+
+const result = await kernel.propose({
+  tool: 'Bash',
+  command: 'git push origin main',
+  agent: 'my-agent',
+});
+
+console.log(result.allowed ? 'ALLOWED' : 'DENIED');
+console.log('Action:', result.decision.intent.action);
+console.log('Reason:', result.decision.decision.reason);

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "build:debug": "node scripts/build.js --sourcemap",
     "budget": "node scripts/build.js --no-sprites",
     "serve": "node scripts/dev-server.js",
+    "demo:guard": "npm run build:ts && node scripts/demo.js",
     "dev": "node dist/cli/bin.js",
     "agentguard": "node dist/cli/bin.js",
     "dev:legacy": "node dist/cli/bin.js",

--- a/scripts/demo.js
+++ b/scripts/demo.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+// AgentGuard governance demo — shows the kernel evaluating a realistic agent session.
+// Run: npm run demo:guard
+
+import { createKernel } from '../dist/agentguard/kernel.js';
+import {
+  renderBanner,
+  renderKernelResult,
+  renderActionGraph,
+} from '../dist/agentguard/renderers/tui.js';
+
+const kernel = createKernel({
+  dryRun: true,
+  policyDefs: [
+    {
+      id: 'demo-policy',
+      name: 'Demo Safety Policy',
+      rules: [
+        {
+          action: 'git.push',
+          effect: 'deny',
+          conditions: { branches: ['main', 'master'] },
+          reason: 'Protected branch — use a PR',
+        },
+        {
+          action: 'git.force-push',
+          effect: 'deny',
+          reason: 'Force push rewrites shared history',
+        },
+        {
+          action: 'file.write',
+          effect: 'deny',
+          conditions: { scope: ['.env'] },
+          reason: 'Secrets files must not be modified',
+        },
+        { action: 'file.read', effect: 'allow', reason: 'Reading is always safe' },
+        { action: 'file.write', effect: 'allow', reason: 'Writes allowed by default' },
+        { action: 'shell.exec', effect: 'allow', reason: 'Shell allowed by default' },
+      ],
+      severity: 4,
+    },
+  ],
+});
+
+// Simulate a realistic agent session
+const actions = [
+  { tool: 'Read', file: 'src/auth/service.ts', agent: 'claude-code' },
+  { tool: 'Write', file: 'src/auth/service.ts', content: 'updated code', agent: 'claude-code' },
+  { tool: 'Bash', command: 'npm test', agent: 'claude-code' },
+  { tool: 'Bash', command: 'git push origin main', agent: 'claude-code' },
+  { tool: 'Write', file: '.env', content: 'SECRET=leaked', agent: 'claude-code' },
+];
+
+process.stderr.write(
+  renderBanner({ policyName: 'Demo Safety Policy', invariantCount: 6 })
+);
+
+const results = [];
+for (const action of actions) {
+  const result = await kernel.propose(action);
+  results.push(result);
+  process.stderr.write(renderKernelResult(result, true) + '\n');
+}
+
+process.stderr.write(renderActionGraph(results));
+
+const allowed = results.filter((r) => r.allowed).length;
+const denied = results.filter((r) => !r.allowed).length;
+process.stderr.write(
+  `  \x1b[2m${allowed} allowed, ${denied} denied, ${kernel.getEventCount()} events emitted\x1b[0m\n\n`
+);
+
+kernel.shutdown();


### PR DESCRIPTION
## Summary

- **Merge governed-action-kernel** into main (kernel, 5 adapters, YAML policy loader, TUI renderer, JSONL sink, `guard`/`inspect` CLI commands, 38 new tests)
- **Add `agentguard.yaml`** default policy in repo root — auto-discovered by `findDefaultPolicy()` in the guard command. Demonstrates all rule features (deny branches, deny targets, allow defaults)
- **Add `scripts/demo.js`** and `npm run demo:guard` — self-contained governance demo that simulates 5 agent actions (3 allowed, 2 denied) with full TUI output and action graph
- **Add `examples/`** directory with governance examples: annotated policy YAML, minimal evaluate-action script, and Claude Code PreToolUse hook wiring
- **Update README** with "30 seconds to see it work" quick start section showing clone → install → demo flow with expected output
- **Add `.agentguard/`** to `.gitignore` (prevents accidental commit of JSONL event logs)

## Test plan

- [x] `npm run build:ts` — TypeScript compiles cleanly
- [x] `npm run demo:guard` — Shows 3 allowed + 2 denied actions with TUI output
- [x] `echo '{"tool":"Bash","command":"git push origin main"}' | node dist/cli/bin.js guard --dry-run` — Correctly denied by default policy
- [x] `node examples/evaluate-action.js` — Prints DENIED with correct reason
- [x] `npm test` — All 1085 JS tests pass
- [x] `npm run ts:test` — All 345 TS tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)