### PR TITLE
feat: add event session export/import for sharing sessions

### DIFF
--- a/src/cli/file-event-store.ts
+++ b/src/cli/file-event-store.ts
@@ -148,3 +148,98 @@ export function loadSession(sessionId: string): DomainEvent[] {
   }
   return events;
 }
+
+/** Metadata header written as the first line of an exported session file. */
+export interface ExportHeader {
+  readonly __agentguard_export: true;
+  readonly version: 1;
+  readonly sessionId: string;
+  readonly exportedAt: number;
+  readonly eventCount: number;
+}
+
+/**
+ * Export a session to a portable JSONL file for sharing.
+ * The first line is a metadata header; subsequent lines are domain events.
+ * Returns the number of events exported.
+ */
+export function exportSession(sessionId: string, outputPath: string): number {
+  const events = loadSession(sessionId);
+  if (events.length === 0) {
+    throw new Error(`Session "${sessionId}" has no events to export`);
+  }
+
+  const header: ExportHeader = {
+    __agentguard_export: true,
+    version: 1,
+    sessionId,
+    exportedAt: Date.now(),
+    eventCount: events.length,
+  };
+
+  const lines = [JSON.stringify(header), ...events.map((e) => JSON.stringify(e))];
+  writeFileSync(outputPath, lines.join('\n') + '\n', 'utf8');
+  return events.length;
+}
+
+/**
+ * Import a session from a portable JSONL file.
+ * Validates the export header and each event before writing.
+ * Returns the sessionId and number of events imported.
+ */
+export function importSession(
+  inputPath: string,
+  targetSessionId?: string
+): { sessionId: string; eventCount: number } {
+  if (!existsSync(inputPath)) {
+    throw new Error(`Import file not found: ${inputPath}`);
+  }
+
+  const content = readFileSync(inputPath, 'utf8');
+  const lines = content.split('\n').filter((l: string) => l.trim());
+  if (lines.length === 0) {
+    throw new Error('Import file is empty');
+  }
+
+  // Parse and validate the metadata header
+  let header: Record<string, unknown>;
+  try {
+    header = JSON.parse(lines[0]) as Record<string, unknown>;
+  } catch {
+    throw new Error('Import file has an invalid header line');
+  }
+
+  if (header.__agentguard_export !== true || header.version !== 1) {
+    throw new Error('Import file is not a valid AgentGuard export (missing or invalid header)');
+  }
+
+  const sessionId = targetSessionId || (header.sessionId as string);
+  if (!sessionId) {
+    throw new Error('No sessionId found in export header and none provided');
+  }
+
+  // Parse and validate events from remaining lines
+  const events: DomainEvent[] = [];
+  for (let i = 1; i < lines.length; i++) {
+    try {
+      const parsed = JSON.parse(lines[i]) as Record<string, unknown>;
+      const { valid } = validateEvent(parsed) as ValidationResult;
+      if (valid) {
+        events.push(parsed as unknown as DomainEvent);
+      }
+    } catch {
+      // Skip malformed lines
+    }
+  }
+
+  if (events.length === 0) {
+    throw new Error('Import file contains no valid events');
+  }
+
+  // Write events to the target session file
+  ensureDir();
+  const eventLines = events.map((e) => JSON.stringify(e)).join('\n') + '\n';
+  appendFileSync(sessionFileName(sessionId), eventLines, 'utf8');
+
+  return { sessionId, eventCount: events.length };
+}

--- a/src/events/store.ts
+++ b/src/events/store.ts
@@ -3,7 +3,6 @@
 //
 // TODO(roadmap): Phase 4 — File-based event store (.agentguard/events/)
 // TODO(roadmap): Phase 4 — Event stream serialization format
-// TODO(roadmap): Phase 4 — Event export/import for sharing sessions
 
 import type { DomainEvent, EventFilter, EventStore, ValidationResult } from '../core/types.js';
 import { validateEvent } from './schema.js';

--- a/tests/ts/event-export-import.test.ts
+++ b/tests/ts/event-export-import.test.ts
@@ -1,0 +1,178 @@
+// Tests for event session export/import functionality
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('node:fs', () => ({
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  existsSync: vi.fn(),
+  readdirSync: vi.fn(),
+  appendFileSync: vi.fn(),
+}));
+
+vi.mock('node:os', () => ({
+  homedir: vi.fn(() => '/mock-home'),
+}));
+
+import { exportSession, importSession } from '../../src/cli/file-event-store.js';
+import { readFileSync, writeFileSync, existsSync, appendFileSync } from 'node:fs';
+import type { DomainEvent } from '../../src/core/types.js';
+
+function makeFakeEvent(overrides: Partial<DomainEvent> = {}): DomainEvent {
+  return {
+    id: 'evt_1700000000000_1',
+    kind: 'ActionRequested',
+    timestamp: 1700000000000,
+    fingerprint: 'fp_abc',
+    actionType: 'file.read',
+    target: 'test.ts',
+    justification: 'testing',
+    ...overrides,
+  } as DomainEvent;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('exportSession', () => {
+  it('exports a session with header and events', () => {
+    const events = [
+      makeFakeEvent({ id: 'evt_1' }),
+      makeFakeEvent({ id: 'evt_2', timestamp: 1700000001000 }),
+    ];
+    const fileContent = events.map((e) => JSON.stringify(e)).join('\n') + '\n';
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(fileContent);
+
+    const count = exportSession('test-session', '/tmp/export.jsonl');
+
+    expect(count).toBe(2);
+    expect(writeFileSync).toHaveBeenCalledTimes(1);
+    const written = vi.mocked(writeFileSync).mock.calls[0][1] as string;
+    const lines = written.trim().split('\n');
+    expect(lines).toHaveLength(3); // header + 2 events
+
+    const header = JSON.parse(lines[0]);
+    expect(header.__agentguard_export).toBe(true);
+    expect(header.version).toBe(1);
+    expect(header.sessionId).toBe('test-session');
+    expect(header.eventCount).toBe(2);
+  });
+
+  it('throws if session has no events', () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    expect(() => exportSession('empty-session', '/tmp/out.jsonl')).toThrow(
+      'has no events to export'
+    );
+  });
+});
+
+describe('importSession', () => {
+  it('imports events from an exported file', () => {
+    const event = makeFakeEvent();
+    const header = JSON.stringify({
+      __agentguard_export: true,
+      version: 1,
+      sessionId: 'original-session',
+      exportedAt: Date.now(),
+      eventCount: 1,
+    });
+    const fileContent = header + '\n' + JSON.stringify(event) + '\n';
+
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(fileContent);
+
+    const result = importSession('/tmp/export.jsonl');
+
+    expect(result.sessionId).toBe('original-session');
+    expect(result.eventCount).toBe(1);
+    expect(appendFileSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses targetSessionId when provided', () => {
+    const event = makeFakeEvent();
+    const header = JSON.stringify({
+      __agentguard_export: true,
+      version: 1,
+      sessionId: 'original',
+      exportedAt: Date.now(),
+      eventCount: 1,
+    });
+    const fileContent = header + '\n' + JSON.stringify(event) + '\n';
+
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(fileContent);
+
+    const result = importSession('/tmp/export.jsonl', 'custom-session');
+
+    expect(result.sessionId).toBe('custom-session');
+    expect(appendFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('custom-session.jsonl'),
+      expect.any(String),
+      'utf8'
+    );
+  });
+
+  it('throws if file does not exist', () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    expect(() => importSession('/tmp/missing.jsonl')).toThrow('Import file not found');
+  });
+
+  it('throws if file is empty', () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue('');
+
+    expect(() => importSession('/tmp/empty.jsonl')).toThrow('Import file is empty');
+  });
+
+  it('throws if header is not valid JSON', () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue('not-json\n');
+
+    expect(() => importSession('/tmp/bad.jsonl')).toThrow('invalid header line');
+  });
+
+  it('throws if header is missing export marker', () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ version: 1 }) + '\n');
+
+    expect(() => importSession('/tmp/bad.jsonl')).toThrow('not a valid AgentGuard export');
+  });
+
+  it('skips malformed event lines and still imports valid ones', () => {
+    const event = makeFakeEvent();
+    const header = JSON.stringify({
+      __agentguard_export: true,
+      version: 1,
+      sessionId: 'sess',
+      exportedAt: Date.now(),
+      eventCount: 2,
+    });
+    const fileContent = header + '\n' + 'garbage-line\n' + JSON.stringify(event) + '\n';
+
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(fileContent);
+
+    const result = importSession('/tmp/mixed.jsonl');
+    expect(result.eventCount).toBe(1);
+  });
+
+  it('throws if no valid events found after header', () => {
+    const header = JSON.stringify({
+      __agentguard_export: true,
+      version: 1,
+      sessionId: 'sess',
+      exportedAt: Date.now(),
+      eventCount: 1,
+    });
+    const fileContent = header + '\ngarbageline\n';
+
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(fileContent);
+
+    expect(() => importSession('/tmp/noevents.jsonl')).toThrow('no valid events');
+  });
+});


### PR DESCRIPTION
Implements the TODO from src/events/store.ts for Phase 4 event
export/import. Adds exportSession() and importSession() to the
file-based event store, enabling users to share governance sessions
as portable JSONL files with a metadata header for validation.

https://claude.ai/code/session_01EAHKddH5mdjNPVA3s4tCry