### PR TITLE
feat: implement full replay engine with event stream processing

### DIFF
--- a/src/cli/commands/replay.ts
+++ b/src/cli/commands/replay.ts
@@ -1,45 +1,92 @@
 /**
  * replay command — Replay execution events from a session.
  *
- * Reconstructs the execution event sequence from a given point,
- * showing the causal chain of actions, failures, and governance events.
+ * Supports two modes:
+ * 1. Governance replay (--run <runId> or --last): Loads JSONL events from the
+ *    AgentGuard event store and reconstructs action encounters using the replay engine.
+ * 2. Execution log replay (default): Loads NDJSON execution event logs for raw
+ *    event-level display.
  */
 
 import type { Command } from 'commander';
 import pino from 'pino';
 import { createExecutionEventLog } from '../../core/execution-log/event-log.js';
+import { loadReplaySession, listRunIds, getLatestRunId } from '../../kernel/replay-engine.js';
+import type { ReplaySession, ReplayAction } from '../../kernel/replay-engine.js';
 
 export function registerReplayCommand(program: Command): void {
   program
     .command('replay')
     .description('Replay execution events from a session log')
-    .argument('[file]', 'NDJSON event log file to replay', '.events.ndjson')
+    .argument('[file]', 'NDJSON event log file to replay (legacy mode)')
     .option('-f, --from <eventId>', 'Start replay from this event ID')
     .option('--kind <kind>', 'Filter by event kind')
     .option('--actor <actor>', 'Filter by actor (human, agent, system)')
     .option('--limit <n>', 'Maximum events to display', '50')
+    .option('-r, --run <runId>', 'Replay a governance run by ID')
+    .option('-l, --last', 'Replay the most recent governance run')
+    .option('--list-runs', 'List available governance runs')
+    .option('--summary', 'Show session summary only')
+    .option('--denied-only', 'Show only denied actions')
+    .option('--base-dir <dir>', 'Base directory for event storage', '.agentguard')
     .action(
       async (
-        file: string,
+        file: string | undefined,
         options: {
           from?: string;
           kind?: string;
           actor?: string;
           limit: string;
+          run?: string;
+          last?: boolean;
+          listRuns?: boolean;
+          summary?: boolean;
+          deniedOnly?: boolean;
+          baseDir: string;
         }
       ) => {
+        // --- Governance replay mode ---
+        if (options.listRuns) {
+          renderRunList(options.baseDir);
+          return;
+        }
+
+        if (options.run || options.last) {
+          const runId = options.run || getLatestRunId(options.baseDir);
+          if (!runId) {
+            console.error('\n  No governance runs found.');
+            console.error('  Run "agentguard guard" first to generate events.\n');
+            return;
+          }
+
+          const session = loadReplaySession(runId, { baseDir: options.baseDir });
+          if (!session) {
+            console.error(`\n  Run "${runId}" not found or has no events.\n`);
+            return;
+          }
+
+          if (options.summary) {
+            renderSessionSummary(session);
+          } else {
+            renderGovernanceReplay(session, { deniedOnly: options.deniedOnly });
+          }
+          return;
+        }
+
+        // --- Legacy execution log replay mode ---
+        const targetFile = file || '.events.ndjson';
         const logger = pino({ name: 'agentguard-replay' });
         const fs = await import('node:fs');
 
-        if (!fs.existsSync(file)) {
-          logger.error({ file }, 'Event log file not found');
-          console.error(`Event log file not found: ${file}`);
+        if (!fs.existsSync(targetFile)) {
+          logger.error({ file: targetFile }, 'Event log file not found');
+          console.error(`Event log file not found: ${targetFile}`);
           console.error('Run "agentguard guard" first to generate events.');
           return;
         }
 
         const log = createExecutionEventLog();
-        const ndjson = fs.readFileSync(file, 'utf-8');
+        const ndjson = fs.readFileSync(targetFile, 'utf-8');
         const loaded = log.fromNDJSON(ndjson);
         logger.info({ loaded }, 'Events loaded');
 
@@ -74,4 +121,141 @@ export function registerReplayCommand(program: Command): void {
         }
       }
     );
+}
+
+// ---------------------------------------------------------------------------
+// Governance replay rendering
+// ---------------------------------------------------------------------------
+
+function renderRunList(baseDir: string): void {
+  const runIds = listRunIds(baseDir);
+  if (runIds.length === 0) {
+    console.error('\n  No governance runs found.');
+    console.error('  Run "agentguard guard" first to generate events.\n');
+    return;
+  }
+
+  console.log('\n  Available governance runs:\n');
+  for (const id of runIds.slice(0, 20)) {
+    console.log(`    ${id}`);
+  }
+  if (runIds.length > 20) {
+    console.log(`    ... and ${runIds.length - 20} more`);
+  }
+  console.log('\n  Usage: agentguard replay --run <runId>\n');
+}
+
+function renderSessionSummary(session: ReplaySession): void {
+  const s = session.summary;
+  console.log(`\n  Governance Session Summary`);
+  console.log(`  Run: ${session.runId}`);
+  console.log(`  Events: ${session.events.length}`);
+  console.log(`  Duration: ${formatDuration(s.durationMs)}`);
+  console.log('');
+  console.log(`  Actions:     ${s.totalActions}`);
+  console.log(`  Allowed:     ${s.allowed}`);
+  console.log(`  Denied:      ${s.denied}`);
+  console.log(`  Executed:    ${s.executed}`);
+  console.log(`  Failed:      ${s.failed}`);
+  console.log(`  Violations:  ${s.violations}`);
+  console.log(`  Escalations: ${s.escalations}`);
+  console.log(`  Simulations: ${s.simulationsRun}`);
+
+  if (Object.keys(s.actionTypes).length > 0) {
+    console.log('\n  Action types:');
+    const sorted = Object.entries(s.actionTypes).sort((a, b) => b[1] - a[1]);
+    for (const [type, count] of sorted) {
+      console.log(`    ${type.padEnd(24)} ${count}`);
+    }
+  }
+
+  if (s.denialReasons.length > 0) {
+    console.log('\n  Denial reasons:');
+    for (const reason of s.denialReasons) {
+      console.log(`    - ${truncate(reason, 70)}`);
+    }
+  }
+
+  console.log('');
+}
+
+interface GovernanceReplayOptions {
+  deniedOnly?: boolean;
+}
+
+function renderGovernanceReplay(
+  session: ReplaySession,
+  options: GovernanceReplayOptions = {}
+): void {
+  let actions = session.actions;
+  if (options.deniedOnly) {
+    actions = actions.filter((a) => !a.allowed);
+  }
+
+  console.log(`\n  Governance Replay — ${session.runId}`);
+  console.log(`  ${session.events.length} events, ${session.actions.length} actions`);
+  console.log('');
+
+  if (actions.length === 0) {
+    console.log('  No actions to display.\n');
+    return;
+  }
+
+  for (const action of actions) {
+    renderAction(action);
+  }
+
+  renderSessionSummary(session);
+}
+
+function renderAction(action: ReplayAction): void {
+  const icon = action.allowed ? (action.succeeded ? '+' : '!') : 'x';
+  const status = action.allowed
+    ? action.succeeded
+      ? 'ALLOWED+EXECUTED'
+      : action.executed
+        ? 'ALLOWED+FAILED'
+        : 'ALLOWED (dry-run)'
+    : 'DENIED';
+
+  const time = new Date(action.requestedEvent.timestamp).toISOString().slice(11, 19);
+  console.log(`  [${time}] ${icon} ${action.actionType} -> ${action.target || '(none)'}`);
+  console.log(`           Status: ${status}`);
+
+  if (action.decisionEvent) {
+    const reason = (action.decisionEvent.reason as string) || '';
+    if (reason) {
+      console.log(`           Reason: ${truncate(reason, 60)}`);
+    }
+  }
+
+  if (action.simulationEvent) {
+    const risk = (action.simulationEvent.riskLevel as string) || 'unknown';
+    const blast = (action.simulationEvent.blastRadius as number) ?? '?';
+    console.log(`           Simulation: risk=${risk}, blast=${blast}`);
+  }
+
+  for (const gov of action.governanceEvents) {
+    const detail =
+      (gov.reason as string) || (gov.invariant as string) || (gov.policy as string) || '';
+    console.log(`           Violation: ${gov.kind}${detail ? ` — ${truncate(detail, 50)}` : ''}`);
+  }
+
+  console.log('');
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const seconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(seconds / 60);
+  if (minutes === 0) return `${seconds}s`;
+  return `${minutes}m ${seconds % 60}s`;
+}
+
+function truncate(str: string, max: number): string {
+  return str.length > max ? str.slice(0, max - 3) + '...' : str;
 }

--- a/src/cli/replay.ts
+++ b/src/cli/replay.ts
@@ -1,6 +1,6 @@
 // Replay CLI — flight recorder playback for debugging sessions.
 //
-// TODO(roadmap): Phase 4 — Full replay engine: feed stored event stream through encounter generator
+// DONE(roadmap): Phase 4 — Full replay engine: see src/kernel/replay-engine.ts
 // TODO(roadmap): Phase 4 — Deterministic replay with seeded RNG
 // TODO(roadmap): Phase 4 — Replay comparator (verify original vs replayed outcomes)
 // TODO(roadmap): Phase 6 — Replay processor plugin interface

--- a/src/kernel/replay-engine.ts
+++ b/src/kernel/replay-engine.ts
@@ -1,0 +1,377 @@
+// Replay Engine — reconstructs governance sessions from persisted JSONL event streams.
+//
+// Loads domain events from .agentguard/events/<runId>.jsonl, groups them into
+// action encounters (REQUESTED → ALLOWED/DENIED → EXECUTED/FAILED), and provides
+// a programmatic API for session analysis, comparators, and CLI display.
+
+import { readFileSync, existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import type { DomainEvent, EventKind } from '../core/types.js';
+import {
+  ACTION_REQUESTED,
+  ACTION_ALLOWED,
+  ACTION_DENIED,
+  ACTION_ESCALATED,
+  ACTION_EXECUTED,
+  ACTION_FAILED,
+  DECISION_RECORDED,
+  SIMULATION_COMPLETED,
+  POLICY_DENIED,
+  INVARIANT_VIOLATION,
+  BLAST_RADIUS_EXCEEDED,
+  MERGE_GUARD_FAILURE,
+  RUN_STARTED,
+  RUN_ENDED,
+} from '../events/schema.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A single action encounter — the full lifecycle of one proposed action. */
+export interface ReplayAction {
+  /** The index of this action in the session (0-based). */
+  readonly index: number;
+  /** The ActionRequested event that started this encounter. */
+  readonly requestedEvent: DomainEvent;
+  /** The ActionAllowed or ActionDenied decision event (null if stream truncated). */
+  readonly decisionEvent: DomainEvent | null;
+  /** The ActionExecuted or ActionFailed result (null if denied or dry-run). */
+  readonly executionEvent: DomainEvent | null;
+  /** The SimulationCompleted event if pre-execution simulation ran. */
+  readonly simulationEvent: DomainEvent | null;
+  /** The DecisionRecorded audit event. */
+  readonly decisionRecordEvent: DomainEvent | null;
+  /** ActionEscalated event if the action was escalated. */
+  readonly escalationEvent: DomainEvent | null;
+  /** Governance violation events (PolicyDenied, InvariantViolation, etc.). */
+  readonly governanceEvents: readonly DomainEvent[];
+  /** Whether this action was ultimately allowed. */
+  readonly allowed: boolean;
+  /** Whether this action was executed (allowed + not dry-run). */
+  readonly executed: boolean;
+  /** Whether execution succeeded (false if ActionFailed). */
+  readonly succeeded: boolean;
+  /** Action type from the requested event (e.g. 'file.write', 'git.push'). */
+  readonly actionType: string;
+  /** Target from the requested event. */
+  readonly target: string;
+}
+
+/** Session-level summary statistics. */
+export interface ReplaySessionSummary {
+  readonly totalActions: number;
+  readonly allowed: number;
+  readonly denied: number;
+  readonly executed: number;
+  readonly failed: number;
+  readonly violations: number;
+  readonly escalations: number;
+  readonly simulationsRun: number;
+  readonly durationMs: number;
+  readonly actionTypes: Readonly<Record<string, number>>;
+  readonly denialReasons: readonly string[];
+}
+
+/** A fully reconstructed governance session. */
+export interface ReplaySession {
+  /** The run ID extracted from events or the JSONL filename. */
+  readonly runId: string;
+  /** All raw events in timestamp order. */
+  readonly events: readonly DomainEvent[];
+  /** Reconstructed action encounters, in order. */
+  readonly actions: readonly ReplayAction[];
+  /** Session-level summary statistics. */
+  readonly summary: ReplaySessionSummary;
+  /** The RunStarted event (if present). */
+  readonly startEvent: DomainEvent | null;
+  /** The RunEnded event (if present). */
+  readonly endEvent: DomainEvent | null;
+}
+
+/** Options for loading a replay session. */
+export interface ReplayLoadOptions {
+  /** Base directory containing the events/ folder. Defaults to '.agentguard'. */
+  readonly baseDir?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEFAULT_BASE_DIR = '.agentguard';
+const EVENTS_DIR = 'events';
+
+/** Event kinds that represent governance violations/denials. */
+const GOVERNANCE_EVENT_KINDS: ReadonlySet<string> = new Set([
+  POLICY_DENIED,
+  INVARIANT_VIOLATION,
+  BLAST_RADIUS_EXCEEDED,
+  MERGE_GUARD_FAILURE,
+]);
+
+/** Event kinds that represent action lifecycle decisions. */
+const DECISION_EVENT_KINDS: ReadonlySet<string> = new Set([ACTION_ALLOWED, ACTION_DENIED]);
+
+/** Event kinds that represent action execution outcomes. */
+const EXECUTION_EVENT_KINDS: ReadonlySet<string> = new Set([ACTION_EXECUTED, ACTION_FAILED]);
+
+// ---------------------------------------------------------------------------
+// JSONL Loading
+// ---------------------------------------------------------------------------
+
+/**
+ * Load domain events from a JSONL file.
+ * Each line is a JSON-serialized DomainEvent.
+ * Malformed lines are silently skipped.
+ */
+export function loadEventsFromJsonl(filePath: string): DomainEvent[] {
+  if (!existsSync(filePath)) {
+    return [];
+  }
+
+  const content = readFileSync(filePath, 'utf8');
+  const events: DomainEvent[] = [];
+
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      events.push(JSON.parse(trimmed) as DomainEvent);
+    } catch {
+      // Skip malformed lines
+    }
+  }
+
+  return events;
+}
+
+/**
+ * Resolve the JSONL file path for a given run ID.
+ */
+export function resolveEventFilePath(runId: string, baseDir?: string): string {
+  return join(baseDir || DEFAULT_BASE_DIR, EVENTS_DIR, `${runId}.jsonl`);
+}
+
+/**
+ * List all available run IDs that have stored events.
+ */
+export function listRunIds(baseDir?: string): string[] {
+  const eventsDir = join(baseDir || DEFAULT_BASE_DIR, EVENTS_DIR);
+  if (!existsSync(eventsDir)) return [];
+
+  return readdirSync(eventsDir)
+    .filter((f) => f.endsWith('.jsonl'))
+    .map((f) => f.replace('.jsonl', ''))
+    .sort()
+    .reverse();
+}
+
+// ---------------------------------------------------------------------------
+// Event Grouping
+// ---------------------------------------------------------------------------
+
+/**
+ * Group a flat list of events into action encounters.
+ * Events are correlated by their position in the stream — each ActionRequested
+ * event starts a new encounter, and subsequent events are attached to it until
+ * the next ActionRequested.
+ */
+function groupEventsIntoActions(events: readonly DomainEvent[]): ReplayAction[] {
+  const actions: ReplayAction[] = [];
+  let currentActionEvents: DomainEvent[] = [];
+  let actionIndex = 0;
+
+  function flushAction(): void {
+    if (currentActionEvents.length === 0) return;
+
+    const requested = currentActionEvents.find((e) => e.kind === ACTION_REQUESTED) || null;
+    if (!requested) {
+      // No ActionRequested — these are orphan events, skip
+      currentActionEvents = [];
+      return;
+    }
+
+    const decisionEvent = currentActionEvents.find((e) => DECISION_EVENT_KINDS.has(e.kind)) || null;
+    const executionEvent =
+      currentActionEvents.find((e) => EXECUTION_EVENT_KINDS.has(e.kind)) || null;
+    const simulationEvent =
+      currentActionEvents.find((e) => e.kind === SIMULATION_COMPLETED) || null;
+    const decisionRecordEvent =
+      currentActionEvents.find((e) => e.kind === DECISION_RECORDED) || null;
+    const escalationEvent = currentActionEvents.find((e) => e.kind === ACTION_ESCALATED) || null;
+    const governanceEvents = currentActionEvents.filter((e) => GOVERNANCE_EVENT_KINDS.has(e.kind));
+
+    const allowed = decisionEvent?.kind === ACTION_ALLOWED;
+    const executed = executionEvent !== null;
+    const succeeded = executionEvent?.kind === ACTION_EXECUTED;
+
+    actions.push({
+      index: actionIndex++,
+      requestedEvent: requested,
+      decisionEvent,
+      executionEvent,
+      simulationEvent,
+      decisionRecordEvent,
+      escalationEvent,
+      governanceEvents,
+      allowed,
+      executed,
+      succeeded,
+      actionType: (requested.actionType as string) || 'unknown',
+      target: (requested.target as string) || '',
+    });
+
+    currentActionEvents = [];
+  }
+
+  for (const event of events) {
+    if (event.kind === ACTION_REQUESTED && currentActionEvents.length > 0) {
+      flushAction();
+    }
+    currentActionEvents.push(event);
+  }
+
+  // Flush the last action
+  flushAction();
+
+  return actions;
+}
+
+// ---------------------------------------------------------------------------
+// Summary Generation
+// ---------------------------------------------------------------------------
+
+function buildSummary(
+  events: readonly DomainEvent[],
+  actions: readonly ReplayAction[]
+): ReplaySessionSummary {
+  const actionTypes: Record<string, number> = {};
+  const denialReasons: string[] = [];
+  let violations = 0;
+  let escalations = 0;
+  let simulationsRun = 0;
+
+  for (const action of actions) {
+    const type = action.actionType;
+    actionTypes[type] = (actionTypes[type] || 0) + 1;
+
+    if (!action.allowed && action.decisionEvent) {
+      const reason = (action.decisionEvent.reason as string) || 'unknown';
+      denialReasons.push(reason);
+    }
+
+    violations += action.governanceEvents.length;
+    if (action.escalationEvent) escalations++;
+    if (action.simulationEvent) simulationsRun++;
+  }
+
+  const timestamps = events.map((e) => e.timestamp);
+  const durationMs = timestamps.length >= 2 ? Math.max(...timestamps) - Math.min(...timestamps) : 0;
+
+  return {
+    totalActions: actions.length,
+    allowed: actions.filter((a) => a.allowed).length,
+    denied: actions.filter((a) => !a.allowed).length,
+    executed: actions.filter((a) => a.executed).length,
+    failed: actions.filter((a) => a.executed && !a.succeeded).length,
+    violations,
+    escalations,
+    simulationsRun,
+    durationMs,
+    actionTypes,
+    denialReasons,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Replay Engine API
+// ---------------------------------------------------------------------------
+
+/**
+ * Load a replay session from a JSONL event file by run ID.
+ * Returns null if the file does not exist.
+ */
+export function loadReplaySession(
+  runId: string,
+  options: ReplayLoadOptions = {}
+): ReplaySession | null {
+  const filePath = resolveEventFilePath(runId, options.baseDir);
+  const events = loadEventsFromJsonl(filePath);
+
+  if (events.length === 0) return null;
+
+  return buildReplaySession(runId, events);
+}
+
+/**
+ * Build a replay session from an in-memory event array.
+ * Useful for testing and when events are already loaded.
+ */
+export function buildReplaySession(runId: string, events: DomainEvent[]): ReplaySession {
+  // Sort events by timestamp for deterministic ordering
+  const sorted = [...events].sort((a, b) => a.timestamp - b.timestamp);
+
+  const startEvent = sorted.find((e) => e.kind === RUN_STARTED) || null;
+  const endEvent = sorted.find((e) => e.kind === RUN_ENDED) || null;
+
+  const actions = groupEventsIntoActions(sorted);
+  const summary = buildSummary(sorted, actions);
+
+  return {
+    runId,
+    events: sorted,
+    actions,
+    summary,
+    startEvent,
+    endEvent,
+  };
+}
+
+/**
+ * Iterator for stepping through action encounters one at a time.
+ * Yields ReplayAction objects in chronological order.
+ */
+export function* iterateActions(session: ReplaySession): Generator<ReplayAction> {
+  for (const action of session.actions) {
+    yield action;
+  }
+}
+
+/**
+ * Filter a replay session's actions by a predicate.
+ * Returns a new session with only matching actions (events are not filtered).
+ */
+export function filterActions(
+  session: ReplaySession,
+  predicate: (action: ReplayAction) => boolean
+): ReplaySession {
+  const filteredActions = session.actions.filter(predicate);
+  const summary = buildSummary(session.events, filteredActions);
+
+  return {
+    ...session,
+    actions: filteredActions,
+    summary,
+  };
+}
+
+/**
+ * Get the most recent run ID from stored events.
+ * Returns null if no runs exist.
+ */
+export function getLatestRunId(baseDir?: string): string | null {
+  const runIds = listRunIds(baseDir);
+  return runIds.length > 0 ? runIds[0] : null;
+}
+
+/**
+ * Extract the event kinds present in a session as a frequency map.
+ */
+export function getEventKindCounts(session: ReplaySession): Record<EventKind, number> {
+  const counts: Record<string, number> = {};
+  for (const event of session.events) {
+    counts[event.kind] = (counts[event.kind] || 0) + 1;
+  }
+  return counts as Record<EventKind, number>;
+}

--- a/tests/ts/replay-engine.test.ts
+++ b/tests/ts/replay-engine.test.ts
@@ -1,0 +1,777 @@
+// Tests for the replay engine — verifies event loading, action grouping,
+// session reconstruction, and summary statistics.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  loadEventsFromJsonl,
+  resolveEventFilePath,
+  listRunIds,
+  loadReplaySession,
+  buildReplaySession,
+  iterateActions,
+  filterActions,
+  getLatestRunId,
+  getEventKindCounts,
+} from '../../src/kernel/replay-engine.js';
+import type { ReplayAction } from '../../src/kernel/replay-engine.js';
+import type { DomainEvent } from '../../src/core/types.js';
+import { resetEventCounter } from '../../src/events/schema.js';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const TEST_BASE_DIR = join('.agentguard-test-replay', 'replay-engine-test');
+const TEST_EVENTS_DIR = join(TEST_BASE_DIR, 'events');
+
+function ensureTestDir(): void {
+  mkdirSync(TEST_EVENTS_DIR, { recursive: true });
+}
+
+function cleanTestDir(): void {
+  if (existsSync(TEST_BASE_DIR)) {
+    rmSync(TEST_BASE_DIR, { recursive: true, force: true });
+  }
+}
+
+function writeTestJsonl(runId: string, events: DomainEvent[]): void {
+  ensureTestDir();
+  const filePath = join(TEST_EVENTS_DIR, `${runId}.jsonl`);
+  const content = events.map((e) => JSON.stringify(e)).join('\n') + '\n';
+  writeFileSync(filePath, content, 'utf8');
+}
+
+/** Create a minimal DomainEvent for testing */
+function testEvent(
+  kind: string,
+  data: Record<string, unknown> = {},
+  timestamp?: number
+): DomainEvent {
+  return {
+    id: `evt_test_${Math.random().toString(36).slice(2, 6)}`,
+    kind: kind as DomainEvent['kind'],
+    timestamp: timestamp || Date.now(),
+    fingerprint: 'test',
+    ...data,
+  };
+}
+
+/** Create a full action lifecycle (requested → allowed → executed → decision recorded) */
+function createAllowedActionEvents(
+  actionType: string,
+  target: string,
+  baseTimestamp: number
+): DomainEvent[] {
+  return [
+    testEvent(
+      'ActionRequested',
+      {
+        actionType,
+        target,
+        justification: 'test action',
+        agentId: 'test-agent',
+        metadata: { runId: 'test-run' },
+      },
+      baseTimestamp
+    ),
+    testEvent(
+      'ActionAllowed',
+      {
+        actionType,
+        target,
+        capability: 'default-allow',
+        reason: 'No matching deny rule',
+      },
+      baseTimestamp + 1
+    ),
+    testEvent(
+      'ActionExecuted',
+      {
+        actionType,
+        target,
+        result: 'success',
+        duration: 10,
+      },
+      baseTimestamp + 2
+    ),
+    testEvent(
+      'DecisionRecorded',
+      {
+        recordId: `rec_${baseTimestamp}`,
+        outcome: 'allow',
+        actionType,
+        target,
+        reason: 'No matching deny rule',
+      },
+      baseTimestamp + 3
+    ),
+  ];
+}
+
+/** Create a denied action lifecycle */
+function createDeniedActionEvents(
+  actionType: string,
+  target: string,
+  reason: string,
+  baseTimestamp: number
+): DomainEvent[] {
+  return [
+    testEvent(
+      'ActionRequested',
+      {
+        actionType,
+        target,
+        justification: 'test action',
+        agentId: 'test-agent',
+      },
+      baseTimestamp
+    ),
+    testEvent(
+      'PolicyDenied',
+      {
+        policy: 'test-policy',
+        action: actionType,
+        reason,
+      },
+      baseTimestamp + 1
+    ),
+    testEvent(
+      'ActionDenied',
+      {
+        actionType,
+        target,
+        reason,
+      },
+      baseTimestamp + 2
+    ),
+    testEvent(
+      'DecisionRecorded',
+      {
+        recordId: `rec_${baseTimestamp}`,
+        outcome: 'deny',
+        actionType,
+        target,
+        reason,
+      },
+      baseTimestamp + 3
+    ),
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('replay-engine', () => {
+  beforeEach(() => {
+    resetEventCounter();
+    cleanTestDir();
+    ensureTestDir();
+  });
+
+  afterEach(() => {
+    cleanTestDir();
+  });
+
+  // ── JSONL Loading ──
+
+  describe('loadEventsFromJsonl', () => {
+    it('loads events from a valid JSONL file', () => {
+      const events = [
+        testEvent(
+          'ActionRequested',
+          { actionType: 'file.write', target: 'foo.ts', justification: 'test' },
+          1000
+        ),
+        testEvent(
+          'ActionAllowed',
+          { actionType: 'file.write', target: 'foo.ts', capability: 'default' },
+          1001
+        ),
+      ];
+      const filePath = join(TEST_EVENTS_DIR, 'test-run.jsonl');
+      writeFileSync(filePath, events.map((e) => JSON.stringify(e)).join('\n') + '\n');
+
+      const loaded = loadEventsFromJsonl(filePath);
+      expect(loaded).toHaveLength(2);
+      expect(loaded[0].kind).toBe('ActionRequested');
+      expect(loaded[1].kind).toBe('ActionAllowed');
+    });
+
+    it('returns empty array for non-existent file', () => {
+      const loaded = loadEventsFromJsonl('/non/existent/path.jsonl');
+      expect(loaded).toHaveLength(0);
+    });
+
+    it('skips malformed lines', () => {
+      const filePath = join(TEST_EVENTS_DIR, 'bad-lines.jsonl');
+      const content = [
+        JSON.stringify(
+          testEvent('ActionRequested', {
+            actionType: 'file.write',
+            target: 'a',
+            justification: 'test',
+          })
+        ),
+        'this is not valid json',
+        '',
+        JSON.stringify(
+          testEvent('ActionAllowed', {
+            actionType: 'file.write',
+            target: 'a',
+            capability: 'default',
+          })
+        ),
+      ].join('\n');
+      writeFileSync(filePath, content);
+
+      const loaded = loadEventsFromJsonl(filePath);
+      expect(loaded).toHaveLength(2);
+    });
+  });
+
+  // ── Path Resolution ──
+
+  describe('resolveEventFilePath', () => {
+    it('resolves path with default base dir', () => {
+      const path = resolveEventFilePath('run_123');
+      expect(path).toBe(join('.agentguard', 'events', 'run_123.jsonl'));
+    });
+
+    it('resolves path with custom base dir', () => {
+      const path = resolveEventFilePath('run_123', '/custom/dir');
+      expect(path).toBe(join('/custom/dir', 'events', 'run_123.jsonl'));
+    });
+  });
+
+  // ── Run ID Listing ──
+
+  describe('listRunIds', () => {
+    it('lists available run IDs sorted in reverse', () => {
+      writeTestJsonl('run_001', [
+        testEvent('ActionRequested', { actionType: 'a', target: 'b', justification: 'c' }),
+      ]);
+      writeTestJsonl('run_003', [
+        testEvent('ActionRequested', { actionType: 'a', target: 'b', justification: 'c' }),
+      ]);
+      writeTestJsonl('run_002', [
+        testEvent('ActionRequested', { actionType: 'a', target: 'b', justification: 'c' }),
+      ]);
+
+      const ids = listRunIds(TEST_BASE_DIR);
+      expect(ids).toEqual(['run_003', 'run_002', 'run_001']);
+    });
+
+    it('returns empty array when no runs exist', () => {
+      const ids = listRunIds(TEST_BASE_DIR);
+      expect(ids).toEqual([]);
+    });
+
+    it('returns empty array for non-existent directory', () => {
+      const ids = listRunIds('/non/existent');
+      expect(ids).toEqual([]);
+    });
+  });
+
+  // ── getLatestRunId ──
+
+  describe('getLatestRunId', () => {
+    it('returns the most recent run ID', () => {
+      writeTestJsonl('run_aaa', [
+        testEvent('ActionRequested', { actionType: 'a', target: 'b', justification: 'c' }),
+      ]);
+      writeTestJsonl('run_zzz', [
+        testEvent('ActionRequested', { actionType: 'a', target: 'b', justification: 'c' }),
+      ]);
+
+      const latest = getLatestRunId(TEST_BASE_DIR);
+      expect(latest).toBe('run_zzz');
+    });
+
+    it('returns null when no runs exist', () => {
+      const latest = getLatestRunId(TEST_BASE_DIR);
+      expect(latest).toBeNull();
+    });
+  });
+
+  // ── Session Loading ──
+
+  describe('loadReplaySession', () => {
+    it('loads a session from JSONL events', () => {
+      const events = [
+        ...createAllowedActionEvents('file.write', 'src/app.ts', 1000),
+        ...createDeniedActionEvents('git.push', 'main', 'Protected branch', 2000),
+      ];
+      writeTestJsonl('run_test', events);
+
+      const session = loadReplaySession('run_test', { baseDir: TEST_BASE_DIR });
+      expect(session).not.toBeNull();
+      expect(session!.runId).toBe('run_test');
+      expect(session!.events).toHaveLength(8);
+      expect(session!.actions).toHaveLength(2);
+    });
+
+    it('returns null for non-existent run', () => {
+      const session = loadReplaySession('run_nonexistent', { baseDir: TEST_BASE_DIR });
+      expect(session).toBeNull();
+    });
+
+    it('returns null for empty JSONL file', () => {
+      ensureTestDir();
+      writeFileSync(join(TEST_EVENTS_DIR, 'run_empty.jsonl'), '');
+
+      const session = loadReplaySession('run_empty', { baseDir: TEST_BASE_DIR });
+      expect(session).toBeNull();
+    });
+  });
+
+  // ── Session Building ──
+
+  describe('buildReplaySession', () => {
+    it('groups events into action encounters', () => {
+      const events = [
+        ...createAllowedActionEvents('file.write', 'src/a.ts', 1000),
+        ...createAllowedActionEvents('file.write', 'src/b.ts', 2000),
+      ];
+
+      const session = buildReplaySession('test-run', events);
+      expect(session.actions).toHaveLength(2);
+      expect(session.actions[0].actionType).toBe('file.write');
+      expect(session.actions[0].target).toBe('src/a.ts');
+      expect(session.actions[1].target).toBe('src/b.ts');
+    });
+
+    it('marks allowed actions correctly', () => {
+      const events = createAllowedActionEvents('file.write', 'test.ts', 1000);
+      const session = buildReplaySession('test-run', events);
+
+      expect(session.actions).toHaveLength(1);
+      const action = session.actions[0];
+      expect(action.allowed).toBe(true);
+      expect(action.executed).toBe(true);
+      expect(action.succeeded).toBe(true);
+    });
+
+    it('marks denied actions correctly', () => {
+      const events = createDeniedActionEvents('git.push', 'main', 'Protected branch', 1000);
+      const session = buildReplaySession('test-run', events);
+
+      expect(session.actions).toHaveLength(1);
+      const action = session.actions[0];
+      expect(action.allowed).toBe(false);
+      expect(action.executed).toBe(false);
+      expect(action.succeeded).toBe(false);
+    });
+
+    it('attaches governance events to actions', () => {
+      const events = createDeniedActionEvents('git.push', 'main', 'Protected branch', 1000);
+      const session = buildReplaySession('test-run', events);
+
+      const action = session.actions[0];
+      expect(action.governanceEvents).toHaveLength(1);
+      expect(action.governanceEvents[0].kind).toBe('PolicyDenied');
+    });
+
+    it('attaches simulation events to actions', () => {
+      const events = [
+        testEvent(
+          'ActionRequested',
+          {
+            actionType: 'file.write',
+            target: 'big-change.ts',
+            justification: 'test',
+          },
+          1000
+        ),
+        testEvent(
+          'SimulationCompleted',
+          {
+            simulatorId: 'filesystem',
+            riskLevel: 'medium',
+            blastRadius: 15,
+          },
+          1001
+        ),
+        testEvent(
+          'ActionAllowed',
+          {
+            actionType: 'file.write',
+            target: 'big-change.ts',
+            capability: 'default',
+          },
+          1002
+        ),
+        testEvent(
+          'ActionExecuted',
+          {
+            actionType: 'file.write',
+            target: 'big-change.ts',
+            result: 'success',
+          },
+          1003
+        ),
+      ];
+
+      const session = buildReplaySession('test-run', events);
+      const action = session.actions[0];
+      expect(action.simulationEvent).not.toBeNull();
+      expect(action.simulationEvent!.riskLevel).toBe('medium');
+    });
+
+    it('attaches escalation events to actions', () => {
+      const events = [
+        testEvent(
+          'ActionRequested',
+          {
+            actionType: 'infra.destroy',
+            target: 'production',
+            justification: 'test',
+          },
+          1000
+        ),
+        testEvent(
+          'ActionEscalated',
+          {
+            actionType: 'infra.destroy',
+            target: 'production',
+            reason: 'Destructive infrastructure action',
+          },
+          1001
+        ),
+        testEvent(
+          'ActionDenied',
+          {
+            actionType: 'infra.destroy',
+            target: 'production',
+            reason: 'Requires human approval',
+          },
+          1002
+        ),
+      ];
+
+      const session = buildReplaySession('test-run', events);
+      const action = session.actions[0];
+      expect(action.escalationEvent).not.toBeNull();
+      expect(action.escalationEvent!.kind).toBe('ActionEscalated');
+    });
+
+    it('detects RunStarted and RunEnded events', () => {
+      const events = [
+        testEvent('RunStarted', { runId: 'test-run' }, 1000),
+        ...createAllowedActionEvents('file.read', 'config.ts', 2000),
+        testEvent('RunEnded', { runId: 'test-run', result: 'completed' }, 3000),
+      ];
+
+      const session = buildReplaySession('test-run', events);
+      expect(session.startEvent).not.toBeNull();
+      expect(session.startEvent!.kind).toBe('RunStarted');
+      expect(session.endEvent).not.toBeNull();
+      expect(session.endEvent!.kind).toBe('RunEnded');
+    });
+
+    it('sorts events by timestamp', () => {
+      // Provide events out of order
+      const events = [
+        testEvent(
+          'ActionAllowed',
+          { actionType: 'file.write', target: 'a', capability: 'default' },
+          2000
+        ),
+        testEvent(
+          'ActionRequested',
+          { actionType: 'file.write', target: 'a', justification: 'test' },
+          1000
+        ),
+        testEvent(
+          'ActionExecuted',
+          { actionType: 'file.write', target: 'a', result: 'success' },
+          3000
+        ),
+      ];
+
+      const session = buildReplaySession('test-run', events);
+      expect(session.events[0].timestamp).toBe(1000);
+      expect(session.events[1].timestamp).toBe(2000);
+      expect(session.events[2].timestamp).toBe(3000);
+    });
+
+    it('handles empty event array', () => {
+      const session = buildReplaySession('empty', []);
+      expect(session.actions).toHaveLength(0);
+      expect(session.summary.totalActions).toBe(0);
+    });
+
+    it('skips orphan events without ActionRequested', () => {
+      const events = [
+        testEvent(
+          'ActionAllowed',
+          { actionType: 'file.write', target: 'a', capability: 'default' },
+          1000
+        ),
+        testEvent(
+          'ActionExecuted',
+          { actionType: 'file.write', target: 'a', result: 'success' },
+          2000
+        ),
+      ];
+
+      const session = buildReplaySession('test-run', events);
+      expect(session.actions).toHaveLength(0);
+    });
+  });
+
+  // ── Summary Statistics ──
+
+  describe('summary statistics', () => {
+    it('computes correct totals for mixed sessions', () => {
+      const events = [
+        ...createAllowedActionEvents('file.write', 'a.ts', 1000),
+        ...createAllowedActionEvents('file.write', 'b.ts', 2000),
+        ...createDeniedActionEvents('git.push', 'main', 'Protected branch', 3000),
+        ...createAllowedActionEvents('test.run', 'suite', 4000),
+      ];
+
+      const session = buildReplaySession('test', events);
+      const s = session.summary;
+      expect(s.totalActions).toBe(4);
+      expect(s.allowed).toBe(3);
+      expect(s.denied).toBe(1);
+      expect(s.executed).toBe(3);
+      expect(s.failed).toBe(0);
+      expect(s.violations).toBe(1); // PolicyDenied from the denied action
+    });
+
+    it('counts action types', () => {
+      const events = [
+        ...createAllowedActionEvents('file.write', 'a.ts', 1000),
+        ...createAllowedActionEvents('file.write', 'b.ts', 2000),
+        ...createAllowedActionEvents('git.push', 'origin', 3000),
+      ];
+
+      const session = buildReplaySession('test', events);
+      expect(session.summary.actionTypes['file.write']).toBe(2);
+      expect(session.summary.actionTypes['git.push']).toBe(1);
+    });
+
+    it('collects denial reasons', () => {
+      const events = [
+        ...createDeniedActionEvents('git.push', 'main', 'Protected branch', 1000),
+        ...createDeniedActionEvents('infra.destroy', 'prod', 'Destructive action blocked', 2000),
+      ];
+
+      const session = buildReplaySession('test', events);
+      expect(session.summary.denialReasons).toHaveLength(2);
+      expect(session.summary.denialReasons).toContain('Protected branch');
+      expect(session.summary.denialReasons).toContain('Destructive action blocked');
+    });
+
+    it('calculates duration from event timestamps', () => {
+      const events = [
+        ...createAllowedActionEvents('file.write', 'a.ts', 1000),
+        ...createAllowedActionEvents('file.write', 'b.ts', 5000),
+      ];
+
+      const session = buildReplaySession('test', events);
+      // Duration spans from first event (1000) to last event (5003)
+      expect(session.summary.durationMs).toBe(5003 - 1000);
+    });
+  });
+
+  // ── Iteration ──
+
+  describe('iterateActions', () => {
+    it('yields actions in order', () => {
+      const events = [
+        ...createAllowedActionEvents('file.write', 'a.ts', 1000),
+        ...createDeniedActionEvents('git.push', 'main', 'Denied', 2000),
+      ];
+
+      const session = buildReplaySession('test', events);
+      const actions: ReplayAction[] = [];
+      for (const action of iterateActions(session)) {
+        actions.push(action);
+      }
+
+      expect(actions).toHaveLength(2);
+      expect(actions[0].index).toBe(0);
+      expect(actions[0].actionType).toBe('file.write');
+      expect(actions[1].index).toBe(1);
+      expect(actions[1].actionType).toBe('git.push');
+    });
+
+    it('yields nothing for empty session', () => {
+      const session = buildReplaySession('empty', []);
+      const actions: ReplayAction[] = [];
+      for (const action of iterateActions(session)) {
+        actions.push(action);
+      }
+      expect(actions).toHaveLength(0);
+    });
+  });
+
+  // ── Filtering ──
+
+  describe('filterActions', () => {
+    it('filters actions by predicate', () => {
+      const events = [
+        ...createAllowedActionEvents('file.write', 'a.ts', 1000),
+        ...createDeniedActionEvents('git.push', 'main', 'Denied', 2000),
+        ...createAllowedActionEvents('file.read', 'b.ts', 3000),
+      ];
+
+      const session = buildReplaySession('test', events);
+      const denied = filterActions(session, (a) => !a.allowed);
+
+      expect(denied.actions).toHaveLength(1);
+      expect(denied.actions[0].actionType).toBe('git.push');
+      expect(denied.summary.totalActions).toBe(1);
+      expect(denied.summary.denied).toBe(1);
+    });
+
+    it('preserves original events in filtered session', () => {
+      const events = [
+        ...createAllowedActionEvents('file.write', 'a.ts', 1000),
+        ...createDeniedActionEvents('git.push', 'main', 'Denied', 2000),
+      ];
+
+      const session = buildReplaySession('test', events);
+      const filtered = filterActions(session, (a) => a.allowed);
+
+      // All events remain, only actions are filtered
+      expect(filtered.events).toHaveLength(session.events.length);
+      expect(filtered.actions).toHaveLength(1);
+    });
+  });
+
+  // ── Event Kind Counts ──
+
+  describe('getEventKindCounts', () => {
+    it('returns frequency map of event kinds', () => {
+      const events = [
+        ...createAllowedActionEvents('file.write', 'a.ts', 1000),
+        ...createDeniedActionEvents('git.push', 'main', 'Denied', 2000),
+      ];
+
+      const session = buildReplaySession('test', events);
+      const counts = getEventKindCounts(session);
+
+      expect(counts['ActionRequested']).toBe(2);
+      expect(counts['ActionAllowed']).toBe(1);
+      expect(counts['ActionDenied']).toBe(1);
+      expect(counts['ActionExecuted']).toBe(1);
+      expect(counts['PolicyDenied']).toBe(1);
+      expect(counts['DecisionRecorded']).toBe(2);
+    });
+  });
+
+  // ── Action lifecycle edge cases ──
+
+  describe('edge cases', () => {
+    it('handles action with failed execution', () => {
+      const events = [
+        testEvent(
+          'ActionRequested',
+          {
+            actionType: 'shell.exec',
+            target: 'rm -rf /',
+            justification: 'test',
+          },
+          1000
+        ),
+        testEvent(
+          'ActionAllowed',
+          {
+            actionType: 'shell.exec',
+            target: 'rm -rf /',
+            capability: 'default',
+          },
+          1001
+        ),
+        testEvent(
+          'ActionFailed',
+          {
+            actionType: 'shell.exec',
+            target: 'rm -rf /',
+            error: 'Permission denied',
+          },
+          1002
+        ),
+      ];
+
+      const session = buildReplaySession('test', events);
+      const action = session.actions[0];
+      expect(action.allowed).toBe(true);
+      expect(action.executed).toBe(true);
+      expect(action.succeeded).toBe(false);
+      expect(session.summary.failed).toBe(1);
+    });
+
+    it('handles truncated action stream (only ActionRequested)', () => {
+      const events = [
+        testEvent(
+          'ActionRequested',
+          {
+            actionType: 'file.write',
+            target: 'a.ts',
+            justification: 'test',
+          },
+          1000
+        ),
+      ];
+
+      const session = buildReplaySession('test', events);
+      expect(session.actions).toHaveLength(1);
+      const action = session.actions[0];
+      expect(action.decisionEvent).toBeNull();
+      expect(action.executionEvent).toBeNull();
+      expect(action.allowed).toBe(false); // No ActionAllowed found
+    });
+
+    it('handles multiple invariant violations in one action', () => {
+      const events = [
+        testEvent(
+          'ActionRequested',
+          {
+            actionType: 'git.push',
+            target: 'main',
+            justification: 'deploy',
+          },
+          1000
+        ),
+        testEvent(
+          'InvariantViolation',
+          {
+            invariant: 'protected-branches',
+            expected: 'not main',
+            actual: 'main',
+          },
+          1001
+        ),
+        testEvent(
+          'BlastRadiusExceeded',
+          {
+            filesAffected: 100,
+            limit: 50,
+          },
+          1002
+        ),
+        testEvent(
+          'ActionDenied',
+          {
+            actionType: 'git.push',
+            target: 'main',
+            reason: 'Multiple violations',
+          },
+          1003
+        ),
+      ];
+
+      const session = buildReplaySession('test', events);
+      const action = session.actions[0];
+      expect(action.governanceEvents).toHaveLength(2);
+      expect(session.summary.violations).toBe(2);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `src/kernel/replay-engine.ts` — loads JSONL event streams from `.agentguard/events/`, groups events into action encounters (REQUESTED → ALLOWED/DENIED → EXECUTED/FAILED), and reconstructs governance sessions with lifecycle tracking
- Update `src/cli/commands/replay.ts` with governance replay mode (`--run`, `--last`, `--list-runs`, `--summary`, `--denied-only`)
- Add 35 tests covering JSONL loading, action grouping, session statistics, filtering, iteration, and edge cases

## Changes

| File | Description |
|------|-------------|
| `src/kernel/replay-engine.ts` | **New** — Core replay engine with `loadReplaySession`, `buildReplaySession`, `iterateActions`, `filterActions`, `getEventKindCounts` APIs |
| `src/cli/commands/replay.ts` | Enhanced with governance replay mode alongside existing execution log replay |
| `src/cli/replay.ts` | Updated TODO comment to mark Phase 4 replay engine as done |
| `tests/ts/replay-engine.test.ts` | **New** — 35 tests covering all replay engine functionality |

## Test plan

- [x] `npm run build:ts` — TypeScript compiles cleanly
- [x] `npm run ts:check` — Type-check passes (tsc --noEmit)
- [x] `npm run ts:test` — 587 tests pass (39 files, including new 35 replay engine tests)
- [x] `npm test` — 210 JS tests pass
- [x] `npx eslint` — Clean on new/modified files
- [x] `npx prettier --check` — Formatted correctly

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)