### PR TITLE
feat: add sync-main skill to prevent stale worktrees

### DIFF
--- a/.claude/skills/sync-main.md
+++ b/.claude/skills/sync-main.md
@@ -1,0 +1,27 @@
+# Skill: Sync Main Branch
+
+Ensure the local `main` branch is up-to-date with the remote before starting any work. This prevents agents from operating on stale code when the scheduler creates a worktree from `main`.
+
+## Steps
+
+### 1. Fetch and Merge Remote Main
+
+```bash
+git fetch origin main && git merge origin/main --ff-only
+```
+
+The `--ff-only` flag ensures a clean fast-forward. If the merge fails (e.g., local commits on main that diverge from origin), report the error and STOP — do not proceed with stale or conflicted state.
+
+### 2. Confirm Sync
+
+Report the current HEAD:
+
+```bash
+git log --oneline -1
+```
+
+## Rules
+
+- This skill MUST run before any other skill in scheduled task workflows
+- If the fetch or merge fails, STOP — do not proceed with stale code
+- Never force-push or reset main — only fast-forward merges are allowed


### PR DESCRIPTION
## Summary
- Adds `.claude/skills/sync-main.md` — a shared skill that runs `git fetch origin main && git merge origin/main --ff-only` to ensure the local main branch is current before any scheduled agent work begins
- Updates all 8 scheduled task prompts to reference `sync-main` as their first step, before `start-governance-runtime`
- Prevents agents from operating on stale code when the scheduler creates worktrees from a local `main` that hasn't been synced with remote

## Test plan
- [ ] Verify `sync-main.md` exists in `.claude/skills/`
- [ ] Confirm all 8 scheduled task SKILL.md files list `sync-main` as step 1
- [ ] Run a scheduled task manually and verify it fetches + fast-forwards main before proceeding

🤖 Generated with [Claude Code](https://claude.com/claude-code)