### PR TITLE
feat: add no-skill-modification invariant to protect .claude/skills/

### DIFF
--- a/agentguard.yaml
+++ b/agentguard.yaml
@@ -21,6 +21,16 @@ rules:
     target: .env
     reason: Secrets files must not be modified
 
+  - action: file.write
+    effect: deny
+    target: ".claude/skills/"
+    reason: Agent skill files are protected from modification
+
+  - action: file.delete
+    effect: deny
+    target: ".claude/skills/"
+    reason: Agent skill files are protected from deletion
+
   - action: shell.exec
     effect: deny
     target: rm -rf

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -803,6 +803,10 @@ export interface SystemState {
   readonly isPush?: boolean;
   readonly testsPass?: boolean;
   readonly blastRadiusLimit?: number;
+  /** File path targeted by the current action */
+  readonly currentTarget?: string;
+  /** Shell command of the current action (for shell.exec detection) */
+  readonly currentCommand?: string;
   [key: string]: unknown;
 }
 

--- a/src/invariants/checker.ts
+++ b/src/invariants/checker.ts
@@ -71,5 +71,7 @@ export function buildSystemState(context: Record<string, unknown> = {}): SystemS
       (context.filesAffected as number) || ((context.modifiedFiles as string[]) || []).length,
     blastRadiusLimit: (context.blastRadiusLimit as number) || 20,
     protectedBranches: (context.protectedBranches as string[]) || ['main', 'master'],
+    currentTarget: (context.currentTarget as string) || '',
+    currentCommand: (context.currentCommand as string) || '',
   };
 }

--- a/src/invariants/definitions.ts
+++ b/src/invariants/definitions.ts
@@ -29,6 +29,10 @@ export interface SystemState {
   simulatedBlastRadius?: number;
   /** Risk level from pre-execution simulation */
   simulatedRiskLevel?: string;
+  /** File path targeted by the current action */
+  currentTarget?: string;
+  /** Shell command of the current action (for shell.exec detection) */
+  currentCommand?: string;
 }
 
 export const DEFAULT_INVARIANTS: AgentGuardInvariant[] = [
@@ -116,6 +120,40 @@ export const DEFAULT_INVARIANTS: AgentGuardInvariant[] = [
         holds: !state.forcePush,
         expected: 'No force push',
         actual: state.forcePush ? 'Force push detected' : 'Normal push',
+      };
+    },
+  },
+
+  {
+    id: 'no-skill-modification',
+    name: 'No Skill Modification',
+    description: 'Agent skill files (.claude/skills/) must not be modified by governed actions',
+    severity: 4,
+    check(state) {
+      const SKILL_PATTERNS = ['.claude/skills/', '.claude\\skills\\'];
+      const matchesSkillPath = (path: string) => SKILL_PATTERNS.some((p) => path.includes(p));
+
+      const target = state.currentTarget || '';
+      const targetViolation = target !== '' && matchesSkillPath(target);
+
+      const command = state.currentCommand || '';
+      const commandViolation = command !== '' && matchesSkillPath(command);
+
+      const skillFiles = (state.modifiedFiles || []).filter((f) => matchesSkillPath(f));
+
+      const holds = !targetViolation && !commandViolation && skillFiles.length === 0;
+
+      const violations: string[] = [];
+      if (targetViolation) violations.push(`target: ${target}`);
+      if (commandViolation) violations.push(`command references skills`);
+      if (skillFiles.length > 0) violations.push(`modified: ${skillFiles.join(', ')}`);
+
+      return {
+        holds,
+        expected: 'No modifications to .claude/skills/',
+        actual: holds
+          ? 'No skill files affected'
+          : `Skill modification detected (${violations.join('; ')})`,
       };
     },
   },

--- a/src/kernel/decision.ts
+++ b/src/kernel/decision.ts
@@ -97,6 +97,8 @@ export function createEngine(config: EngineConfig = {}): Engine {
 
       const state = buildSystemState({
         ...systemContext,
+        currentTarget: intent.target,
+        currentCommand: intent.command,
         filesAffected: intent.filesAffected || systemContext.filesAffected,
         targetBranch: intent.branch || systemContext.targetBranch,
         forcePush: intent.action === 'git.force-push',

--- a/tests/ts/agentguard-engine.test.ts
+++ b/tests/ts/agentguard-engine.test.ts
@@ -15,7 +15,7 @@ describe('agentguard/core/engine', () => {
     it('creates an engine with defaults', () => {
       const engine = createEngine();
       expect(engine.getPolicyCount()).toBe(0);
-      expect(engine.getInvariantCount()).toBe(6); // DEFAULT_INVARIANTS
+      expect(engine.getInvariantCount()).toBe(7); // DEFAULT_INVARIANTS
       expect(engine.getPolicyErrors()).toEqual([]);
     });
 

--- a/tests/ts/invariant-definitions.test.ts
+++ b/tests/ts/invariant-definitions.test.ts
@@ -167,6 +167,55 @@ describe('no-force-push', () => {
   });
 });
 
+describe('no-skill-modification', () => {
+  const inv = findInvariant('no-skill-modification');
+
+  it('holds when target is outside .claude/skills/', () => {
+    const result = inv.check({ currentTarget: 'src/index.ts' });
+    expect(result.holds).toBe(true);
+  });
+
+  it('fails when currentTarget is a skill file', () => {
+    const result = inv.check({ currentTarget: '.claude/skills/my-skill/SKILL.md' });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('target');
+  });
+
+  it('fails when currentTarget is nested in skills directory', () => {
+    const result = inv.check({ currentTarget: '.claude/skills/ui-ux-pro-max/data/landing.csv' });
+    expect(result.holds).toBe(false);
+  });
+
+  it('fails when currentCommand references .claude/skills/', () => {
+    const result = inv.check({ currentCommand: 'rm -rf .claude/skills/old-skill' });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('command');
+  });
+
+  it('fails when modifiedFiles includes skill files', () => {
+    const result = inv.check({
+      modifiedFiles: ['src/index.ts', '.claude/skills/my-skill/SKILL.md'],
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('modified');
+  });
+
+  it('handles Windows backslash paths', () => {
+    const result = inv.check({ currentTarget: '.claude\\skills\\my-skill\\SKILL.md' });
+    expect(result.holds).toBe(false);
+  });
+
+  it('holds with empty state', () => {
+    const result = inv.check({});
+    expect(result.holds).toBe(true);
+  });
+
+  it('holds when .claude path does not include skills', () => {
+    const result = inv.check({ currentTarget: '.claude/settings.json' });
+    expect(result.holds).toBe(true);
+  });
+});
+
 describe('lockfile-integrity', () => {
   const inv = findInvariant('lockfile-integrity');
 
@@ -266,6 +315,8 @@ describe('buildSystemState', () => {
     expect(state.filesAffected).toBe(0);
     expect(state.blastRadiusLimit).toBe(20);
     expect(state.protectedBranches).toEqual(['main', 'master']);
+    expect(state.currentTarget).toBe('');
+    expect(state.currentCommand).toBe('');
   });
 
   it('populates from context values', () => {
@@ -279,11 +330,15 @@ describe('buildSystemState', () => {
       filesAffected: 5,
       blastRadiusLimit: 10,
       protectedBranches: ['production'],
+      currentTarget: 'src/index.ts',
+      currentCommand: 'npm test',
     });
     expect(state.modifiedFiles).toEqual(['a.ts', 'b.ts']);
     expect(state.targetBranch).toBe('main');
     expect(state.directPush).toBe(true);
     expect(state.filesAffected).toBe(5);
+    expect(state.currentTarget).toBe('src/index.ts');
+    expect(state.currentCommand).toBe('npm test');
   });
 
   it('computes filesAffected from modifiedFiles when not specified', () => {


### PR DESCRIPTION
## Summary
- Adds a new `no-skill-modification` kernel invariant (severity 4) that blocks agents from modifying files in `.claude/skills/`, preventing self-modification of governance behavior
- Threads `intent.target` and `intent.command` into `SystemState`, enabling invariants to inspect per-action targets (not just accumulated session state)
- Adds policy deny rules in `agentguard.yaml` for `file.write` and `file.delete` to `.claude/skills/` as a first-pass defense layer

## Test plan
- [x] 8 new tests for `no-skill-modification` invariant (currentTarget, currentCommand, modifiedFiles, Windows paths, edge cases)
- [x] Updated `buildSystemState` tests to cover `currentTarget`/`currentCommand` fields
- [x] Updated engine test for 7 default invariants (was 6)
- [x] All 560 tests pass across 38 test files
- [x] Build (`npm run build:ts`) and type-check pass
- [x] ESLint passes (no new warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)