### PR TITLE
docs: sync documentation with codebase state

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -49,6 +49,7 @@ src/
 ├── invariants/    Invariant system (6 built-in definitions, checker)
 ├── adapters/      Execution adapters (file, shell, git, claude-code)
 ├── cli/           CLI entry point and commands
+├── telemetry/     Runtime telemetry and logging
 └── core/          Shared utilities (types, actions, hash, execution-log)
 ```
 
@@ -60,6 +61,7 @@ src/
 - **invariants/** may import from core/, events/ only
 - **adapters/** may import from core/, kernel/ only
 - **cli/** may import from kernel/, events/, policy/, core/
+- **telemetry/** may import from core/ only
 - **core/** has no project imports (leaf layer)
 
 ## Key Design Decisions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ src/
 ├── kernel/                 # Governed action kernel
 │   ├── kernel.ts           # Orchestrator (propose → evaluate → execute → emit)
 │   ├── aab.ts              # Action Authorization Boundary (normalization)
+│   ├── blast-radius.ts     # Weighted blast radius computation engine
 │   ├── decision.ts         # Runtime assurance engine
 │   ├── monitor.ts          # Escalation state machine
 │   ├── evidence.ts         # Evidence pack generation
@@ -74,6 +75,7 @@ src/
 │   ├── args.ts             # Argument parsing utilities
 │   ├── colors.ts           # Terminal color helpers
 │   ├── tui.ts              # TUI renderer (terminal action stream)
+│   ├── policy-resolver.ts  # Policy file discovery and resolution
 │   ├── recorder.ts         # Event recording
 │   ├── replay.ts           # Session replay logic
 │   ├── session-store.ts    # Session management
@@ -90,10 +92,14 @@ src/
         ├── event-projections.ts # Event projections
         ├── event-schema.ts # Event schema definitions
         └── index.ts        # Module re-exports
+├── telemetry/              # Runtime telemetry
+│   ├── index.ts            # Module re-exports
+│   ├── runtimeLogger.ts    # Runtime logging implementation
+│   └── types.ts            # Telemetry type definitions
 
 tests/
 ├── *.test.js               # 14 JS test files (custom zero-dependency harness)
-└── ts/*.test.ts            # 35 TS test files (vitest)
+└── ts/*.test.ts            # 38 TS test files (vitest)
 policy/                     # Policy configuration (JSON: action_rules, capabilities)
 docs/                       # System documentation (architecture, event model, specs)
 hooks/                      # Git hooks (post-commit, post-merge)
@@ -149,6 +155,7 @@ Each top-level directory maps to a single architectural concept:
 - **src/adapters/** — Execution adapters (file, shell, git, claude-code)
 - **src/cli/** — CLI entry point and commands
 - **src/core/** — Shared utilities (types, actions, hash, execution-log)
+- **src/telemetry/** — Runtime telemetry and logging
 
 ### CLI Commands
 - `agentguard guard` — Start the governed action runtime (policy + invariant enforcement)
@@ -169,6 +176,7 @@ The canonical event model is the architectural spine. Event kinds defined in `sr
 - **Decision & Simulation**: `DecisionRecorded`, `SimulationCompleted`
 - **Pipeline**: `PipelineStarted`, `StageCompleted`, `StageFailed`, `PipelineCompleted`, `PipelineFailed`, `FileScopeViolation`
 - **Dev activity**: `FileSaved`, `TestCompleted`, `BuildCompleted`, `CommitCreated`, `CodeReviewed`, `DeployCompleted`, `LintCompleted`
+- **Battle lifecycle**: `ENCOUNTER_STARTED`, `MOVE_USED`, `DAMAGE_DEALT`, `HEALING_APPLIED`, `PASSIVE_ACTIVATED`, `BUGMON_FAINTED`, `CACHE_ATTEMPTED`, `CACHE_SUCCESS`, `BATTLE_ENDED`
 - **Ingestion**: `ErrorObserved`, `BugClassified`, `ActivityRecorded`, `EvolutionTriggered`
 
 ### Action Classes & Types
@@ -222,8 +230,8 @@ npm run test:coverage      # Run with coverage (c8, 50% line threshold)
 
 **Test structure:**
 - **JS tests** (`tests/*.test.js`): 14 files using a custom zero-dependency harness (`tests/run.js` with `node:assert`)
-- **TypeScript tests** (`tests/ts/*.test.ts`): 35 files using vitest
-- **Coverage areas**: adapters, kernel (AAB, engine, monitor), CLI commands, decision records, domain models, events, evidence packs, execution log, invariants, JSONL persistence, policy evaluation, simulation, YAML loading
+- **TypeScript tests** (`tests/ts/*.test.ts`): 38 files using vitest
+- **Coverage areas**: adapters, kernel (AAB, engine, monitor, blast radius), CLI commands, decision records, domain models, events, evidence packs, execution log, invariants, JSONL persistence, policy evaluation, simulation, telemetry, TUI renderer, YAML loading
 
 ## CI/CD & Automation
 

--- a/README.md
+++ b/README.md
@@ -235,8 +235,9 @@ src/
 │   └── registry.ts         # Adapter registry
 ├── cli/                    # CLI entry point + commands
 │   ├── bin.ts              # Main entry
-│   └── commands/           # guard, inspect, replay, claude-hook
-└── core/                   # Shared utilities (types, actions, hash)
+│   └── commands/           # guard, inspect, replay, claude-hook, claude-init
+├── telemetry/              # Runtime telemetry and logging
+└── core/                   # Shared utilities (types, actions, hash, execution-log)
 ```
 
 ## Run Locally

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -52,7 +52,7 @@ Extend the event system into the formal canonical event model.
 - [x] Event store interface (persist, query, replay)
 - [x] Tests for all event types and lifecycle
 
-## Phase 2 — AgentGuard Governance Runtime `MOSTLY COMPLETE`
+## Phase 2 — AgentGuard Governance Runtime `COMPLETE`
 
 > **Theme:** Deterministic agent governance
 
@@ -64,11 +64,11 @@ Build the governance runtime that evaluates agent actions against policies and i
 - [x] Deterministic policy evaluator (`src/policy/evaluator.ts`)
 - [x] Invariant monitoring engine (`src/invariants/checker.ts`)
 - [x] Built-in invariants (`src/invariants/definitions.ts`)
-- [ ] Blast radius computation
+- [x] Blast radius computation (`src/kernel/blast-radius.ts`)
 - [x] Evidence pack generation and persistence (`src/kernel/evidence.ts`)
 - [x] CLI governance commands (`agentguard guard`, `agentguard inspect`)
 - [x] Governance event emission into canonical event model
-- [ ] Integration with Claude Code hook (governance events from agent actions)
+- [x] Integration with Claude Code hook (`src/adapters/claude-code.ts`, `src/cli/commands/claude-hook.ts`)
 
 ## Phase 3 — Event Persistence + Replay `PARTIALLY COMPLETE`
 


### PR DESCRIPTION
## Summary

- Automated documentation sync detected drift between codebase and docs
- Added missing source files to project structure trees (`blast-radius.ts`, `policy-resolver.ts`, `telemetry/` directory)
- Updated test file count from 35 to 38 TS test files
- Added 9 battle lifecycle event kinds missing from event model documentation
- Updated ROADMAP Phase 2 status to COMPLETE (blast radius computation and Claude Code hook integration now verified as implemented)

## Changes

- **CLAUDE.md** — Added `blast-radius.ts` to kernel tree, `policy-resolver.ts` to CLI tree, `telemetry/` directory, battle lifecycle events to event model, updated test counts and coverage areas
- **README.md** — Added `telemetry/` directory to structure tree, updated commands comment to include `claude-init`, updated `core/` description
- **ARCHITECTURE.md** — Added `telemetry/` to directory layout and layer rules
- **ROADMAP.md** — Marked blast radius computation and Claude Code hook integration as done, updated Phase 2 status to COMPLETE

## Source

Auto-generated by the **Scheduled Docs Sync** skill.

---
*Run: 2026-03-09*