### PR TITLE
Agent implementation: #29 Agent identity propagation

### DIFF
--- a/src/adapters/claude-code.ts
+++ b/src/adapters/claude-code.ts
@@ -1,8 +1,10 @@
 // Claude Code adapter — normalizes Claude Code hook payloads into kernel actions.
 // Handles PreToolUse and PostToolUse hook events.
+// Propagates agent session identity for audit correlation.
 
 import type { RawAgentAction } from '../kernel/aab.js';
 import type { Kernel, KernelResult } from '../kernel/kernel.js';
+import { simpleHash } from '../core/hash.js';
 
 export interface ClaudeCodeToolUse {
   tool_name: string;
@@ -15,10 +17,24 @@ export interface ClaudeCodeHookPayload {
   tool_name: string;
   tool_input?: Record<string, unknown>;
   tool_output?: Record<string, unknown>;
+  /** Claude Code session identifier for agent identity propagation */
+  session_id?: string;
+}
+
+/**
+ * Resolve a meaningful agent identity from the session ID.
+ * Format: 'claude-code' (no session) or 'claude-code:<hash>' (with session).
+ */
+export function resolveAgentIdentity(sessionId?: string): string {
+  if (!sessionId || typeof sessionId !== 'string' || sessionId.trim() === '') {
+    return 'claude-code';
+  }
+  return `claude-code:${simpleHash(sessionId.trim())}`;
 }
 
 export function normalizeClaudeCodeAction(payload: ClaudeCodeHookPayload): RawAgentAction {
   const input = payload.tool_input || {};
+  const agent = resolveAgentIdentity(payload.session_id);
 
   switch (payload.tool_name) {
     case 'Write':
@@ -26,8 +42,8 @@ export function normalizeClaudeCodeAction(payload: ClaudeCodeHookPayload): RawAg
         tool: 'Write',
         file: input.file_path as string | undefined,
         content: input.content as string | undefined,
-        agent: 'claude-code',
-        metadata: { hook: payload.hook },
+        agent,
+        metadata: { hook: payload.hook, sessionId: payload.session_id },
       };
 
     case 'Edit':
@@ -35,10 +51,11 @@ export function normalizeClaudeCodeAction(payload: ClaudeCodeHookPayload): RawAg
         tool: 'Edit',
         file: input.file_path as string | undefined,
         content: input.new_string as string | undefined,
-        agent: 'claude-code',
+        agent,
         metadata: {
           hook: payload.hook,
           old_string: input.old_string,
+          sessionId: payload.session_id,
         },
       };
 
@@ -46,8 +63,8 @@ export function normalizeClaudeCodeAction(payload: ClaudeCodeHookPayload): RawAg
       return {
         tool: 'Read',
         file: input.file_path as string | undefined,
-        agent: 'claude-code',
-        metadata: { hook: payload.hook },
+        agent,
+        metadata: { hook: payload.hook, sessionId: payload.session_id },
       };
 
     case 'Bash': {
@@ -56,11 +73,12 @@ export function normalizeClaudeCodeAction(payload: ClaudeCodeHookPayload): RawAg
         tool: 'Bash',
         command,
         target: command?.slice(0, 100),
-        agent: 'claude-code',
+        agent,
         metadata: {
           hook: payload.hook,
           timeout: input.timeout,
           description: input.description,
+          sessionId: payload.session_id,
         },
       };
     }
@@ -69,23 +87,23 @@ export function normalizeClaudeCodeAction(payload: ClaudeCodeHookPayload): RawAg
       return {
         tool: 'Glob',
         target: input.pattern as string | undefined,
-        agent: 'claude-code',
-        metadata: { hook: payload.hook, path: input.path },
+        agent,
+        metadata: { hook: payload.hook, path: input.path, sessionId: payload.session_id },
       };
 
     case 'Grep':
       return {
         tool: 'Grep',
         target: input.pattern as string | undefined,
-        agent: 'claude-code',
-        metadata: { hook: payload.hook, path: input.path },
+        agent,
+        metadata: { hook: payload.hook, path: input.path, sessionId: payload.session_id },
       };
 
     default:
       return {
         tool: payload.tool_name,
-        agent: 'claude-code',
-        metadata: { hook: payload.hook, input },
+        agent,
+        metadata: { hook: payload.hook, input, sessionId: payload.session_id },
       };
   }
 }

--- a/src/cli/commands/claude-hook.ts
+++ b/src/cli/commands/claude-hook.ts
@@ -25,7 +25,11 @@ export async function claudeHook(hookType?: string): Promise<void> {
       (!hookType && !data.tool_output);
 
     if (isPreToolUse) {
-      await handlePreToolUse(data as unknown as ClaudeCodeHookPayload);
+      // Resolve session_id: payload field > environment variable > undefined
+      const sessionId =
+        (data.session_id as string | undefined) || process.env.CLAUDE_SESSION_ID || undefined;
+      const payload = { ...data, session_id: sessionId } as unknown as ClaudeCodeHookPayload;
+      await handlePreToolUse(payload);
     } else {
       handlePostToolUse(data);
     }

--- a/tests/ts/claude-code-adapter.test.ts
+++ b/tests/ts/claude-code-adapter.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from 'vitest';
 import {
   normalizeClaudeCodeAction,
   formatHookResponse,
+  resolveAgentIdentity,
 } from '../../src/adapters/claude-code.js';
 import type { ClaudeCodeHookPayload } from '../../src/adapters/claude-code.js';
 import { createKernel } from '../../src/kernel/kernel.js';
@@ -81,6 +82,121 @@ describe('normalizeClaudeCodeAction', () => {
     const action = normalizeClaudeCodeAction(payload);
     expect(action.tool).toBe('Agent');
     expect(action.agent).toBe('claude-code');
+  });
+});
+
+describe('resolveAgentIdentity', () => {
+  it('returns claude-code when no session_id', () => {
+    expect(resolveAgentIdentity()).toBe('claude-code');
+    expect(resolveAgentIdentity(undefined)).toBe('claude-code');
+  });
+
+  it('returns claude-code for empty or whitespace session_id', () => {
+    expect(resolveAgentIdentity('')).toBe('claude-code');
+    expect(resolveAgentIdentity('   ')).toBe('claude-code');
+  });
+
+  it('returns claude-code:<hash> for valid session_id', () => {
+    const identity = resolveAgentIdentity('abc123');
+    expect(identity).toMatch(/^claude-code:[a-z0-9]+$/);
+    expect(identity).not.toBe('claude-code');
+  });
+
+  it('produces consistent hash for same session_id', () => {
+    const a = resolveAgentIdentity('session-xyz');
+    const b = resolveAgentIdentity('session-xyz');
+    expect(a).toBe(b);
+  });
+
+  it('produces different hashes for different session_ids', () => {
+    const a = resolveAgentIdentity('session-1');
+    const b = resolveAgentIdentity('session-2');
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('normalizeClaudeCodeAction — session_id propagation', () => {
+  it('uses session_id for agent identity when provided', () => {
+    const payload: ClaudeCodeHookPayload = {
+      hook: 'PreToolUse',
+      tool_name: 'Write',
+      tool_input: { file_path: 'test.ts', content: 'hello' },
+      session_id: 'sess-abc123',
+    };
+    const action = normalizeClaudeCodeAction(payload);
+    expect(action.agent).toMatch(/^claude-code:[a-z0-9]+$/);
+    expect(action.agent).not.toBe('claude-code');
+  });
+
+  it('falls back to claude-code without session_id', () => {
+    const payload: ClaudeCodeHookPayload = {
+      hook: 'PreToolUse',
+      tool_name: 'Write',
+      tool_input: { file_path: 'test.ts', content: 'hello' },
+    };
+    const action = normalizeClaudeCodeAction(payload);
+    expect(action.agent).toBe('claude-code');
+  });
+
+  it('propagates session_id in metadata', () => {
+    const payload: ClaudeCodeHookPayload = {
+      hook: 'PreToolUse',
+      tool_name: 'Bash',
+      tool_input: { command: 'npm test' },
+      session_id: 'sess-xyz',
+    };
+    const action = normalizeClaudeCodeAction(payload);
+    expect(action.metadata).toHaveProperty('sessionId', 'sess-xyz');
+  });
+
+  it('propagates session identity through all tool types', () => {
+    const tools = ['Write', 'Edit', 'Read', 'Bash', 'Glob', 'Grep', 'Agent'];
+    for (const tool of tools) {
+      const payload: ClaudeCodeHookPayload = {
+        hook: 'PreToolUse',
+        tool_name: tool,
+        tool_input: {},
+        session_id: 'consistent-session',
+      };
+      const action = normalizeClaudeCodeAction(payload);
+      expect(action.agent).toMatch(/^claude-code:[a-z0-9]+$/);
+    }
+  });
+});
+
+describe('Integration: session_id through kernel pipeline', () => {
+  it('decision record shows session-derived agent identity', async () => {
+    const kernel = createKernel({ dryRun: true });
+    const payload: ClaudeCodeHookPayload = {
+      hook: 'PreToolUse',
+      tool_name: 'Read',
+      tool_input: { file_path: 'src/index.ts' },
+      session_id: 'session-42',
+    };
+    const rawAction = normalizeClaudeCodeAction(payload);
+    const result = await kernel.propose(rawAction);
+    expect(result.allowed).toBe(true);
+    expect(result.decisionRecord?.action.agent).toMatch(/^claude-code:[a-z0-9]+$/);
+    expect(result.decisionRecord?.action.agent).not.toBe('claude-code');
+  });
+
+  it('events include session-derived agentId', async () => {
+    const kernel = createKernel({ dryRun: true });
+    const payload: ClaudeCodeHookPayload = {
+      hook: 'PreToolUse',
+      tool_name: 'Read',
+      tool_input: { file_path: 'src/index.ts' },
+      session_id: 'session-99',
+    };
+    const rawAction = normalizeClaudeCodeAction(payload);
+    const result = await kernel.propose(rawAction);
+    const requestedEvent = result.events.find(
+      (e) => e.kind === 'ActionRequested'
+    );
+    expect(requestedEvent).toBeDefined();
+    expect((requestedEvent as Record<string, unknown>).agentId).toMatch(
+      /^claude-code:[a-z0-9]+$/
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- Resolves #29 — agent identity (agentId) now propagated through governance pipeline
- Claude Code adapter accepts `session_id` in hook payload and derives a correlatable identity (`claude-code:<hash>`)
- CLI hook resolves session ID from payload field or `CLAUDE_SESSION_ID` environment variable
- Falls back to `'claude-code'` when no session ID is available (backward compatible)

## Changes

- **`src/adapters/claude-code.ts`**: Added `session_id` to `ClaudeCodeHookPayload`, new `resolveAgentIdentity()` function, all tool normalizers use session-derived identity
- **`src/cli/commands/claude-hook.ts`**: Resolves session_id from payload > env var > undefined before routing to adapter
- **`tests/ts/claude-code-adapter.test.ts`**: 10 new tests covering identity resolution, propagation through all tool types, and end-to-end kernel pipeline integration

## Test plan

- [x] All 22 claude-code-adapter tests pass (12 existing + 10 new)
- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] Build succeeds (`tsc + esbuild`)
- [ ] Verify session_id flows correctly from a live Claude Code hook invocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)