### PR TITLE
Add decision records and pre-execution simulation

### DIFF
--- a/src/agentguard/decisions/factory.ts
+++ b/src/agentguard/decisions/factory.ts
@@ -1,0 +1,70 @@
+// Decision record factory — builds GovernanceDecisionRecord from kernel data.
+// Pure logic. Combines MonitorDecision + execution result into a single record.
+
+import type { GovernanceDecisionRecord, SimulationSummary } from './types.js';
+import type { MonitorDecision } from '../monitor.js';
+import type { ExecutionResult } from '../../core/types.js';
+import { simpleHash } from '../../domain/hash.js';
+
+export interface DecisionFactoryInput {
+  runId: string;
+  decision: MonitorDecision;
+  execution: ExecutionResult | null;
+  executionDurationMs: number | null;
+  simulation: SimulationSummary | null;
+}
+
+function generateRecordId(timestamp: number, runId: string, action: string): string {
+  const content = `${timestamp}:${runId}:${action}`;
+  return `dec_${timestamp}_${simpleHash(content)}`;
+}
+
+export function buildDecisionRecord(input: DecisionFactoryInput): GovernanceDecisionRecord {
+  const { runId, decision, execution, executionDurationMs, simulation } = input;
+  const timestamp = Date.now();
+  const intent = decision.intent;
+
+  return {
+    recordId: generateRecordId(timestamp, runId, intent.action),
+    runId,
+    timestamp,
+    action: {
+      type: intent.action,
+      target: intent.target,
+      agent: intent.agent,
+      destructive: intent.destructive,
+      command: intent.command,
+    },
+    outcome: decision.allowed ? 'allow' : 'deny',
+    reason: decision.decision.reason,
+    intervention: decision.intervention,
+    policy: {
+      matchedPolicyId: decision.decision.matchedPolicy?.id ?? null,
+      matchedPolicyName: decision.decision.matchedPolicy?.name ?? null,
+      severity: decision.decision.severity,
+    },
+    invariants: {
+      allHold: decision.violations.length === 0,
+      violations: decision.violations.map((v) => ({
+        invariantId: v.invariantId,
+        name: v.name,
+        severity: v.severity,
+        expected: v.expected,
+        actual: v.actual,
+      })),
+    },
+    simulation,
+    evidencePackId: decision.evidencePack?.packId ?? null,
+    monitor: {
+      escalationLevel: decision.monitor.escalationLevel,
+      totalEvaluations: decision.monitor.totalEvaluations,
+      totalDenials: decision.monitor.totalDenials,
+    },
+    execution: {
+      executed: execution !== null,
+      success: execution?.success ?? null,
+      durationMs: executionDurationMs,
+      error: execution?.error ?? null,
+    },
+  };
+}

--- a/src/agentguard/decisions/types.ts
+++ b/src/agentguard/decisions/types.ts
@@ -1,0 +1,75 @@
+// Governance Decision Record — first-class audit artifact.
+// Aggregates monitor decision, execution data, and evidence into
+// a single persisted, queryable record per agent action.
+
+export interface GovernanceDecisionRecord {
+  /** Unique record ID: "dec_<timestamp>_<hash>" */
+  recordId: string;
+  /** Kernel run ID this decision belongs to */
+  runId: string;
+  /** When the decision was made */
+  timestamp: number;
+  /** The action that was evaluated */
+  action: {
+    type: string;
+    target: string;
+    agent: string;
+    destructive: boolean;
+    command?: string;
+  };
+  /** Final governance outcome */
+  outcome: 'allow' | 'deny';
+  /** Human-readable reason for the outcome */
+  reason: string;
+  /** Intervention type if denied (deny, rollback, pause, test-only) */
+  intervention: string | null;
+  /** Policy matching details */
+  policy: {
+    matchedPolicyId: string | null;
+    matchedPolicyName: string | null;
+    severity: number;
+  };
+  /** Invariant evaluation results */
+  invariants: {
+    allHold: boolean;
+    violations: Array<{
+      invariantId: string;
+      name: string;
+      severity: number;
+      expected: string;
+      actual: string;
+    }>;
+  };
+  /** Pre-execution simulation results (Phase 2 integration point) */
+  simulation: SimulationSummary | null;
+  /** Evidence pack ID if generated */
+  evidencePackId: string | null;
+  /** Monitor state at decision time */
+  monitor: {
+    escalationLevel: number;
+    totalEvaluations: number;
+    totalDenials: number;
+  };
+  /** Execution results (null if denied or dry-run) */
+  execution: {
+    executed: boolean;
+    success: boolean | null;
+    durationMs: number | null;
+    error: string | null;
+  };
+}
+
+/** Placeholder for Phase 2 simulation integration */
+export interface SimulationSummary {
+  predictedChanges: string[];
+  blastRadius: number;
+  riskLevel: 'low' | 'medium' | 'high';
+  simulatorId: string;
+  durationMs: number;
+}
+
+/** Sink interface for decision records (mirrors EventSink pattern) */
+export interface DecisionSink {
+  write(record: GovernanceDecisionRecord): void;
+  flush?(): void;
+}

--- a/src/agentguard/invariants/definitions.ts
+++ b/src/agentguard/invariants/definitions.ts
@@ -25,6 +25,10 @@ export interface SystemState {
   filesAffected?: number;
   blastRadiusLimit?: number;
   protectedBranches?: string[];
+  /** Blast radius from pre-execution simulation (overrides filesAffected in blast-radius check) */
+  simulatedBlastRadius?: number;
+  /** Risk level from pre-execution simulation */
+  simulatedRiskLevel?: string;
 }
 
 export const DEFAULT_INVARIANTS: AgentGuardInvariant[] = [
@@ -74,11 +78,13 @@ export const DEFAULT_INVARIANTS: AgentGuardInvariant[] = [
     severity: 3,
     check(state) {
       const limit = state.blastRadiusLimit || 20;
-      const count = state.filesAffected || 0;
+      // Prefer simulated blast radius over static file count when available
+      const count = state.simulatedBlastRadius ?? state.filesAffected ?? 0;
+      const source = state.simulatedBlastRadius !== undefined ? 'simulated' : 'static';
       return {
         holds: count <= limit,
         expected: `At most ${limit} files modified`,
-        actual: `${count} files modified`,
+        actual: `${count} files modified (${source})`,
       };
     },
   },

--- a/src/agentguard/kernel.ts
+++ b/src/agentguard/kernel.ts
@@ -1,6 +1,7 @@
 // Governed Action Kernel — the core orchestrator.
 // Connects monitor (AAB + policy + invariants) with execution adapters.
 // Emits full action lifecycle events: REQUESTED → ALLOWED/DENIED → EXECUTED/FAILED.
+// Builds GovernanceDecisionRecords and sinks them for audit.
 
 import type { DomainEvent, CanonicalAction } from '../core/types.js';
 import { createMonitor } from './monitor.js';
@@ -16,8 +17,13 @@ import {
   ACTION_DENIED,
   ACTION_EXECUTED,
   ACTION_FAILED,
+  DECISION_RECORDED,
+  SIMULATION_COMPLETED,
 } from '../domain/events.js';
 import { simpleHash } from '../domain/hash.js';
+import type { GovernanceDecisionRecord, DecisionSink } from './decisions/types.js';
+import { buildDecisionRecord } from './decisions/factory.js';
+import type { SimulatorRegistry } from './simulation/types.js';
 
 export interface KernelResult {
   allowed: boolean;
@@ -27,6 +33,8 @@ export interface KernelResult {
   action: CanonicalAction | null;
   events: DomainEvent[];
   runId: string;
+  /** Governance decision record (additive — not present in older results) */
+  decisionRecord?: GovernanceDecisionRecord;
 }
 
 export interface EventSink {
@@ -39,6 +47,12 @@ export interface KernelConfig extends MonitorConfig {
   sinks?: EventSink[];
   adapters?: AdapterRegistry;
   dryRun?: boolean;
+  /** Optional decision sinks for persisting GovernanceDecisionRecords */
+  decisionSinks?: DecisionSink[];
+  /** Optional simulator registry for pre-execution impact simulation */
+  simulators?: SimulatorRegistry;
+  /** Blast radius threshold — simulation above this triggers invariant re-check */
+  simulationBlastRadiusThreshold?: number;
 }
 
 export interface Kernel {
@@ -59,8 +73,11 @@ function generateRunId(): string {
 export function createKernel(config: KernelConfig = {}): Kernel {
   const runId = config.runId || generateRunId();
   const sinks: EventSink[] = config.sinks || [];
+  const decisionSinks: DecisionSink[] = config.decisionSinks || [];
   const adapters = config.adapters || createAdapterRegistry();
   const dryRun = config.dryRun ?? false;
+  const simulators = config.simulators || null;
+  const blastRadiusThreshold = config.simulationBlastRadiusThreshold ?? 50;
   const actionLog: KernelResult[] = [];
   let eventCount = 0;
 
@@ -82,6 +99,12 @@ export function createKernel(config: KernelConfig = {}): Kernel {
   function sinkEvents(events: DomainEvent[]): void {
     for (const event of events) {
       sinkEvent(event);
+    }
+  }
+
+  function sinkDecision(record: GovernanceDecisionRecord): void {
+    for (const sink of decisionSinks) {
+      sink.write(record);
     }
   }
 
@@ -123,7 +146,7 @@ export function createKernel(config: KernelConfig = {}): Kernel {
       sinkEvents(decision.events);
 
       if (!decision.allowed) {
-        // 5a. DENIED — emit denial event
+        // 5a. DENIED — emit denial event, build decision record
         const deniedEvent = createEvent(ACTION_DENIED, {
           actionType: decision.intent.action,
           target: decision.intent.target,
@@ -139,6 +162,25 @@ export function createKernel(config: KernelConfig = {}): Kernel {
         allEvents.push(deniedEvent);
         sinkEvents(allEvents);
 
+        const decisionRecord = buildDecisionRecord({
+          runId,
+          decision,
+          execution: null,
+          executionDurationMs: null,
+          simulation: null,
+        });
+        sinkDecision(decisionRecord);
+
+        // Emit DECISION_RECORDED event
+        const decisionEvent = createEvent(DECISION_RECORDED, {
+          recordId: decisionRecord.recordId,
+          outcome: decisionRecord.outcome,
+          actionType: decisionRecord.action.type,
+          target: decisionRecord.action.target,
+          reason: decisionRecord.reason,
+        });
+        sinkEvent(decisionEvent);
+
         const result: KernelResult = {
           allowed: false,
           executed: false,
@@ -147,12 +189,151 @@ export function createKernel(config: KernelConfig = {}): Kernel {
           action,
           events: allEvents,
           runId,
+          decisionRecord,
         };
         actionLog.push(result);
         return result;
       }
 
-      // 5b. ALLOWED — emit allowed event
+      // 5b. ALLOWED — run simulation if available, then re-check
+      let simulationResult = null;
+
+      if (simulators && simulators.find(decision.intent)) {
+        const simulator = simulators.find(decision.intent)!;
+        try {
+          simulationResult = await simulator.simulate(decision.intent, systemContext);
+
+          // Emit simulation event
+          const simEvent = createEvent(SIMULATION_COMPLETED, {
+            simulatorId: simulationResult.simulatorId,
+            riskLevel: simulationResult.riskLevel,
+            blastRadius: simulationResult.blastRadius,
+            predictedChanges: simulationResult.predictedChanges,
+            durationMs: simulationResult.durationMs,
+          });
+          allEvents.push(simEvent);
+          sinkEvent(simEvent);
+
+          // Re-check invariants if simulation reveals elevated risk
+          if (
+            simulationResult.blastRadius > blastRadiusThreshold ||
+            simulationResult.riskLevel === 'high'
+          ) {
+            // Import checker for re-check
+            const { checkAllInvariants, buildSystemState } = await import(
+              './invariants/checker.js'
+            );
+            const { DEFAULT_INVARIANTS } = await import('./invariants/definitions.js');
+
+            const reCheckState = buildSystemState({
+              ...systemContext,
+              filesAffected: simulationResult.blastRadius,
+              simulatedBlastRadius: simulationResult.blastRadius,
+              simulatedRiskLevel: simulationResult.riskLevel,
+              targetBranch: decision.intent.branch || (systemContext.targetBranch as string),
+              forcePush: decision.intent.action === 'git.force-push',
+              directPush: decision.intent.action === 'git.push',
+              isPush:
+                decision.intent.action === 'git.push' ||
+                decision.intent.action === 'git.force-push',
+            });
+
+            const reCheck = checkAllInvariants(
+              config.invariants || DEFAULT_INVARIANTS,
+              reCheckState
+            );
+
+            if (!reCheck.allHold) {
+              // Simulation-triggered denial
+              sinkEvents(reCheck.events);
+
+              const deniedEvent = createEvent(ACTION_DENIED, {
+                actionType: decision.intent.action,
+                target: decision.intent.target,
+                reason: `Simulation revealed elevated risk: ${simulationResult.riskLevel} (blast radius: ${simulationResult.blastRadius})`,
+                actionId: action?.id,
+                metadata: {
+                  runId,
+                  simulationTriggered: true,
+                  simulatorId: simulationResult.simulatorId,
+                  violations: reCheck.violations.map((v) => ({
+                    invariantId: v.invariant.id,
+                    name: v.invariant.name,
+                    severity: v.invariant.severity,
+                    expected: v.result.expected,
+                    actual: v.result.actual,
+                  })),
+                },
+              });
+              allEvents.push(deniedEvent);
+              sinkEvents(allEvents);
+
+              const simSummary = {
+                predictedChanges: simulationResult.predictedChanges,
+                blastRadius: simulationResult.blastRadius,
+                riskLevel: simulationResult.riskLevel,
+                simulatorId: simulationResult.simulatorId,
+                durationMs: simulationResult.durationMs,
+              };
+
+              const decisionRecord = buildDecisionRecord({
+                runId,
+                decision: {
+                  ...decision,
+                  allowed: false,
+                  violations: reCheck.violations.map((v) => ({
+                    invariantId: v.invariant.id,
+                    name: v.invariant.name,
+                    severity: v.invariant.severity,
+                    expected: v.result.expected,
+                    actual: v.result.actual,
+                  })),
+                },
+                execution: null,
+                executionDurationMs: null,
+                simulation: simSummary,
+              });
+              sinkDecision(decisionRecord);
+
+              const decisionEvent = createEvent(DECISION_RECORDED, {
+                recordId: decisionRecord.recordId,
+                outcome: 'deny',
+                actionType: decisionRecord.action.type,
+                target: decisionRecord.action.target,
+                reason: `Simulation-triggered denial`,
+              });
+              sinkEvent(decisionEvent);
+
+              const result: KernelResult = {
+                allowed: false,
+                executed: false,
+                decision: {
+                  ...decision,
+                  allowed: false,
+                  violations: reCheck.violations.map((v) => ({
+                    invariantId: v.invariant.id,
+                    name: v.invariant.name,
+                    severity: v.invariant.severity,
+                    expected: v.result.expected,
+                    actual: v.result.actual,
+                  })),
+                },
+                execution: null,
+                action,
+                events: allEvents,
+                runId,
+                decisionRecord,
+              };
+              actionLog.push(result);
+              return result;
+            }
+          }
+        } catch {
+          // Simulation failure is non-fatal — continue with execution
+        }
+      }
+
+      // Emit allowed event
       const allowedEvent = createEvent(ACTION_ALLOWED, {
         actionType: decision.intent.action,
         target: decision.intent.target,
@@ -165,10 +346,11 @@ export function createKernel(config: KernelConfig = {}): Kernel {
 
       // 6. Execute via adapter (unless dry-run)
       let execution: ExecutionResult | null = null;
+      let executionDurationMs: number | null = null;
       if (!dryRun && action) {
         const actionClass = getActionClass(action.type);
         if (actionClass && adapters.has(actionClass)) {
-          const decisionRecord: DecisionRecord = {
+          const adapterDecisionRecord: DecisionRecord = {
             actionId: action.id,
             decision: 'allow',
             reason: decision.decision.reason,
@@ -178,41 +360,39 @@ export function createKernel(config: KernelConfig = {}): Kernel {
 
           const startTime = Date.now();
           try {
-            execution = await adapters.execute(action, decisionRecord);
-            const duration = Date.now() - startTime;
+            execution = await adapters.execute(action, adapterDecisionRecord);
+            executionDurationMs = Date.now() - startTime;
 
             if (execution.success) {
-              // 7a. Execution succeeded
               const executedEvent = createEvent(ACTION_EXECUTED, {
                 actionType: action.type,
                 target: action.target,
                 result: 'success',
                 actionId: action.id,
-                duration,
+                duration: executionDurationMs,
                 metadata: { runId },
               });
               allEvents.push(executedEvent);
             } else {
-              // 7b. Execution failed
               const failedEvent = createEvent(ACTION_FAILED, {
                 actionType: action.type,
                 target: action.target,
                 error: execution.error || 'Unknown execution error',
                 actionId: action.id,
-                duration,
+                duration: executionDurationMs,
                 metadata: { runId },
               });
               allEvents.push(failedEvent);
             }
           } catch (err) {
-            const duration = Date.now() - startTime;
+            executionDurationMs = Date.now() - startTime;
             execution = { success: false, error: (err as Error).message };
             const failedEvent = createEvent(ACTION_FAILED, {
               actionType: action.type,
               target: action.target,
               error: (err as Error).message,
               actionId: action.id,
-              duration,
+              duration: executionDurationMs,
               metadata: { runId },
             });
             allEvents.push(failedEvent);
@@ -222,6 +402,36 @@ export function createKernel(config: KernelConfig = {}): Kernel {
 
       sinkEvents(allEvents);
 
+      // Build and sink governance decision record
+      const simSummary = simulationResult
+        ? {
+            predictedChanges: simulationResult.predictedChanges,
+            blastRadius: simulationResult.blastRadius,
+            riskLevel: simulationResult.riskLevel,
+            simulatorId: simulationResult.simulatorId,
+            durationMs: simulationResult.durationMs,
+          }
+        : null;
+
+      const decisionRecord = buildDecisionRecord({
+        runId,
+        decision,
+        execution,
+        executionDurationMs,
+        simulation: simSummary,
+      });
+      sinkDecision(decisionRecord);
+
+      // Emit DECISION_RECORDED event
+      const decisionEvent = createEvent(DECISION_RECORDED, {
+        recordId: decisionRecord.recordId,
+        outcome: decisionRecord.outcome,
+        actionType: decisionRecord.action.type,
+        target: decisionRecord.action.target,
+        reason: decisionRecord.reason,
+      });
+      sinkEvent(decisionEvent);
+
       const result: KernelResult = {
         allowed: true,
         executed: execution !== null,
@@ -230,6 +440,7 @@ export function createKernel(config: KernelConfig = {}): Kernel {
         action,
         events: allEvents,
         runId,
+        decisionRecord,
       };
       actionLog.push(result);
       return result;
@@ -249,6 +460,9 @@ export function createKernel(config: KernelConfig = {}): Kernel {
 
     shutdown() {
       for (const sink of sinks) {
+        if (sink.flush) sink.flush();
+      }
+      for (const sink of decisionSinks) {
         if (sink.flush) sink.flush();
       }
     },

--- a/src/agentguard/renderers/tui.ts
+++ b/src/agentguard/renderers/tui.ts
@@ -3,6 +3,8 @@
 
 import type { KernelResult } from '../kernel.js';
 import type { MonitorDecision } from '../monitor.js';
+import type { GovernanceDecisionRecord } from '../decisions/types.js';
+import type { SimulationResult } from '../simulation/types.js';
 
 const ANSI = {
   reset: '\x1b[0m',
@@ -104,6 +106,91 @@ export function renderMonitorStatus(decision: MonitorDecision): string {
           : ANSI.bold + ANSI.red;
 
   return `  ${ANSI.dim}[${levelColor}${level}${ANSI.reset}${ANSI.dim}] evals:${m.totalEvaluations} denied:${m.totalDenials} violations:${m.totalViolations}${ANSI.reset}`;
+}
+
+export function renderSimulation(simulation: SimulationResult): string {
+  const lines: string[] = [];
+  const riskColor =
+    simulation.riskLevel === 'high'
+      ? ANSI.red
+      : simulation.riskLevel === 'medium'
+        ? ANSI.yellow
+        : ANSI.green;
+
+  lines.push(`  ${ANSI.bold}${ANSI.blue}Simulation${ANSI.reset} ${ANSI.dim}(${simulation.simulatorId})${ANSI.reset}`);
+
+  for (const change of simulation.predictedChanges) {
+    lines.push(`    ${ANSI.dim}${ICONS.bullet} ${change}${ANSI.reset}`);
+  }
+
+  lines.push(
+    `    blast radius: ${ANSI.bold}${simulation.blastRadius}${ANSI.reset} | risk: ${riskColor}${simulation.riskLevel}${ANSI.reset} | ${ANSI.dim}${simulation.durationMs}ms${ANSI.reset}`
+  );
+
+  return lines.join('\n');
+}
+
+export function renderDecisionRecord(record: GovernanceDecisionRecord): string {
+  const lines: string[] = [];
+  const outcomeColor = record.outcome === 'allow' ? ANSI.green : ANSI.red;
+  const outcomeIcon = record.outcome === 'allow' ? ICONS.allowed : ICONS.denied;
+
+  lines.push(`  ${ANSI.bold}Decision Record${ANSI.reset} ${ANSI.dim}${record.recordId}${ANSI.reset}`);
+  lines.push(`    action: ${record.action.type} ${ANSI.dim}${record.action.target}${ANSI.reset}`);
+  lines.push(`    outcome: ${outcomeColor}${outcomeIcon} ${record.outcome.toUpperCase()}${ANSI.reset}`);
+  lines.push(`    reason: ${ANSI.dim}${record.reason}${ANSI.reset}`);
+
+  if (record.policy.matchedPolicyId) {
+    lines.push(`    policy: ${ANSI.dim}${record.policy.matchedPolicyName} (${record.policy.matchedPolicyId})${ANSI.reset}`);
+  }
+
+  if (record.invariants.violations.length > 0) {
+    for (const v of record.invariants.violations) {
+      lines.push(`    ${ANSI.yellow}${ICONS.warning} ${v.name}${ANSI.reset} ${ANSI.dim}(${v.actual})${ANSI.reset}`);
+    }
+  }
+
+  if (record.simulation) {
+    const sim = record.simulation;
+    const riskColor = sim.riskLevel === 'high' ? ANSI.red : sim.riskLevel === 'medium' ? ANSI.yellow : ANSI.green;
+    lines.push(`    simulation: blast=${sim.blastRadius} risk=${riskColor}${sim.riskLevel}${ANSI.reset}`);
+  }
+
+  if (record.execution.executed) {
+    const execStatus = record.execution.success
+      ? `${ANSI.green}success${ANSI.reset}`
+      : `${ANSI.red}failed${ANSI.reset}`;
+    lines.push(`    execution: ${execStatus} ${ANSI.dim}(${record.execution.durationMs}ms)${ANSI.reset}`);
+  }
+
+  return lines.join('\n');
+}
+
+export function renderDecisionTable(records: GovernanceDecisionRecord[]): string {
+  const lines: string[] = [];
+  lines.push('');
+  lines.push(`  ${ANSI.bold}Decision Records${ANSI.reset} ${ANSI.dim}(${records.length} decisions)${ANSI.reset}`);
+  lines.push(`  ${ANSI.dim}${'─'.repeat(50)}${ANSI.reset}`);
+
+  for (let i = 0; i < records.length; i++) {
+    const r = records[i];
+    const num = `${i + 1}.`.padStart(4);
+    const icon = r.outcome === 'allow'
+      ? `${ANSI.green}${ICONS.allowed}${ANSI.reset}`
+      : `${ANSI.red}${ICONS.denied}${ANSI.reset}`;
+
+    lines.push(`  ${num} ${icon} ${r.action.type} ${ANSI.dim}${r.action.target}${ANSI.reset}`);
+    lines.push(`       ${ANSI.dim}${r.reason}${ANSI.reset}`);
+
+    if (r.invariants.violations.length > 0) {
+      for (const v of r.invariants.violations) {
+        lines.push(`       ${ANSI.yellow}${ICONS.warning} ${v.name}${ANSI.reset}`);
+      }
+    }
+  }
+
+  lines.push('');
+  return lines.join('\n');
 }
 
 export function renderKernelResult(result: KernelResult, verbose?: boolean): string {

--- a/src/agentguard/simulation/filesystem-simulator.ts
+++ b/src/agentguard/simulation/filesystem-simulator.ts
@@ -1,0 +1,105 @@
+// Filesystem simulator — predicts impact of file operations.
+// Evaluates path sensitivity without touching the filesystem.
+
+import type { NormalizedIntent } from '../policies/evaluator.js';
+import type { ActionSimulator, SimulationResult } from './types.js';
+
+const FILE_ACTIONS = new Set(['file.write', 'file.delete']);
+
+// Reuses sensitive path patterns from no-secret-exposure invariant
+const SENSITIVE_PATTERNS = ['.env', 'credentials', '.pem', '.key', 'secret', 'token'];
+
+const CONFIG_PATTERNS = [
+  'package.json',
+  'tsconfig.json',
+  'eslint',
+  '.prettierrc',
+  'webpack.config',
+  'vite.config',
+  'next.config',
+  'jest.config',
+  'vitest.config',
+  '.babelrc',
+  'babel.config',
+];
+
+const LOCKFILE_PATTERNS = ['package-lock.json', 'yarn.lock', 'pnpm-lock.yaml'];
+
+const CI_PATTERNS = ['.github/', '.gitlab-ci', 'Jenkinsfile', '.circleci/', 'Dockerfile'];
+
+function assessPathRisk(target: string): {
+  riskLevel: 'low' | 'medium' | 'high';
+  reasons: string[];
+} {
+  const lower = target.toLowerCase();
+  const reasons: string[] = [];
+  let riskLevel: 'low' | 'medium' | 'high' = 'low';
+
+  // Check sensitive files (highest risk)
+  if (SENSITIVE_PATTERNS.some((p) => lower.includes(p))) {
+    riskLevel = 'high';
+    reasons.push(`Sensitive file: ${target}`);
+  }
+
+  // Check lockfiles
+  if (LOCKFILE_PATTERNS.some((p) => lower.includes(p))) {
+    riskLevel = riskLevel === 'high' ? 'high' : 'medium';
+    reasons.push(`Lockfile modification: ${target}`);
+  }
+
+  // Check CI/CD configs
+  if (CI_PATTERNS.some((p) => lower.includes(p))) {
+    riskLevel = riskLevel === 'high' ? 'high' : 'medium';
+    reasons.push(`CI/CD config: ${target}`);
+  }
+
+  // Check project configs
+  if (CONFIG_PATTERNS.some((p) => lower.includes(p))) {
+    riskLevel = riskLevel === 'low' ? 'medium' : riskLevel;
+    reasons.push(`Project config: ${target}`);
+  }
+
+  return { riskLevel, reasons };
+}
+
+export function createFilesystemSimulator(): ActionSimulator {
+  return {
+    id: 'filesystem-simulator',
+
+    supports(intent: NormalizedIntent): boolean {
+      return FILE_ACTIONS.has(intent.action);
+    },
+
+    async simulate(intent: NormalizedIntent): Promise<SimulationResult> {
+      const start = Date.now();
+      const target = intent.target || '';
+      const { riskLevel, reasons } = assessPathRisk(target);
+
+      const predictedChanges: string[] = [];
+      const details: Record<string, unknown> = {};
+
+      if (intent.action === 'file.delete') {
+        predictedChanges.push(`Delete: ${target}`);
+        details.operation = 'delete';
+      } else {
+        predictedChanges.push(`Write: ${target}`);
+        details.operation = 'write';
+      }
+
+      predictedChanges.push(...reasons);
+      details.pathRisk = riskLevel;
+      details.sensitiveMatch = SENSITIVE_PATTERNS.some((p) =>
+        target.toLowerCase().includes(p)
+      );
+
+      return {
+        predictedChanges,
+        blastRadius: intent.filesAffected || 1,
+        riskLevel,
+        details,
+        simulatorId: 'filesystem-simulator',
+        durationMs: Date.now() - start,
+      };
+    },
+  };
+}

--- a/src/agentguard/simulation/git-simulator.ts
+++ b/src/agentguard/simulation/git-simulator.ts
@@ -1,0 +1,101 @@
+// Git simulator — predicts impact of git operations.
+// Runs git commands to assess risk without modifying state.
+
+import { execSync } from 'node:child_process';
+import type { NormalizedIntent } from '../policies/evaluator.js';
+import type { ActionSimulator, SimulationResult } from './types.js';
+
+const GIT_ACTIONS = new Set(['git.push', 'git.force-push', 'git.merge', 'git.branch.delete']);
+
+export function createGitSimulator(): ActionSimulator {
+  return {
+    id: 'git-simulator',
+
+    supports(intent: NormalizedIntent): boolean {
+      return GIT_ACTIONS.has(intent.action);
+    },
+
+    async simulate(
+      intent: NormalizedIntent,
+      context: Record<string, unknown>
+    ): Promise<SimulationResult> {
+      const start = Date.now();
+      const predictedChanges: string[] = [];
+      const details: Record<string, unknown> = {};
+      let blastRadius = 0;
+      let riskLevel: 'low' | 'medium' | 'high' = 'low';
+
+      // Force push is always high risk
+      if (intent.action === 'git.force-push') {
+        riskLevel = 'high';
+        predictedChanges.push('Force push will rewrite remote history');
+        details.forcePush = true;
+        blastRadius = 100; // Maximum blast radius signal
+      }
+
+      // Count unpushed commits
+      const branch = intent.branch || intent.target || '';
+      if (branch && (intent.action === 'git.push' || intent.action === 'git.force-push')) {
+        try {
+          const count = execSync(`git rev-list --count origin/${branch}..HEAD`, {
+            encoding: 'utf8',
+            timeout: 5000,
+          }).trim();
+          const unpushed = parseInt(count, 10);
+          if (!isNaN(unpushed)) {
+            details.unpushedCommits = unpushed;
+            blastRadius = Math.max(blastRadius, unpushed);
+            predictedChanges.push(`${unpushed} unpushed commit(s) to ${branch}`);
+            if (unpushed > 10) riskLevel = riskLevel === 'high' ? 'high' : 'medium';
+          }
+        } catch {
+          // Branch may not have a remote — not an error
+          details.remoteTrackingError = true;
+        }
+      }
+
+      // Check for protected branch push
+      const protectedBranches = (context.protectedBranches as string[]) || ['main', 'master'];
+      if (branch && protectedBranches.includes(branch)) {
+        riskLevel = riskLevel === 'low' ? 'medium' : riskLevel;
+        predictedChanges.push(`Push targets protected branch: ${branch}`);
+        details.protectedBranch = true;
+      }
+
+      // Git merge: check for conflicts
+      if (intent.action === 'git.merge' && branch) {
+        try {
+          const diffStat = execSync(`git diff --stat HEAD...${branch}`, {
+            encoding: 'utf8',
+            timeout: 5000,
+          }).trim();
+          const fileCount = (diffStat.match(/\d+ files? changed/)?.[0] || '').match(/\d+/)?.[0];
+          if (fileCount) {
+            const count = parseInt(fileCount, 10);
+            blastRadius = Math.max(blastRadius, count);
+            predictedChanges.push(`Merge would affect ${count} file(s)`);
+            if (count > 20) riskLevel = riskLevel === 'high' ? 'high' : 'medium';
+          }
+        } catch {
+          details.mergeSimError = true;
+        }
+      }
+
+      // Branch delete
+      if (intent.action === 'git.branch.delete') {
+        predictedChanges.push(`Delete branch: ${branch}`);
+        riskLevel = protectedBranches.includes(branch) ? 'high' : 'low';
+        blastRadius = protectedBranches.includes(branch) ? 100 : 1;
+      }
+
+      return {
+        predictedChanges,
+        blastRadius,
+        riskLevel,
+        details,
+        simulatorId: 'git-simulator',
+        durationMs: Date.now() - start,
+      };
+    },
+  };
+}

--- a/src/agentguard/simulation/package-simulator.ts
+++ b/src/agentguard/simulation/package-simulator.ts
@@ -1,0 +1,129 @@
+// Package simulator — predicts impact of package management operations.
+// Uses `npm install --dry-run` to preview dependency changes.
+
+import { execSync } from 'node:child_process';
+import type { NormalizedIntent } from '../policies/evaluator.js';
+import type { ActionSimulator, SimulationResult } from './types.js';
+
+const INSTALL_PATTERNS = [
+  /\bnpm\s+install\b/,
+  /\bnpm\s+i\b/,
+  /\byarn\s+add\b/,
+  /\bpnpm\s+add\b/,
+  /\bpnpm\s+install\b/,
+  /\bnpm\s+uninstall\b/,
+  /\bnpm\s+remove\b/,
+  /\byarn\s+remove\b/,
+  /\bpnpm\s+remove\b/,
+];
+
+function isPackageCommand(command: string | undefined): boolean {
+  if (!command) return false;
+  return INSTALL_PATTERNS.some((p) => p.test(command));
+}
+
+function parseNpmDryRunOutput(output: string): {
+  added: number;
+  removed: number;
+  changed: number;
+  packages: string[];
+} {
+  let added = 0;
+  let removed = 0;
+  let changed = 0;
+  const packages: string[] = [];
+
+  // Parse "added X packages" style output
+  const addedMatch = output.match(/added\s+(\d+)\s+package/);
+  if (addedMatch) added = parseInt(addedMatch[1], 10);
+
+  const removedMatch = output.match(/removed\s+(\d+)\s+package/);
+  if (removedMatch) removed = parseInt(removedMatch[1], 10);
+
+  const changedMatch = output.match(/changed\s+(\d+)\s+package/);
+  if (changedMatch) changed = parseInt(changedMatch[1], 10);
+
+  // Extract package names from lines like "+ package@version"
+  const lines = output.split('\n');
+  for (const line of lines) {
+    const pkgMatch = line.match(/[+\-]\s+(\S+@\S+)/);
+    if (pkgMatch) packages.push(pkgMatch[1]);
+  }
+
+  return { added, removed, changed, packages };
+}
+
+export function createPackageSimulator(): ActionSimulator {
+  return {
+    id: 'package-simulator',
+
+    supports(intent: NormalizedIntent): boolean {
+      return intent.action === 'shell.exec' && isPackageCommand(intent.command);
+    },
+
+    async simulate(intent: NormalizedIntent): Promise<SimulationResult> {
+      const start = Date.now();
+      const command = intent.command || '';
+      const predictedChanges: string[] = [];
+      const details: Record<string, unknown> = {};
+      let blastRadius = 0;
+      let riskLevel: 'low' | 'medium' | 'high' = 'low';
+
+      // Try npm install --dry-run to preview changes
+      if (/\bnpm\s+(install|i)\b/.test(command)) {
+        const dryRunCmd = command.replace(/\bnpm\s+(install|i)\b/, 'npm install --dry-run');
+        try {
+          const output = execSync(dryRunCmd, {
+            encoding: 'utf8',
+            timeout: 30000,
+            env: { ...process.env, npm_config_fund: 'false', npm_config_audit: 'false' },
+          });
+
+          const parsed = parseNpmDryRunOutput(output);
+          details.npmDryRun = parsed;
+          blastRadius = parsed.added + parsed.removed + parsed.changed;
+
+          if (parsed.added > 0) predictedChanges.push(`${parsed.added} packages added`);
+          if (parsed.removed > 0) predictedChanges.push(`${parsed.removed} packages removed`);
+          if (parsed.changed > 0) predictedChanges.push(`${parsed.changed} packages changed`);
+          if (parsed.packages.length > 0) {
+            details.affectedPackages = parsed.packages;
+          }
+        } catch {
+          // Dry-run failed — estimate from command
+          details.dryRunFailed = true;
+          predictedChanges.push('Package installation (dry-run unavailable)');
+          blastRadius = 10; // Conservative estimate
+        }
+      } else {
+        // For yarn/pnpm or remove commands, do basic analysis
+        predictedChanges.push(`Package operation: ${command}`);
+        blastRadius = 5; // Conservative estimate
+        details.estimatedOnly = true;
+      }
+
+      // Risk assessment
+      if (blastRadius > 50) {
+        riskLevel = 'high';
+      } else if (blastRadius > 10) {
+        riskLevel = 'medium';
+      }
+
+      // Check for global installs (always medium+ risk)
+      if (/\s-g\b|\s--global\b/.test(command)) {
+        riskLevel = riskLevel === 'high' ? 'high' : 'medium';
+        predictedChanges.push('Global package installation');
+        details.globalInstall = true;
+      }
+
+      return {
+        predictedChanges,
+        blastRadius,
+        riskLevel,
+        details,
+        simulatorId: 'package-simulator',
+        durationMs: Date.now() - start,
+      };
+    },
+  };
+}

--- a/src/agentguard/simulation/registry.ts
+++ b/src/agentguard/simulation/registry.ts
@@ -1,0 +1,28 @@
+// Simulator registry — routes intents to the correct ActionSimulator.
+// Same array-based pattern as AdapterRegistry.
+
+import type { NormalizedIntent } from '../policies/evaluator.js';
+import type { ActionSimulator, SimulatorRegistry } from './types.js';
+
+export function createSimulatorRegistry(): SimulatorRegistry {
+  const simulators: ActionSimulator[] = [];
+
+  return {
+    register(simulator: ActionSimulator): void {
+      // Prevent duplicate registration
+      if (simulators.some((s) => s.id === simulator.id)) return;
+      simulators.push(simulator);
+    },
+
+    find(intent: NormalizedIntent): ActionSimulator | null {
+      for (const simulator of simulators) {
+        if (simulator.supports(intent)) return simulator;
+      }
+      return null;
+    },
+
+    all(): ActionSimulator[] {
+      return [...simulators];
+    },
+  };
+}

--- a/src/agentguard/simulation/types.ts
+++ b/src/agentguard/simulation/types.ts
@@ -1,0 +1,43 @@
+// Simulation types — pre-execution impact prediction interfaces.
+// Pure type definitions. No DOM, no Node.js-specific APIs.
+
+import type { NormalizedIntent } from '../policies/evaluator.js';
+
+/** Result of simulating an action before execution */
+export interface SimulationResult {
+  /** Human-readable list of predicted changes */
+  predictedChanges: string[];
+  /** Estimated number of files/entities affected */
+  blastRadius: number;
+  /** Overall risk assessment */
+  riskLevel: 'low' | 'medium' | 'high';
+  /** Simulator-specific details */
+  details: Record<string, unknown>;
+  /** Which simulator produced this result */
+  simulatorId: string;
+  /** How long the simulation took (ms) */
+  durationMs: number;
+}
+
+/** An action simulator predicts the impact of an action before execution */
+export interface ActionSimulator {
+  /** Unique simulator identifier */
+  readonly id: string;
+  /** Check if this simulator can handle the given intent */
+  supports(intent: NormalizedIntent): boolean;
+  /** Simulate the action and predict its impact */
+  simulate(
+    intent: NormalizedIntent,
+    context: Record<string, unknown>
+  ): Promise<SimulationResult>;
+}
+
+/** Registry of action simulators, routes intents to the correct simulator */
+export interface SimulatorRegistry {
+  /** Register a simulator */
+  register(simulator: ActionSimulator): void;
+  /** Find a simulator that supports the given intent */
+  find(intent: NormalizedIntent): ActionSimulator | null;
+  /** Get all registered simulators */
+  all(): ActionSimulator[];
+}

--- a/src/agentguard/sinks/decision-jsonl.ts
+++ b/src/agentguard/sinks/decision-jsonl.ts
@@ -1,0 +1,55 @@
+// Decision JSONL sink — persists GovernanceDecisionRecords to
+// .agentguard/decisions/<runId>.jsonl.
+// Follows the same pattern as the event JSONL sink (jsonl.ts).
+
+import { mkdirSync, appendFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { GovernanceDecisionRecord, DecisionSink } from '../decisions/types.js';
+
+const DEFAULT_BASE_DIR = '.agentguard';
+const DECISIONS_DIR = 'decisions';
+
+export interface DecisionJsonlSinkOptions {
+  baseDir?: string;
+  runId: string;
+}
+
+export function createDecisionJsonlSink(options: DecisionJsonlSinkOptions): DecisionSink {
+  const baseDir = options.baseDir || DEFAULT_BASE_DIR;
+  const decisionsDir = join(baseDir, DECISIONS_DIR);
+  const filePath = join(decisionsDir, `${options.runId}.jsonl`);
+
+  let initialized = false;
+
+  function ensureDir(): void {
+    if (initialized) return;
+    try {
+      mkdirSync(decisionsDir, { recursive: true });
+      initialized = true;
+    } catch {
+      // Directory may already exist
+      initialized = true;
+    }
+  }
+
+  return {
+    write(record: GovernanceDecisionRecord): void {
+      ensureDir();
+      const line = JSON.stringify(record) + '\n';
+
+      try {
+        appendFileSync(filePath, line, 'utf8');
+      } catch {
+        // Swallow write errors — don't crash the kernel
+      }
+    },
+
+    flush(): void {
+      // No buffering — writes are immediate for durability
+    },
+  };
+}
+
+export function getDecisionFilePath(runId: string, baseDir?: string): string {
+  return join(baseDir || DEFAULT_BASE_DIR, DECISIONS_DIR, `${runId}.jsonl`);
+}

--- a/src/cli/commands/guard.ts
+++ b/src/cli/commands/guard.ts
@@ -7,8 +7,18 @@ import { createKernel } from '../../agentguard/kernel.js';
 import type { KernelConfig } from '../../agentguard/kernel.js';
 import { createLiveRegistry } from '../../agentguard/adapters/registry.js';
 import { createJsonlSink } from '../../agentguard/sinks/jsonl.js';
+import { createDecisionJsonlSink } from '../../agentguard/sinks/decision-jsonl.js';
 import { loadYamlPolicy } from '../../agentguard/policies/yaml-loader.js';
-import { renderBanner, renderKernelResult, renderMonitorStatus } from '../../agentguard/renderers/tui.js';
+import {
+  renderBanner,
+  renderKernelResult,
+  renderMonitorStatus,
+  renderDecisionRecord,
+} from '../../agentguard/renderers/tui.js';
+import { createSimulatorRegistry } from '../../agentguard/simulation/registry.js';
+import { createGitSimulator } from '../../agentguard/simulation/git-simulator.js';
+import { createFilesystemSimulator } from '../../agentguard/simulation/filesystem-simulator.js';
+import { createPackageSimulator } from '../../agentguard/simulation/package-simulator.js';
 import type { RawAgentAction } from '../../agentguard/core/aab.js';
 
 export interface GuardOptions {
@@ -16,6 +26,7 @@ export interface GuardOptions {
   dryRun?: boolean;
   verbose?: boolean;
   stdin?: boolean;
+  simulate?: boolean;
 }
 
 function loadPolicyFile(policyPath: string): unknown[] {
@@ -54,29 +65,37 @@ export async function guard(_args: string[], options: GuardOptions = {}): Promis
   const policyPath = options.policy || findDefaultPolicy();
   const policyDefs = policyPath ? loadPolicyFile(policyPath) : [];
 
+  // Build simulator registry (enabled by default)
+  const simulators = createSimulatorRegistry();
+  if (options.simulate !== false) {
+    simulators.register(createGitSimulator());
+    simulators.register(createFilesystemSimulator());
+    simulators.register(createPackageSimulator());
+  }
+
+  // Generate run ID early so both sinks share it
+  const runId = `run_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+
+  // Create sinks
+  const jsonlSink = createJsonlSink({ runId });
+  const decisionSink = createDecisionJsonlSink({ runId });
+
   // Build kernel config
   const kernelConfig: KernelConfig = {
+    runId,
     policyDefs,
     dryRun: options.dryRun ?? false,
     adapters: options.dryRun ? undefined : createLiveRegistry(),
+    sinks: [jsonlSink],
+    decisionSinks: [decisionSink],
+    simulators: simulators.all().length > 0 ? simulators : undefined,
   };
 
   const kernel = createKernel(kernelConfig);
-  const runId = kernel.getRunId();
-
-  // Add JSONL sink
-  const jsonlSink = createJsonlSink({ runId });
-  kernelConfig.sinks = [jsonlSink];
-
-  // Re-create kernel with sink (sinks are set at creation time)
-  const fullKernel = createKernel({
-    ...kernelConfig,
-    runId,
-    sinks: [jsonlSink],
-  });
 
   // Render banner
   const policyName = policyPath || 'default (no file)';
+  const simCount = simulators.all().length;
   process.stderr.write(
     renderBanner({
       policyName,
@@ -84,18 +103,21 @@ export async function guard(_args: string[], options: GuardOptions = {}): Promis
       verbose: options.verbose,
     })
   );
-  process.stderr.write(`  ${'\x1b[2m'}run: ${runId}${'\x1b[0m'}\n\n`);
+  process.stderr.write(`  ${'\x1b[2m'}run: ${runId}${'\x1b[0m'}\n`);
+  if (simCount > 0) {
+    process.stderr.write(`  ${'\x1b[2m'}simulators: ${simCount} active${'\x1b[0m'}\n`);
+  }
+  process.stderr.write('\n');
 
   if (options.stdin) {
-    // Read actions from stdin (one JSON per line)
-    return processStdin(fullKernel, options);
+    return processStdin(kernel, options);
   }
 
   // Interactive mode: read from stdin line by line
   process.stderr.write(`  ${'\x1b[2m'}Listening for actions on stdin (JSON per line)...${'\x1b[0m'}\n`);
   process.stderr.write(`  ${'\x1b[2m'}Press Ctrl+C to stop.${'\x1b[0m'}\n\n`);
 
-  return processStdin(fullKernel, options);
+  return processStdin(kernel, options);
 }
 
 async function processStdin(kernel: ReturnType<typeof createKernel>, options: GuardOptions): Promise<number> {
@@ -118,6 +140,12 @@ async function processStdin(kernel: ReturnType<typeof createKernel>, options: Gu
 
           // Render result to stderr
           process.stderr.write(renderKernelResult(result, options.verbose) + '\n');
+
+          // Render decision record if verbose
+          if (options.verbose && result.decisionRecord) {
+            process.stderr.write(renderDecisionRecord(result.decisionRecord) + '\n');
+          }
+
           if (result.decision.violations.length > 0 || !result.allowed) {
             process.stderr.write(renderMonitorStatus(result.decision) + '\n');
           }
@@ -131,6 +159,7 @@ async function processStdin(kernel: ReturnType<typeof createKernel>, options: Gu
             reason: result.decision.decision.reason,
             violations: result.decision.violations.map((v) => v.name),
             runId: result.runId,
+            decisionRecordId: result.decisionRecord?.recordId,
           };
           process.stdout.write(JSON.stringify(output) + '\n');
         } catch (err) {

--- a/src/cli/commands/inspect.ts
+++ b/src/cli/commands/inspect.ts
@@ -3,9 +3,11 @@
 
 import { readFileSync, existsSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
-import { renderEventStream } from '../../agentguard/renderers/tui.js';
+import { renderEventStream, renderDecisionTable } from '../../agentguard/renderers/tui.js';
 import { getEventFilePath } from '../../agentguard/sinks/jsonl.js';
+import { getDecisionFilePath } from '../../agentguard/sinks/decision-jsonl.js';
 import type { DomainEvent } from '../../core/types.js';
+import type { GovernanceDecisionRecord } from '../../agentguard/decisions/types.js';
 
 const BASE_DIR = '.agentguard';
 const EVENTS_DIR = join(BASE_DIR, 'events');
@@ -34,6 +36,28 @@ function loadEvents(runId: string): DomainEvent[] {
   return events;
 }
 
+function loadDecisions(runId: string): GovernanceDecisionRecord[] {
+  const filePath = getDecisionFilePath(runId);
+  if (!existsSync(filePath)) {
+    return [];
+  }
+
+  const content = readFileSync(filePath, 'utf8');
+  const records: GovernanceDecisionRecord[] = [];
+
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      records.push(JSON.parse(trimmed) as GovernanceDecisionRecord);
+    } catch {
+      // Skip malformed lines
+    }
+  }
+
+  return records;
+}
+
 function listRuns(): string[] {
   if (!existsSync(EVENTS_DIR)) return [];
   return readdirSync(EVENTS_DIR)
@@ -44,9 +68,11 @@ function listRuns(): string[] {
 }
 
 export async function inspect(args: string[]): Promise<void> {
-  const runId = args[0];
+  const showDecisions = args.includes('--decisions');
+  const filteredArgs = args.filter((a) => a !== '--decisions');
+  const targetArg = filteredArgs[0];
 
-  if (!runId || runId === '--list') {
+  if (!targetArg || targetArg === '--list') {
     const runs = listRuns();
     if (runs.length === 0) {
       process.stderr.write('\n  \x1b[2mNo runs recorded yet.\x1b[0m\n');
@@ -65,16 +91,26 @@ export async function inspect(args: string[]): Promise<void> {
   }
 
   // Check for --last flag
-  const targetRunId = runId === '--last' ? listRuns()[0] : runId;
+  const targetRunId = targetArg === '--last' ? listRuns()[0] : targetArg;
   if (!targetRunId) {
     process.stderr.write('\n  \x1b[2mNo runs recorded yet.\x1b[0m\n\n');
     return;
   }
 
   const events = loadEvents(targetRunId);
-  if (events.length === 0) return;
+  if (events.length === 0 && !showDecisions) return;
 
   process.stderr.write(`\n  \x1b[1mRun:\x1b[0m ${targetRunId}\n`);
+
+  // Show decision records if --decisions flag is present
+  if (showDecisions) {
+    const decisions = loadDecisions(targetRunId);
+    if (decisions.length > 0) {
+      process.stderr.write(renderDecisionTable(decisions));
+    } else {
+      process.stderr.write('\n  \x1b[2mNo decision records found for this run.\x1b[0m\n');
+    }
+  }
 
   // Reconstruct action graph from events
   const actionEvents = events.filter(
@@ -148,7 +184,9 @@ export async function inspect(args: string[]): Promise<void> {
   }
 
   // Show event stream
-  process.stderr.write(renderEventStream(events));
+  if (events.length > 0) {
+    process.stderr.write(renderEventStream(events));
+  }
 }
 
 export async function events(args: string[]): Promise<void> {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -191,6 +191,10 @@ export type EventKind =
   | 'ActionEscalated'
   | 'ActionExecuted'
   | 'ActionFailed'
+  // Decision Records
+  | 'DecisionRecorded'
+  // Simulation
+  | 'SimulationCompleted'
   // Pipeline
   | 'PipelineStarted'
   | 'StageCompleted'

--- a/src/domain/events.ts
+++ b/src/domain/events.ts
@@ -47,6 +47,12 @@ export const ACTION_ESCALATED: EventKind = 'ActionEscalated';
 export const ACTION_EXECUTED: EventKind = 'ActionExecuted';
 export const ACTION_FAILED: EventKind = 'ActionFailed';
 
+// Decision Records
+export const DECISION_RECORDED: EventKind = 'DecisionRecorded';
+
+// Simulation
+export const SIMULATION_COMPLETED: EventKind = 'SimulationCompleted';
+
 // Pipeline
 export const PIPELINE_STARTED: EventKind = 'PipelineStarted';
 export const STAGE_COMPLETED: EventKind = 'StageCompleted';
@@ -181,6 +187,14 @@ const EVENT_SCHEMAS: Record<string, EventSchema> = {
   [ACTION_FAILED]: {
     required: ['actionType', 'target', 'error'],
     optional: ['actionId', 'duration', 'metadata'],
+  },
+  [DECISION_RECORDED]: {
+    required: ['recordId', 'outcome', 'actionType'],
+    optional: ['target', 'reason', 'metadata'],
+  },
+  [SIMULATION_COMPLETED]: {
+    required: ['simulatorId', 'riskLevel', 'blastRadius'],
+    optional: ['predictedChanges', 'durationMs', 'metadata'],
   },
   [PIPELINE_STARTED]: {
     required: ['runId', 'task'],

--- a/tests/domain-events.test.js
+++ b/tests/domain-events.test.js
@@ -38,8 +38,8 @@ import {
 } from '../dist/domain/events.js';
 
 suite('Domain Events — Schema Validation', () => {
-  test('ALL_EVENT_KINDS contains all 42 event kinds', () => {
-    assert.strictEqual(ALL_EVENT_KINDS.size, 42);
+  test('ALL_EVENT_KINDS contains all 44 event kinds', () => {
+    assert.strictEqual(ALL_EVENT_KINDS.size, 44);
     assert.ok(ALL_EVENT_KINDS.has(ERROR_OBSERVED));
     assert.ok(ALL_EVENT_KINDS.has(BATTLE_ENDED));
     assert.ok(ALL_EVENT_KINDS.has(STATE_CHANGED));

--- a/tests/ts/decision-records.test.ts
+++ b/tests/ts/decision-records.test.ts
@@ -1,0 +1,293 @@
+// Tests for Governance Decision Records
+import { describe, it, expect, beforeEach } from 'vitest';
+import { buildDecisionRecord } from '../../src/agentguard/decisions/factory.js';
+import type { DecisionFactoryInput } from '../../src/agentguard/decisions/factory.js';
+import type { MonitorDecision } from '../../src/agentguard/monitor.js';
+import { createKernel } from '../../src/agentguard/kernel.js';
+import type { EventSink } from '../../src/agentguard/kernel.js';
+import type { GovernanceDecisionRecord, DecisionSink } from '../../src/agentguard/decisions/types.js';
+import { resetActionCounter } from '../../src/domain/actions.js';
+import { resetEventCounter } from '../../src/domain/events.js';
+import type { DomainEvent } from '../../src/core/types.js';
+
+beforeEach(() => {
+  resetActionCounter();
+  resetEventCounter();
+});
+
+function makeDecision(overrides: Partial<MonitorDecision> = {}): MonitorDecision {
+  return {
+    allowed: true,
+    intent: {
+      action: 'file.read',
+      target: 'src/index.ts',
+      agent: 'test-agent',
+      destructive: false,
+    },
+    decision: {
+      allowed: true,
+      decision: 'allow',
+      matchedRule: null,
+      matchedPolicy: null,
+      reason: 'No matching policy — default allow',
+      severity: 0,
+    },
+    violations: [],
+    events: [],
+    evidencePack: null,
+    intervention: null,
+    monitor: {
+      escalationLevel: 0,
+      totalEvaluations: 1,
+      totalDenials: 0,
+      totalViolations: 0,
+    },
+    ...overrides,
+  };
+}
+
+describe('Decision Record Factory', () => {
+  it('builds a record for an allowed action', () => {
+    const input: DecisionFactoryInput = {
+      runId: 'test-run-1',
+      decision: makeDecision(),
+      execution: { success: true },
+      executionDurationMs: 42,
+      simulation: null,
+    };
+
+    const record = buildDecisionRecord(input);
+
+    expect(record.recordId).toMatch(/^dec_/);
+    expect(record.runId).toBe('test-run-1');
+    expect(record.outcome).toBe('allow');
+    expect(record.action.type).toBe('file.read');
+    expect(record.action.target).toBe('src/index.ts');
+    expect(record.action.agent).toBe('test-agent');
+    expect(record.action.destructive).toBe(false);
+    expect(record.reason).toBe('No matching policy — default allow');
+    expect(record.intervention).toBeNull();
+    expect(record.policy.matchedPolicyId).toBeNull();
+    expect(record.policy.severity).toBe(0);
+    expect(record.invariants.allHold).toBe(true);
+    expect(record.invariants.violations).toHaveLength(0);
+    expect(record.simulation).toBeNull();
+    expect(record.evidencePackId).toBeNull();
+    expect(record.monitor.escalationLevel).toBe(0);
+    expect(record.execution.executed).toBe(true);
+    expect(record.execution.success).toBe(true);
+    expect(record.execution.durationMs).toBe(42);
+    expect(record.execution.error).toBeNull();
+  });
+
+  it('builds a record for a denied action', () => {
+    const decision = makeDecision({
+      allowed: false,
+      decision: {
+        allowed: false,
+        decision: 'deny',
+        matchedRule: { action: 'git.push', effect: 'deny', reason: 'Protected branch' },
+        matchedPolicy: { id: 'protect-main', name: 'Protect Main', rules: [], severity: 4 },
+        reason: 'Protected branch',
+        severity: 4,
+      },
+      intervention: 'pause',
+      violations: [
+        {
+          invariantId: 'protected-branch',
+          name: 'Protected Branch Safety',
+          severity: 4,
+          expected: 'No direct push to protected branch',
+          actual: 'Direct push to main',
+        },
+      ],
+    });
+
+    const record = buildDecisionRecord({
+      runId: 'test-run-2',
+      decision,
+      execution: null,
+      executionDurationMs: null,
+      simulation: null,
+    });
+
+    expect(record.outcome).toBe('deny');
+    expect(record.reason).toBe('Protected branch');
+    expect(record.intervention).toBe('pause');
+    expect(record.policy.matchedPolicyId).toBe('protect-main');
+    expect(record.policy.matchedPolicyName).toBe('Protect Main');
+    expect(record.policy.severity).toBe(4);
+    expect(record.invariants.allHold).toBe(false);
+    expect(record.invariants.violations).toHaveLength(1);
+    expect(record.invariants.violations[0].invariantId).toBe('protected-branch');
+    expect(record.execution.executed).toBe(false);
+    expect(record.execution.success).toBeNull();
+  });
+
+  it('includes simulation data when provided', () => {
+    const simulation = {
+      predictedChanges: ['3 unpushed commits to main'],
+      blastRadius: 3,
+      riskLevel: 'medium' as const,
+      simulatorId: 'git-simulator',
+      durationMs: 15,
+    };
+
+    const record = buildDecisionRecord({
+      runId: 'test-run-3',
+      decision: makeDecision(),
+      execution: null,
+      executionDurationMs: null,
+      simulation,
+    });
+
+    expect(record.simulation).not.toBeNull();
+    expect(record.simulation!.blastRadius).toBe(3);
+    expect(record.simulation!.riskLevel).toBe('medium');
+    expect(record.simulation!.simulatorId).toBe('git-simulator');
+  });
+
+  it('records execution failure', () => {
+    const record = buildDecisionRecord({
+      runId: 'test-run-4',
+      decision: makeDecision(),
+      execution: { success: false, error: 'Permission denied' },
+      executionDurationMs: 100,
+      simulation: null,
+    });
+
+    expect(record.execution.executed).toBe(true);
+    expect(record.execution.success).toBe(false);
+    expect(record.execution.error).toBe('Permission denied');
+    expect(record.execution.durationMs).toBe(100);
+  });
+
+  it('includes evidence pack ID when available', () => {
+    const decision = makeDecision({
+      evidencePack: {
+        packId: 'pack_abc123',
+        timestamp: Date.now(),
+        intent: { action: 'git.push', target: 'main', agent: 'test', destructive: false },
+        decision: { allowed: false, decision: 'deny', matchedRule: null, matchedPolicy: null, reason: 'test', severity: 3 },
+        violations: [],
+        events: [],
+        summary: 'test',
+        severity: 3,
+      },
+    });
+
+    const record = buildDecisionRecord({
+      runId: 'test-run-5',
+      decision,
+      execution: null,
+      executionDurationMs: null,
+      simulation: null,
+    });
+
+    expect(record.evidencePackId).toBe('pack_abc123');
+  });
+});
+
+describe('Kernel Decision Record Integration', () => {
+  it('includes decisionRecord in KernelResult for allowed actions', async () => {
+    const kernel = createKernel({ dryRun: true });
+    const result = await kernel.propose({
+      tool: 'Read',
+      file: 'src/index.ts',
+      agent: 'test-agent',
+    });
+
+    expect(result.decisionRecord).toBeDefined();
+    expect(result.decisionRecord!.outcome).toBe('allow');
+    expect(result.decisionRecord!.action.type).toBe('file.read');
+    expect(result.decisionRecord!.runId).toBe(result.runId);
+  });
+
+  it('includes decisionRecord in KernelResult for denied actions', async () => {
+    const kernel = createKernel({ dryRun: true });
+    const result = await kernel.propose({
+      tool: 'Bash',
+      command: 'rm -rf /',
+      agent: 'test-agent',
+    });
+
+    expect(result.decisionRecord).toBeDefined();
+    expect(result.decisionRecord!.outcome).toBe('deny');
+    expect(result.decisionRecord!.action.destructive).toBe(true);
+  });
+
+  it('sinks decision records to configured decision sinks', async () => {
+    const sunkRecords: GovernanceDecisionRecord[] = [];
+    const testDecisionSink: DecisionSink = {
+      write(record) {
+        sunkRecords.push(record);
+      },
+    };
+
+    const kernel = createKernel({
+      dryRun: true,
+      decisionSinks: [testDecisionSink],
+    });
+
+    await kernel.propose({ tool: 'Read', file: 'test.ts', agent: 'test' });
+    await kernel.propose({ tool: 'Bash', command: 'rm -rf /', agent: 'test' });
+
+    expect(sunkRecords).toHaveLength(2);
+    expect(sunkRecords[0].outcome).toBe('allow');
+    expect(sunkRecords[1].outcome).toBe('deny');
+  });
+
+  it('emits DECISION_RECORDED events', async () => {
+    const sunkEvents: DomainEvent[] = [];
+    const testSink: EventSink = {
+      write(event) {
+        sunkEvents.push(event);
+      },
+    };
+
+    const kernel = createKernel({ dryRun: true, sinks: [testSink] });
+    await kernel.propose({ tool: 'Read', file: 'test.ts', agent: 'test' });
+
+    const decisionEvents = sunkEvents.filter((e) => e.kind === 'DecisionRecorded');
+    expect(decisionEvents.length).toBeGreaterThan(0);
+  });
+
+  it('shutdown flushes decision sinks', () => {
+    let flushed = false;
+    const testSink: DecisionSink = {
+      write() {},
+      flush() {
+        flushed = true;
+      },
+    };
+
+    const kernel = createKernel({ dryRun: true, decisionSinks: [testSink] });
+    kernel.shutdown();
+    expect(flushed).toBe(true);
+  });
+
+  it('decision record has correct policy info on policy denial', async () => {
+    const kernel = createKernel({
+      dryRun: true,
+      policyDefs: [
+        {
+          id: 'no-push',
+          name: 'No Push Policy',
+          rules: [{ action: 'git.push', effect: 'deny', reason: 'Pushing forbidden' }],
+          severity: 4,
+        },
+      ],
+    });
+
+    const result = await kernel.propose({
+      tool: 'Bash',
+      command: 'git push origin main',
+      agent: 'test',
+    });
+
+    expect(result.decisionRecord).toBeDefined();
+    expect(result.decisionRecord!.policy.matchedPolicyId).toBe('no-push');
+    expect(result.decisionRecord!.policy.matchedPolicyName).toBe('No Push Policy');
+    expect(result.decisionRecord!.policy.severity).toBe(4);
+  });
+});

--- a/tests/ts/kernel-simulation.test.ts
+++ b/tests/ts/kernel-simulation.test.ts
@@ -1,0 +1,201 @@
+// Integration tests: kernel + simulation + invariant re-check
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createKernel } from '../../src/agentguard/kernel.js';
+import { createSimulatorRegistry } from '../../src/agentguard/simulation/registry.js';
+import type { ActionSimulator, SimulationResult } from '../../src/agentguard/simulation/types.js';
+import type { NormalizedIntent } from '../../src/agentguard/policies/evaluator.js';
+import type { GovernanceDecisionRecord, DecisionSink } from '../../src/agentguard/decisions/types.js';
+import { resetActionCounter } from '../../src/domain/actions.js';
+import { resetEventCounter } from '../../src/domain/events.js';
+
+beforeEach(() => {
+  resetActionCounter();
+  resetEventCounter();
+});
+
+function makeHighRiskSimulator(): ActionSimulator {
+  return {
+    id: 'test-high-risk',
+    supports(intent: NormalizedIntent): boolean {
+      return intent.action === 'git.push';
+    },
+    async simulate(): Promise<SimulationResult> {
+      return {
+        predictedChanges: ['100 files affected', 'Production database migration'],
+        blastRadius: 100,
+        riskLevel: 'high',
+        details: { critical: true },
+        simulatorId: 'test-high-risk',
+        durationMs: 5,
+      };
+    },
+  };
+}
+
+function makeLowRiskSimulator(): ActionSimulator {
+  return {
+    id: 'test-low-risk',
+    supports(intent: NormalizedIntent): boolean {
+      return intent.action === 'file.write';
+    },
+    async simulate(): Promise<SimulationResult> {
+      return {
+        predictedChanges: ['1 file modified'],
+        blastRadius: 1,
+        riskLevel: 'low',
+        details: {},
+        simulatorId: 'test-low-risk',
+        durationMs: 1,
+      };
+    },
+  };
+}
+
+function makeFailingSimulator(): ActionSimulator {
+  return {
+    id: 'test-failing',
+    supports(intent: NormalizedIntent): boolean {
+      return intent.action === 'shell.exec';
+    },
+    async simulate(): Promise<SimulationResult> {
+      throw new Error('Simulator crashed');
+    },
+  };
+}
+
+describe('Kernel Simulation Integration', () => {
+  it('high-risk simulation flips allowed to denied via blast-radius invariant', async () => {
+    const registry = createSimulatorRegistry();
+    registry.register(makeHighRiskSimulator());
+
+    const sunkRecords: GovernanceDecisionRecord[] = [];
+    const decisionSink: DecisionSink = { write(r) { sunkRecords.push(r); } };
+
+    const kernel = createKernel({
+      dryRun: true,
+      simulators: registry,
+      decisionSinks: [decisionSink],
+      // Default blast radius limit is 20; simulation returns 100
+      simulationBlastRadiusThreshold: 50,
+    });
+
+    // Must pass testsPass: true so test-before-push invariant doesn't deny first
+    const result = await kernel.propose(
+      { tool: 'Bash', command: 'git push origin feature', agent: 'test' },
+      { testsPass: true }
+    );
+
+    // The action should be denied because simulation blast radius (100) > limit (20)
+    expect(result.allowed).toBe(false);
+    expect(result.decisionRecord).toBeDefined();
+    expect(result.decisionRecord!.outcome).toBe('deny');
+    expect(result.decisionRecord!.simulation).not.toBeNull();
+    expect(result.decisionRecord!.simulation!.riskLevel).toBe('high');
+    expect(result.decisionRecord!.simulation!.blastRadius).toBe(100);
+
+    // Decision sink should have received the record
+    expect(sunkRecords).toHaveLength(1);
+    expect(sunkRecords[0].outcome).toBe('deny');
+  });
+
+  it('low-risk simulation allows action to proceed', async () => {
+    const registry = createSimulatorRegistry();
+    registry.register(makeLowRiskSimulator());
+
+    const kernel = createKernel({
+      dryRun: true,
+      simulators: registry,
+    });
+
+    const result = await kernel.propose({
+      tool: 'Write',
+      file: 'src/helper.ts',
+      agent: 'test',
+    });
+
+    expect(result.allowed).toBe(true);
+    expect(result.decisionRecord).toBeDefined();
+    expect(result.decisionRecord!.outcome).toBe('allow');
+    // Simulation data should be present
+    expect(result.decisionRecord!.simulation).not.toBeNull();
+    expect(result.decisionRecord!.simulation!.riskLevel).toBe('low');
+  });
+
+  it('simulation failure does not crash kernel', async () => {
+    const registry = createSimulatorRegistry();
+    registry.register(makeFailingSimulator());
+
+    const kernel = createKernel({
+      dryRun: true,
+      simulators: registry,
+    });
+
+    const result = await kernel.propose({
+      tool: 'Bash',
+      command: 'npm test',
+      agent: 'test',
+    });
+
+    // Should still process normally despite simulator crash
+    expect(result.allowed).toBe(true);
+    expect(result.decisionRecord).toBeDefined();
+  });
+
+  it('kernel without simulators works as before', async () => {
+    const kernel = createKernel({ dryRun: true });
+
+    const result = await kernel.propose({
+      tool: 'Read',
+      file: 'test.ts',
+      agent: 'test',
+    });
+
+    expect(result.allowed).toBe(true);
+    expect(result.decisionRecord).toBeDefined();
+    expect(result.decisionRecord!.simulation).toBeNull();
+  });
+
+  it('simulation events are included in result events', async () => {
+    const registry = createSimulatorRegistry();
+    registry.register(makeLowRiskSimulator());
+
+    const kernel = createKernel({
+      dryRun: true,
+      simulators: registry,
+    });
+
+    const result = await kernel.propose({
+      tool: 'Write',
+      file: 'src/test.ts',
+      agent: 'test',
+    });
+
+    const simEvents = result.events.filter((e) => e.kind === 'SimulationCompleted');
+    expect(simEvents.length).toBe(1);
+  });
+
+  it('simulation-triggered denial includes violation details', async () => {
+    const registry = createSimulatorRegistry();
+    registry.register(makeHighRiskSimulator());
+
+    const kernel = createKernel({
+      dryRun: true,
+      simulators: registry,
+      simulationBlastRadiusThreshold: 10,
+    });
+
+    // Must pass testsPass: true so test-before-push invariant doesn't deny first
+    const result = await kernel.propose(
+      { tool: 'Bash', command: 'git push origin feature', agent: 'test' },
+      { testsPass: true }
+    );
+
+    expect(result.allowed).toBe(false);
+    expect(result.decision.violations.length).toBeGreaterThan(0);
+    // Should have blast-radius-limit violation
+    const blastViolation = result.decision.violations.find(
+      (v) => v.invariantId === 'blast-radius-limit'
+    );
+    expect(blastViolation).toBeDefined();
+  });
+});

--- a/tests/ts/simulation-filesystem.test.ts
+++ b/tests/ts/simulation-filesystem.test.ts
@@ -1,0 +1,119 @@
+// Tests for Filesystem Simulator
+import { describe, it, expect } from 'vitest';
+import { createFilesystemSimulator } from '../../src/agentguard/simulation/filesystem-simulator.js';
+
+describe('FilesystemSimulator', () => {
+  const simulator = createFilesystemSimulator();
+
+  it('has correct id', () => {
+    expect(simulator.id).toBe('filesystem-simulator');
+  });
+
+  it('supports file.write', () => {
+    expect(
+      simulator.supports({ action: 'file.write', target: 'test.ts', agent: 'test', destructive: false })
+    ).toBe(true);
+  });
+
+  it('supports file.delete', () => {
+    expect(
+      simulator.supports({ action: 'file.delete', target: 'test.ts', agent: 'test', destructive: false })
+    ).toBe(true);
+  });
+
+  it('does not support file.read', () => {
+    expect(
+      simulator.supports({ action: 'file.read', target: 'test.ts', agent: 'test', destructive: false })
+    ).toBe(false);
+  });
+
+  it('does not support git actions', () => {
+    expect(
+      simulator.supports({ action: 'git.push', target: 'main', agent: 'test', destructive: false })
+    ).toBe(false);
+  });
+
+  it('returns high risk for .env files', async () => {
+    const result = await simulator.simulate(
+      { action: 'file.write', target: '.env', agent: 'test', destructive: false },
+      {}
+    );
+
+    expect(result.riskLevel).toBe('high');
+    expect(result.predictedChanges.some((c) => c.includes('Sensitive'))).toBe(true);
+    expect(result.simulatorId).toBe('filesystem-simulator');
+  });
+
+  it('returns high risk for credential files', async () => {
+    const result = await simulator.simulate(
+      { action: 'file.write', target: 'config/credentials.json', agent: 'test', destructive: false },
+      {}
+    );
+
+    expect(result.riskLevel).toBe('high');
+  });
+
+  it('returns high risk for .pem files', async () => {
+    const result = await simulator.simulate(
+      { action: 'file.write', target: 'ssl/server.pem', agent: 'test', destructive: false },
+      {}
+    );
+
+    expect(result.riskLevel).toBe('high');
+  });
+
+  it('returns medium risk for lockfiles', async () => {
+    const result = await simulator.simulate(
+      { action: 'file.write', target: 'package-lock.json', agent: 'test', destructive: false },
+      {}
+    );
+
+    expect(result.riskLevel).toBe('medium');
+  });
+
+  it('returns medium risk for CI config', async () => {
+    const result = await simulator.simulate(
+      { action: 'file.write', target: '.github/workflows/ci.yml', agent: 'test', destructive: false },
+      {}
+    );
+
+    expect(result.riskLevel).toBe('medium');
+  });
+
+  it('returns medium risk for project configs', async () => {
+    const result = await simulator.simulate(
+      { action: 'file.write', target: 'tsconfig.json', agent: 'test', destructive: false },
+      {}
+    );
+
+    expect(result.riskLevel).toBe('medium');
+  });
+
+  it('returns low risk for regular source files', async () => {
+    const result = await simulator.simulate(
+      { action: 'file.write', target: 'src/utils/helper.ts', agent: 'test', destructive: false },
+      {}
+    );
+
+    expect(result.riskLevel).toBe('low');
+  });
+
+  it('identifies delete operations', async () => {
+    const result = await simulator.simulate(
+      { action: 'file.delete', target: 'test.ts', agent: 'test', destructive: false },
+      {}
+    );
+
+    expect(result.predictedChanges.some((c) => c.includes('Delete'))).toBe(true);
+    expect(result.details.operation).toBe('delete');
+  });
+
+  it('uses filesAffected for blast radius', async () => {
+    const result = await simulator.simulate(
+      { action: 'file.write', target: 'test.ts', agent: 'test', destructive: false, filesAffected: 5 },
+      {}
+    );
+
+    expect(result.blastRadius).toBe(5);
+  });
+});

--- a/tests/ts/simulation-git.test.ts
+++ b/tests/ts/simulation-git.test.ts
@@ -1,0 +1,100 @@
+// Tests for Git Simulator
+import { describe, it, expect } from 'vitest';
+import { createGitSimulator } from '../../src/agentguard/simulation/git-simulator.js';
+
+describe('GitSimulator', () => {
+  const simulator = createGitSimulator();
+
+  it('has correct id', () => {
+    expect(simulator.id).toBe('git-simulator');
+  });
+
+  it('supports git.push', () => {
+    expect(
+      simulator.supports({ action: 'git.push', target: 'main', agent: 'test', destructive: false })
+    ).toBe(true);
+  });
+
+  it('supports git.force-push', () => {
+    expect(
+      simulator.supports({ action: 'git.force-push', target: 'main', agent: 'test', destructive: false })
+    ).toBe(true);
+  });
+
+  it('supports git.merge', () => {
+    expect(
+      simulator.supports({ action: 'git.merge', target: 'feature', agent: 'test', destructive: false })
+    ).toBe(true);
+  });
+
+  it('supports git.branch.delete', () => {
+    expect(
+      simulator.supports({ action: 'git.branch.delete', target: 'feature', agent: 'test', destructive: false })
+    ).toBe(true);
+  });
+
+  it('does not support file actions', () => {
+    expect(
+      simulator.supports({ action: 'file.write', target: 'test.ts', agent: 'test', destructive: false })
+    ).toBe(false);
+  });
+
+  it('returns high risk for force push', async () => {
+    const result = await simulator.simulate(
+      { action: 'git.force-push', target: 'main', agent: 'test', destructive: false },
+      {}
+    );
+
+    expect(result.riskLevel).toBe('high');
+    expect(result.blastRadius).toBe(100);
+    expect(result.predictedChanges.some((c) => c.includes('Force push'))).toBe(true);
+    expect(result.simulatorId).toBe('git-simulator');
+  });
+
+  it('detects protected branch push', async () => {
+    const result = await simulator.simulate(
+      { action: 'git.push', target: 'main', branch: 'main', agent: 'test', destructive: false },
+      { protectedBranches: ['main', 'master'] }
+    );
+
+    expect(result.predictedChanges.some((c) => c.includes('protected branch'))).toBe(true);
+    expect(result.details.protectedBranch).toBe(true);
+  });
+
+  it('returns high risk for deleting protected branch', async () => {
+    const result = await simulator.simulate(
+      { action: 'git.branch.delete', target: 'main', agent: 'test', destructive: false },
+      { protectedBranches: ['main'] }
+    );
+
+    expect(result.riskLevel).toBe('high');
+    expect(result.blastRadius).toBe(100);
+  });
+
+  it('returns low risk for deleting non-protected branch', async () => {
+    const result = await simulator.simulate(
+      { action: 'git.branch.delete', target: 'feature-xyz', agent: 'test', destructive: false },
+      { protectedBranches: ['main'] }
+    );
+
+    expect(result.riskLevel).toBe('low');
+    expect(result.blastRadius).toBe(1);
+  });
+
+  it('returns valid SimulationResult shape', async () => {
+    const result = await simulator.simulate(
+      { action: 'git.push', target: 'feature', agent: 'test', destructive: false },
+      {}
+    );
+
+    expect(result).toHaveProperty('predictedChanges');
+    expect(result).toHaveProperty('blastRadius');
+    expect(result).toHaveProperty('riskLevel');
+    expect(result).toHaveProperty('details');
+    expect(result).toHaveProperty('simulatorId');
+    expect(result).toHaveProperty('durationMs');
+    expect(Array.isArray(result.predictedChanges)).toBe(true);
+    expect(typeof result.blastRadius).toBe('number');
+    expect(['low', 'medium', 'high']).toContain(result.riskLevel);
+  });
+});

--- a/tests/ts/simulation-package.test.ts
+++ b/tests/ts/simulation-package.test.ts
@@ -1,0 +1,132 @@
+// Tests for Package Simulator
+import { describe, it, expect } from 'vitest';
+import { createPackageSimulator } from '../../src/agentguard/simulation/package-simulator.js';
+
+describe('PackageSimulator', () => {
+  const simulator = createPackageSimulator();
+
+  it('has correct id', () => {
+    expect(simulator.id).toBe('package-simulator');
+  });
+
+  it('supports npm install commands', () => {
+    expect(
+      simulator.supports({
+        action: 'shell.exec',
+        target: '',
+        agent: 'test',
+        destructive: false,
+        command: 'npm install lodash',
+      })
+    ).toBe(true);
+  });
+
+  it('supports npm i shorthand', () => {
+    expect(
+      simulator.supports({
+        action: 'shell.exec',
+        target: '',
+        agent: 'test',
+        destructive: false,
+        command: 'npm i lodash',
+      })
+    ).toBe(true);
+  });
+
+  it('supports yarn add', () => {
+    expect(
+      simulator.supports({
+        action: 'shell.exec',
+        target: '',
+        agent: 'test',
+        destructive: false,
+        command: 'yarn add lodash',
+      })
+    ).toBe(true);
+  });
+
+  it('supports pnpm add', () => {
+    expect(
+      simulator.supports({
+        action: 'shell.exec',
+        target: '',
+        agent: 'test',
+        destructive: false,
+        command: 'pnpm add lodash',
+      })
+    ).toBe(true);
+  });
+
+  it('supports npm uninstall', () => {
+    expect(
+      simulator.supports({
+        action: 'shell.exec',
+        target: '',
+        agent: 'test',
+        destructive: false,
+        command: 'npm uninstall lodash',
+      })
+    ).toBe(true);
+  });
+
+  it('does not support non-package shell commands', () => {
+    expect(
+      simulator.supports({
+        action: 'shell.exec',
+        target: '',
+        agent: 'test',
+        destructive: false,
+        command: 'git push origin main',
+      })
+    ).toBe(false);
+  });
+
+  it('does not support file actions', () => {
+    expect(
+      simulator.supports({
+        action: 'file.write',
+        target: 'package.json',
+        agent: 'test',
+        destructive: false,
+      })
+    ).toBe(false);
+  });
+
+  it('detects global installs as medium+ risk', async () => {
+    const result = await simulator.simulate(
+      {
+        action: 'shell.exec',
+        target: '',
+        agent: 'test',
+        destructive: false,
+        command: 'npm install -g typescript',
+      },
+      {}
+    );
+
+    expect(['medium', 'high']).toContain(result.riskLevel);
+    expect(result.predictedChanges.some((c) => c.includes('Global'))).toBe(true);
+    expect(result.details.globalInstall).toBe(true);
+  });
+
+  it('returns valid SimulationResult shape', async () => {
+    const result = await simulator.simulate(
+      {
+        action: 'shell.exec',
+        target: '',
+        agent: 'test',
+        destructive: false,
+        command: 'yarn add react',
+      },
+      {}
+    );
+
+    expect(result).toHaveProperty('predictedChanges');
+    expect(result).toHaveProperty('blastRadius');
+    expect(result).toHaveProperty('riskLevel');
+    expect(result).toHaveProperty('details');
+    expect(result).toHaveProperty('simulatorId');
+    expect(result).toHaveProperty('durationMs');
+    expect(result.simulatorId).toBe('package-simulator');
+  });
+});

--- a/tests/ts/simulation-registry.test.ts
+++ b/tests/ts/simulation-registry.test.ts
@@ -1,0 +1,96 @@
+// Tests for Simulator Registry
+import { describe, it, expect } from 'vitest';
+import { createSimulatorRegistry } from '../../src/agentguard/simulation/registry.js';
+import type { ActionSimulator, SimulationResult } from '../../src/agentguard/simulation/types.js';
+import type { NormalizedIntent } from '../../src/agentguard/policies/evaluator.js';
+
+function makeStubSimulator(id: string, supportedActions: string[]): ActionSimulator {
+  return {
+    id,
+    supports(intent: NormalizedIntent): boolean {
+      return supportedActions.includes(intent.action);
+    },
+    async simulate(): Promise<SimulationResult> {
+      return {
+        predictedChanges: [],
+        blastRadius: 0,
+        riskLevel: 'low',
+        details: {},
+        simulatorId: id,
+        durationMs: 0,
+      };
+    },
+  };
+}
+
+describe('SimulatorRegistry', () => {
+  it('creates empty registry', () => {
+    const registry = createSimulatorRegistry();
+    expect(registry.all()).toHaveLength(0);
+  });
+
+  it('registers a simulator', () => {
+    const registry = createSimulatorRegistry();
+    registry.register(makeStubSimulator('test', ['file.read']));
+    expect(registry.all()).toHaveLength(1);
+  });
+
+  it('prevents duplicate registration', () => {
+    const registry = createSimulatorRegistry();
+    const sim = makeStubSimulator('test', ['file.read']);
+    registry.register(sim);
+    registry.register(sim);
+    expect(registry.all()).toHaveLength(1);
+  });
+
+  it('finds simulator for matching intent', () => {
+    const registry = createSimulatorRegistry();
+    registry.register(makeStubSimulator('git', ['git.push', 'git.force-push']));
+    registry.register(makeStubSimulator('fs', ['file.write', 'file.delete']));
+
+    const gitResult = registry.find({
+      action: 'git.push',
+      target: 'main',
+      agent: 'test',
+      destructive: false,
+    });
+    expect(gitResult).not.toBeNull();
+    expect(gitResult!.id).toBe('git');
+
+    const fsResult = registry.find({
+      action: 'file.write',
+      target: 'test.ts',
+      agent: 'test',
+      destructive: false,
+    });
+    expect(fsResult).not.toBeNull();
+    expect(fsResult!.id).toBe('fs');
+  });
+
+  it('returns null when no simulator matches', () => {
+    const registry = createSimulatorRegistry();
+    registry.register(makeStubSimulator('git', ['git.push']));
+
+    const result = registry.find({
+      action: 'file.read',
+      target: 'test.ts',
+      agent: 'test',
+      destructive: false,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('returns first matching simulator', () => {
+    const registry = createSimulatorRegistry();
+    registry.register(makeStubSimulator('first', ['git.push']));
+    registry.register(makeStubSimulator('second', ['git.push']));
+
+    const result = registry.find({
+      action: 'git.push',
+      target: 'main',
+      agent: 'test',
+      destructive: false,
+    });
+    expect(result!.id).toBe('first');
+  });
+});


### PR DESCRIPTION
## Summary

- **Decision Records**: `GovernanceDecisionRecord` as a first-class audit artifact that aggregates monitor decisions, execution data, violations, evidence, and simulation results into a single persisted JSONL record per agent action. Adds `decisionRecord` to `KernelResult`, `decisionSinks` to `KernelConfig`, `DECISION_RECORDED` event kind, CLI `inspect --decisions` flag, and TUI rendering.
- **Pre-Execution Impact Simulation**: `ActionSimulator` interface with three built-in simulators (git, filesystem, package) that predict action impact before execution. The kernel runs simulation after initial policy/invariant evaluation — if simulation reveals elevated risk, invariants are re-checked with simulated blast radius and can flip an allowed action to denied.
- **58 new tests** across 6 test files covering factory, sinks, registry, all three simulators, and kernel integration (including the simulation-triggered denial path). All 1085 JS + 403 TS tests pass.

## Test plan

- [x] `npm run build:ts` — build succeeds
- [x] `npm run ts:test` — 403 TS tests pass (345 existing + 58 new)
- [x] `npm test` — 1085 JS tests pass
- [x] `npm run lint` — 0 errors (1 pre-existing warning in game code)
- [ ] Manual: `echo '{"tool":"Bash","command":"git push origin main"}' | npx agentguard guard --dry-run` shows decision record
- [ ] Manual: `npx agentguard inspect --last --decisions` renders decision table

🤖 Generated with [Claude Code](https://claude.com/claude-code)