### PR TITLE
feat: add no-scheduled-task-modification invariant

### DIFF
--- a/src/invariants/definitions.ts
+++ b/src/invariants/definitions.ts
@@ -159,6 +159,42 @@ export const DEFAULT_INVARIANTS: AgentGuardInvariant[] = [
   },
 
   {
+    id: 'no-scheduled-task-modification',
+    name: 'No Scheduled Task Modification',
+    description:
+      'Agents must not modify scheduled task definitions (.claude/scheduled-tasks/) directly',
+    severity: 5,
+    check(state) {
+      const SCHEDULED_TASK_PATTERNS = ['.claude/scheduled-tasks/', '.claude\\scheduled-tasks\\'];
+      const matchesScheduledPath = (path: string) =>
+        SCHEDULED_TASK_PATTERNS.some((p) => path.includes(p));
+
+      const target = state.currentTarget || '';
+      const targetViolation = target !== '' && matchesScheduledPath(target);
+
+      const command = state.currentCommand || '';
+      const commandViolation = command !== '' && matchesScheduledPath(command);
+
+      const scheduledFiles = (state.modifiedFiles || []).filter((f) => matchesScheduledPath(f));
+
+      const holds = !targetViolation && !commandViolation && scheduledFiles.length === 0;
+
+      const violations: string[] = [];
+      if (targetViolation) violations.push(`target: ${target}`);
+      if (commandViolation) violations.push(`command references scheduled tasks`);
+      if (scheduledFiles.length > 0) violations.push(`modified: ${scheduledFiles.join(', ')}`);
+
+      return {
+        holds,
+        expected: 'No modifications to .claude/scheduled-tasks/',
+        actual: holds
+          ? 'No scheduled task files affected'
+          : `Scheduled task modification detected (${violations.join('; ')})`,
+      };
+    },
+  },
+
+  {
     id: 'lockfile-integrity',
     name: 'Lockfile Integrity',
     description: 'Package lockfiles must stay in sync with manifests',

--- a/tests/ts/agentguard-engine.test.ts
+++ b/tests/ts/agentguard-engine.test.ts
@@ -15,7 +15,7 @@ describe('agentguard/core/engine', () => {
     it('creates an engine with defaults', () => {
       const engine = createEngine();
       expect(engine.getPolicyCount()).toBe(0);
-      expect(engine.getInvariantCount()).toBe(7); // DEFAULT_INVARIANTS
+      expect(engine.getInvariantCount()).toBe(8); // DEFAULT_INVARIANTS
       expect(engine.getPolicyErrors()).toEqual([]);
     });
 

--- a/tests/ts/invariant-definitions.test.ts
+++ b/tests/ts/invariant-definitions.test.ts
@@ -216,6 +216,84 @@ describe('no-skill-modification', () => {
   });
 });
 
+describe('no-scheduled-task-modification', () => {
+  const inv = findInvariant('no-scheduled-task-modification');
+
+  it('holds when target is outside .claude/scheduled-tasks/', () => {
+    const result = inv.check({ currentTarget: 'src/index.ts' });
+    expect(result.holds).toBe(true);
+  });
+
+  it('fails when currentTarget is a scheduled task file', () => {
+    const result = inv.check({
+      currentTarget: '.claude/scheduled-tasks/daily-sync/SKILL.md',
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('target');
+  });
+
+  it('fails when currentTarget is nested in scheduled-tasks directory', () => {
+    const result = inv.check({
+      currentTarget: '.claude/scheduled-tasks/check-inbox/config.json',
+    });
+    expect(result.holds).toBe(false);
+  });
+
+  it('fails when currentCommand references .claude/scheduled-tasks/', () => {
+    const result = inv.check({
+      currentCommand: 'rm -rf .claude/scheduled-tasks/old-task',
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('command');
+  });
+
+  it('fails when modifiedFiles includes scheduled task files', () => {
+    const result = inv.check({
+      modifiedFiles: ['src/index.ts', '.claude/scheduled-tasks/daily-sync/SKILL.md'],
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('modified');
+  });
+
+  it('handles Windows backslash paths', () => {
+    const result = inv.check({
+      currentTarget: '.claude\\scheduled-tasks\\daily-sync\\SKILL.md',
+    });
+    expect(result.holds).toBe(false);
+  });
+
+  it('holds with empty state', () => {
+    const result = inv.check({});
+    expect(result.holds).toBe(true);
+  });
+
+  it('holds when .claude path does not include scheduled-tasks', () => {
+    const result = inv.check({ currentTarget: '.claude/settings.json' });
+    expect(result.holds).toBe(true);
+  });
+
+  it('holds when path contains "scheduled" but not "scheduled-tasks/"', () => {
+    const result = inv.check({ currentTarget: 'src/scheduled-handler.ts' });
+    expect(result.holds).toBe(true);
+  });
+
+  it('detects all three violation vectors simultaneously', () => {
+    const result = inv.check({
+      currentTarget: '.claude/scheduled-tasks/task-a/SKILL.md',
+      currentCommand: 'cat .claude/scheduled-tasks/task-b/SKILL.md',
+      modifiedFiles: ['.claude/scheduled-tasks/task-c/SKILL.md'],
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('target');
+    expect(result.actual).toContain('command');
+    expect(result.actual).toContain('modified');
+  });
+
+  it('has severity 5 (highest — DENY intervention)', () => {
+    expect(inv.severity).toBe(5);
+  });
+});
+
 describe('lockfile-integrity', () => {
   const inv = findInvariant('lockfile-integrity');
 


### PR DESCRIPTION
## Summary
- Adds the 8th built-in invariant `no-scheduled-task-modification` (severity 5 / DENY) to prevent agents from modifying scheduled task definitions in `.claude/scheduled-tasks/`
- Detects violations via three vectors: `currentTarget` (file writes), `currentCommand` (shell commands), and `modifiedFiles` (batch operations)
- Closes a privilege escalation vector where an agent could rewrite its own scheduled instructions to bypass governance constraints

## Test plan
- [x] 11 new tests covering all detection vectors (target, command, modifiedFiles, Windows paths, edge cases, severity check)
- [x] Updated engine invariant count assertion from 7 → 8
- [x] All 644 TypeScript tests pass
- [x] All 210 JS tests pass
- [x] TypeScript build succeeds


🤖 Generated with [Claude Code](https://claude.com/claude-code)