### PR TITLE
docs: sync documentation with codebase state

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -46,7 +46,7 @@ src/
 ├── kernel/        Governed action kernel (orchestrate, normalize, decide, escalate)
 ├── events/        Canonical event model (schema, bus, store, JSONL persistence)
 ├── policy/        Policy system (evaluator, loaders)
-├── invariants/    Invariant system (6 built-in definitions, checker)
+├── invariants/    Invariant system (7 built-in definitions, checker)
 ├── adapters/      Execution adapters (file, shell, git, claude-code)
 ├── cli/           CLI entry point and commands
 ├── telemetry/     Runtime telemetry and logging

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ The system has one architectural spine: the **canonical event model**. All syste
 
 **Key characteristics:**
 - Governed action kernel: propose → normalize → evaluate → execute → emit
-- 6 built-in invariants (secret exposure, protected branches, blast radius, test-before-push, no force push, lockfile integrity)
+- 7 built-in invariants (secret exposure, protected branches, blast radius, test-before-push, no force push, no skill modification, lockfile integrity)
 - YAML/JSON policy format with pattern matching, scopes, and branch conditions
 - Escalation tracking: NORMAL → ELEVATED → HIGH → LOCKDOWN
 - JSONL event persistence for audit trail and replay
@@ -44,6 +44,8 @@ src/
 │   ├── decision.ts         # Runtime assurance engine
 │   ├── monitor.ts          # Escalation state machine
 │   ├── evidence.ts         # Evidence pack generation
+│   ├── replay-comparator.ts # Replay outcome comparison
+│   ├── replay-engine.ts    # Deterministic replay engine
 │   ├── decisions/          # Typed decision records
 │   │   ├── factory.ts      # Decision record factory
 │   │   └── types.ts        # Decision record type definitions
@@ -64,7 +66,7 @@ src/
 │   ├── loader.ts           # Policy validation + loading
 │   └── yaml-loader.ts      # YAML policy parser
 ├── invariants/             # Invariant system
-│   ├── definitions.ts      # 6 built-in invariant definitions
+│   ├── definitions.ts      # 7 built-in invariant definitions
 │   └── checker.ts          # Invariant evaluation engine
 ├── adapters/               # Execution adapters
 │   ├── registry.ts         # Adapter registry (action class → handler)
@@ -86,6 +88,7 @@ src/
     ├── actions.ts          # 23 canonical action types across 8 classes
     ├── hash.ts             # Content hashing utilities
     ├── adapters.ts         # Adapter registry interface
+    ├── rng.ts              # Seeded random number generator
     └── execution-log/      # Execution audit log
         ├── bridge.ts       # Bridge between event systems
         ├── event-log.ts    # Event logging
@@ -99,7 +102,7 @@ src/
 
 tests/
 ├── *.test.js               # 14 JS test files (custom zero-dependency harness)
-└── ts/*.test.ts            # 38 TS test files (vitest)
+└── ts/*.test.ts            # 41 TS test files (vitest)
 policy/                     # Policy configuration (JSON: action_rules, capabilities)
 docs/                       # System documentation (architecture, event model, specs)
 hooks/                      # Git hooks (post-commit, post-merge)
@@ -138,7 +141,7 @@ The kernel loop is the core of AgentGuard. Every agent action passes through it:
 1. Agent proposes action (Claude Code tool call → `RawAgentAction`)
 2. AAB normalizes intent (tool → action type, detect git/destructive commands)
 3. Policy evaluator matches rules (deny/allow with scopes, branches, limits)
-4. Invariant checker verifies system state (6 defaults)
+4. Invariant checker verifies system state (7 defaults)
 5. If allowed: execute via adapter (file/shell/git handlers)
 6. Emit lifecycle events: `ACTION_REQUESTED` → `ACTION_ALLOWED/DENIED` → `ACTION_EXECUTED/FAILED`
 7. Sink all events to JSONL for audit trail
@@ -230,7 +233,7 @@ npm run test:coverage      # Run with coverage (c8, 50% line threshold)
 
 **Test structure:**
 - **JS tests** (`tests/*.test.js`): 14 files using a custom zero-dependency harness (`tests/run.js` with `node:assert`)
-- **TypeScript tests** (`tests/ts/*.test.ts`): 38 files using vitest
+- **TypeScript tests** (`tests/ts/*.test.ts`): 41 files using vitest
 - **Coverage areas**: adapters, kernel (AAB, engine, monitor, blast radius), CLI commands, decision records, domain models, events, evidence packs, execution log, invariants, JSONL persistence, policy evaluation, simulation, telemetry, TUI renderer, YAML loading
 
 ## CI/CD & Automation

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Expected output:
 
 ```
   AgentGuard Runtime Active
-  policy: Demo Safety Policy | invariants: 6 active
+  policy: Demo Safety Policy | invariants: 7 active
 
   ✓ file.read src/auth/service.ts (dry-run)
   ✓ file.write src/auth/service.ts (dry-run)
@@ -62,7 +62,7 @@ AI coding agents execute file writes, shell commands, and git operations autonom
 AgentGuard adds a **deterministic decision point** between proposal and execution:
 
 - **Safety policies** — declare what agents can and cannot do in YAML
-- **Invariant enforcement** — 6 built-in checks (secrets, protected branches, blast radius) run on every action
+- **Invariant enforcement** — 7 built-in checks (secrets, protected branches, blast radius, skill protection) run on every action
 - **Audit trail** — every decision is recorded as structured JSONL, inspectable after the fact
 - **Session debugging** — replay any agent session to see exactly what happened and why
 
@@ -72,7 +72,7 @@ AgentGuard evaluates every agent action through a **governed action kernel**:
 
 1. **Normalize** — Claude Code tool calls (Bash, Write, Edit, Read) are mapped to canonical action types (shell.exec, file.write, file.read)
 2. **Evaluate** — policies match against the action (deny git.push to main, deny destructive commands, enforce scope limits)
-3. **Check invariants** — 6 built-in safety checks run on every action
+3. **Check invariants** — 7 built-in safety checks run on every action
 4. **Execute** — if allowed, the action runs via adapters (file, shell, git handlers)
 5. **Emit events** — full lifecycle events sunk to JSONL for audit trail
 
@@ -80,7 +80,7 @@ AgentGuard evaluates every agent action through a **governed action kernel**:
 
 ```
   AgentGuard Runtime Active
-  policy: agentguard.yaml | invariants: 6 active
+  policy: agentguard.yaml | invariants: 7 active
 
   ✓ file.write src/auth/service.ts
   ✓ shell.exec npm test
@@ -120,13 +120,14 @@ Drop an `agentguard.yaml` in your repo root — the CLI picks it up automaticall
 
 ## Built-in Invariants
 
-6 safety invariants run on every action evaluation:
+7 safety invariants run on every action evaluation:
 
 | Invariant | Severity | Description |
 |-----------|----------|-------------|
 | **no-secret-exposure** | 5 (critical) | Blocks access to .env, credentials, .pem, .key files |
 | **protected-branch** | 4 (high) | Prevents direct push to main/master |
 | **no-force-push** | 4 (high) | Forbids force push |
+| **no-skill-modification** | 4 (high) | Prevents modification of .claude/skills/ files |
 | **blast-radius-limit** | 3 (medium) | Enforces file modification limit (default 20) |
 | **test-before-push** | 3 (medium) | Requires tests pass before push |
 | **lockfile-integrity** | 2 (low) | Ensures package.json changes sync with lockfiles |
@@ -214,6 +215,8 @@ src/
 │   ├── decision.ts         # Runtime assurance engine
 │   ├── monitor.ts          # Escalation state machine
 │   ├── evidence.ts         # Evidence pack generation
+│   ├── replay-comparator.ts # Replay outcome comparison
+│   ├── replay-engine.ts    # Deterministic replay engine
 │   ├── decisions/          # Typed decision records
 │   └── simulation/         # Pre-execution impact simulation
 ├── events/                 # Canonical event model
@@ -227,7 +230,7 @@ src/
 │   ├── loader.ts           # Policy validation + loading
 │   └── yaml-loader.ts      # YAML policy parser
 ├── invariants/             # Invariant system
-│   ├── definitions.ts      # 6 built-in invariants
+│   ├── definitions.ts      # 7 built-in invariants
 │   └── checker.ts          # Invariant evaluation engine
 ├── adapters/               # Execution adapters
 │   ├── file.ts, shell.ts, git.ts  # Action handlers
@@ -237,7 +240,7 @@ src/
 │   ├── bin.ts              # Main entry
 │   └── commands/           # guard, inspect, replay, claude-hook, claude-init
 ├── telemetry/              # Runtime telemetry and logging
-└── core/                   # Shared utilities (types, actions, hash, execution-log)
+└── core/                   # Shared utilities (types, actions, hash, rng, execution-log)
 ```
 
 ## Run Locally

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -70,7 +70,7 @@ Build the governance runtime that evaluates agent actions against policies and i
 - [x] Governance event emission into canonical event model
 - [x] Integration with Claude Code hook (`src/adapters/claude-code.ts`, `src/cli/commands/claude-hook.ts`)
 
-## Phase 3 — Event Persistence + Replay `PARTIALLY COMPLETE`
+## Phase 3 — Event Persistence + Replay `MOSTLY COMPLETE`
 
 > **Theme:** Every session is replayable
 
@@ -81,8 +81,8 @@ Implement durable event storage and deterministic replay.
 - [x] Session metadata (run ID, timestamps)
 - [x] Execution event log (`src/core/execution-log/`)
 - [x] CLI replay command (`agentguard replay`)
-- [ ] Deterministic replay with seeded RNG
-- [ ] Replay comparator (verify original vs replayed outcomes)
+- [x] Deterministic replay with seeded RNG (`src/core/rng.ts`, `src/kernel/replay-engine.ts`)
+- [x] Replay comparator (verify original vs replayed outcomes) (`src/kernel/replay-comparator.ts`)
 - [ ] Event export/import for sharing sessions
 
 ## Phase 4 — Plugin Ecosystem


### PR DESCRIPTION
## Summary

- Updated invariant count from 6 to 7 across all docs (added `no-skill-modification`)
- Updated TS test file count from 38 to 41 (new: replay-comparator, replay-engine, seeded-rng)
- Added missing source files to directory trees (`rng.ts`, `replay-comparator.ts`, `replay-engine.ts`)
- Marked ROADMAP Phase 3 items as done (seeded RNG, replay comparator) and updated status to MOSTLY COMPLETE
- Added `no-skill-modification` row to README invariant table

## Files Modified

- **CLAUDE.md** — invariant count, test count, directory tree
- **README.md** — invariant count, invariant table, directory tree
- **ARCHITECTURE.md** — invariant count in directory layout
- **ROADMAP.md** — Phase 3 item checkboxes and status label

## Source

Auto-generated by the **Scheduled Docs Sync** skill.

---
*Run: 2026-03-09T01:04:00Z*