### PR TITLE
Add runtime telemetry logger

### DIFF
--- a/src/cli/commands/guard.ts
+++ b/src/cli/commands/guard.ts
@@ -8,6 +8,7 @@ import type { KernelConfig } from '../../kernel/kernel.js';
 import { createLiveRegistry } from '../../adapters/registry.js';
 import { createJsonlSink } from '../../events/jsonl.js';
 import { createDecisionJsonlSink } from '../../events/decision-jsonl.js';
+import { createTelemetryDecisionSink } from '../../telemetry/runtimeLogger.js';
 import { loadYamlPolicy } from '../../policy/yaml-loader.js';
 import {
   renderBanner,
@@ -85,6 +86,7 @@ export async function guard(_args: string[], options: GuardOptions = {}): Promis
   // Create sinks
   const jsonlSink = createJsonlSink({ runId });
   const decisionSink = createDecisionJsonlSink({ runId });
+  const telemetrySink = createTelemetryDecisionSink();
 
   // Build kernel config
   const kernelConfig: KernelConfig = {
@@ -93,7 +95,7 @@ export async function guard(_args: string[], options: GuardOptions = {}): Promis
     dryRun: options.dryRun ?? false,
     adapters: options.dryRun ? undefined : createLiveRegistry(),
     sinks: [jsonlSink],
-    decisionSinks: [decisionSink],
+    decisionSinks: [decisionSink, telemetrySink],
     simulators: simulators.all().length > 0 ? simulators : undefined,
   };
 

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -1,0 +1,6 @@
+export type { TelemetryEvent, TelemetryLoggerOptions, TelemetrySink } from './types.js';
+export {
+  buildTelemetryEvent,
+  createTelemetryLogger,
+  createTelemetryDecisionSink,
+} from './runtimeLogger.js';

--- a/src/telemetry/runtimeLogger.ts
+++ b/src/telemetry/runtimeLogger.ts
@@ -1,0 +1,78 @@
+// Runtime telemetry logger — persists flattened governance events to
+// logs/runtime-events.jsonl for downstream agents and monitors.
+// Implements DecisionSink so it plugs directly into the kernel pipeline.
+
+import { mkdirSync, appendFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { GovernanceDecisionRecord, DecisionSink } from '../kernel/decisions/types.js';
+import type { TelemetryEvent, TelemetryLoggerOptions, TelemetrySink } from './types.js';
+
+const DEFAULT_LOG_DIR = 'logs';
+const DEFAULT_LOG_FILE = 'runtime-events.jsonl';
+
+/** Map a GovernanceDecisionRecord to a flattened TelemetryEvent. */
+export function buildTelemetryEvent(record: GovernanceDecisionRecord): TelemetryEvent {
+  return {
+    timestamp: new Date(record.timestamp).toISOString(),
+    agent: record.action.agent,
+    run_id: record.runId,
+    syscall: record.action.type,
+    target: record.action.target,
+    capability: record.policy.matchedPolicyId ?? 'default-allow',
+    policy_result: record.outcome,
+    invariant_result: record.invariants.allHold ? 'pass' : 'fail',
+  };
+}
+
+/** Create a TelemetrySink that appends JSON lines to a single shared log file. */
+export function createTelemetryLogger(options?: TelemetryLoggerOptions): TelemetrySink {
+  const logDir = options?.logDir ?? DEFAULT_LOG_DIR;
+  const logFile = options?.logFile ?? DEFAULT_LOG_FILE;
+  const filePath = join(logDir, logFile);
+
+  let initialized = false;
+
+  function ensureDir(): void {
+    if (initialized) return;
+    try {
+      mkdirSync(logDir, { recursive: true });
+      initialized = true;
+    } catch {
+      // Directory may already exist
+      initialized = true;
+    }
+  }
+
+  return {
+    write(event: TelemetryEvent): void {
+      ensureDir();
+      const line = JSON.stringify(event) + '\n';
+
+      try {
+        appendFileSync(filePath, line, 'utf8');
+      } catch {
+        // Swallow write errors — don't crash the kernel
+      }
+    },
+
+    flush(): void {
+      // No buffering — writes are immediate for durability
+    },
+  };
+}
+
+/** Create a DecisionSink adapter that converts decision records to telemetry events. */
+export function createTelemetryDecisionSink(options?: TelemetryLoggerOptions): DecisionSink {
+  const logger = createTelemetryLogger(options);
+
+  return {
+    write(record: GovernanceDecisionRecord): void {
+      const event = buildTelemetryEvent(record);
+      logger.write(event);
+    },
+
+    flush(): void {
+      logger.flush?.();
+    },
+  };
+}

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -1,0 +1,26 @@
+// Telemetry event types — external contract for downstream agents and monitors.
+// Snake_case field names are intentional: this is an external-facing format.
+
+export interface TelemetryEvent {
+  timestamp: string; // ISO 8601
+  agent: string;
+  run_id: string;
+  syscall: string; // e.g., 'file.write', 'git.push'
+  target: string;
+  capability: string; // matched policy ID or 'default-allow'
+  policy_result: 'allow' | 'deny';
+  invariant_result: 'pass' | 'fail';
+  issue_id?: number;
+  diff_size?: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface TelemetryLoggerOptions {
+  logDir?: string; // default: 'logs'
+  logFile?: string; // default: 'runtime-events.jsonl'
+}
+
+export interface TelemetrySink {
+  write(event: TelemetryEvent): void;
+  flush?(): void;
+}

--- a/tests/ts/telemetry-logger.test.ts
+++ b/tests/ts/telemetry-logger.test.ts
@@ -1,0 +1,296 @@
+// Tests for runtime telemetry logger and DecisionSink adapter
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('node:fs', () => ({
+  mkdirSync: vi.fn(),
+  appendFileSync: vi.fn(),
+}));
+
+import {
+  createTelemetryLogger,
+  buildTelemetryEvent,
+  createTelemetryDecisionSink,
+} from '../../src/telemetry/runtimeLogger.js';
+import { mkdirSync, appendFileSync } from 'node:fs';
+import type { GovernanceDecisionRecord } from '../../src/kernel/decisions/types.js';
+import type { TelemetryEvent } from '../../src/telemetry/types.js';
+
+function makeFakeDecisionRecord(
+  overrides: Partial<GovernanceDecisionRecord> = {}
+): GovernanceDecisionRecord {
+  return {
+    recordId: 'dec_1',
+    runId: 'run_1',
+    timestamp: 1700000000000,
+    action: { type: 'file.read', target: 'test.ts', agent: 'coder-agent', destructive: false },
+    outcome: 'allow',
+    reason: 'Allowed by default',
+    intervention: null,
+    policy: { matchedPolicyId: null, matchedPolicyName: null, severity: 0 },
+    invariants: { allHold: true, violations: [] },
+    simulation: null,
+    evidencePackId: null,
+    monitor: { escalationLevel: 'NORMAL', totalEvaluations: 1, totalDenials: 0 },
+    execution: { executed: false, success: null, durationMs: null, error: null },
+    ...overrides,
+  } as GovernanceDecisionRecord;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('createTelemetryLogger', () => {
+  it('creates logs/ directory on first write', () => {
+    const logger = createTelemetryLogger();
+    const event: TelemetryEvent = {
+      timestamp: '2023-11-14T22:13:20.000Z',
+      agent: 'coder-agent',
+      run_id: 'run_1',
+      syscall: 'file.read',
+      target: 'test.ts',
+      capability: 'default-allow',
+      policy_result: 'allow',
+      invariant_result: 'pass',
+    };
+    logger.write(event);
+
+    expect(mkdirSync).toHaveBeenCalledWith('logs', { recursive: true });
+  });
+
+  it('only creates directory once', () => {
+    const logger = createTelemetryLogger();
+    const event: TelemetryEvent = {
+      timestamp: '2023-11-14T22:13:20.000Z',
+      agent: 'coder-agent',
+      run_id: 'run_1',
+      syscall: 'file.read',
+      target: 'test.ts',
+      capability: 'default-allow',
+      policy_result: 'allow',
+      invariant_result: 'pass',
+    };
+    logger.write(event);
+    logger.write(event);
+
+    expect(mkdirSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('writes telemetry event as JSON line', () => {
+    const logger = createTelemetryLogger();
+    const event: TelemetryEvent = {
+      timestamp: '2023-11-14T22:13:20.000Z',
+      agent: 'coder-agent',
+      run_id: 'run_1',
+      syscall: 'file.read',
+      target: 'test.ts',
+      capability: 'default-allow',
+      policy_result: 'allow',
+      invariant_result: 'pass',
+    };
+    logger.write(event);
+
+    expect(appendFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('runtime-events.jsonl'),
+      JSON.stringify(event) + '\n',
+      'utf8'
+    );
+  });
+
+  it('supports custom logDir and logFile', () => {
+    const logger = createTelemetryLogger({ logDir: '/custom/dir', logFile: 'custom.jsonl' });
+    const event: TelemetryEvent = {
+      timestamp: '2023-11-14T22:13:20.000Z',
+      agent: 'coder-agent',
+      run_id: 'run_1',
+      syscall: 'file.read',
+      target: 'test.ts',
+      capability: 'default-allow',
+      policy_result: 'allow',
+      invariant_result: 'pass',
+    };
+    logger.write(event);
+
+    expect(mkdirSync).toHaveBeenCalledWith('/custom/dir', { recursive: true });
+    expect(appendFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('custom.jsonl'),
+      expect.any(String),
+      'utf8'
+    );
+  });
+
+  it('swallows mkdir errors gracefully', () => {
+    vi.mocked(mkdirSync).mockImplementation(() => {
+      throw new Error('EEXIST');
+    });
+
+    const logger = createTelemetryLogger();
+    const event: TelemetryEvent = {
+      timestamp: '2023-11-14T22:13:20.000Z',
+      agent: 'coder-agent',
+      run_id: 'run_1',
+      syscall: 'file.read',
+      target: 'test.ts',
+      capability: 'default-allow',
+      policy_result: 'allow',
+      invariant_result: 'pass',
+    };
+    expect(() => logger.write(event)).not.toThrow();
+  });
+
+  it('swallows write errors gracefully', () => {
+    vi.mocked(appendFileSync).mockImplementation(() => {
+      throw new Error('ENOSPC');
+    });
+
+    const logger = createTelemetryLogger();
+    const event: TelemetryEvent = {
+      timestamp: '2023-11-14T22:13:20.000Z',
+      agent: 'coder-agent',
+      run_id: 'run_1',
+      syscall: 'file.read',
+      target: 'test.ts',
+      capability: 'default-allow',
+      policy_result: 'allow',
+      invariant_result: 'pass',
+    };
+    expect(() => logger.write(event)).not.toThrow();
+  });
+
+  it('flush does not throw', () => {
+    const logger = createTelemetryLogger();
+    expect(() => logger.flush?.()).not.toThrow();
+  });
+});
+
+describe('buildTelemetryEvent', () => {
+  it('maps all required fields from GovernanceDecisionRecord', () => {
+    const record = makeFakeDecisionRecord({
+      timestamp: 1700000000000,
+      runId: 'run_42',
+      action: { type: 'git.push', target: 'origin/main', agent: 'deploy-agent', destructive: true },
+      outcome: 'deny',
+      policy: { matchedPolicyId: 'policy-1', matchedPolicyName: 'no-force-push', severity: 8 },
+      invariants: {
+        allHold: false,
+        violations: [
+          {
+            invariantId: 'inv-1',
+            name: 'no-force-push',
+            severity: 8,
+            expected: 'no force push',
+            actual: 'force push detected',
+          },
+        ],
+      },
+    });
+
+    const event = buildTelemetryEvent(record);
+
+    expect(event.timestamp).toBe('2023-11-14T22:13:20.000Z');
+    expect(event.agent).toBe('deploy-agent');
+    expect(event.run_id).toBe('run_42');
+    expect(event.syscall).toBe('git.push');
+    expect(event.target).toBe('origin/main');
+    expect(event.capability).toBe('policy-1');
+    expect(event.policy_result).toBe('deny');
+    expect(event.invariant_result).toBe('fail');
+  });
+
+  it('falls back to default-allow when matchedPolicyId is null', () => {
+    const record = makeFakeDecisionRecord({
+      policy: { matchedPolicyId: null, matchedPolicyName: null, severity: 0 },
+    });
+
+    const event = buildTelemetryEvent(record);
+    expect(event.capability).toBe('default-allow');
+  });
+
+  it('sets invariant_result to pass when allHold is true', () => {
+    const record = makeFakeDecisionRecord({
+      invariants: { allHold: true, violations: [] },
+    });
+
+    const event = buildTelemetryEvent(record);
+    expect(event.invariant_result).toBe('pass');
+  });
+
+  it('sets invariant_result to fail when allHold is false', () => {
+    const record = makeFakeDecisionRecord({
+      invariants: {
+        allHold: false,
+        violations: [
+          {
+            invariantId: 'inv-1',
+            name: 'secret-check',
+            severity: 10,
+            expected: 'no secrets',
+            actual: 'secret detected',
+          },
+        ],
+      },
+    });
+
+    const event = buildTelemetryEvent(record);
+    expect(event.invariant_result).toBe('fail');
+  });
+});
+
+describe('createTelemetryDecisionSink', () => {
+  it('converts GovernanceDecisionRecord to TelemetryEvent and writes', () => {
+    const sink = createTelemetryDecisionSink();
+    const record = makeFakeDecisionRecord();
+    sink.write(record);
+
+    expect(appendFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('runtime-events.jsonl'),
+      expect.any(String),
+      'utf8'
+    );
+
+    // Verify the written JSON contains telemetry fields
+    const writtenLine = vi.mocked(appendFileSync).mock.calls[0][1] as string;
+    const parsed = JSON.parse(writtenLine.trim()) as TelemetryEvent;
+    expect(parsed.syscall).toBe('file.read');
+    expect(parsed.agent).toBe('coder-agent');
+    expect(parsed.policy_result).toBe('allow');
+    expect(parsed.invariant_result).toBe('pass');
+    expect(parsed.capability).toBe('default-allow');
+  });
+
+  it('maps denied outcome correctly', () => {
+    const sink = createTelemetryDecisionSink();
+    const record = makeFakeDecisionRecord({
+      outcome: 'deny',
+      invariants: {
+        allHold: false,
+        violations: [
+          {
+            invariantId: 'inv-1',
+            name: 'blast-radius',
+            severity: 7,
+            expected: '< 10 files',
+            actual: '25 files affected',
+          },
+        ],
+      },
+      policy: {
+        matchedPolicyId: 'deny-large-changes',
+        matchedPolicyName: 'Deny Large Changes',
+        severity: 7,
+      },
+    });
+    sink.write(record);
+
+    const writtenLine = vi.mocked(appendFileSync).mock.calls[0][1] as string;
+    const parsed = JSON.parse(writtenLine.trim()) as TelemetryEvent;
+    expect(parsed.policy_result).toBe('deny');
+    expect(parsed.invariant_result).toBe('fail');
+    expect(parsed.capability).toBe('deny-large-changes');
+  });
+
+  it('flush does not throw', () => {
+    const sink = createTelemetryDecisionSink();
+    expect(() => sink.flush?.()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a `src/telemetry/` module that implements a `DecisionSink` adapter to emit flattened `TelemetryEvent` JSONL to `logs/runtime-events.jsonl`
- Maps `GovernanceDecisionRecord` fields (policy result, invariant result, action type, agent, target) into a snake_case external contract format
- Wires the telemetry sink into the `guard` command's kernel config (3-line change in `guard.ts`)
- Includes 14 unit tests covering the logger, event builder, and decision sink adapter

## Test plan
- [x] `npm run build:ts` — TypeScript compiles cleanly
- [x] `npx vitest run tests/ts/telemetry-logger.test.ts` — all 14 new tests pass
- [x] `npm run lint` — no new lint errors
- [ ] Manual: `echo '{"tool":"Read","file":"test.ts","agent":"coder-agent"}' | npx agentguard guard --dry-run` then verify `logs/runtime-events.jsonl` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)