### PR TITLE
feat(issue-43): replay comparator for outcome verification

### DIFF
--- a/src/cli/replay.ts
+++ b/src/cli/replay.ts
@@ -1,7 +1,7 @@
 // Replay CLI — flight recorder playback for debugging sessions.
 //
 // DONE(roadmap): Phase 4 — Full replay engine: see src/kernel/replay-engine.ts
-// TODO(roadmap): Phase 4 — Replay comparator (verify original vs replayed outcomes)
+// DONE(roadmap): Phase 4 — Replay comparator: see src/kernel/replay-comparator.ts
 // TODO(roadmap): Phase 6 — Replay processor plugin interface
 
 import { loadSession, listSessions } from './session-store.js';

--- a/src/kernel/replay-comparator.ts
+++ b/src/kernel/replay-comparator.ts
@@ -1,0 +1,358 @@
+// Replay Comparator — diffs two governance sessions to detect decision changes.
+//
+// Compares original vs replayed outcomes action-by-action, producing a structured
+// report of matching decisions, divergences, and missing/extra actions.
+// Use cases: policy regression testing, kernel correctness verification, audit validation.
+
+import type { DomainEvent } from '../core/types.js';
+import type {
+  ReplayAction,
+  ReplaySession,
+  ReplaySessionSummary,
+  ReplayLoadOptions,
+} from './replay-engine.js';
+import { loadReplaySession, buildReplaySession } from './replay-engine.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** The result of comparing a single field between original and replayed. */
+export interface FieldDifference {
+  readonly field: string;
+  readonly original: unknown;
+  readonly replayed: unknown;
+}
+
+/** Comparison status for a single action. */
+export type ComparisonStatus = 'match' | 'divergent' | 'missing' | 'extra';
+
+/** Side-by-side comparison of a single action encounter. */
+export interface ActionComparison {
+  /** Position in the comparison list (0-based). */
+  readonly index: number;
+  /** Whether the action matched, diverged, or was only in one session. */
+  readonly status: ComparisonStatus;
+  /** The action from the original session (null if status is 'extra'). */
+  readonly original: ReplayAction | null;
+  /** The action from the replayed session (null if status is 'missing'). */
+  readonly replayed: ReplayAction | null;
+  /** Field-level differences (empty for 'match', 'missing', 'extra'). */
+  readonly differences: readonly FieldDifference[];
+}
+
+/** Diff of session-level summary statistics. */
+export interface SummaryDiff {
+  readonly original: ReplaySessionSummary;
+  readonly replayed: ReplaySessionSummary;
+  readonly differences: readonly FieldDifference[];
+}
+
+/** Full comparison report between two governance sessions. */
+export interface ComparisonReport {
+  readonly originalRunId: string;
+  readonly replayedRunId: string;
+  /** Total number of action comparisons performed. */
+  readonly totalComparisons: number;
+  /** Number of actions that produced identical decisions. */
+  readonly matches: number;
+  /** Number of actions that produced different decisions. */
+  readonly divergences: number;
+  /** Number of actions present in original but absent in replayed. */
+  readonly missing: number;
+  /** Number of actions present in replayed but absent in original. */
+  readonly extra: number;
+  /** Per-action comparison details. */
+  readonly comparisons: readonly ActionComparison[];
+  /** Session-level summary diff. */
+  readonly summaryDiff: SummaryDiff;
+  /** Whether the two sessions produced identical governance decisions. */
+  readonly identical: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Action Comparison
+// ---------------------------------------------------------------------------
+
+/** Fields compared on each action to determine match vs divergence. */
+const COMPARED_FIELDS = ['allowed', 'executed', 'succeeded', 'actionType', 'target'] as const;
+
+/**
+ * Compare two ReplayAction objects field-by-field.
+ * Returns an array of field differences (empty if they match).
+ */
+function diffActions(original: ReplayAction, replayed: ReplayAction): FieldDifference[] {
+  const differences: FieldDifference[] = [];
+
+  for (const field of COMPARED_FIELDS) {
+    const origVal = original[field];
+    const replayVal = replayed[field];
+    if (origVal !== replayVal) {
+      differences.push({ field, original: origVal, replayed: replayVal });
+    }
+  }
+
+  // Compare governance event counts
+  const origGovCount = original.governanceEvents.length;
+  const replayGovCount = replayed.governanceEvents.length;
+  if (origGovCount !== replayGovCount) {
+    differences.push({
+      field: 'governanceEventCount',
+      original: origGovCount,
+      replayed: replayGovCount,
+    });
+  }
+
+  // Compare denial reasons (from decision events)
+  const origReason = original.decisionEvent?.reason ?? null;
+  const replayReason = replayed.decisionEvent?.reason ?? null;
+  if (origReason !== replayReason) {
+    differences.push({ field: 'decisionReason', original: origReason, replayed: replayReason });
+  }
+
+  return differences;
+}
+
+// ---------------------------------------------------------------------------
+// Summary Comparison
+// ---------------------------------------------------------------------------
+
+/** Summary fields to compare. */
+const SUMMARY_FIELDS = [
+  'totalActions',
+  'allowed',
+  'denied',
+  'executed',
+  'failed',
+  'violations',
+  'escalations',
+  'simulationsRun',
+] as const;
+
+/**
+ * Compare two session summaries field-by-field.
+ */
+function diffSummaries(
+  original: ReplaySessionSummary,
+  replayed: ReplaySessionSummary
+): FieldDifference[] {
+  const differences: FieldDifference[] = [];
+
+  for (const field of SUMMARY_FIELDS) {
+    const origVal = original[field];
+    const replayVal = replayed[field];
+    if (origVal !== replayVal) {
+      differences.push({ field, original: origVal, replayed: replayVal });
+    }
+  }
+
+  return differences;
+}
+
+// ---------------------------------------------------------------------------
+// Core Comparator
+// ---------------------------------------------------------------------------
+
+/**
+ * Compare two replay sessions action-by-action.
+ *
+ * Actions are matched by position (index). If one session has more actions
+ * than the other, the extra actions are reported as 'missing' or 'extra'.
+ */
+export function compareReplaySessions(
+  original: ReplaySession,
+  replayed: ReplaySession
+): ComparisonReport {
+  const origActions = original.actions;
+  const replayActions = replayed.actions;
+  const maxLen = Math.max(origActions.length, replayActions.length);
+
+  const comparisons: ActionComparison[] = [];
+  let matches = 0;
+  let divergences = 0;
+  let missing = 0;
+  let extra = 0;
+
+  for (let i = 0; i < maxLen; i++) {
+    const origAction = i < origActions.length ? origActions[i] : null;
+    const replayAction = i < replayActions.length ? replayActions[i] : null;
+
+    if (origAction && replayAction) {
+      const differences = diffActions(origAction, replayAction);
+      if (differences.length === 0) {
+        comparisons.push({
+          index: i,
+          status: 'match',
+          original: origAction,
+          replayed: replayAction,
+          differences,
+        });
+        matches++;
+      } else {
+        comparisons.push({
+          index: i,
+          status: 'divergent',
+          original: origAction,
+          replayed: replayAction,
+          differences,
+        });
+        divergences++;
+      }
+    } else if (origAction && !replayAction) {
+      comparisons.push({
+        index: i,
+        status: 'missing',
+        original: origAction,
+        replayed: null,
+        differences: [],
+      });
+      missing++;
+    } else if (!origAction && replayAction) {
+      comparisons.push({
+        index: i,
+        status: 'extra',
+        original: null,
+        replayed: replayAction,
+        differences: [],
+      });
+      extra++;
+    }
+  }
+
+  const summaryDiff: SummaryDiff = {
+    original: original.summary,
+    replayed: replayed.summary,
+    differences: diffSummaries(original.summary, replayed.summary),
+  };
+
+  return {
+    originalRunId: original.runId,
+    replayedRunId: replayed.runId,
+    totalComparisons: comparisons.length,
+    matches,
+    divergences,
+    missing,
+    extra,
+    comparisons,
+    summaryDiff,
+    identical: divergences === 0 && missing === 0 && extra === 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Convenience API
+// ---------------------------------------------------------------------------
+
+/**
+ * Compare two sessions by run ID, loading from JSONL files.
+ * Returns null if either session cannot be loaded.
+ */
+export function compareRunIds(
+  originalRunId: string,
+  replayedRunId: string,
+  options: ReplayLoadOptions = {}
+): ComparisonReport | null {
+  const original = loadReplaySession(originalRunId, options);
+  const replayed = loadReplaySession(replayedRunId, options);
+
+  if (!original || !replayed) return null;
+
+  return compareReplaySessions(original, replayed);
+}
+
+/**
+ * Compare an original session against an in-memory event array.
+ * Useful for re-evaluating a recorded session with a modified policy.
+ */
+export function compareSessionWithEvents(
+  original: ReplaySession,
+  replayedEvents: DomainEvent[],
+  replayedRunId?: string
+): ComparisonReport {
+  const replayed = buildReplaySession(replayedRunId || `${original.runId}-replay`, replayedEvents);
+  return compareReplaySessions(original, replayed);
+}
+
+// ---------------------------------------------------------------------------
+// Report Formatting
+// ---------------------------------------------------------------------------
+
+/**
+ * Format a comparison report as a human-readable string.
+ */
+export function formatComparisonReport(report: ComparisonReport): string {
+  const lines: string[] = [];
+
+  lines.push('Replay Comparison Report');
+  lines.push('========================');
+  lines.push(`Original: ${report.originalRunId}`);
+  lines.push(`Replayed: ${report.replayedRunId}`);
+  lines.push('');
+
+  // Overall result
+  if (report.identical) {
+    lines.push('Result: IDENTICAL — all governance decisions match.');
+  } else {
+    lines.push('Result: DIVERGENT — governance decisions differ.');
+  }
+  lines.push('');
+
+  // Stats
+  lines.push('Summary:');
+  lines.push(`  Total comparisons: ${report.totalComparisons}`);
+  lines.push(`  Matches:           ${report.matches}`);
+  lines.push(`  Divergences:       ${report.divergences}`);
+  lines.push(`  Missing (original only): ${report.missing}`);
+  lines.push(`  Extra (replayed only):   ${report.extra}`);
+  lines.push('');
+
+  // Divergent actions
+  const divergent = report.comparisons.filter((c) => c.status === 'divergent');
+  if (divergent.length > 0) {
+    lines.push('Divergent Actions:');
+    lines.push('------------------');
+    for (const comp of divergent) {
+      const actionType = comp.original?.actionType || comp.replayed?.actionType || 'unknown';
+      const target = comp.original?.target || comp.replayed?.target || '';
+      lines.push(`  [${comp.index}] ${actionType} → ${target}`);
+      for (const diff of comp.differences) {
+        lines.push(`    ${diff.field}: ${String(diff.original)} → ${String(diff.replayed)}`);
+      }
+    }
+    lines.push('');
+  }
+
+  // Missing actions
+  const missingActions = report.comparisons.filter((c) => c.status === 'missing');
+  if (missingActions.length > 0) {
+    lines.push('Missing Actions (in original, not in replayed):');
+    lines.push('-----------------------------------------------');
+    for (const comp of missingActions) {
+      lines.push(`  [${comp.index}] ${comp.original!.actionType} → ${comp.original!.target}`);
+    }
+    lines.push('');
+  }
+
+  // Extra actions
+  const extraActions = report.comparisons.filter((c) => c.status === 'extra');
+  if (extraActions.length > 0) {
+    lines.push('Extra Actions (in replayed, not in original):');
+    lines.push('---------------------------------------------');
+    for (const comp of extraActions) {
+      lines.push(`  [${comp.index}] ${comp.replayed!.actionType} → ${comp.replayed!.target}`);
+    }
+    lines.push('');
+  }
+
+  // Summary-level diffs
+  if (report.summaryDiff.differences.length > 0) {
+    lines.push('Summary Differences:');
+    lines.push('--------------------');
+    for (const diff of report.summaryDiff.differences) {
+      lines.push(`  ${diff.field}: ${String(diff.original)} → ${String(diff.replayed)}`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}

--- a/tests/ts/replay-comparator.test.ts
+++ b/tests/ts/replay-comparator.test.ts
@@ -1,0 +1,545 @@
+// Tests for the replay comparator — verifies action-by-action diffing,
+// missing/extra detection, summary comparison, and report formatting.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  compareReplaySessions,
+  compareRunIds,
+  compareSessionWithEvents,
+  formatComparisonReport,
+} from '../../src/kernel/replay-comparator.js';
+import { buildReplaySession } from '../../src/kernel/replay-engine.js';
+import type { DomainEvent } from '../../src/core/types.js';
+import { resetEventCounter } from '../../src/events/schema.js';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const TEST_BASE_DIR = join('.agentguard-test-replay', 'comparator-test');
+const TEST_EVENTS_DIR = join(TEST_BASE_DIR, 'events');
+
+function ensureTestDir(): void {
+  mkdirSync(TEST_EVENTS_DIR, { recursive: true });
+}
+
+function cleanTestDir(): void {
+  if (existsSync(TEST_BASE_DIR)) {
+    rmSync(TEST_BASE_DIR, { recursive: true, force: true });
+  }
+}
+
+function writeTestJsonl(runId: string, events: DomainEvent[]): void {
+  ensureTestDir();
+  const filePath = join(TEST_EVENTS_DIR, `${runId}.jsonl`);
+  const content = events.map((e) => JSON.stringify(e)).join('\n') + '\n';
+  writeFileSync(filePath, content, 'utf8');
+}
+
+/** Create a minimal DomainEvent for testing. */
+function testEvent(
+  kind: string,
+  data: Record<string, unknown> = {},
+  timestamp?: number
+): DomainEvent {
+  return {
+    id: `evt_test_${Math.random().toString(36).slice(2, 6)}`,
+    kind: kind as DomainEvent['kind'],
+    timestamp: timestamp || Date.now(),
+    fingerprint: 'test',
+    ...data,
+  };
+}
+
+/** Create a full allowed action lifecycle. */
+function createAllowedActionEvents(
+  actionType: string,
+  target: string,
+  baseTimestamp: number
+): DomainEvent[] {
+  return [
+    testEvent(
+      'ActionRequested',
+      { actionType, target, justification: 'test action', agentId: 'test-agent' },
+      baseTimestamp
+    ),
+    testEvent(
+      'ActionAllowed',
+      { actionType, target, capability: 'default-allow', reason: 'No matching deny rule' },
+      baseTimestamp + 1
+    ),
+    testEvent(
+      'ActionExecuted',
+      { actionType, target, result: 'success', duration: 10 },
+      baseTimestamp + 2
+    ),
+    testEvent(
+      'DecisionRecorded',
+      {
+        recordId: `rec_${baseTimestamp}`,
+        outcome: 'allow',
+        actionType,
+        target,
+        reason: 'No matching deny rule',
+      },
+      baseTimestamp + 3
+    ),
+  ];
+}
+
+/** Create a denied action lifecycle. */
+function createDeniedActionEvents(
+  actionType: string,
+  target: string,
+  reason: string,
+  baseTimestamp: number
+): DomainEvent[] {
+  return [
+    testEvent(
+      'ActionRequested',
+      { actionType, target, justification: 'test action', agentId: 'test-agent' },
+      baseTimestamp
+    ),
+    testEvent(
+      'PolicyDenied',
+      { policy: 'test-policy', action: actionType, reason },
+      baseTimestamp + 1
+    ),
+    testEvent('ActionDenied', { actionType, target, reason }, baseTimestamp + 2),
+    testEvent(
+      'DecisionRecorded',
+      { recordId: `rec_${baseTimestamp}`, outcome: 'deny', actionType, target, reason },
+      baseTimestamp + 3
+    ),
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('replay-comparator', () => {
+  beforeEach(() => {
+    resetEventCounter();
+    cleanTestDir();
+    ensureTestDir();
+  });
+
+  afterEach(() => {
+    cleanTestDir();
+  });
+
+  // ── Identical Sessions ──
+
+  describe('identical sessions', () => {
+    it('reports identical when both sessions have the same actions', () => {
+      const events = [
+        ...createAllowedActionEvents('file.write', 'src/a.ts', 1000),
+        ...createAllowedActionEvents('file.read', 'src/b.ts', 2000),
+      ];
+
+      const original = buildReplaySession('run-original', events);
+      const replayed = buildReplaySession('run-replay', events);
+      const report = compareReplaySessions(original, replayed);
+
+      expect(report.identical).toBe(true);
+      expect(report.matches).toBe(2);
+      expect(report.divergences).toBe(0);
+      expect(report.missing).toBe(0);
+      expect(report.extra).toBe(0);
+      expect(report.totalComparisons).toBe(2);
+    });
+
+    it('reports identical for empty sessions', () => {
+      const original = buildReplaySession('run-a', []);
+      const replayed = buildReplaySession('run-b', []);
+      const report = compareReplaySessions(original, replayed);
+
+      expect(report.identical).toBe(true);
+      expect(report.totalComparisons).toBe(0);
+    });
+  });
+
+  // ── Divergent Decisions ──
+
+  describe('divergent decisions', () => {
+    it('detects when an allowed action becomes denied', () => {
+      const origEvents = createAllowedActionEvents('git.push', 'main', 1000);
+      const replayEvents = createDeniedActionEvents('git.push', 'main', 'Protected branch', 1000);
+
+      const original = buildReplaySession('run-original', origEvents);
+      const replayed = buildReplaySession('run-replay', replayEvents);
+      const report = compareReplaySessions(original, replayed);
+
+      expect(report.identical).toBe(false);
+      expect(report.divergences).toBe(1);
+      expect(report.matches).toBe(0);
+
+      const comp = report.comparisons[0];
+      expect(comp.status).toBe('divergent');
+      const allowedDiff = comp.differences.find((d) => d.field === 'allowed');
+      expect(allowedDiff).toBeDefined();
+      expect(allowedDiff!.original).toBe(true);
+      expect(allowedDiff!.replayed).toBe(false);
+    });
+
+    it('detects when a denied action becomes allowed', () => {
+      const origEvents = createDeniedActionEvents(
+        'file.delete',
+        'config.ts',
+        'Protected path',
+        1000
+      );
+      const replayEvents = createAllowedActionEvents('file.delete', 'config.ts', 1000);
+
+      const original = buildReplaySession('run-original', origEvents);
+      const replayed = buildReplaySession('run-replay', replayEvents);
+      const report = compareReplaySessions(original, replayed);
+
+      expect(report.identical).toBe(false);
+      expect(report.divergences).toBe(1);
+
+      const comp = report.comparisons[0];
+      expect(comp.differences.some((d) => d.field === 'allowed')).toBe(true);
+      expect(comp.differences.some((d) => d.field === 'executed')).toBe(true);
+    });
+
+    it('detects governance event count changes', () => {
+      // Original has a PolicyDenied governance event
+      const origEvents = createDeniedActionEvents('git.push', 'main', 'Blocked', 1000);
+
+      // Replayed: same denial but with extra InvariantViolation
+      const replayEvents = [
+        testEvent(
+          'ActionRequested',
+          { actionType: 'git.push', target: 'main', justification: 'test' },
+          1000
+        ),
+        testEvent(
+          'PolicyDenied',
+          { policy: 'test-policy', action: 'git.push', reason: 'Blocked' },
+          1001
+        ),
+        testEvent(
+          'InvariantViolation',
+          { invariant: 'protected-branches', expected: 'not main', actual: 'main' },
+          1002
+        ),
+        testEvent(
+          'ActionDenied',
+          { actionType: 'git.push', target: 'main', reason: 'Blocked' },
+          1003
+        ),
+      ];
+
+      const original = buildReplaySession('run-original', origEvents);
+      const replayed = buildReplaySession('run-replay', replayEvents);
+      const report = compareReplaySessions(original, replayed);
+
+      // Both denied, but governance event counts differ
+      const comp = report.comparisons[0];
+      const govDiff = comp.differences.find((d) => d.field === 'governanceEventCount');
+      expect(govDiff).toBeDefined();
+      expect(govDiff!.original).toBe(1);
+      expect(govDiff!.replayed).toBe(2);
+    });
+
+    it('detects multiple divergences in a mixed session', () => {
+      const origEvents = [
+        ...createAllowedActionEvents('file.write', 'a.ts', 1000),
+        ...createAllowedActionEvents('git.push', 'main', 2000),
+        ...createDeniedActionEvents('infra.destroy', 'prod', 'Blocked', 3000),
+      ];
+
+      const replayEvents = [
+        ...createAllowedActionEvents('file.write', 'a.ts', 1000), // same
+        ...createDeniedActionEvents('git.push', 'main', 'New policy', 2000), // changed
+        ...createAllowedActionEvents('infra.destroy', 'prod', 3000), // changed
+      ];
+
+      const original = buildReplaySession('run-original', origEvents);
+      const replayed = buildReplaySession('run-replay', replayEvents);
+      const report = compareReplaySessions(original, replayed);
+
+      expect(report.matches).toBe(1);
+      expect(report.divergences).toBe(2);
+    });
+  });
+
+  // ── Missing and Extra Actions ──
+
+  describe('missing and extra actions', () => {
+    it('detects missing actions when replayed has fewer', () => {
+      const origEvents = [
+        ...createAllowedActionEvents('file.write', 'a.ts', 1000),
+        ...createAllowedActionEvents('file.write', 'b.ts', 2000),
+        ...createAllowedActionEvents('file.write', 'c.ts', 3000),
+      ];
+
+      const replayEvents = [...createAllowedActionEvents('file.write', 'a.ts', 1000)];
+
+      const original = buildReplaySession('run-original', origEvents);
+      const replayed = buildReplaySession('run-replay', replayEvents);
+      const report = compareReplaySessions(original, replayed);
+
+      expect(report.matches).toBe(1);
+      expect(report.missing).toBe(2);
+      expect(report.extra).toBe(0);
+      expect(report.totalComparisons).toBe(3);
+
+      const missingComps = report.comparisons.filter((c) => c.status === 'missing');
+      expect(missingComps).toHaveLength(2);
+      expect(missingComps[0].original).not.toBeNull();
+      expect(missingComps[0].replayed).toBeNull();
+    });
+
+    it('detects extra actions when replayed has more', () => {
+      const origEvents = [...createAllowedActionEvents('file.write', 'a.ts', 1000)];
+
+      const replayEvents = [
+        ...createAllowedActionEvents('file.write', 'a.ts', 1000),
+        ...createAllowedActionEvents('file.write', 'b.ts', 2000),
+      ];
+
+      const original = buildReplaySession('run-original', origEvents);
+      const replayed = buildReplaySession('run-replay', replayEvents);
+      const report = compareReplaySessions(original, replayed);
+
+      expect(report.matches).toBe(1);
+      expect(report.extra).toBe(1);
+      expect(report.missing).toBe(0);
+
+      const extraComps = report.comparisons.filter((c) => c.status === 'extra');
+      expect(extraComps).toHaveLength(1);
+      expect(extraComps[0].original).toBeNull();
+      expect(extraComps[0].replayed).not.toBeNull();
+    });
+  });
+
+  // ── Summary Diff ──
+
+  describe('summary diff', () => {
+    it('reports summary differences between sessions', () => {
+      const origEvents = [
+        ...createAllowedActionEvents('file.write', 'a.ts', 1000),
+        ...createAllowedActionEvents('file.write', 'b.ts', 2000),
+      ];
+
+      const replayEvents = [
+        ...createAllowedActionEvents('file.write', 'a.ts', 1000),
+        ...createDeniedActionEvents('file.write', 'b.ts', 'New deny rule', 2000),
+      ];
+
+      const original = buildReplaySession('run-original', origEvents);
+      const replayed = buildReplaySession('run-replay', replayEvents);
+      const report = compareReplaySessions(original, replayed);
+
+      expect(report.summaryDiff.differences.length).toBeGreaterThan(0);
+      const allowedDiff = report.summaryDiff.differences.find((d) => d.field === 'allowed');
+      expect(allowedDiff).toBeDefined();
+      expect(allowedDiff!.original).toBe(2);
+      expect(allowedDiff!.replayed).toBe(1);
+    });
+
+    it('reports no summary differences for identical sessions', () => {
+      const events = createAllowedActionEvents('file.write', 'a.ts', 1000);
+
+      const original = buildReplaySession('run-a', events);
+      const replayed = buildReplaySession('run-b', events);
+      const report = compareReplaySessions(original, replayed);
+
+      expect(report.summaryDiff.differences).toHaveLength(0);
+    });
+  });
+
+  // ── Run ID-based Comparison ──
+
+  describe('compareRunIds', () => {
+    it('loads and compares two sessions by run ID', () => {
+      const origEvents = createAllowedActionEvents('file.write', 'a.ts', 1000);
+      const replayEvents = createDeniedActionEvents('file.write', 'a.ts', 'Denied', 1000);
+
+      writeTestJsonl('run-orig', origEvents);
+      writeTestJsonl('run-replay', replayEvents);
+
+      const report = compareRunIds('run-orig', 'run-replay', { baseDir: TEST_BASE_DIR });
+      expect(report).not.toBeNull();
+      expect(report!.originalRunId).toBe('run-orig');
+      expect(report!.replayedRunId).toBe('run-replay');
+      expect(report!.divergences).toBe(1);
+    });
+
+    it('returns null when original session does not exist', () => {
+      writeTestJsonl('run-exists', createAllowedActionEvents('file.write', 'a.ts', 1000));
+
+      const report = compareRunIds('run-missing', 'run-exists', { baseDir: TEST_BASE_DIR });
+      expect(report).toBeNull();
+    });
+
+    it('returns null when replayed session does not exist', () => {
+      writeTestJsonl('run-exists', createAllowedActionEvents('file.write', 'a.ts', 1000));
+
+      const report = compareRunIds('run-exists', 'run-missing', { baseDir: TEST_BASE_DIR });
+      expect(report).toBeNull();
+    });
+  });
+
+  // ── In-memory Event Comparison ──
+
+  describe('compareSessionWithEvents', () => {
+    it('compares a loaded session against in-memory events', () => {
+      const origEvents = createAllowedActionEvents('file.write', 'a.ts', 1000);
+      const original = buildReplaySession('run-original', origEvents);
+
+      const replayEvents = createDeniedActionEvents('file.write', 'a.ts', 'New policy', 1000);
+
+      const report = compareSessionWithEvents(original, replayEvents);
+      expect(report.originalRunId).toBe('run-original');
+      expect(report.replayedRunId).toBe('run-original-replay');
+      expect(report.divergences).toBe(1);
+    });
+
+    it('uses custom replay run ID when provided', () => {
+      const origEvents = createAllowedActionEvents('file.write', 'a.ts', 1000);
+      const original = buildReplaySession('run-original', origEvents);
+
+      const report = compareSessionWithEvents(original, origEvents, 'custom-replay-id');
+      expect(report.replayedRunId).toBe('custom-replay-id');
+    });
+  });
+
+  // ── Report Formatting ──
+
+  describe('formatComparisonReport', () => {
+    it('formats an identical report', () => {
+      const events = createAllowedActionEvents('file.write', 'a.ts', 1000);
+      const original = buildReplaySession('run-a', events);
+      const replayed = buildReplaySession('run-b', events);
+      const report = compareReplaySessions(original, replayed);
+
+      const formatted = formatComparisonReport(report);
+      expect(formatted).toContain('IDENTICAL');
+      expect(formatted).toContain('run-a');
+      expect(formatted).toContain('run-b');
+      expect(formatted).toContain('Matches:           1');
+    });
+
+    it('formats a divergent report with action details', () => {
+      const origEvents = createAllowedActionEvents('git.push', 'main', 1000);
+      const replayEvents = createDeniedActionEvents('git.push', 'main', 'Protected', 1000);
+
+      const original = buildReplaySession('run-orig', origEvents);
+      const replayed = buildReplaySession('run-replay', replayEvents);
+      const report = compareReplaySessions(original, replayed);
+
+      const formatted = formatComparisonReport(report);
+      expect(formatted).toContain('DIVERGENT');
+      expect(formatted).toContain('Divergent Actions:');
+      expect(formatted).toContain('git.push');
+      expect(formatted).toContain('allowed');
+    });
+
+    it('formats missing and extra actions', () => {
+      const origEvents = [
+        ...createAllowedActionEvents('file.write', 'a.ts', 1000),
+        ...createAllowedActionEvents('file.write', 'b.ts', 2000),
+      ];
+      const replayEvents = [
+        ...createAllowedActionEvents('file.write', 'a.ts', 1000),
+        ...createAllowedActionEvents('file.write', 'c.ts', 2000),
+        ...createAllowedActionEvents('file.write', 'd.ts', 3000),
+      ];
+
+      const original = buildReplaySession('run-orig', origEvents);
+      const replayed = buildReplaySession('run-replay', replayEvents);
+      const report = compareReplaySessions(original, replayed);
+
+      const formatted = formatComparisonReport(report);
+      expect(formatted).toContain('run-orig');
+      expect(formatted).toContain('run-replay');
+    });
+
+    it('formats summary differences', () => {
+      const origEvents = [
+        ...createAllowedActionEvents('file.write', 'a.ts', 1000),
+        ...createAllowedActionEvents('file.write', 'b.ts', 2000),
+      ];
+      const replayEvents = [
+        ...createAllowedActionEvents('file.write', 'a.ts', 1000),
+        ...createDeniedActionEvents('file.write', 'b.ts', 'Denied', 2000),
+      ];
+
+      const original = buildReplaySession('run-orig', origEvents);
+      const replayed = buildReplaySession('run-replay', replayEvents);
+      const report = compareReplaySessions(original, replayed);
+
+      const formatted = formatComparisonReport(report);
+      expect(formatted).toContain('Summary Differences:');
+    });
+  });
+
+  // ── Edge Cases ──
+
+  describe('edge cases', () => {
+    it('handles comparison when both sessions are empty', () => {
+      const original = buildReplaySession('empty-a', []);
+      const replayed = buildReplaySession('empty-b', []);
+      const report = compareReplaySessions(original, replayed);
+
+      expect(report.identical).toBe(true);
+      expect(report.comparisons).toHaveLength(0);
+    });
+
+    it('handles comparison of original empty vs replayed with actions', () => {
+      const original = buildReplaySession('empty', []);
+      const replayEvents = createAllowedActionEvents('file.write', 'a.ts', 1000);
+      const replayed = buildReplaySession('has-actions', replayEvents);
+      const report = compareReplaySessions(original, replayed);
+
+      expect(report.identical).toBe(false);
+      expect(report.extra).toBe(1);
+      expect(report.missing).toBe(0);
+    });
+
+    it('handles comparison of original with actions vs replayed empty', () => {
+      const origEvents = createAllowedActionEvents('file.write', 'a.ts', 1000);
+      const original = buildReplaySession('has-actions', origEvents);
+      const replayed = buildReplaySession('empty', []);
+      const report = compareReplaySessions(original, replayed);
+
+      expect(report.identical).toBe(false);
+      expect(report.missing).toBe(1);
+      expect(report.extra).toBe(0);
+    });
+
+    it('detects decision reason changes even when outcome is the same', () => {
+      // Both denied, but for different reasons
+      const origEvents = createDeniedActionEvents('git.push', 'main', 'Protected branch', 1000);
+      const replayEvents = createDeniedActionEvents('git.push', 'main', 'No permission', 1000);
+
+      const original = buildReplaySession('run-original', origEvents);
+      const replayed = buildReplaySession('run-replay', replayEvents);
+      const report = compareReplaySessions(original, replayed);
+
+      // Still divergent because the reason changed
+      expect(report.divergences).toBe(1);
+      const comp = report.comparisons[0];
+      const reasonDiff = comp.differences.find((d) => d.field === 'decisionReason');
+      expect(reasonDiff).toBeDefined();
+      expect(reasonDiff!.original).toBe('Protected branch');
+      expect(reasonDiff!.replayed).toBe('No permission');
+    });
+
+    it('preserves run IDs in the report', () => {
+      const events = createAllowedActionEvents('file.write', 'a.ts', 1000);
+      const original = buildReplaySession('session-alpha', events);
+      const replayed = buildReplaySession('session-beta', events);
+      const report = compareReplaySessions(original, replayed);
+
+      expect(report.originalRunId).toBe('session-alpha');
+      expect(report.replayedRunId).toBe('session-beta');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implement a replay comparator that diffs two governance sessions action-by-action to detect decision changes
- Enables policy regression testing, kernel correctness verification, and audit validation
- Closes #43

## Changes
- `src/kernel/replay-comparator.ts` — New module with core comparison engine:
  - `compareReplaySessions()` — Compare two `ReplaySession` objects
  - `compareRunIds()` — Load and compare sessions by run ID from JSONL files
  - `compareSessionWithEvents()` — Compare a session against in-memory events
  - `formatComparisonReport()` — Human-readable report formatting
  - Types: `ComparisonReport`, `ActionComparison`, `FieldDifference`, `SummaryDiff`
- `tests/ts/replay-comparator.test.ts` — 24 comprehensive tests covering:
  - Identical session detection
  - Divergent decisions (allowed→denied, denied→allowed, reason changes)
  - Missing/extra action detection
  - Summary-level diffs
  - File-based and in-memory comparison
  - Report formatting
  - Edge cases (empty sessions, asymmetric comparisons)
- `src/cli/replay.ts` — Updated TODO marker to DONE

## Test Plan
- [x] TypeScript build passes (`npm run build:ts`)
- [x] Vitest tests pass (`npm run ts:test`) — 657 pass / 0 fail
- [x] JS tests pass (`npm test`) — 210 pass / 0 fail
- [x] ESLint clean (`npm run lint`) — 0 errors
- [x] Prettier clean (`npm run format`)
- [x] Type-check clean (`npm run ts:check`)

## Governance Report

| Metric | Count |
|--------|-------|
| Total events | 24 |
| Actions allowed | 8 |
| Actions denied | 0 |
| Policy denials | 0 |
| Invariant violations | 0 |

<details>
<summary>Telemetry details</summary>

Source: `.agentguard/events/` and `logs/runtime-events.jsonl`

8 governance event files recorded during this session. All actions were allowed — no policy denials or invariant violations occurred.

</details>