### PR TITLE
Add NDJSON serialization to EventStore (Phase 4 TODO)

### DIFF
--- a/src/cli/file-event-store.ts
+++ b/src/cli/file-event-store.ts
@@ -87,6 +87,23 @@ export function createFileEventStore(sessionId?: string): EventStore & { session
         writeFileSync(filePath, '', 'utf8');
       }
     },
+
+    toNDJSON(): string {
+      const allEvents = loadAllEvents();
+      return allEvents.map((e) => JSON.stringify(e)).join('\n');
+    },
+
+    fromNDJSON(ndjson: string): number {
+      const lines = ndjson.split('\n').filter((line) => line.trim().length > 0);
+      let loaded = 0;
+      ensureDir();
+      for (const line of lines) {
+        const parsed = JSON.parse(line) as DomainEvent;
+        appendFileSync(sessionFileName(sid), JSON.stringify(parsed) + '\n', 'utf8');
+        loaded++;
+      }
+      return loaded;
+    },
   };
 }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -241,6 +241,8 @@ export interface EventStore {
   replay(fromId?: string): DomainEvent[];
   count(): number;
   clear(): void;
+  toNDJSON(): string;
+  fromNDJSON(ndjson: string): number;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/events/store.ts
+++ b/src/events/store.ts
@@ -2,7 +2,6 @@
 // No DOM, no Node.js APIs — pure domain logic.
 //
 // TODO(roadmap): Phase 4 — File-based event store (.agentguard/events/)
-// TODO(roadmap): Phase 4 — Event stream serialization format
 
 import type { DomainEvent, EventFilter, EventStore, ValidationResult } from '../core/types.js';
 import { validateEvent } from './schema.js';
@@ -55,6 +54,21 @@ export function createInMemoryStore(): EventStore {
 
     clear(): void {
       events = [];
+    },
+
+    toNDJSON(): string {
+      return events.map((e) => JSON.stringify(e)).join('\n');
+    },
+
+    fromNDJSON(ndjson: string): number {
+      const lines = ndjson.split('\n').filter((line) => line.trim().length > 0);
+      let loaded = 0;
+      for (const line of lines) {
+        const parsed = JSON.parse(line) as DomainEvent;
+        events.push(parsed);
+        loaded++;
+      }
+      return loaded;
     },
   };
 }

--- a/tests/ts/domain-event-store.test.ts
+++ b/tests/ts/domain-event-store.test.ts
@@ -76,4 +76,64 @@ describe('domain/event-store', () => {
     store.clear();
     expect(store.count()).toBe(0);
   });
+
+  describe('NDJSON serialization', () => {
+    it('toNDJSON returns empty string for empty store', () => {
+      const store = createInMemoryStore();
+      expect(store.toNDJSON()).toBe('');
+    });
+
+    it('toNDJSON serializes events as newline-delimited JSON', () => {
+      const store = createInMemoryStore();
+      const e1 = createEvent(ERROR_OBSERVED, { message: 'err1' });
+      const e2 = createEvent(MOVE_USED, { move: 'segfault', attacker: 'NullPointer' });
+      store.append(e1);
+      store.append(e2);
+
+      const ndjson = store.toNDJSON();
+      const lines = ndjson.split('\n');
+      expect(lines).toHaveLength(2);
+      expect(JSON.parse(lines[0])).toMatchObject({ kind: ERROR_OBSERVED, message: 'err1' });
+      expect(JSON.parse(lines[1])).toMatchObject({ kind: MOVE_USED, move: 'segfault' });
+    });
+
+    it('fromNDJSON loads events and returns count', () => {
+      const source = createInMemoryStore();
+      source.append(createEvent(ERROR_OBSERVED, { message: 'err1' }));
+      source.append(createEvent(ERROR_OBSERVED, { message: 'err2' }));
+      const ndjson = source.toNDJSON();
+
+      const target = createInMemoryStore();
+      const loaded = target.fromNDJSON(ndjson);
+      expect(loaded).toBe(2);
+      expect(target.count()).toBe(2);
+    });
+
+    it('fromNDJSON skips blank lines', () => {
+      const store = createInMemoryStore();
+      const e = createEvent(ERROR_OBSERVED, { message: 'test' });
+      const ndjson = '\n' + JSON.stringify(e) + '\n\n  \n';
+      const loaded = store.fromNDJSON(ndjson);
+      expect(loaded).toBe(1);
+      expect(store.count()).toBe(1);
+    });
+
+    it('round-trips events through toNDJSON and fromNDJSON', () => {
+      const source = createInMemoryStore();
+      const e1 = createEvent(ERROR_OBSERVED, { message: 'err1' });
+      const e2 = createEvent(MOVE_USED, { move: 'segfault', attacker: 'NullPointer' });
+      source.append(e1);
+      source.append(e2);
+
+      const target = createInMemoryStore();
+      target.fromNDJSON(source.toNDJSON());
+
+      expect(target.count()).toBe(source.count());
+      const replayed = target.replay();
+      expect(replayed[0].id).toBe(e1.id);
+      expect(replayed[1].id).toBe(e2.id);
+      expect(replayed[0].kind).toBe(ERROR_OBSERVED);
+      expect(replayed[1].kind).toBe(MOVE_USED);
+    });
+  });
 });


### PR DESCRIPTION
Implement toNDJSON() and fromNDJSON() methods on the EventStore interface
and both implementations (in-memory and file-based), enabling event stream
serialization for persistence and portability.

https://claude.ai/code/session_01EEbKhQXs9Kza2aGJiAHbV2