### PR TITLE
fix(issue-49): remove stale TODO, fix ROADMAP reference

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -76,7 +76,7 @@ Build the governance runtime that evaluates agent actions against policies and i
 
 Implement durable event storage and deterministic replay.
 
-- [x] File-based event store (`src/events/store.ts`)
+- [x] File-based event store (`src/cli/file-event-store.ts`)
 - [x] Event stream serialization (NDJSON/JSONL)
 - [x] Session metadata (run ID, timestamps)
 - [x] Execution event log (`src/core/execution-log/`)

--- a/src/events/store.ts
+++ b/src/events/store.ts
@@ -1,7 +1,6 @@
 // Event store interface and in-memory reference implementation.
 // No DOM, no Node.js APIs — pure domain logic.
-//
-// TODO(roadmap): Phase 4 — File-based event store (.agentguard/events/)
+// File-based persistence: see src/cli/file-event-store.ts
 
 import type { DomainEvent, EventFilter, EventStore, ValidationResult } from '../core/types.js';
 import { validateEvent } from './schema.js';


### PR DESCRIPTION
## Summary
- Resolves stale `TODO(roadmap)` in `src/events/store.ts` that referenced Phase 4 file-based event store — this work is already complete in `src/cli/file-event-store.ts`
- Fixes ROADMAP.md Phase 3 entry to reference the correct implementation file
- Closes #49

## Changes
- `src/events/store.ts`: Removed stale TODO comment, replaced with cross-reference to `src/cli/file-event-store.ts`
- `ROADMAP.md`: Updated Phase 3 file-based event store entry from `src/events/store.ts` (in-memory) to `src/cli/file-event-store.ts` (actual file-based implementation)

## Test Plan
- [x] TypeScript build passes (`npm run build:ts`)
- [x] Vitest tests pass (`npm run ts:test`) — 552/552
- [x] JS tests pass (`npm test`) — 210/210
- [x] ESLint clean (`npm run lint`) — 0 errors
- [x] Prettier clean (`npm run format`) — modified files formatted

## Governance Report

| Metric | Count |
|--------|-------|
| Total events | 12 |
| Actions allowed | 4 |
| Actions denied | 0 |
| Policy denials | 0 |
| Invariant violations | 0 |

<details>
<summary>Telemetry details</summary>

Source: `.agentguard/events/` and `logs/runtime-events.jsonl`

No denials or violations recorded. All tool actions were allowed by policy.

</details>