### PR TITLE
feat: add 8 new test files covering CLI, policy loader, and integration gaps

### DIFF
--- a/tests/ts/cli-args.test.ts
+++ b/tests/ts/cli-args.test.ts
@@ -1,0 +1,155 @@
+// Tests for CLI argument parser
+import { describe, it, expect } from 'vitest';
+import { parseArgs, formatHelp } from '../../src/cli/args.js';
+
+// ---------------------------------------------------------------------------
+// parseArgs
+// ---------------------------------------------------------------------------
+
+describe('parseArgs', () => {
+  it('parses boolean flags', () => {
+    const result = parseArgs(['--dry-run', '--verbose'], {
+      boolean: ['--dry-run', '--verbose'],
+    });
+    expect(result.flags['dry-run']).toBe(true);
+    expect(result.flags['verbose']).toBe(true);
+  });
+
+  it('parses string flags with values', () => {
+    const result = parseArgs(['--policy', 'agentguard.yaml'], {
+      string: ['--policy'],
+    });
+    expect(result.flags['policy']).toBe('agentguard.yaml');
+  });
+
+  it('sets string flag to null when value is missing (end of args)', () => {
+    const result = parseArgs(['--policy'], {
+      string: ['--policy'],
+    });
+    expect(result.flags['policy']).toBeNull();
+  });
+
+  it('sets string flag to null when next arg is a flag', () => {
+    const result = parseArgs(['--policy', '--verbose'], {
+      string: ['--policy'],
+      boolean: ['--verbose'],
+    });
+    expect(result.flags['policy']).toBeNull();
+  });
+
+  it('resolves aliases', () => {
+    const result = parseArgs(['-p', 'my-policy.yaml'], {
+      string: ['--policy'],
+      alias: { '-p': '--policy' },
+    });
+    expect(result.flags['policy']).toBe('my-policy.yaml');
+  });
+
+  it('resolves boolean aliases', () => {
+    const result = parseArgs(['-v'], {
+      boolean: ['--verbose'],
+      alias: { '-v': '--verbose' },
+    });
+    expect(result.flags['verbose']).toBe(true);
+  });
+
+  it('collects positional arguments', () => {
+    const result = parseArgs(['run-123', 'extra'], {});
+    expect(result.positional).toEqual(['run-123', 'extra']);
+  });
+
+  it('treats unknown flags as booleans', () => {
+    const result = parseArgs(['--unknown-flag'], {});
+    expect(result.flags['unknown-flag']).toBe(true);
+  });
+
+  it('handles stopAt to collect rest args', () => {
+    const result = parseArgs(['--verbose', '--', 'cmd', 'arg1', 'arg2'], {
+      boolean: ['--verbose'],
+      stopAt: '--',
+    });
+    expect(result.flags['verbose']).toBe(true);
+    expect(result.rest).toEqual(['cmd', 'arg1', 'arg2']);
+  });
+
+  it('returns empty results for empty argv', () => {
+    const result = parseArgs([], {});
+    expect(result.flags).toEqual({});
+    expect(result.positional).toEqual([]);
+    expect(result.rest).toEqual([]);
+  });
+
+  it('handles mixed flags and positional args', () => {
+    const result = parseArgs(['--verbose', 'run_abc', '--policy', 'test.yaml'], {
+      boolean: ['--verbose'],
+      string: ['--policy'],
+    });
+    expect(result.flags['verbose']).toBe(true);
+    expect(result.flags['policy']).toBe('test.yaml');
+    expect(result.positional).toEqual(['run_abc']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatHelp
+// ---------------------------------------------------------------------------
+
+describe('formatHelp', () => {
+  it('renders name and description', () => {
+    const output = formatHelp({
+      name: 'guard',
+      description: 'Start the runtime',
+      usage: 'agentguard guard [options]',
+    });
+    expect(output).toContain('guard');
+    expect(output).toContain('Start the runtime');
+    expect(output).toContain('Usage:');
+    expect(output).toContain('agentguard guard [options]');
+  });
+
+  it('renders flags section', () => {
+    const output = formatHelp({
+      name: 'guard',
+      description: 'Start the runtime',
+      usage: 'agentguard guard [options]',
+      flags: [
+        { flag: '--policy <file>', description: 'Policy file to load' },
+        { flag: '--dry-run', description: 'Evaluate without executing' },
+      ],
+    });
+    expect(output).toContain('Flags:');
+    expect(output).toContain('--policy <file>');
+    expect(output).toContain('Policy file to load');
+    expect(output).toContain('--dry-run');
+  });
+
+  it('renders examples section', () => {
+    const output = formatHelp({
+      name: 'guard',
+      description: 'Start',
+      usage: 'agentguard guard',
+      examples: ['agentguard guard --dry-run', 'agentguard guard --policy custom.yaml'],
+    });
+    expect(output).toContain('Examples:');
+    expect(output).toContain('agentguard guard --dry-run');
+    expect(output).toContain('agentguard guard --policy custom.yaml');
+  });
+
+  it('omits flags section when no flags provided', () => {
+    const output = formatHelp({
+      name: 'test',
+      description: 'Test cmd',
+      usage: 'agentguard test',
+    });
+    expect(output).not.toContain('Flags:');
+  });
+
+  it('omits examples section when no examples provided', () => {
+    const output = formatHelp({
+      name: 'test',
+      description: 'Test cmd',
+      usage: 'agentguard test',
+    });
+    expect(output).not.toContain('Examples:');
+  });
+});

--- a/tests/ts/cli-claude-hook.test.ts
+++ b/tests/ts/cli-claude-hook.test.ts
@@ -1,0 +1,159 @@
+// Tests for claude-hook CLI command (PostToolUse handler)
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { claudeHook } from '../../src/cli/commands/claude-hook.js';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(process, 'exit').mockImplementation((() => {}) as never);
+  vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+});
+
+function mockStdin(data: string) {
+  const originalStdin = process.stdin;
+  const mockStdinObj = {
+    isTTY: false,
+    setEncoding: vi.fn(),
+    on: vi.fn((event: string, cb: (arg?: string) => void) => {
+      if (event === 'data') cb(data);
+      if (event === 'end') setTimeout(() => cb(), 0);
+      return mockStdinObj;
+    }),
+  };
+  Object.defineProperty(process, 'stdin', {
+    value: mockStdinObj,
+    writable: true,
+    configurable: true,
+  });
+  return () => {
+    Object.defineProperty(process, 'stdin', {
+      value: originalStdin,
+      writable: true,
+      configurable: true,
+    });
+  };
+}
+
+function mockTTYStdin() {
+  const originalStdin = process.stdin;
+  const mockStdinObj = {
+    isTTY: true,
+    setEncoding: vi.fn(),
+    on: vi.fn(() => mockStdinObj),
+  };
+  Object.defineProperty(process, 'stdin', {
+    value: mockStdinObj,
+    writable: true,
+    configurable: true,
+  });
+  return () => {
+    Object.defineProperty(process, 'stdin', {
+      value: originalStdin,
+      writable: true,
+      configurable: true,
+    });
+  };
+}
+
+describe('claudeHook', () => {
+  it('exits 0 for TTY stdin (no piped input)', async () => {
+    const restore = mockTTYStdin();
+    try {
+      await claudeHook();
+      expect(process.exit).toHaveBeenCalledWith(0);
+    } finally {
+      restore();
+    }
+  });
+
+  it('exits 0 for non-Bash tool calls', async () => {
+    const input = JSON.stringify({ tool_name: 'Write', tool_output: {} });
+    const restore = mockStdin(input);
+    try {
+      await claudeHook();
+      expect(process.exit).toHaveBeenCalledWith(0);
+      expect(process.stdout.write).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
+
+  it('exits 0 silently for Bash with exit code 0', async () => {
+    const input = JSON.stringify({
+      tool_name: 'Bash',
+      tool_output: { exit_code: 0, stdout: 'ok', stderr: '' },
+    });
+    const restore = mockStdin(input);
+    try {
+      await claudeHook();
+      expect(process.exit).toHaveBeenCalledWith(0);
+      expect(process.stdout.write).not.toHaveBeenCalledWith(
+        expect.stringContaining('Error detected')
+      );
+    } finally {
+      restore();
+    }
+  });
+
+  it('prints error summary for Bash with non-zero exit and stderr', async () => {
+    const input = JSON.stringify({
+      tool_name: 'Bash',
+      tool_output: { exit_code: 1, stdout: '', stderr: 'Permission denied: /etc/hosts' },
+    });
+    const restore = mockStdin(input);
+    try {
+      await claudeHook();
+      expect(process.exit).toHaveBeenCalledWith(0);
+      expect(process.stdout.write).toHaveBeenCalledWith(
+        expect.stringContaining('Error detected')
+      );
+      expect(process.stdout.write).toHaveBeenCalledWith(
+        expect.stringContaining('Permission denied')
+      );
+    } finally {
+      restore();
+    }
+  });
+
+  it('exits 0 for invalid JSON input', async () => {
+    const restore = mockStdin('not valid json!!!');
+    try {
+      await claudeHook();
+      expect(process.exit).toHaveBeenCalledWith(0);
+    } finally {
+      restore();
+    }
+  });
+
+  it('uses exitCode field as fallback', async () => {
+    const input = JSON.stringify({
+      tool_name: 'Bash',
+      tool_output: { exitCode: 2, stderr: 'command not found' },
+    });
+    const restore = mockStdin(input);
+    try {
+      await claudeHook();
+      expect(process.stdout.write).toHaveBeenCalledWith(
+        expect.stringContaining('Error detected')
+      );
+    } finally {
+      restore();
+    }
+  });
+
+  it('does not print error when stderr is empty even with non-zero exit', async () => {
+    const input = JSON.stringify({
+      tool_name: 'Bash',
+      tool_output: { exit_code: 1, stderr: '' },
+    });
+    const restore = mockStdin(input);
+    try {
+      await claudeHook();
+      expect(process.exit).toHaveBeenCalledWith(0);
+      expect(process.stdout.write).not.toHaveBeenCalledWith(
+        expect.stringContaining('Error detected')
+      );
+    } finally {
+      restore();
+    }
+  });
+});

--- a/tests/ts/cli-claude-init.test.ts
+++ b/tests/ts/cli-claude-init.test.ts
@@ -1,0 +1,197 @@
+// Tests for claude-init CLI command
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('node:fs', () => ({
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+}));
+
+vi.mock('node:os', () => ({
+  homedir: vi.fn(() => '/mock-home'),
+}));
+
+import { claudeInit } from '../../src/cli/commands/claude-init.js';
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+});
+
+describe('claudeInit', () => {
+  it('creates fresh settings with hook on first install', async () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    await claudeInit([]);
+
+    expect(mkdirSync).toHaveBeenCalledWith(expect.stringContaining('.claude'), { recursive: true });
+    expect(writeFileSync).toHaveBeenCalledTimes(1);
+
+    const written = JSON.parse(vi.mocked(writeFileSync).mock.calls[0][1] as string);
+    expect(written.hooks).toBeDefined();
+    expect(written.hooks.PostToolUse).toHaveLength(1);
+    expect(written.hooks.PostToolUse[0].matcher).toBe('Bash');
+    expect(written.hooks.PostToolUse[0].hooks[0].type).toBe('command');
+    expect(written.hooks.PostToolUse[0].hooks[0].command).toContain('claude-hook');
+  });
+
+  it('detects already-configured hook and warns', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(
+      JSON.stringify({
+        hooks: {
+          PostToolUse: [
+            {
+              matcher: 'Bash',
+              hooks: [{ type: 'command', command: 'node /path/to/claude-hook.js' }],
+            },
+          ],
+        },
+      })
+    );
+
+    await claudeInit([]);
+
+    expect(writeFileSync).not.toHaveBeenCalled();
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      expect.stringContaining('Already configured')
+    );
+  });
+
+  it('handles corrupt settings.json gracefully', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue('not valid json{{{');
+
+    await claudeInit([]);
+
+    // Should still install the hook (with fresh config)
+    expect(writeFileSync).toHaveBeenCalledTimes(1);
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      expect.stringContaining('Warning')
+    );
+  });
+
+  it('uses global path with --global flag', async () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    await claudeInit(['--global']);
+
+    expect(mkdirSync).toHaveBeenCalledWith(
+      expect.stringContaining('/mock-home/.claude'),
+      { recursive: true }
+    );
+    expect(writeFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('/mock-home/.claude/settings.json'),
+      expect.any(String),
+      'utf8'
+    );
+  });
+
+  it('uses global path with -g alias', async () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    await claudeInit(['-g']);
+
+    expect(mkdirSync).toHaveBeenCalledWith(
+      expect.stringContaining('/mock-home/.claude'),
+      { recursive: true }
+    );
+  });
+
+  it('removes hook with --remove flag', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(
+      JSON.stringify({
+        hooks: {
+          PostToolUse: [
+            {
+              matcher: 'Bash',
+              hooks: [{ type: 'command', command: 'node /path/to/claude-hook.js' }],
+            },
+          ],
+        },
+      })
+    );
+
+    await claudeInit(['--remove']);
+
+    expect(writeFileSync).toHaveBeenCalledTimes(1);
+    const written = JSON.parse(vi.mocked(writeFileSync).mock.calls[0][1] as string);
+    // hooks and PostToolUse should be cleaned up (empty)
+    expect(written.hooks).toBeUndefined();
+  });
+
+  it('removes hook with --uninstall alias', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(
+      JSON.stringify({
+        hooks: {
+          PostToolUse: [
+            {
+              matcher: 'Bash',
+              hooks: [{ type: 'command', command: 'node /path/to/claude-hook.js' }],
+            },
+          ],
+        },
+      })
+    );
+
+    await claudeInit(['--uninstall']);
+
+    expect(writeFileSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports nothing to remove when no hook is present', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({}));
+
+    await claudeInit(['--remove']);
+
+    expect(writeFileSync).not.toHaveBeenCalled();
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      expect.stringContaining('No AgentGuard hook found')
+    );
+  });
+
+  it('reports nothing to remove when no settings file exists', async () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    await claudeInit(['--remove']);
+
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      expect.stringContaining('No settings file found')
+    );
+  });
+
+  it('preserves other hooks when removing', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(
+      JSON.stringify({
+        hooks: {
+          PostToolUse: [
+            {
+              matcher: 'Bash',
+              hooks: [{ type: 'command', command: 'node /path/to/claude-hook.js' }],
+            },
+            {
+              matcher: 'Write',
+              hooks: [{ type: 'command', command: 'echo custom' }],
+            },
+          ],
+          PreToolUse: [{ matcher: '*', hooks: [{ type: 'command', command: 'echo pre' }] }],
+        },
+      })
+    );
+
+    await claudeInit(['--remove']);
+
+    const written = JSON.parse(vi.mocked(writeFileSync).mock.calls[0][1] as string);
+    // PostToolUse should retain the Write matcher
+    expect(written.hooks.PostToolUse).toHaveLength(1);
+    expect(written.hooks.PostToolUse[0].matcher).toBe('Write');
+    // PreToolUse should be untouched
+    expect(written.hooks.PreToolUse).toBeDefined();
+  });
+});

--- a/tests/ts/cli-inspect.test.ts
+++ b/tests/ts/cli-inspect.test.ts
@@ -1,0 +1,208 @@
+// Tests for inspect CLI command
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('node:fs', () => ({
+  readFileSync: vi.fn(),
+  existsSync: vi.fn(),
+  readdirSync: vi.fn(),
+}));
+
+import { inspect, events } from '../../src/cli/commands/inspect.js';
+import { readFileSync, existsSync, readdirSync } from 'node:fs';
+
+const EVENTS_DIR = '.agentguard/events';
+
+function makeActionEvent(kind: string, overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    id: `evt_${Date.now()}_1`,
+    kind,
+    timestamp: 1700000000000,
+    fingerprint: 'fp_1',
+    actionType: 'file.write',
+    target: 'src/app.ts',
+    reason: 'test reason',
+    ...overrides,
+  });
+}
+
+function makeDecisionRecord(): string {
+  return JSON.stringify({
+    recordId: 'dec_123',
+    runId: 'run_1',
+    timestamp: 1700000000000,
+    action: { type: 'file.write', target: 'src/app.ts', agent: 'test', destructive: false },
+    outcome: 'allow',
+    reason: 'Default allow',
+    intervention: null,
+    policy: { matchedPolicyId: null, matchedPolicyName: null, severity: 3 },
+    invariants: { allHold: true, violations: [] },
+    simulation: null,
+    evidencePackId: null,
+    monitor: { escalationLevel: 0, totalEvaluations: 1, totalDenials: 0 },
+    execution: { executed: true, success: true, durationMs: 5, error: null },
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+});
+
+describe('inspect', () => {
+  it('shows "no runs" message when events directory is missing', async () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(readdirSync).mockReturnValue([]);
+
+    await inspect([]);
+
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      expect.stringContaining('No runs recorded yet')
+    );
+  });
+
+  it('lists runs when called with --list', async () => {
+    vi.mocked(existsSync).mockImplementation((p) => {
+      if (String(p) === EVENTS_DIR) return true;
+      return true;
+    });
+    vi.mocked(readdirSync).mockReturnValue(['run_001.jsonl', 'run_002.jsonl'] as unknown as ReturnType<typeof readdirSync>);
+
+    const eventContent = makeActionEvent('ActionAllowed') + '\n';
+    vi.mocked(readFileSync).mockReturnValue(eventContent);
+
+    await inspect(['--list']);
+
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      expect.stringContaining('Recorded Runs')
+    );
+  });
+
+  it('loads specific run by ID', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    const content =
+      makeActionEvent('ActionAllowed') + '\n' + makeActionEvent('ActionExecuted') + '\n';
+    vi.mocked(readFileSync).mockReturnValue(content);
+
+    await inspect(['run_001']);
+
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      expect.stringContaining('run_001')
+    );
+  });
+
+  it('loads most recent run with --last', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readdirSync).mockReturnValue(['run_001.jsonl', 'run_002.jsonl'] as unknown as ReturnType<typeof readdirSync>);
+    const content = makeActionEvent('ActionAllowed') + '\n';
+    vi.mocked(readFileSync).mockReturnValue(content);
+
+    await inspect(['--last']);
+
+    // Should load the most recent (sorted reverse → run_002)
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      expect.stringContaining('run_002')
+    );
+  });
+
+  it('shows decision records with --decisions flag', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockImplementation((p) => {
+      const path = String(p);
+      if (path.includes('decisions')) {
+        return makeDecisionRecord() + '\n';
+      }
+      return makeActionEvent('ActionAllowed') + '\n';
+    });
+
+    await inspect(['run_001', '--decisions']);
+
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      expect.stringContaining('Decision Records')
+    );
+  });
+
+  it('handles no events found for a run', async () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    await inspect(['run_missing']);
+
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      expect.stringContaining('No events found')
+    );
+  });
+
+  it('skips malformed JSONL lines gracefully', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    const content = 'garbage-line\n' + makeActionEvent('ActionAllowed') + '\n';
+    vi.mocked(readFileSync).mockReturnValue(content);
+
+    await inspect(['run_001']);
+
+    // Should still render without throwing
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      expect.stringContaining('run_001')
+    );
+  });
+
+  it('shows denied actions with reason', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    const denied = makeActionEvent('ActionDenied', {
+      reason: 'Protected branch policy',
+      metadata: { violations: [{ name: 'no-force-push' }] },
+    });
+    const content = denied + '\n';
+    vi.mocked(readFileSync).mockReturnValue(content);
+
+    await inspect(['run_001']);
+
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      expect.stringContaining('DENIED')
+    );
+  });
+});
+
+describe('events', () => {
+  it('shows usage when no run ID provided', async () => {
+    await events([]);
+
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      expect.stringContaining('Usage:')
+    );
+  });
+
+  it('dumps raw events as JSON to stdout', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    const content = makeActionEvent('ActionRequested') + '\n';
+    vi.mocked(readFileSync).mockReturnValue(content);
+
+    await events(['run_001']);
+
+    expect(process.stdout.write).toHaveBeenCalled();
+    const written = vi.mocked(process.stdout.write).mock.calls[0][0] as string;
+    const parsed = JSON.parse(written.trim());
+    expect(parsed.kind).toBe('ActionRequested');
+  });
+
+  it('handles --last flag', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readdirSync).mockReturnValue(['run_latest.jsonl'] as unknown as ReturnType<typeof readdirSync>);
+    const content = makeActionEvent('ActionAllowed') + '\n';
+    vi.mocked(readFileSync).mockReturnValue(content);
+
+    await events(['--last']);
+
+    expect(process.stdout.write).toHaveBeenCalled();
+  });
+
+  it('shows no runs message for --last when no runs exist', async () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(readdirSync).mockReturnValue([]);
+
+    await events(['--last']);
+
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      expect.stringContaining('No runs recorded')
+    );
+  });
+});

--- a/tests/ts/file-event-store.test.ts
+++ b/tests/ts/file-event-store.test.ts
@@ -1,0 +1,313 @@
+// Tests for createFileEventStore, listSessions, loadSession
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('node:fs', () => ({
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  existsSync: vi.fn(),
+  readdirSync: vi.fn(),
+  appendFileSync: vi.fn(),
+}));
+
+vi.mock('node:os', () => ({
+  homedir: vi.fn(() => '/mock-home'),
+}));
+
+import {
+  createFileEventStore,
+  listSessions,
+  loadSession,
+} from '../../src/cli/file-event-store.js';
+import {
+  readFileSync,
+  writeFileSync,
+  existsSync,
+  readdirSync,
+  appendFileSync,
+} from 'node:fs';
+import type { DomainEvent } from '../../src/core/types.js';
+
+function makeFakeEvent(overrides: Partial<DomainEvent> = {}): DomainEvent {
+  return {
+    id: 'evt_1700000000000_1',
+    kind: 'ActionRequested',
+    timestamp: 1700000000000,
+    fingerprint: 'fp_abc',
+    actionType: 'file.read',
+    target: 'test.ts',
+    justification: 'testing',
+    ...overrides,
+  } as DomainEvent;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// createFileEventStore
+// ---------------------------------------------------------------------------
+
+describe('createFileEventStore', () => {
+  it('creates with provided session ID', () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    const store = createFileEventStore('my-session');
+    expect(store.sessionId).toBe('my-session');
+  });
+
+  it('generates session ID when not provided', () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    const store = createFileEventStore();
+    expect(store.sessionId).toMatch(/^session_/);
+  });
+
+  describe('append', () => {
+    it('appends valid event to file', () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      const store = createFileEventStore('sess1');
+      const event = makeFakeEvent();
+
+      store.append(event);
+
+      expect(appendFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('sess1.jsonl'),
+        expect.stringContaining('"ActionRequested"'),
+        'utf8'
+      );
+    });
+
+    it('throws for invalid event', () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      const store = createFileEventStore('sess1');
+
+      expect(() => store.append({} as DomainEvent)).toThrow('Cannot append invalid event');
+    });
+  });
+
+  describe('query', () => {
+    it('returns all events with no filter', () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readdirSync).mockReturnValue(['s1.jsonl'] as unknown as ReturnType<typeof readdirSync>);
+      const event = makeFakeEvent();
+      vi.mocked(readFileSync).mockReturnValue(JSON.stringify(event) + '\n');
+
+      const store = createFileEventStore('s1');
+      const results = store.query();
+      expect(results).toHaveLength(1);
+      expect(results[0].kind).toBe('ActionRequested');
+    });
+
+    it('filters by kind', () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readdirSync).mockReturnValue(['s1.jsonl'] as unknown as ReturnType<typeof readdirSync>);
+      const events = [
+        makeFakeEvent({ kind: 'ActionRequested' }),
+        makeFakeEvent({ id: 'evt_2', kind: 'ActionAllowed' }),
+      ];
+      vi.mocked(readFileSync).mockReturnValue(
+        events.map((e) => JSON.stringify(e)).join('\n') + '\n'
+      );
+
+      const store = createFileEventStore('s1');
+      const results = store.query({ kind: 'ActionAllowed' });
+      expect(results).toHaveLength(1);
+      expect(results[0].kind).toBe('ActionAllowed');
+    });
+
+    it('filters by since timestamp', () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readdirSync).mockReturnValue(['s1.jsonl'] as unknown as ReturnType<typeof readdirSync>);
+      const events = [
+        makeFakeEvent({ timestamp: 1000 }),
+        makeFakeEvent({ id: 'evt_2', timestamp: 2000 }),
+      ];
+      vi.mocked(readFileSync).mockReturnValue(
+        events.map((e) => JSON.stringify(e)).join('\n') + '\n'
+      );
+
+      const store = createFileEventStore('s1');
+      const results = store.query({ since: 1500 });
+      expect(results).toHaveLength(1);
+      expect(results[0].timestamp).toBe(2000);
+    });
+
+    it('filters by until timestamp', () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readdirSync).mockReturnValue(['s1.jsonl'] as unknown as ReturnType<typeof readdirSync>);
+      const events = [
+        makeFakeEvent({ timestamp: 1000 }),
+        makeFakeEvent({ id: 'evt_2', timestamp: 2000 }),
+      ];
+      vi.mocked(readFileSync).mockReturnValue(
+        events.map((e) => JSON.stringify(e)).join('\n') + '\n'
+      );
+
+      const store = createFileEventStore('s1');
+      const results = store.query({ until: 1500 });
+      expect(results).toHaveLength(1);
+      expect(results[0].timestamp).toBe(1000);
+    });
+
+    it('filters by fingerprint', () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readdirSync).mockReturnValue(['s1.jsonl'] as unknown as ReturnType<typeof readdirSync>);
+      const events = [
+        makeFakeEvent({ fingerprint: 'fp_1' }),
+        makeFakeEvent({ id: 'evt_2', fingerprint: 'fp_2' }),
+      ];
+      vi.mocked(readFileSync).mockReturnValue(
+        events.map((e) => JSON.stringify(e)).join('\n') + '\n'
+      );
+
+      const store = createFileEventStore('s1');
+      const results = store.query({ fingerprint: 'fp_2' });
+      expect(results).toHaveLength(1);
+    });
+  });
+
+  describe('replay', () => {
+    it('returns all events when no fromId specified', () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readdirSync).mockReturnValue(['s1.jsonl'] as unknown as ReturnType<typeof readdirSync>);
+      const events = [makeFakeEvent({ id: 'evt_1' }), makeFakeEvent({ id: 'evt_2' })];
+      vi.mocked(readFileSync).mockReturnValue(
+        events.map((e) => JSON.stringify(e)).join('\n') + '\n'
+      );
+
+      const store = createFileEventStore('s1');
+      const results = store.replay();
+      expect(results).toHaveLength(2);
+    });
+
+    it('returns events from specific ID onward', () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readdirSync).mockReturnValue(['s1.jsonl'] as unknown as ReturnType<typeof readdirSync>);
+      const events = [
+        makeFakeEvent({ id: 'evt_1', timestamp: 1000 }),
+        makeFakeEvent({ id: 'evt_2', timestamp: 2000 }),
+        makeFakeEvent({ id: 'evt_3', timestamp: 3000 }),
+      ];
+      vi.mocked(readFileSync).mockReturnValue(
+        events.map((e) => JSON.stringify(e)).join('\n') + '\n'
+      );
+
+      const store = createFileEventStore('s1');
+      const results = store.replay('evt_2');
+      expect(results).toHaveLength(2);
+      expect(results[0].id).toBe('evt_2');
+    });
+
+    it('returns empty array when fromId not found', () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readdirSync).mockReturnValue(['s1.jsonl'] as unknown as ReturnType<typeof readdirSync>);
+      vi.mocked(readFileSync).mockReturnValue(
+        JSON.stringify(makeFakeEvent()) + '\n'
+      );
+
+      const store = createFileEventStore('s1');
+      const results = store.replay('nonexistent');
+      expect(results).toEqual([]);
+    });
+  });
+
+  describe('count', () => {
+    it('returns total event count', () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readdirSync).mockReturnValue(['s1.jsonl'] as unknown as ReturnType<typeof readdirSync>);
+      const events = [makeFakeEvent({ id: 'evt_1' }), makeFakeEvent({ id: 'evt_2' })];
+      vi.mocked(readFileSync).mockReturnValue(
+        events.map((e) => JSON.stringify(e)).join('\n') + '\n'
+      );
+
+      const store = createFileEventStore('s1');
+      expect(store.count()).toBe(2);
+    });
+  });
+
+  describe('clear', () => {
+    it('empties the session file', () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      const store = createFileEventStore('sess1');
+
+      store.clear();
+
+      expect(writeFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('sess1.jsonl'),
+        '',
+        'utf8'
+      );
+    });
+
+    it('does nothing when session file does not exist', () => {
+      vi.mocked(existsSync).mockImplementation((p) => {
+        // Return true for dir creation, false for session file
+        return !String(p).endsWith('.jsonl');
+      });
+      const store = createFileEventStore('missing');
+
+      store.clear(); // Should not throw
+
+      expect(writeFileSync).not.toHaveBeenCalled();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listSessions
+// ---------------------------------------------------------------------------
+
+describe('listSessions', () => {
+  it('returns session IDs from directory', () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readdirSync).mockReturnValue([
+      'session_1.jsonl',
+      'session_2.jsonl',
+      'other.txt',
+    ] as unknown as ReturnType<typeof readdirSync>);
+
+    const sessions = listSessions();
+    expect(sessions).toEqual(['session_1', 'session_2']);
+  });
+
+  it('returns empty array when no files exist', () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readdirSync).mockReturnValue([]);
+
+    expect(listSessions()).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadSession
+// ---------------------------------------------------------------------------
+
+describe('loadSession', () => {
+  it('loads events from a specific session file', () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    const event = makeFakeEvent();
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify(event) + '\n');
+
+    const events = loadSession('my-session');
+    expect(events).toHaveLength(1);
+    expect(events[0].kind).toBe('ActionRequested');
+  });
+
+  it('returns empty array when session file does not exist', () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    const events = loadSession('nonexistent');
+    expect(events).toEqual([]);
+  });
+
+  it('skips malformed lines', () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    const event = makeFakeEvent();
+    vi.mocked(readFileSync).mockReturnValue(
+      'garbage\n' + JSON.stringify(event) + '\n'
+    );
+
+    const events = loadSession('partial');
+    expect(events).toHaveLength(1);
+  });
+});

--- a/tests/ts/kernel-integration.test.ts
+++ b/tests/ts/kernel-integration.test.ts
@@ -1,0 +1,262 @@
+// Integration test — end-to-end kernel pipeline with policies, invariants, events, and escalation
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createKernel } from '../../src/kernel/kernel.js';
+import type { KernelConfig, KernelResult, EventSink } from '../../src/kernel/kernel.js';
+import type { DomainEvent } from '../../src/core/types.js';
+import type { GovernanceDecisionRecord, DecisionSink } from '../../src/kernel/decisions/types.js';
+import { resetActionCounter } from '../../src/core/actions.js';
+import { resetEventCounter } from '../../src/events/schema.js';
+
+beforeEach(() => {
+  resetActionCounter();
+  resetEventCounter();
+});
+
+// ---------------------------------------------------------------------------
+// Full pipeline: policy + events + decisions
+// ---------------------------------------------------------------------------
+
+describe('Kernel integration — full pipeline', () => {
+  it('processes multiple actions and tracks full event lifecycle', async () => {
+    const collectedEvents: DomainEvent[] = [];
+    const eventSink: EventSink = { write: (e) => collectedEvents.push(e) };
+
+    const kernel = createKernel({
+      dryRun: true,
+      sinks: [eventSink],
+      policyDefs: [
+        {
+          id: 'protect-main',
+          name: 'Protect Main',
+          rules: [{ action: 'git.push', effect: 'deny', reason: 'No pushing' }],
+          severity: 4,
+        },
+      ],
+    });
+
+    // Action 1: allowed file read
+    const r1 = await kernel.propose({ tool: 'Read', file: 'src/app.ts', agent: 'ci-agent' });
+    expect(r1.allowed).toBe(true);
+
+    // Action 2: allowed shell command
+    const r2 = await kernel.propose({ tool: 'Bash', command: 'npm test', agent: 'ci-agent' });
+    expect(r2.allowed).toBe(true);
+
+    // Action 3: denied git push
+    const r3 = await kernel.propose({
+      tool: 'Bash',
+      command: 'git push origin main',
+      agent: 'ci-agent',
+    });
+    expect(r3.allowed).toBe(false);
+    expect(r3.decision.decision.reason).toContain('No pushing');
+
+    // Verify event lifecycle
+    expect(kernel.getActionLog()).toHaveLength(3);
+    expect(kernel.getEventCount()).toBeGreaterThan(0);
+
+    // All events should have been sunk
+    expect(collectedEvents.length).toBe(kernel.getEventCount());
+
+    // Should have ActionRequested events for each action
+    const requested = collectedEvents.filter((e) => e.kind === 'ActionRequested');
+    expect(requested.length).toBe(3);
+
+    // Should have ActionAllowed for allowed actions
+    const allowed = collectedEvents.filter((e) => e.kind === 'ActionAllowed');
+    expect(allowed.length).toBe(2);
+
+    // Should have ActionDenied for denied action
+    const denied = collectedEvents.filter((e) => e.kind === 'ActionDenied');
+    expect(denied.length).toBe(1);
+  });
+
+  it('generates decision records and sinks them', async () => {
+    const records: GovernanceDecisionRecord[] = [];
+    const decisionSink: DecisionSink = { write: (r) => records.push(r) };
+
+    const kernel = createKernel({
+      dryRun: true,
+      decisionSinks: [decisionSink],
+    });
+
+    await kernel.propose({ tool: 'Read', file: 'a.ts', agent: 'test' });
+    await kernel.propose({ tool: 'Bash', command: 'rm -rf /', agent: 'test' });
+
+    expect(records).toHaveLength(2);
+    expect(records[0].outcome).toBe('allow');
+    expect(records[1].outcome).toBe('deny');
+    expect(records[0].runId).toBe(kernel.getRunId());
+    expect(records[1].runId).toBe(kernel.getRunId());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Escalation tracking
+// ---------------------------------------------------------------------------
+
+describe('Kernel integration — escalation', () => {
+  it('escalation level increases after repeated denials', async () => {
+    const kernel = createKernel({
+      dryRun: true,
+      denialThreshold: 3,
+      policyDefs: [
+        {
+          id: 'deny-all-push',
+          name: 'Deny Push',
+          rules: [{ action: 'git.push', effect: 'deny', reason: 'blocked' }],
+          severity: 4,
+        },
+      ],
+    });
+
+    // Generate multiple denials to trigger escalation
+    const results: KernelResult[] = [];
+    for (let i = 0; i < 5; i++) {
+      const r = await kernel.propose({
+        tool: 'Bash',
+        command: 'git push origin main',
+        agent: 'test',
+      });
+      results.push(r);
+    }
+
+    // All should be denied
+    expect(results.every((r) => !r.allowed)).toBe(true);
+
+    // Escalation should have increased beyond NORMAL (0)
+    const lastResult = results[results.length - 1];
+    expect(lastResult.decision.monitor.escalationLevel).toBeGreaterThan(0);
+    expect(lastResult.decision.monitor.totalDenials).toBeGreaterThanOrEqual(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Policy + invariant interaction
+// ---------------------------------------------------------------------------
+
+describe('Kernel integration — policy and invariant interaction', () => {
+  it('denies destructive command even without explicit policy', async () => {
+    const kernel = createKernel({ dryRun: true });
+
+    const result = await kernel.propose({
+      tool: 'Bash',
+      command: 'rm -rf /',
+      agent: 'test',
+    });
+
+    expect(result.allowed).toBe(false);
+    expect(result.decision.intent.destructive).toBe(true);
+  });
+
+  it('detects git force push as destructive', async () => {
+    const kernel = createKernel({ dryRun: true });
+
+    const result = await kernel.propose({
+      tool: 'Bash',
+      command: 'git push --force origin main',
+      agent: 'test',
+    });
+
+    expect(result.allowed).toBe(false);
+    expect(result.decision.intent.action).toBe('git.force-push');
+  });
+
+  it('allows benign commands through', async () => {
+    const kernel = createKernel({ dryRun: true });
+
+    const result = await kernel.propose({
+      tool: 'Bash',
+      command: 'echo hello',
+      agent: 'test',
+    });
+
+    expect(result.allowed).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Multiple policies
+// ---------------------------------------------------------------------------
+
+describe('Kernel integration — multiple policies', () => {
+  it('evaluates actions against all loaded policies', async () => {
+    const kernel = createKernel({
+      dryRun: true,
+      policyDefs: [
+        {
+          id: 'no-push',
+          name: 'No Push',
+          rules: [{ action: 'git.push', effect: 'deny', reason: 'Push denied by policy 1' }],
+          severity: 4,
+        },
+        {
+          id: 'no-deploy',
+          name: 'No Deploy',
+          rules: [
+            { action: 'deploy.trigger', effect: 'deny', reason: 'Deploy denied by policy 2' },
+          ],
+          severity: 5,
+        },
+      ],
+    });
+
+    const pushResult = await kernel.propose({
+      tool: 'Bash',
+      command: 'git push origin main',
+      agent: 'test',
+    });
+    expect(pushResult.allowed).toBe(false);
+    expect(pushResult.decision.decision.reason).toContain('Push denied');
+
+    // File reads should still be allowed
+    const readResult = await kernel.propose({
+      tool: 'Read',
+      file: 'package.json',
+      agent: 'test',
+    });
+    expect(readResult.allowed).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Event ordering
+// ---------------------------------------------------------------------------
+
+describe('Kernel integration — event ordering', () => {
+  it('events are emitted in correct lifecycle order', async () => {
+    const events: DomainEvent[] = [];
+    const sink: EventSink = { write: (e) => events.push(e) };
+
+    const kernel = createKernel({ dryRun: true, sinks: [sink] });
+
+    await kernel.propose({ tool: 'Read', file: 'test.ts', agent: 'test' });
+
+    // Filter to action lifecycle events only
+    const lifecycleKinds = events
+      .filter((e) =>
+        ['ActionRequested', 'ActionAllowed', 'ActionDenied', 'ActionExecuted'].includes(e.kind)
+      )
+      .map((e) => e.kind);
+
+    // For an allowed dry-run: ActionRequested → ActionAllowed
+    expect(lifecycleKinds[0]).toBe('ActionRequested');
+    expect(lifecycleKinds[1]).toBe('ActionAllowed');
+  });
+
+  it('denied actions emit ActionRequested → ActionDenied', async () => {
+    const events: DomainEvent[] = [];
+    const sink: EventSink = { write: (e) => events.push(e) };
+
+    const kernel = createKernel({ dryRun: true, sinks: [sink] });
+
+    await kernel.propose({ tool: 'Bash', command: 'rm -rf /', agent: 'test' });
+
+    const lifecycleKinds = events
+      .filter((e) => ['ActionRequested', 'ActionDenied'].includes(e.kind))
+      .map((e) => e.kind);
+
+    expect(lifecycleKinds[0]).toBe('ActionRequested');
+    expect(lifecycleKinds[1]).toBe('ActionDenied');
+  });
+});

--- a/tests/ts/policy-loader.test.ts
+++ b/tests/ts/policy-loader.test.ts
@@ -1,0 +1,265 @@
+// Tests for policy loader — validation and loading
+import { describe, it, expect } from 'vitest';
+import { validatePolicy, loadPolicies, VALID_ACTIONS } from '../../src/policy/loader.js';
+
+// ---------------------------------------------------------------------------
+// validatePolicy
+// ---------------------------------------------------------------------------
+
+describe('validatePolicy', () => {
+  it('accepts a valid policy', () => {
+    const result = validatePolicy({
+      id: 'test-policy',
+      name: 'Test Policy',
+      rules: [{ action: 'file.write', effect: 'deny', reason: 'No writes' }],
+    });
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('rejects null policy', () => {
+    const result = validatePolicy(null);
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toContain('non-null object');
+  });
+
+  it('rejects policy missing id', () => {
+    const result = validatePolicy({
+      name: 'No ID',
+      rules: [{ action: '*', effect: 'allow' }],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toEqual(expect.arrayContaining([expect.stringContaining('id')]));
+  });
+
+  it('rejects policy missing name', () => {
+    const result = validatePolicy({
+      id: 'no-name',
+      rules: [{ action: '*', effect: 'allow' }],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toEqual(expect.arrayContaining([expect.stringContaining('name')]));
+  });
+
+  it('rejects policy with no rules', () => {
+    const result = validatePolicy({
+      id: 'no-rules',
+      name: 'No Rules',
+      rules: [],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toEqual(
+      expect.arrayContaining([expect.stringContaining('at least one rule')])
+    );
+  });
+
+  it('rejects policy with missing rules array', () => {
+    const result = validatePolicy({
+      id: 'bad',
+      name: 'Bad',
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  it('reports rule validation errors with index', () => {
+    const result = validatePolicy({
+      id: 'bad-rules',
+      name: 'Bad Rules',
+      rules: [{ action: 'file.write', effect: 'invalid-effect' }],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toContain('Rule[0]');
+    expect(result.errors[0]).toContain('Invalid effect');
+  });
+
+  it('validates rule missing action', () => {
+    const result = validatePolicy({
+      id: 'no-action',
+      name: 'No Action',
+      rules: [{ effect: 'deny' }],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toEqual(
+      expect.arrayContaining([expect.stringContaining('action')])
+    );
+  });
+
+  it('validates rule missing effect', () => {
+    const result = validatePolicy({
+      id: 'no-effect',
+      name: 'No Effect',
+      rules: [{ action: 'file.write' }],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toEqual(
+      expect.arrayContaining([expect.stringContaining('effect')])
+    );
+  });
+
+  it('validates non-string action type', () => {
+    const result = validatePolicy({
+      id: 'bad-action',
+      name: 'Bad Action',
+      rules: [{ action: 123, effect: 'deny' }],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toEqual(
+      expect.arrayContaining([expect.stringContaining('Invalid action type')])
+    );
+  });
+
+  it('accepts array of actions in a rule', () => {
+    const result = validatePolicy({
+      id: 'multi-action',
+      name: 'Multi',
+      rules: [{ action: ['file.write', 'file.delete'], effect: 'deny' }],
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it('validates severity range (1-5)', () => {
+    const valid = validatePolicy({
+      id: 's',
+      name: 's',
+      rules: [{ action: '*', effect: 'allow' }],
+      severity: 3,
+    });
+    expect(valid.valid).toBe(true);
+
+    const tooLow = validatePolicy({
+      id: 's',
+      name: 's',
+      rules: [{ action: '*', effect: 'allow' }],
+      severity: 0,
+    });
+    expect(tooLow.valid).toBe(false);
+
+    const tooHigh = validatePolicy({
+      id: 's',
+      name: 's',
+      rules: [{ action: '*', effect: 'allow' }],
+      severity: 6,
+    });
+    expect(tooHigh.valid).toBe(false);
+  });
+
+  it('validates condition types', () => {
+    const result = validatePolicy({
+      id: 'cond',
+      name: 'Cond',
+      rules: [{ action: '*', effect: 'deny', conditions: { limit: 'not-a-number' } }],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toEqual(
+      expect.arrayContaining([expect.stringContaining('limit')])
+    );
+  });
+
+  it('rejects non-object conditions', () => {
+    const result = validatePolicy({
+      id: 'cond',
+      name: 'Cond',
+      rules: [{ action: '*', effect: 'deny', conditions: 'string' }],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toEqual(
+      expect.arrayContaining([expect.stringContaining('Conditions must be an object')])
+    );
+  });
+
+  it('rejects non-object rule', () => {
+    const result = validatePolicy({
+      id: 'bad',
+      name: 'Bad',
+      rules: ['not-an-object'],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toEqual(
+      expect.arrayContaining([expect.stringContaining('non-null object')])
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadPolicies
+// ---------------------------------------------------------------------------
+
+describe('loadPolicies', () => {
+  it('loads valid policies', () => {
+    const { policies, errors } = loadPolicies([
+      {
+        id: 'p1',
+        name: 'Policy 1',
+        rules: [{ action: '*', effect: 'allow' }],
+      },
+    ]);
+    expect(policies).toHaveLength(1);
+    expect(policies[0].id).toBe('p1');
+    expect(errors).toHaveLength(0);
+  });
+
+  it('sets default severity to 3', () => {
+    const { policies } = loadPolicies([
+      {
+        id: 'p1',
+        name: 'Policy 1',
+        rules: [{ action: '*', effect: 'allow' }],
+      },
+    ]);
+    expect(policies[0].severity).toBe(3);
+  });
+
+  it('preserves explicit severity', () => {
+    const { policies } = loadPolicies([
+      {
+        id: 'p1',
+        name: 'Policy 1',
+        rules: [{ action: '*', effect: 'allow' }],
+        severity: 5,
+      },
+    ]);
+    expect(policies[0].severity).toBe(5);
+  });
+
+  it('detects duplicate policy IDs', () => {
+    const { policies, errors } = loadPolicies([
+      { id: 'dup', name: 'First', rules: [{ action: '*', effect: 'allow' }] },
+      { id: 'dup', name: 'Second', rules: [{ action: '*', effect: 'deny' }] },
+    ]);
+    expect(policies).toHaveLength(1);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('Duplicate policy ID');
+  });
+
+  it('skips invalid policies and collects errors', () => {
+    const { policies, errors } = loadPolicies([
+      { id: 'valid', name: 'Valid', rules: [{ action: '*', effect: 'allow' }] },
+      { id: 'invalid' }, // missing name and rules
+    ]);
+    expect(policies).toHaveLength(1);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('returns error for non-array input', () => {
+    const { policies, errors } = loadPolicies('not-an-array' as unknown as unknown[]);
+    expect(policies).toHaveLength(0);
+    expect(errors[0]).toContain('must be an array');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// VALID_ACTIONS
+// ---------------------------------------------------------------------------
+
+describe('VALID_ACTIONS', () => {
+  it('includes core action types', () => {
+    expect(VALID_ACTIONS.has('file.write')).toBe(true);
+    expect(VALID_ACTIONS.has('git.push')).toBe(true);
+    expect(VALID_ACTIONS.has('shell.exec')).toBe(true);
+    expect(VALID_ACTIONS.has('*')).toBe(true);
+  });
+
+  it('does not include arbitrary strings', () => {
+    expect(VALID_ACTIONS.has('random.action')).toBe(false);
+  });
+});

--- a/tests/ts/tui-renderer.test.ts
+++ b/tests/ts/tui-renderer.test.ts
@@ -1,0 +1,492 @@
+// Tests for TUI renderer — pure string-rendering functions
+import { describe, it, expect } from 'vitest';
+import {
+  renderBanner,
+  renderAction,
+  renderViolations,
+  renderMonitorStatus,
+  renderSimulation,
+  renderDecisionRecord,
+  renderDecisionTable,
+  renderKernelResult,
+  renderActionGraph,
+  renderEventStream,
+} from '../../src/cli/tui.js';
+import type { KernelResult } from '../../src/kernel/kernel.js';
+import type { MonitorDecision } from '../../src/kernel/monitor.js';
+import type { GovernanceDecisionRecord } from '../../src/kernel/decisions/types.js';
+import type { SimulationResult } from '../../src/kernel/simulation/types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeKernelResult(overrides: Partial<KernelResult> = {}): KernelResult {
+  return {
+    allowed: true,
+    executed: true,
+    decision: {
+      intent: { action: 'file.read', target: 'src/index.ts', agent: 'test' },
+      decision: { allowed: true, reason: 'default allow', matchedPolicy: null },
+      violations: [],
+      monitor: { escalationLevel: 0, totalEvaluations: 1, totalDenials: 0, totalViolations: 0 },
+    } as unknown as MonitorDecision,
+    execution: null,
+    action: null,
+    events: [],
+    runId: 'run_123',
+    ...overrides,
+  };
+}
+
+function makeDeniedResult(overrides: Partial<KernelResult> = {}): KernelResult {
+  return makeKernelResult({
+    allowed: false,
+    executed: false,
+    decision: {
+      intent: { action: 'git.push', target: 'origin/main', agent: 'test' },
+      decision: {
+        allowed: false,
+        reason: 'Protected branch',
+        matchedPolicy: { id: 'protect-main', name: 'Protect Main', severity: 4 },
+      },
+      violations: [],
+      monitor: { escalationLevel: 0, totalEvaluations: 1, totalDenials: 1, totalViolations: 0 },
+    } as unknown as MonitorDecision,
+    ...overrides,
+  });
+}
+
+function makeDecisionRecord(overrides: Partial<GovernanceDecisionRecord> = {}): GovernanceDecisionRecord {
+  return {
+    recordId: 'dec_123',
+    runId: 'run_123',
+    timestamp: 1700000000000,
+    action: { type: 'file.write', target: 'src/app.ts', agent: 'test', destructive: false },
+    outcome: 'allow',
+    reason: 'Default allow',
+    intervention: null,
+    policy: { matchedPolicyId: null, matchedPolicyName: null, severity: 3 },
+    invariants: { allHold: true, violations: [] },
+    simulation: null,
+    evidencePackId: null,
+    monitor: { escalationLevel: 0, totalEvaluations: 1, totalDenials: 0 },
+    execution: { executed: true, success: true, durationMs: 12, error: null },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// renderBanner
+// ---------------------------------------------------------------------------
+
+describe('renderBanner', () => {
+  it('renders banner with no config', () => {
+    const output = renderBanner({});
+    expect(output).toContain('AgentGuard Runtime Active');
+  });
+
+  it('includes policy name when provided', () => {
+    const output = renderBanner({ policyName: 'security-policy' });
+    expect(output).toContain('policy:');
+    expect(output).toContain('security-policy');
+  });
+
+  it('includes invariant count when provided', () => {
+    const output = renderBanner({ invariantCount: 6 });
+    expect(output).toContain('invariants:');
+    expect(output).toContain('6');
+    expect(output).toContain('active');
+  });
+
+  it('includes both policy name and invariant count', () => {
+    const output = renderBanner({ policyName: 'test-policy', invariantCount: 3 });
+    expect(output).toContain('test-policy');
+    expect(output).toContain('3');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderAction
+// ---------------------------------------------------------------------------
+
+describe('renderAction', () => {
+  it('renders allowed action with checkmark', () => {
+    const output = renderAction(makeKernelResult());
+    expect(output).toContain('\u2713'); // ✓
+    expect(output).toContain('file.read');
+    expect(output).toContain('src/index.ts');
+  });
+
+  it('renders dry-run tag when not executed', () => {
+    const output = renderAction(makeKernelResult({ executed: false }));
+    expect(output).toContain('dry-run');
+  });
+
+  it('renders denied action with cross mark and reason', () => {
+    const output = renderAction(makeDeniedResult());
+    expect(output).toContain('\u2717'); // ✗
+    expect(output).toContain('DENIED');
+    expect(output).toContain('protect-main');
+  });
+
+  it('shows reason in verbose mode', () => {
+    const output = renderAction(makeDeniedResult(), true);
+    expect(output).toContain('Protected branch');
+  });
+
+  it('does not show reason when not verbose', () => {
+    const lines = renderAction(makeDeniedResult(), false).split('\n');
+    // Only the main line, no reason line
+    expect(lines).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderViolations
+// ---------------------------------------------------------------------------
+
+describe('renderViolations', () => {
+  it('returns empty string when no violations', () => {
+    const output = renderViolations(makeKernelResult());
+    expect(output).toBe('');
+  });
+
+  it('renders each violation with warning icon', () => {
+    const result = makeKernelResult({
+      decision: {
+        ...makeKernelResult().decision,
+        violations: [
+          { name: 'no-secret-exposure', holds: false, severity: 5, expected: 'no secrets', actual: 'found API key' },
+          { name: 'blast-radius-limit', holds: false, severity: 3, expected: '<=10', actual: '25' },
+        ],
+      } as unknown as MonitorDecision,
+    });
+    const output = renderViolations(result);
+    expect(output).toContain('\u26A0'); // ⚠
+    expect(output).toContain('no-secret-exposure');
+    expect(output).toContain('blast-radius-limit');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderMonitorStatus
+// ---------------------------------------------------------------------------
+
+describe('renderMonitorStatus', () => {
+  it('renders NORMAL level in green', () => {
+    const output = renderMonitorStatus({
+      monitor: { escalationLevel: 0, totalEvaluations: 5, totalDenials: 0, totalViolations: 0 },
+    } as MonitorDecision);
+    expect(output).toContain('NORMAL');
+    expect(output).toContain('evals:5');
+    expect(output).toContain('denied:0');
+  });
+
+  it('renders ELEVATED level', () => {
+    const output = renderMonitorStatus({
+      monitor: { escalationLevel: 1, totalEvaluations: 10, totalDenials: 3, totalViolations: 1 },
+    } as MonitorDecision);
+    expect(output).toContain('ELEVATED');
+    expect(output).toContain('denied:3');
+  });
+
+  it('renders HIGH level', () => {
+    const output = renderMonitorStatus({
+      monitor: { escalationLevel: 2, totalEvaluations: 20, totalDenials: 8, totalViolations: 3 },
+    } as MonitorDecision);
+    expect(output).toContain('HIGH');
+  });
+
+  it('renders LOCKDOWN level', () => {
+    const output = renderMonitorStatus({
+      monitor: { escalationLevel: 3, totalEvaluations: 50, totalDenials: 20, totalViolations: 10 },
+    } as MonitorDecision);
+    expect(output).toContain('LOCKDOWN');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderSimulation
+// ---------------------------------------------------------------------------
+
+describe('renderSimulation', () => {
+  it('renders simulation with predicted changes', () => {
+    const sim: SimulationResult = {
+      predictedChanges: ['Create file: src/new.ts', 'Modify file: src/app.ts'],
+      blastRadius: 2,
+      riskLevel: 'low',
+      details: {},
+      simulatorId: 'filesystem',
+      durationMs: 5,
+    };
+    const output = renderSimulation(sim);
+    expect(output).toContain('Simulation');
+    expect(output).toContain('filesystem');
+    expect(output).toContain('Create file: src/new.ts');
+    expect(output).toContain('Modify file: src/app.ts');
+    expect(output).toContain('blast radius:');
+    expect(output).toContain('2');
+    expect(output).toContain('low');
+    expect(output).toContain('5ms');
+  });
+
+  it('applies red color for high risk', () => {
+    const sim: SimulationResult = {
+      predictedChanges: ['Delete entire dist/'],
+      blastRadius: 50,
+      riskLevel: 'high',
+      details: {},
+      simulatorId: 'filesystem',
+      durationMs: 10,
+    };
+    const output = renderSimulation(sim);
+    expect(output).toContain('high');
+    expect(output).toContain('\x1b[31m'); // red ANSI code
+  });
+
+  it('applies yellow color for medium risk', () => {
+    const sim: SimulationResult = {
+      predictedChanges: [],
+      blastRadius: 5,
+      riskLevel: 'medium',
+      details: {},
+      simulatorId: 'git',
+      durationMs: 3,
+    };
+    const output = renderSimulation(sim);
+    expect(output).toContain('medium');
+    expect(output).toContain('\x1b[33m'); // yellow ANSI code
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderDecisionRecord
+// ---------------------------------------------------------------------------
+
+describe('renderDecisionRecord', () => {
+  it('renders an allow decision', () => {
+    const output = renderDecisionRecord(makeDecisionRecord());
+    expect(output).toContain('Decision Record');
+    expect(output).toContain('dec_123');
+    expect(output).toContain('file.write');
+    expect(output).toContain('ALLOW');
+    expect(output).toContain('\u2713'); // ✓
+    expect(output).toContain('12ms');
+  });
+
+  it('renders a deny decision', () => {
+    const output = renderDecisionRecord(
+      makeDecisionRecord({ outcome: 'deny', reason: 'Policy denied' })
+    );
+    expect(output).toContain('DENY');
+    expect(output).toContain('\u2717'); // ✗
+    expect(output).toContain('Policy denied');
+  });
+
+  it('shows matched policy when present', () => {
+    const output = renderDecisionRecord(
+      makeDecisionRecord({
+        policy: { matchedPolicyId: 'p1', matchedPolicyName: 'Security', severity: 4 },
+      })
+    );
+    expect(output).toContain('Security');
+    expect(output).toContain('p1');
+  });
+
+  it('shows invariant violations', () => {
+    const output = renderDecisionRecord(
+      makeDecisionRecord({
+        invariants: {
+          allHold: false,
+          violations: [
+            { invariantId: 'inv_1', name: 'no-force-push', severity: 5, expected: 'no force push', actual: 'force push detected' },
+          ],
+        },
+      })
+    );
+    expect(output).toContain('\u26A0'); // ⚠
+    expect(output).toContain('no-force-push');
+  });
+
+  it('shows simulation summary when present', () => {
+    const output = renderDecisionRecord(
+      makeDecisionRecord({
+        simulation: {
+          predictedChanges: ['x'],
+          blastRadius: 3,
+          riskLevel: 'medium',
+          simulatorId: 'fs',
+          durationMs: 2,
+        },
+      })
+    );
+    expect(output).toContain('simulation:');
+    expect(output).toContain('blast=3');
+    expect(output).toContain('medium');
+  });
+
+  it('shows failed execution status', () => {
+    const output = renderDecisionRecord(
+      makeDecisionRecord({
+        execution: { executed: true, success: false, durationMs: 50, error: 'ENOENT' },
+      })
+    );
+    expect(output).toContain('failed');
+    expect(output).toContain('50ms');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderDecisionTable
+// ---------------------------------------------------------------------------
+
+describe('renderDecisionTable', () => {
+  it('renders table header with count', () => {
+    const output = renderDecisionTable([makeDecisionRecord()]);
+    expect(output).toContain('Decision Records');
+    expect(output).toContain('1 decisions');
+  });
+
+  it('renders multiple records with numbering', () => {
+    const records = [
+      makeDecisionRecord({ outcome: 'allow' }),
+      makeDecisionRecord({ recordId: 'dec_456', outcome: 'deny', reason: 'denied by policy' }),
+    ];
+    const output = renderDecisionTable(records);
+    expect(output).toContain('2 decisions');
+    expect(output).toContain('\u2713'); // ✓
+    expect(output).toContain('\u2717'); // ✗
+  });
+
+  it('shows violations for denied records', () => {
+    const records = [
+      makeDecisionRecord({
+        outcome: 'deny',
+        invariants: {
+          allHold: false,
+          violations: [
+            { invariantId: 'inv_1', name: 'protected-branch', severity: 4, expected: '', actual: '' },
+          ],
+        },
+      }),
+    ];
+    const output = renderDecisionTable(records);
+    expect(output).toContain('protected-branch');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderKernelResult
+// ---------------------------------------------------------------------------
+
+describe('renderKernelResult', () => {
+  it('renders action without violations', () => {
+    const output = renderKernelResult(makeKernelResult());
+    expect(output).toContain('file.read');
+    expect(output).toContain('\u2713');
+  });
+
+  it('renders action with violations', () => {
+    const result = makeKernelResult({
+      decision: {
+        ...makeKernelResult().decision,
+        violations: [
+          { name: 'lockfile-integrity', holds: false, severity: 3, expected: '', actual: '' },
+        ],
+      } as unknown as MonitorDecision,
+    });
+    const output = renderKernelResult(result);
+    expect(output).toContain('lockfile-integrity');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderActionGraph
+// ---------------------------------------------------------------------------
+
+describe('renderActionGraph', () => {
+  it('renders graph header with action count', () => {
+    const output = renderActionGraph([makeKernelResult()]);
+    expect(output).toContain('Action Graph');
+    expect(output).toContain('1 actions');
+  });
+
+  it('renders mixed allowed and denied actions', () => {
+    const results = [makeKernelResult(), makeDeniedResult()];
+    const output = renderActionGraph(results);
+    expect(output).toContain('EXECUTED');
+    expect(output).toContain('DENIED');
+    expect(output).toContain('Protected branch');
+  });
+
+  it('shows ALLOWED status for allowed but not executed', () => {
+    const output = renderActionGraph([makeKernelResult({ executed: false })]);
+    expect(output).toContain('ALLOWED');
+  });
+
+  it('renders violations for denied actions', () => {
+    const denied = makeDeniedResult({
+      decision: {
+        ...makeDeniedResult().decision,
+        violations: [
+          { name: 'no-force-push', holds: false, severity: 5, expected: '', actual: '' },
+        ],
+      } as unknown as MonitorDecision,
+    });
+    const output = renderActionGraph([denied]);
+    expect(output).toContain('no-force-push');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderEventStream
+// ---------------------------------------------------------------------------
+
+describe('renderEventStream', () => {
+  it('renders event stream header with count', () => {
+    const events = [{ kind: 'ActionRequested', timestamp: 1700000000000 }];
+    const output = renderEventStream(events);
+    expect(output).toContain('Event Stream');
+    expect(output).toContain('1 events');
+  });
+
+  it('colors denied/violation events in red', () => {
+    const events = [{ kind: 'ActionDenied', timestamp: 1700000000000 }];
+    const output = renderEventStream(events);
+    expect(output).toContain('\x1b[31m'); // red
+    expect(output).toContain('ActionDenied');
+  });
+
+  it('colors allowed/executed events in green', () => {
+    const events = [{ kind: 'ActionAllowed', timestamp: 1700000000000 }];
+    const output = renderEventStream(events);
+    expect(output).toContain('\x1b[32m'); // green
+  });
+
+  it('colors other events in cyan', () => {
+    const events = [{ kind: 'RunStarted', timestamp: 1700000000000 }];
+    const output = renderEventStream(events);
+    expect(output).toContain('\x1b[36m'); // cyan
+  });
+
+  it('formats timestamps as HH:MM:SS.mmm', () => {
+    const events = [{ kind: 'RunStarted', timestamp: 1700000000000 }];
+    const output = renderEventStream(events);
+    // Should contain a time format like HH:MM:SS.mmm
+    expect(output).toMatch(/\d{2}:\d{2}:\d{2}\.\d{3}/);
+  });
+
+  it('renders multiple events in order', () => {
+    const events = [
+      { kind: 'ActionRequested', timestamp: 1700000000000 },
+      { kind: 'ActionAllowed', timestamp: 1700000001000 },
+      { kind: 'ActionExecuted', timestamp: 1700000002000 },
+    ];
+    const output = renderEventStream(events);
+    expect(output).toContain('3 events');
+    const lines = output.split('\n');
+    const eventLines = lines.filter((l) => l.includes('Action'));
+    expect(eventLines).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
Add comprehensive tests for previously untested modules:
- tui-renderer: 39 tests for all TUI render functions
- cli-args: 16 tests for argument parser and help formatter
- cli-inspect: 12 tests for inspect/events commands
- cli-claude-init: 10 tests for hook install/remove
- cli-claude-hook: 7 tests for PostToolUse handler
- file-event-store: 20 tests for CRUD, query, replay
- policy-loader: 23 tests for validation and loading
- kernel-integration: 9 tests for end-to-end pipeline and escalation

Total: 136 new tests, bringing TS test count from 344 to 480.

https://claude.ai/code/session_01BB35JEZ2hiDcqhCHy355VP