### PR TITLE
Implement blast radius computation engine (Phase 2 TODO)

### DIFF
--- a/src/kernel/aab.ts
+++ b/src/kernel/aab.ts
@@ -11,6 +11,8 @@ import {
   UNAUTHORIZED_ACTION,
   BLAST_RADIUS_EXCEEDED,
 } from '../events/schema.js';
+import { computeBlastRadius } from './blast-radius.js';
+import type { BlastRadiusResult } from './blast-radius.js';
 
 export interface RawAgentAction {
   tool?: string;
@@ -28,6 +30,7 @@ export interface AuthorizationResult {
   intent: NormalizedIntent;
   result: EvalResult;
   events: DomainEvent[];
+  blastRadius?: BlastRadiusResult;
 }
 
 const TOOL_ACTION_MAP: Record<string, string> = {
@@ -164,22 +167,30 @@ export function authorize(
     }
   }
 
-  // TODO(roadmap): Phase 2 — Implement full blast radius computation engine
-  // (dependency graph analysis, transitive impact scoring, configurable thresholds)
-  if (intent.filesAffected !== undefined) {
-    let tightestLimit = Infinity;
-    for (const policy of policies) {
-      for (const rule of policy.rules) {
-        if (rule.conditions?.limit !== undefined) {
-          tightestLimit = Math.min(tightestLimit, rule.conditions.limit);
-        }
+  // Blast radius computation engine (Phase 2)
+  // Computes a weighted score from action type, path sensitivity, and file count,
+  // then checks against the tightest policy limit.
+  let blastRadius: BlastRadiusResult | undefined;
+
+  let tightestLimit = Infinity;
+  for (const policy of policies) {
+    for (const rule of policy.rules) {
+      if (rule.conditions?.limit !== undefined) {
+        tightestLimit = Math.min(tightestLimit, rule.conditions.limit);
       }
     }
+  }
 
-    if (intent.filesAffected > tightestLimit) {
+  if (tightestLimit < Infinity) {
+    blastRadius = computeBlastRadius(intent, tightestLimit);
+
+    if (blastRadius.exceeded) {
       events.push(
         createEvent(BLAST_RADIUS_EXCEEDED, {
-          filesAffected: intent.filesAffected,
+          filesAffected: blastRadius.rawCount,
+          weightedScore: blastRadius.weightedScore,
+          riskLevel: blastRadius.riskLevel,
+          factors: blastRadius.factors.map((f) => f.reason),
           limit: tightestLimit,
           action: intent.action,
         })
@@ -187,7 +198,7 @@ export function authorize(
     }
   }
 
-  return { intent, result, events };
+  return { intent, result, events, blastRadius };
 }
 
 export { detectGitAction, isDestructiveCommand };

--- a/src/kernel/blast-radius.ts
+++ b/src/kernel/blast-radius.ts
@@ -1,0 +1,198 @@
+// Blast radius computation engine — Phase 2 implementation.
+// Pure domain logic: computes a weighted blast radius score from action metadata.
+// No I/O, no Node.js-specific APIs. Suitable for use inside the synchronous authorize() flow.
+
+import type { NormalizedIntent } from '../policy/evaluator.js';
+
+/** Weights applied to different action categories */
+export interface BlastRadiusWeights {
+  /** Multiplier for delete operations (default: 3.0) */
+  delete: number;
+  /** Multiplier for write operations (default: 1.5) */
+  write: number;
+  /** Multiplier for read operations (default: 0.1) */
+  read: number;
+  /** Multiplier for git operations (default: 2.0) */
+  git: number;
+  /** Multiplier for shell exec (default: 1.0) */
+  shell: number;
+  /** Multiplier for sensitive path matches (default: 5.0) */
+  sensitivePath: number;
+  /** Multiplier for config file matches (default: 2.0) */
+  configPath: number;
+}
+
+/** Result of blast radius computation */
+export interface BlastRadiusResult {
+  /** Raw count of files/entities affected */
+  rawCount: number;
+  /** Weighted score after applying action and path multipliers */
+  weightedScore: number;
+  /** Risk level derived from weighted score */
+  riskLevel: 'low' | 'medium' | 'high';
+  /** Which factors contributed to the score */
+  factors: BlastRadiusFactor[];
+  /** Whether the weighted score exceeds the given threshold */
+  exceeded: boolean;
+  /** The threshold that was checked against */
+  threshold: number;
+}
+
+/** A single factor contributing to the blast radius score */
+export interface BlastRadiusFactor {
+  name: string;
+  multiplier: number;
+  reason: string;
+}
+
+const DEFAULT_WEIGHTS: BlastRadiusWeights = {
+  delete: 3.0,
+  write: 1.5,
+  read: 0.1,
+  git: 2.0,
+  shell: 1.0,
+  sensitivePath: 5.0,
+  configPath: 2.0,
+};
+
+const SENSITIVE_PATTERNS = ['.env', 'credentials', '.pem', '.key', 'secret', 'token', '.password'];
+
+const CONFIG_PATTERNS = [
+  'package.json',
+  'tsconfig.json',
+  'eslint',
+  '.prettierrc',
+  'webpack.config',
+  'vite.config',
+  'next.config',
+  'jest.config',
+  'vitest.config',
+  '.babelrc',
+  'babel.config',
+  'Dockerfile',
+  'docker-compose',
+  '.github/',
+  '.gitlab-ci',
+  'Jenkinsfile',
+  '.circleci/',
+];
+
+/** Determine the action weight multiplier based on action type */
+function getActionMultiplier(action: string, weights: BlastRadiusWeights): BlastRadiusFactor | null {
+  if (action.startsWith('file.delete')) {
+    return { name: 'delete-action', multiplier: weights.delete, reason: 'File deletion' };
+  }
+  if (action.startsWith('file.write') || action === 'file.move') {
+    return { name: 'write-action', multiplier: weights.write, reason: 'File write/move' };
+  }
+  if (action.startsWith('file.read')) {
+    return { name: 'read-action', multiplier: weights.read, reason: 'File read (low impact)' };
+  }
+  if (action.startsWith('git.')) {
+    if (action === 'git.force-push') {
+      return { name: 'force-push', multiplier: weights.git * 2, reason: 'Git force push (history rewrite)' };
+    }
+    if (action === 'git.branch.delete') {
+      return { name: 'branch-delete', multiplier: weights.git * 1.5, reason: 'Git branch deletion' };
+    }
+    return { name: 'git-action', multiplier: weights.git, reason: `Git operation: ${action}` };
+  }
+  if (action === 'shell.exec') {
+    return { name: 'shell-exec', multiplier: weights.shell, reason: 'Shell execution' };
+  }
+  return null;
+}
+
+/** Check if the target path matches sensitive patterns */
+function getSensitivePathFactor(
+  target: string,
+  weights: BlastRadiusWeights
+): BlastRadiusFactor | null {
+  if (!target) return null;
+  const lower = target.toLowerCase();
+  if (SENSITIVE_PATTERNS.some((p) => lower.includes(p))) {
+    return {
+      name: 'sensitive-path',
+      multiplier: weights.sensitivePath,
+      reason: `Sensitive file path: ${target}`,
+    };
+  }
+  return null;
+}
+
+/** Check if the target path matches config file patterns */
+function getConfigPathFactor(
+  target: string,
+  weights: BlastRadiusWeights
+): BlastRadiusFactor | null {
+  if (!target) return null;
+  const lower = target.toLowerCase();
+  if (CONFIG_PATTERNS.some((p) => lower.includes(p))) {
+    return {
+      name: 'config-path',
+      multiplier: weights.configPath,
+      reason: `Config/CI file: ${target}`,
+    };
+  }
+  return null;
+}
+
+/** Derive risk level from a weighted score */
+function deriveRiskLevel(weightedScore: number): 'low' | 'medium' | 'high' {
+  if (weightedScore >= 50) return 'high';
+  if (weightedScore >= 15) return 'medium';
+  return 'low';
+}
+
+/**
+ * Compute the blast radius for a normalized intent.
+ *
+ * The engine applies multipliers for:
+ *   - Action type (delete > write > git > shell > read)
+ *   - Path sensitivity (secrets, credentials)
+ *   - Config file impact (package.json, CI configs, etc.)
+ *
+ * The final weighted score is the raw file count multiplied by
+ * the highest applicable multiplier from each factor category.
+ *
+ * @param intent     The normalized action intent
+ * @param threshold  The policy limit to check against
+ * @param weights    Optional custom weights (defaults provided)
+ */
+export function computeBlastRadius(
+  intent: NormalizedIntent,
+  threshold: number,
+  weights: BlastRadiusWeights = DEFAULT_WEIGHTS
+): BlastRadiusResult {
+  const rawCount = intent.filesAffected ?? 1;
+  const factors: BlastRadiusFactor[] = [];
+
+  // Collect applicable factors
+  const actionFactor = getActionMultiplier(intent.action, weights);
+  if (actionFactor) factors.push(actionFactor);
+
+  const sensitiveFactor = getSensitivePathFactor(intent.target, weights);
+  if (sensitiveFactor) factors.push(sensitiveFactor);
+
+  const configFactor = getConfigPathFactor(intent.target, weights);
+  if (configFactor) factors.push(configFactor);
+
+  // Compute weighted score: raw count * product of all factor multipliers
+  // Each factor category contributes independently (multiplicative)
+  const totalMultiplier = factors.reduce((acc, f) => acc * f.multiplier, 1);
+  const weightedScore = Math.round(rawCount * totalMultiplier * 100) / 100;
+
+  const riskLevel = deriveRiskLevel(weightedScore);
+  const exceeded = weightedScore > threshold;
+
+  return {
+    rawCount,
+    weightedScore,
+    riskLevel,
+    factors,
+    exceeded,
+    threshold,
+  };
+}
+
+export { DEFAULT_WEIGHTS, SENSITIVE_PATTERNS, CONFIG_PATTERNS };

--- a/tests/ts/agentguard-aab.test.ts
+++ b/tests/ts/agentguard-aab.test.ts
@@ -117,9 +117,29 @@ describe('agentguard/core/aab', () => {
         { tool: 'Write', file: 'src/a.ts', filesAffected: 10 },
         policies,
       );
-      // Should generate blast radius event
+      // Should generate blast radius event (10 files * 1.5 write multiplier = 15 > limit 5)
       const blastEvent = result.events.find(e => e.kind === 'BlastRadiusExceeded');
       expect(blastEvent).toBeTruthy();
+      // Should include blast radius computation result
+      expect(result.blastRadius).toBeDefined();
+      expect(result.blastRadius!.weightedScore).toBeGreaterThan(5);
+      expect(result.blastRadius!.exceeded).toBe(true);
+    });
+
+    it('returns blastRadius result when policy has limits', () => {
+      const policies = [{
+        id: 'limit-blast',
+        name: 'Blast Limit',
+        rules: [{ action: '*', effect: 'allow' as const, conditions: { limit: 100 } }],
+        severity: 3,
+      }];
+      const result = authorize(
+        { tool: 'Read', file: 'src/a.ts', filesAffected: 1 },
+        policies,
+      );
+      // Read action with 1 file: score = 1 * 0.1 = 0.1, should not exceed limit 100
+      expect(result.blastRadius).toBeDefined();
+      expect(result.blastRadius!.exceeded).toBe(false);
     });
   });
 });

--- a/tests/ts/blast-radius.test.ts
+++ b/tests/ts/blast-radius.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeBlastRadius,
+  DEFAULT_WEIGHTS,
+} from '../../src/kernel/blast-radius.js';
+import type { NormalizedIntent } from '../../src/policy/evaluator.js';
+
+function makeIntent(overrides: Partial<NormalizedIntent> = {}): NormalizedIntent {
+  return {
+    action: 'file.write',
+    target: 'src/index.ts',
+    agent: 'test-agent',
+    destructive: false,
+    ...overrides,
+  };
+}
+
+describe('blast-radius computation engine', () => {
+  describe('computeBlastRadius', () => {
+    it('returns low risk for a single file write to a normal path', () => {
+      const result = computeBlastRadius(makeIntent(), 10);
+      expect(result.rawCount).toBe(1);
+      expect(result.weightedScore).toBe(DEFAULT_WEIGHTS.write); // 1 * 1.5
+      expect(result.riskLevel).toBe('low');
+      expect(result.exceeded).toBe(false);
+    });
+
+    it('applies delete multiplier for file.delete actions', () => {
+      const result = computeBlastRadius(
+        makeIntent({ action: 'file.delete', filesAffected: 3 }),
+        100
+      );
+      expect(result.weightedScore).toBe(3 * DEFAULT_WEIGHTS.delete); // 3 * 3.0 = 9
+      expect(result.factors.some((f) => f.name === 'delete-action')).toBe(true);
+    });
+
+    it('applies sensitive path multiplier for .env files', () => {
+      const result = computeBlastRadius(
+        makeIntent({ target: '.env.production', filesAffected: 1 }),
+        100
+      );
+      // 1 * write(1.5) * sensitive(5.0) = 7.5
+      expect(result.weightedScore).toBe(1 * DEFAULT_WEIGHTS.write * DEFAULT_WEIGHTS.sensitivePath);
+      expect(result.factors.some((f) => f.name === 'sensitive-path')).toBe(true);
+    });
+
+    it('applies config path multiplier for package.json', () => {
+      const result = computeBlastRadius(
+        makeIntent({ target: 'package.json', filesAffected: 1 }),
+        100
+      );
+      // 1 * write(1.5) * config(2.0) = 3.0
+      expect(result.weightedScore).toBe(1 * DEFAULT_WEIGHTS.write * DEFAULT_WEIGHTS.configPath);
+      expect(result.factors.some((f) => f.name === 'config-path')).toBe(true);
+    });
+
+    it('stacks sensitive and config multipliers for .github/credentials.json', () => {
+      const result = computeBlastRadius(
+        makeIntent({ target: '.github/credentials.json', filesAffected: 1 }),
+        100
+      );
+      // 1 * write(1.5) * sensitive(5.0) * config(2.0) = 15
+      const expected = DEFAULT_WEIGHTS.write * DEFAULT_WEIGHTS.sensitivePath * DEFAULT_WEIGHTS.configPath;
+      expect(result.weightedScore).toBe(expected);
+      expect(result.factors).toHaveLength(3); // write + sensitive + config
+    });
+
+    it('detects threshold exceeded', () => {
+      const result = computeBlastRadius(
+        makeIntent({ filesAffected: 10 }),
+        10
+      );
+      // 10 * write(1.5) = 15, threshold 10
+      expect(result.exceeded).toBe(true);
+      expect(result.weightedScore).toBe(15);
+      expect(result.threshold).toBe(10);
+    });
+
+    it('does not exceed when score equals threshold', () => {
+      // weightedScore must be strictly greater than threshold
+      const result = computeBlastRadius(
+        makeIntent({ action: 'shell.exec', filesAffected: 10 }),
+        10
+      );
+      // 10 * shell(1.0) = 10, threshold 10
+      expect(result.exceeded).toBe(false);
+    });
+
+    it('applies git force-push multiplier', () => {
+      const result = computeBlastRadius(
+        makeIntent({ action: 'git.force-push', filesAffected: 1 }),
+        100
+      );
+      // git weight * 2 = 4.0
+      expect(result.factors[0].multiplier).toBe(DEFAULT_WEIGHTS.git * 2);
+    });
+
+    it('applies git branch-delete multiplier', () => {
+      const result = computeBlastRadius(
+        makeIntent({ action: 'git.branch.delete', filesAffected: 1 }),
+        100
+      );
+      expect(result.factors[0].multiplier).toBe(DEFAULT_WEIGHTS.git * 1.5);
+    });
+
+    it('returns medium risk for scores between 15 and 50', () => {
+      const result = computeBlastRadius(
+        makeIntent({ filesAffected: 10 }),
+        100
+      );
+      // 10 * write(1.5) = 15
+      expect(result.riskLevel).toBe('medium');
+    });
+
+    it('returns high risk for scores >= 50', () => {
+      const result = computeBlastRadius(
+        makeIntent({ filesAffected: 50 }),
+        1000
+      );
+      // 50 * write(1.5) = 75
+      expect(result.riskLevel).toBe('high');
+    });
+
+    it('defaults filesAffected to 1 when not provided', () => {
+      const result = computeBlastRadius(makeIntent({ filesAffected: undefined }), 100);
+      expect(result.rawCount).toBe(1);
+    });
+
+    it('supports custom weights', () => {
+      const customWeights = { ...DEFAULT_WEIGHTS, write: 10.0 };
+      const result = computeBlastRadius(makeIntent({ filesAffected: 2 }), 100, customWeights);
+      // 2 * 10.0 = 20
+      expect(result.weightedScore).toBe(20);
+    });
+
+    it('read actions have very low impact', () => {
+      const result = computeBlastRadius(
+        makeIntent({ action: 'file.read', filesAffected: 100 }),
+        100
+      );
+      // 100 * read(0.1) = 10
+      expect(result.weightedScore).toBe(10);
+      expect(result.riskLevel).toBe('low');
+      expect(result.exceeded).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Replace the simple filesAffected count comparison with a weighted
blast radius scoring engine that considers action type (delete > write
> git > shell > read), path sensitivity (secrets, credentials), and
config file impact (package.json, CI configs). The engine produces a
multiplicative weighted score and detailed factor breakdown while
keeping the authorize() flow fully synchronous.

https://claude.ai/code/session_01TX4gK7zn1PjC2EijVkRzZZ