### PR TITLE
feat(issue-51): add renderer plugin interface

### DIFF
--- a/src/cli/commands/guard.ts
+++ b/src/cli/commands/guard.ts
@@ -1,5 +1,6 @@
 // CLI command: agentguard guard — start the governed action runtime.
 // Reads stdin for action proposals (JSON), evaluates them, writes results to stdout.
+// Uses the renderer plugin system for all human-facing output.
 
 import { createKernel } from '../../kernel/kernel.js';
 import type { KernelConfig } from '../../kernel/kernel.js';
@@ -8,12 +9,6 @@ import { createJsonlSink } from '../../events/jsonl.js';
 import { createDecisionJsonlSink } from '../../events/decision-jsonl.js';
 import { createTelemetryDecisionSink } from '../../telemetry/runtimeLogger.js';
 import { loadPolicyDefs } from '../policy-resolver.js';
-import {
-  renderBanner,
-  renderKernelResult,
-  renderMonitorStatus,
-  renderDecisionRecord,
-} from '../tui.js';
 import { createSimulatorRegistry } from '../../kernel/simulation/registry.js';
 import { createGitSimulator } from '../../kernel/simulation/git-simulator.js';
 import { createFilesystemSimulator } from '../../kernel/simulation/filesystem-simulator.js';
@@ -21,6 +16,9 @@ import { createPackageSimulator } from '../../kernel/simulation/package-simulato
 import type { RawAgentAction } from '../../kernel/aab.js';
 import { generateSeed, createSeededRng } from '../../core/rng.js';
 import { simpleHash } from '../../core/hash.js';
+import { createRendererRegistry } from '../../renderers/registry.js';
+import type { RendererRegistry } from '../../renderers/registry.js';
+import { createTuiRenderer } from '../../renderers/tui-renderer.js';
 
 export interface GuardOptions {
   policy?: string;
@@ -28,6 +26,8 @@ export interface GuardOptions {
   verbose?: boolean;
   stdin?: boolean;
   simulate?: boolean;
+  /** Optional pre-configured renderer registry (for custom renderers) */
+  renderers?: RendererRegistry;
 }
 
 export async function guard(_args: string[], options: GuardOptions = {}): Promise<number> {
@@ -69,39 +69,45 @@ export async function guard(_args: string[], options: GuardOptions = {}): Promis
 
   const kernel = createKernel(kernelConfig);
 
-  // Render banner
+  // Set up renderer registry — use provided registry or create default with TUI
+  const renderers = options.renderers ?? createRendererRegistry();
+  if (!options.renderers) {
+    renderers.register(createTuiRenderer({ verbose: options.verbose }));
+  }
+
+  // Notify renderers: run started
   const policyName = policyPath || 'default (no file)';
   const simCount = simulators.all().length;
-  process.stderr.write(
-    renderBanner({
-      policyName,
-      invariantCount: 6,
-      verbose: options.verbose,
-    })
-  );
-  process.stderr.write(`  ${'\x1b[2m'}run: ${runId}${'\x1b[0m'}\n`);
-  if (simCount > 0) {
-    process.stderr.write(`  ${'\x1b[2m'}simulators: ${simCount} active${'\x1b[0m'}\n`);
+  renderers.notifyRunStarted({
+    runId,
+    policyName,
+    invariantCount: 6,
+    verbose: options.verbose,
+    dryRun: options.dryRun,
+    simulatorCount: simCount,
+  });
+
+  if (!options.stdin) {
+    // Interactive mode prompt
+    process.stderr.write(
+      `  ${'\x1b[2m'}Listening for actions on stdin (JSON per line)...${'\x1b[0m'}\n`
+    );
+    process.stderr.write(`  ${'\x1b[2m'}Press Ctrl+C to stop.${'\x1b[0m'}\n\n`);
   }
-  process.stderr.write('\n');
 
-  if (options.stdin) {
-    return processStdin(kernel, options);
-  }
-
-  // Interactive mode: read from stdin line by line
-  process.stderr.write(
-    `  ${'\x1b[2m'}Listening for actions on stdin (JSON per line)...${'\x1b[0m'}\n`
-  );
-  process.stderr.write(`  ${'\x1b[2m'}Press Ctrl+C to stop.${'\x1b[0m'}\n\n`);
-
-  return processStdin(kernel, options);
+  return processStdin(kernel, renderers);
 }
 
 async function processStdin(
   kernel: ReturnType<typeof createKernel>,
-  options: GuardOptions
+  renderers: RendererRegistry
 ): Promise<number> {
+  const startTime = Date.now();
+  let totalActions = 0;
+  let allowedCount = 0;
+  let deniedCount = 0;
+  let violationCount = 0;
+
   return new Promise((resolvePromise) => {
     let buffer = '';
 
@@ -119,16 +125,16 @@ async function processStdin(
           const rawAction = JSON.parse(trimmed) as RawAgentAction;
           const result = await kernel.propose(rawAction);
 
-          // Render result to stderr
-          process.stderr.write(renderKernelResult(result, options.verbose) + '\n');
+          totalActions++;
+          if (result.allowed) allowedCount++;
+          else deniedCount++;
+          violationCount += result.decision.violations.length;
 
-          // Render decision record if verbose
-          if (options.verbose && result.decisionRecord) {
-            process.stderr.write(renderDecisionRecord(result.decisionRecord) + '\n');
-          }
+          // Dispatch to all registered renderers
+          renderers.notifyActionResult(result);
 
-          if (result.decision.violations.length > 0 || !result.allowed) {
-            process.stderr.write(renderMonitorStatus(result.decision) + '\n');
+          if (result.decisionRecord) {
+            renderers.notifyDecisionRecord(result.decisionRecord);
           }
 
           // Write machine-readable result to stdout
@@ -151,13 +157,26 @@ async function processStdin(
       }
     });
 
-    process.stdin.on('end', () => {
+    const shutdown = () => {
       kernel.shutdown();
+      renderers.notifyRunEnded({
+        runId: kernel.getRunId(),
+        totalActions,
+        allowed: allowedCount,
+        denied: deniedCount,
+        violations: violationCount,
+        durationMs: Date.now() - startTime,
+      });
+      renderers.disposeAll();
+    };
+
+    process.stdin.on('end', () => {
+      shutdown();
       resolvePromise(0);
     });
 
     process.on('SIGINT', () => {
-      kernel.shutdown();
+      shutdown();
       process.stderr.write('\n  \x1b[33mAgentGuard stopped.\x1b[0m\n\n');
       resolvePromise(0);
     });

--- a/src/renderers/index.ts
+++ b/src/renderers/index.ts
@@ -1,0 +1,9 @@
+// Renderer plugin system — re-exports for public API.
+
+export type { GovernanceRenderer, RendererConfig, RunSummary } from './types.js';
+
+export { createRendererRegistry } from './registry.js';
+export type { RendererRegistry } from './registry.js';
+
+export { createTuiRenderer } from './tui-renderer.js';
+export type { TuiRendererOptions } from './tui-renderer.js';

--- a/src/renderers/registry.ts
+++ b/src/renderers/registry.ts
@@ -1,0 +1,152 @@
+// Renderer registry — manages multiple governance renderers.
+// Dispatches lifecycle events to all registered renderers.
+
+import type { GovernanceRenderer, RendererConfig, RunSummary } from './types.js';
+import type { KernelResult } from '../kernel/kernel.js';
+import type { MonitorDecision } from '../kernel/monitor.js';
+import type { GovernanceDecisionRecord } from '../kernel/decisions/types.js';
+import type { SimulationResult } from '../kernel/simulation/types.js';
+
+export interface RendererRegistry {
+  /** Register a renderer. Throws if a renderer with the same ID already exists. */
+  register(renderer: GovernanceRenderer): void;
+
+  /** Unregister a renderer by ID. Calls dispose() if available. Returns true if found. */
+  unregister(id: string): boolean;
+
+  /** Get a registered renderer by ID */
+  get(id: string): GovernanceRenderer | undefined;
+
+  /** List all registered renderer IDs */
+  list(): string[];
+
+  /** Number of registered renderers */
+  count(): number;
+
+  /** Dispatch: run started */
+  notifyRunStarted(config: RendererConfig): void;
+
+  /** Dispatch: action result */
+  notifyActionResult(result: KernelResult): void;
+
+  /** Dispatch: monitor status */
+  notifyMonitorStatus(decision: MonitorDecision): void;
+
+  /** Dispatch: simulation completed */
+  notifySimulation(simulation: SimulationResult): void;
+
+  /** Dispatch: decision record */
+  notifyDecisionRecord(record: GovernanceDecisionRecord): void;
+
+  /** Dispatch: run ended */
+  notifyRunEnded(summary: RunSummary): void;
+
+  /** Dispose all renderers and clear the registry */
+  disposeAll(): void;
+}
+
+/**
+ * Create a new renderer registry.
+ *
+ * Renderers are dispatched in registration order.
+ * Errors in one renderer do not prevent other renderers from receiving events.
+ */
+export function createRendererRegistry(): RendererRegistry {
+  const renderers = new Map<string, GovernanceRenderer>();
+
+  const safeCall = (fn: () => void): void => {
+    try {
+      fn();
+    } catch {
+      // Renderer errors are non-fatal — isolate failures
+    }
+  };
+
+  return {
+    register(renderer) {
+      if (renderers.has(renderer.id)) {
+        throw new Error(`Renderer already registered: "${renderer.id}"`);
+      }
+      renderers.set(renderer.id, renderer);
+    },
+
+    unregister(id) {
+      const renderer = renderers.get(id);
+      if (!renderer) return false;
+      if (renderer.dispose) {
+        safeCall(() => renderer.dispose!());
+      }
+      renderers.delete(id);
+      return true;
+    },
+
+    get(id) {
+      return renderers.get(id);
+    },
+
+    list() {
+      return [...renderers.keys()];
+    },
+
+    count() {
+      return renderers.size;
+    },
+
+    notifyRunStarted(config) {
+      for (const renderer of renderers.values()) {
+        if (renderer.onRunStarted) {
+          safeCall(() => renderer.onRunStarted!(config));
+        }
+      }
+    },
+
+    notifyActionResult(result) {
+      for (const renderer of renderers.values()) {
+        if (renderer.onActionResult) {
+          safeCall(() => renderer.onActionResult!(result));
+        }
+      }
+    },
+
+    notifyMonitorStatus(decision) {
+      for (const renderer of renderers.values()) {
+        if (renderer.onMonitorStatus) {
+          safeCall(() => renderer.onMonitorStatus!(decision));
+        }
+      }
+    },
+
+    notifySimulation(simulation) {
+      for (const renderer of renderers.values()) {
+        if (renderer.onSimulation) {
+          safeCall(() => renderer.onSimulation!(simulation));
+        }
+      }
+    },
+
+    notifyDecisionRecord(record) {
+      for (const renderer of renderers.values()) {
+        if (renderer.onDecisionRecord) {
+          safeCall(() => renderer.onDecisionRecord!(record));
+        }
+      }
+    },
+
+    notifyRunEnded(summary) {
+      for (const renderer of renderers.values()) {
+        if (renderer.onRunEnded) {
+          safeCall(() => renderer.onRunEnded!(summary));
+        }
+      }
+    },
+
+    disposeAll() {
+      for (const renderer of renderers.values()) {
+        if (renderer.dispose) {
+          safeCall(() => renderer.dispose!());
+        }
+      }
+      renderers.clear();
+    },
+  };
+}

--- a/src/renderers/tui-renderer.ts
+++ b/src/renderers/tui-renderer.ts
@@ -1,0 +1,87 @@
+// TUI governance renderer — wraps the existing tui.ts render functions
+// into a GovernanceRenderer plugin. Writes ANSI-colored output to a stream.
+
+import type { GovernanceRenderer, RendererConfig, RunSummary } from './types.js';
+import type { KernelResult } from '../kernel/kernel.js';
+import type { MonitorDecision } from '../kernel/monitor.js';
+import type { GovernanceDecisionRecord } from '../kernel/decisions/types.js';
+import type { SimulationResult } from '../kernel/simulation/types.js';
+import {
+  renderBanner,
+  renderKernelResult,
+  renderMonitorStatus,
+  renderDecisionRecord,
+  renderSimulation,
+} from '../cli/tui.js';
+
+export interface TuiRendererOptions {
+  /** Output stream — defaults to process.stderr */
+  output?: { write(s: string): boolean };
+  /** Show verbose output (decision records, reasons) */
+  verbose?: boolean;
+}
+
+/**
+ * Create a TUI governance renderer.
+ *
+ * This is the reference implementation of GovernanceRenderer. It adapts
+ * the existing tui.ts render functions into the plugin interface, writing
+ * ANSI-colored output to the configured stream (stderr by default).
+ */
+export function createTuiRenderer(options: TuiRendererOptions = {}): GovernanceRenderer {
+  const output = options.output ?? process.stderr;
+  const verbose = options.verbose ?? false;
+
+  return {
+    id: 'tui',
+    name: 'Terminal UI Renderer',
+
+    onRunStarted(config: RendererConfig) {
+      output.write(
+        renderBanner({
+          policyName: config.policyName,
+          invariantCount: config.invariantCount,
+          verbose: config.verbose ?? verbose,
+        })
+      );
+      output.write(`  \x1b[2mrun: ${config.runId}\x1b[0m\n`);
+      if (config.simulatorCount && config.simulatorCount > 0) {
+        output.write(`  \x1b[2msimulators: ${config.simulatorCount} active\x1b[0m\n`);
+      }
+      output.write('\n');
+    },
+
+    onActionResult(result: KernelResult) {
+      output.write(renderKernelResult(result, verbose) + '\n');
+      if (result.decision.violations.length > 0 || !result.allowed) {
+        output.write(renderMonitorStatus(result.decision) + '\n');
+      }
+    },
+
+    onMonitorStatus(decision: MonitorDecision) {
+      output.write(renderMonitorStatus(decision) + '\n');
+    },
+
+    onSimulation(simulation: SimulationResult) {
+      output.write(renderSimulation(simulation) + '\n');
+    },
+
+    onDecisionRecord(record: GovernanceDecisionRecord) {
+      if (verbose) {
+        output.write(renderDecisionRecord(record) + '\n');
+      }
+    },
+
+    onRunEnded(summary: RunSummary) {
+      const lines: string[] = [];
+      lines.push('');
+      lines.push(`  \x1b[1m\x1b[36mRun Complete\x1b[0m \x1b[2m${summary.runId}\x1b[0m`);
+      lines.push(
+        `  \x1b[2mactions: ${summary.totalActions} | allowed: ${summary.allowed} | denied: ${summary.denied} | violations: ${summary.violations}\x1b[0m`
+      );
+      lines.push(`  \x1b[2mduration: ${summary.durationMs}ms\x1b[0m`);
+      lines.push('');
+      output.write(lines.join('\n'));
+    },
+  };
+}

--- a/src/renderers/types.ts
+++ b/src/renderers/types.ts
@@ -1,0 +1,65 @@
+// Renderer plugin interface — contracts for governance output renderers.
+// Renderers consume kernel results and produce output (terminal, file, etc.).
+
+import type { KernelResult } from '../kernel/kernel.js';
+import type { MonitorDecision } from '../kernel/monitor.js';
+import type { GovernanceDecisionRecord } from '../kernel/decisions/types.js';
+import type { SimulationResult } from '../kernel/simulation/types.js';
+
+/** Configuration passed to renderers at run start */
+export interface RendererConfig {
+  readonly runId: string;
+  readonly policyName?: string;
+  readonly invariantCount?: number;
+  readonly verbose?: boolean;
+  readonly dryRun?: boolean;
+  readonly simulatorCount?: number;
+}
+
+/** Summary provided to renderers at run end */
+export interface RunSummary {
+  readonly runId: string;
+  readonly totalActions: number;
+  readonly allowed: number;
+  readonly denied: number;
+  readonly violations: number;
+  readonly durationMs: number;
+}
+
+/**
+ * GovernanceRenderer — the plugin interface for output renderers.
+ *
+ * Renderers receive lifecycle callbacks as actions flow through the kernel.
+ * Multiple renderers can be active simultaneously (e.g., TUI + file report).
+ *
+ * All methods are optional — implement only the hooks you need.
+ * All methods are synchronous to avoid blocking the kernel pipeline.
+ */
+export interface GovernanceRenderer {
+  /** Unique identifier for this renderer */
+  readonly id: string;
+
+  /** Human-readable name */
+  readonly name: string;
+
+  /** Called when a governance run starts */
+  onRunStarted?(config: RendererConfig): void;
+
+  /** Called after each action is evaluated (allowed or denied) */
+  onActionResult?(result: KernelResult): void;
+
+  /** Called when escalation state changes */
+  onMonitorStatus?(decision: MonitorDecision): void;
+
+  /** Called when a pre-execution simulation completes */
+  onSimulation?(simulation: SimulationResult): void;
+
+  /** Called when a governance decision record is persisted */
+  onDecisionRecord?(record: GovernanceDecisionRecord): void;
+
+  /** Called when a governance run ends */
+  onRunEnded?(summary: RunSummary): void;
+
+  /** Called to release resources when the renderer is unregistered */
+  dispose?(): void;
+}

--- a/tests/ts/renderer-registry.test.ts
+++ b/tests/ts/renderer-registry.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createRendererRegistry } from '../../src/renderers/registry.js';
+import type { GovernanceRenderer, RendererConfig, RunSummary } from '../../src/renderers/types.js';
+import type { KernelResult } from '../../src/kernel/kernel.js';
+
+function makeRenderer(id: string, overrides: Partial<GovernanceRenderer> = {}): GovernanceRenderer {
+  return {
+    id,
+    name: `Test Renderer ${id}`,
+    ...overrides,
+  };
+}
+
+function makeConfig(overrides: Partial<RendererConfig> = {}): RendererConfig {
+  return {
+    runId: 'run_test_123',
+    policyName: 'test-policy',
+    invariantCount: 6,
+    ...overrides,
+  };
+}
+
+function makeSummary(overrides: Partial<RunSummary> = {}): RunSummary {
+  return {
+    runId: 'run_test_123',
+    totalActions: 5,
+    allowed: 4,
+    denied: 1,
+    violations: 0,
+    durationMs: 1000,
+    ...overrides,
+  };
+}
+
+describe('RendererRegistry', () => {
+  describe('register/unregister', () => {
+    it('registers a renderer', () => {
+      const registry = createRendererRegistry();
+      const renderer = makeRenderer('tui');
+      registry.register(renderer);
+      expect(registry.count()).toBe(1);
+      expect(registry.list()).toEqual(['tui']);
+    });
+
+    it('throws on duplicate ID', () => {
+      const registry = createRendererRegistry();
+      registry.register(makeRenderer('tui'));
+      expect(() => registry.register(makeRenderer('tui'))).toThrow(
+        'Renderer already registered: "tui"'
+      );
+    });
+
+    it('unregisters a renderer and calls dispose', () => {
+      const registry = createRendererRegistry();
+      const dispose = vi.fn();
+      registry.register(makeRenderer('tui', { dispose }));
+      const removed = registry.unregister('tui');
+      expect(removed).toBe(true);
+      expect(dispose).toHaveBeenCalledOnce();
+      expect(registry.count()).toBe(0);
+    });
+
+    it('returns false for unknown ID on unregister', () => {
+      const registry = createRendererRegistry();
+      expect(registry.unregister('nonexistent')).toBe(false);
+    });
+
+    it('gets a renderer by ID', () => {
+      const registry = createRendererRegistry();
+      const renderer = makeRenderer('tui');
+      registry.register(renderer);
+      expect(registry.get('tui')).toBe(renderer);
+      expect(registry.get('nonexistent')).toBeUndefined();
+    });
+  });
+
+  describe('multiple renderers', () => {
+    it('supports multiple simultaneous renderers', () => {
+      const registry = createRendererRegistry();
+      registry.register(makeRenderer('tui'));
+      registry.register(makeRenderer('html'));
+      registry.register(makeRenderer('json'));
+      expect(registry.count()).toBe(3);
+      expect(registry.list()).toEqual(['tui', 'html', 'json']);
+    });
+  });
+
+  describe('lifecycle dispatch', () => {
+    it('dispatches onRunStarted to all renderers', () => {
+      const registry = createRendererRegistry();
+      const onRunStarted1 = vi.fn();
+      const onRunStarted2 = vi.fn();
+      registry.register(makeRenderer('r1', { onRunStarted: onRunStarted1 }));
+      registry.register(makeRenderer('r2', { onRunStarted: onRunStarted2 }));
+
+      const config = makeConfig();
+      registry.notifyRunStarted(config);
+
+      expect(onRunStarted1).toHaveBeenCalledWith(config);
+      expect(onRunStarted2).toHaveBeenCalledWith(config);
+    });
+
+    it('dispatches onActionResult to all renderers', () => {
+      const registry = createRendererRegistry();
+      const onActionResult = vi.fn();
+      registry.register(makeRenderer('r1', { onActionResult }));
+
+      const result = { allowed: true, runId: 'test' } as unknown as KernelResult;
+      registry.notifyActionResult(result);
+
+      expect(onActionResult).toHaveBeenCalledWith(result);
+    });
+
+    it('dispatches onRunEnded to all renderers', () => {
+      const registry = createRendererRegistry();
+      const onRunEnded = vi.fn();
+      registry.register(makeRenderer('r1', { onRunEnded }));
+
+      const summary = makeSummary();
+      registry.notifyRunEnded(summary);
+
+      expect(onRunEnded).toHaveBeenCalledWith(summary);
+    });
+
+    it('skips renderers without the hook', () => {
+      const registry = createRendererRegistry();
+      // Renderer without onRunStarted — should not throw
+      registry.register(makeRenderer('minimal'));
+      expect(() => registry.notifyRunStarted(makeConfig())).not.toThrow();
+    });
+  });
+
+  describe('error isolation', () => {
+    it('isolates errors in one renderer from others', () => {
+      const registry = createRendererRegistry();
+      const onRunStarted1 = vi.fn(() => {
+        throw new Error('Renderer 1 crashed');
+      });
+      const onRunStarted2 = vi.fn();
+
+      registry.register(makeRenderer('r1', { onRunStarted: onRunStarted1 }));
+      registry.register(makeRenderer('r2', { onRunStarted: onRunStarted2 }));
+
+      const config = makeConfig();
+      registry.notifyRunStarted(config);
+
+      // r1 threw, but r2 still received the event
+      expect(onRunStarted1).toHaveBeenCalled();
+      expect(onRunStarted2).toHaveBeenCalledWith(config);
+    });
+
+    it('isolates dispose errors', () => {
+      const registry = createRendererRegistry();
+      registry.register(
+        makeRenderer('r1', {
+          dispose: () => {
+            throw new Error('Dispose failed');
+          },
+        })
+      );
+      registry.register(makeRenderer('r2', { dispose: vi.fn() }));
+
+      // Should not throw even if r1.dispose crashes
+      expect(() => registry.disposeAll()).not.toThrow();
+      expect(registry.count()).toBe(0);
+    });
+  });
+
+  describe('disposeAll', () => {
+    it('disposes all renderers and clears registry', () => {
+      const registry = createRendererRegistry();
+      const dispose1 = vi.fn();
+      const dispose2 = vi.fn();
+      registry.register(makeRenderer('r1', { dispose: dispose1 }));
+      registry.register(makeRenderer('r2', { dispose: dispose2 }));
+
+      registry.disposeAll();
+
+      expect(dispose1).toHaveBeenCalledOnce();
+      expect(dispose2).toHaveBeenCalledOnce();
+      expect(registry.count()).toBe(0);
+    });
+  });
+});

--- a/tests/ts/tui-renderer-plugin.test.ts
+++ b/tests/ts/tui-renderer-plugin.test.ts
@@ -1,0 +1,234 @@
+// Tests for TUI governance renderer plugin (GovernanceRenderer implementation)
+import { describe, it, expect, vi } from 'vitest';
+import { createTuiRenderer } from '../../src/renderers/tui-renderer.js';
+import type { RendererConfig, RunSummary } from '../../src/renderers/types.js';
+import type { KernelResult } from '../../src/kernel/kernel.js';
+import type { MonitorDecision } from '../../src/kernel/monitor.js';
+
+function makeOutput() {
+  const chunks: string[] = [];
+  return {
+    write: vi.fn((s: string) => {
+      chunks.push(s);
+      return true;
+    }),
+    chunks,
+    text: () => chunks.join(''),
+  };
+}
+
+function makeConfig(overrides: Partial<RendererConfig> = {}): RendererConfig {
+  return {
+    runId: 'run_test_123',
+    policyName: 'test-policy',
+    invariantCount: 6,
+    ...overrides,
+  };
+}
+
+function makeKernelResult(overrides: Partial<KernelResult> = {}): KernelResult {
+  return {
+    allowed: true,
+    executed: true,
+    decision: {
+      allowed: true,
+      intent: { action: 'file.read', target: 'src/index.ts', agent: 'test', destructive: false },
+      decision: {
+        allowed: true,
+        decision: 'allow',
+        reason: 'Default allow',
+        matchedPolicy: null,
+      },
+      violations: [],
+      events: [],
+      evidencePack: null,
+      intervention: null,
+      monitor: { escalationLevel: 0, totalEvaluations: 1, totalDenials: 0, totalViolations: 0 },
+    } as unknown as MonitorDecision,
+    execution: null,
+    action: null,
+    events: [],
+    runId: 'run_test_123',
+    ...overrides,
+  } as KernelResult;
+}
+
+describe('TuiRenderer plugin', () => {
+  it('has correct id and name', () => {
+    const renderer = createTuiRenderer();
+    expect(renderer.id).toBe('tui');
+    expect(renderer.name).toBe('Terminal UI Renderer');
+  });
+
+  describe('onRunStarted', () => {
+    it('renders banner with policy name and run ID', () => {
+      const output = makeOutput();
+      const renderer = createTuiRenderer({ output });
+      renderer.onRunStarted!(makeConfig({ policyName: 'my-policy' }));
+
+      const text = output.text();
+      expect(text).toContain('AgentGuard Runtime Active');
+      expect(text).toContain('my-policy');
+      expect(text).toContain('run_test_123');
+    });
+
+    it('renders simulator count when > 0', () => {
+      const output = makeOutput();
+      const renderer = createTuiRenderer({ output });
+      renderer.onRunStarted!(makeConfig({ simulatorCount: 3 }));
+
+      const text = output.text();
+      expect(text).toContain('simulators: 3 active');
+    });
+
+    it('omits simulator line when count is 0', () => {
+      const output = makeOutput();
+      const renderer = createTuiRenderer({ output });
+      renderer.onRunStarted!(makeConfig({ simulatorCount: 0 }));
+
+      const text = output.text();
+      expect(text).not.toContain('simulators');
+    });
+  });
+
+  describe('onActionResult', () => {
+    it('renders allowed action', () => {
+      const output = makeOutput();
+      const renderer = createTuiRenderer({ output });
+      renderer.onActionResult!(makeKernelResult());
+
+      const text = output.text();
+      expect(text).toContain('file.read');
+      expect(text).toContain('src/index.ts');
+    });
+
+    it('renders denied action with monitor status', () => {
+      const output = makeOutput();
+      const renderer = createTuiRenderer({ output });
+      renderer.onActionResult!(
+        makeKernelResult({
+          allowed: false,
+          decision: {
+            allowed: false,
+            intent: {
+              action: 'shell.exec',
+              target: 'rm -rf /',
+              agent: 'test',
+              destructive: true,
+            },
+            decision: {
+              allowed: false,
+              decision: 'deny',
+              reason: 'Destructive command',
+              matchedPolicy: { id: 'no-shell' },
+            },
+            violations: [],
+            events: [],
+            evidencePack: null,
+            intervention: 'deny',
+            monitor: {
+              escalationLevel: 1,
+              totalEvaluations: 1,
+              totalDenials: 1,
+              totalViolations: 0,
+            },
+          } as unknown as MonitorDecision,
+        })
+      );
+
+      const text = output.text();
+      expect(text).toContain('DENIED');
+      expect(text).toContain('ELEVATED');
+    });
+  });
+
+  describe('onRunEnded', () => {
+    it('renders run summary', () => {
+      const output = makeOutput();
+      const renderer = createTuiRenderer({ output });
+      const summary: RunSummary = {
+        runId: 'run_test_123',
+        totalActions: 10,
+        allowed: 8,
+        denied: 2,
+        violations: 1,
+        durationMs: 5000,
+      };
+      renderer.onRunEnded!(summary);
+
+      const text = output.text();
+      expect(text).toContain('Run Complete');
+      expect(text).toContain('run_test_123');
+      expect(text).toContain('actions: 10');
+      expect(text).toContain('allowed: 8');
+      expect(text).toContain('denied: 2');
+      expect(text).toContain('5000ms');
+    });
+  });
+
+  describe('onDecisionRecord', () => {
+    it('renders decision records when verbose', () => {
+      const output = makeOutput();
+      const renderer = createTuiRenderer({ output, verbose: true });
+
+      renderer.onDecisionRecord!({
+        recordId: 'dec_123',
+        runId: 'run_test_123',
+        timestamp: Date.now(),
+        sequence: 1,
+        action: { type: 'file.read', target: 'src/index.ts', class: 'file' },
+        outcome: 'allow',
+        reason: 'Default allow',
+        policy: {
+          matchedPolicyId: null,
+          matchedPolicyName: null,
+          evaluatedRules: 0,
+        },
+        invariants: { checked: 6, violations: [] },
+        execution: { executed: true, success: true, durationMs: 5 },
+        simulation: null,
+      });
+
+      const text = output.text();
+      expect(text).toContain('Decision Record');
+      expect(text).toContain('dec_123');
+    });
+
+    it('suppresses decision records when not verbose', () => {
+      const output = makeOutput();
+      const renderer = createTuiRenderer({ output, verbose: false });
+
+      renderer.onDecisionRecord!({
+        recordId: 'dec_123',
+        runId: 'run_test_123',
+        timestamp: Date.now(),
+        sequence: 1,
+        action: { type: 'file.read', target: 'src/index.ts', class: 'file' },
+        outcome: 'allow',
+        reason: 'Default allow',
+        policy: {
+          matchedPolicyId: null,
+          matchedPolicyName: null,
+          evaluatedRules: 0,
+        },
+        invariants: { checked: 6, violations: [] },
+        execution: { executed: true, success: true, durationMs: 5 },
+        simulation: null,
+      });
+
+      expect(output.write).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('implements GovernanceRenderer contract', () => {
+    it('has all optional lifecycle hooks', () => {
+      const renderer = createTuiRenderer();
+      expect(renderer.onRunStarted).toBeDefined();
+      expect(renderer.onActionResult).toBeDefined();
+      expect(renderer.onMonitorStatus).toBeDefined();
+      expect(renderer.onSimulation).toBeDefined();
+      expect(renderer.onDecisionRecord).toBeDefined();
+      expect(renderer.onRunEnded).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implements the renderer plugin interface for governance output renderers
- Defines `GovernanceRenderer` interface with lifecycle hooks, creates `RendererRegistry` for managing multiple simultaneous renderers, and wraps existing TUI into the plugin contract
- Closes #51

## Changes
- `src/renderers/types.ts` — `GovernanceRenderer` interface with `onRunStarted`, `onActionResult`, `onMonitorStatus`, `onSimulation`, `onDecisionRecord`, `onRunEnded` lifecycle hooks
- `src/renderers/registry.ts` — `RendererRegistry` with error isolation (one renderer crashing doesn't affect others)
- `src/renderers/tui-renderer.ts` — Reference implementation wrapping existing `tui.ts` render functions
- `src/renderers/index.ts` — Public API re-exports
- `src/cli/commands/guard.ts` — Refactored to use renderer registry instead of direct TUI calls; added `GuardOptions.renderers` for custom renderer injection
- `tests/ts/renderer-registry.test.ts` — 13 tests covering registration, dispatch, error isolation, disposal
- `tests/ts/tui-renderer-plugin.test.ts` — 10 tests covering TUI renderer lifecycle hooks

## Test Plan
- [x] TypeScript build passes (`npm run build:ts`)
- [x] Vitest tests pass (`npm run ts:test`) — 726 pass / 0 fail
- [x] JS tests pass (`npm test`) — 210 pass / 0 fail
- [x] ESLint clean (`npm run lint`) — 0 errors on modified files
- [x] Prettier clean (`npm run format`) — formatted on modified files
- [x] Type-check clean (`npm run ts:check`)

## Governance Report

| Metric | Count |
|--------|-------|
| Total events | 143 |
| Actions allowed | 44 |
| Actions denied | 2 |
| Policy denials | 2 |
| Invariant violations | 2 |

<details>
<summary>Telemetry details</summary>

Source: `.agentguard/events/` and `logs/runtime-events.jsonl`

Runtime telemetry: 41 events logged. 2 actions denied during governance enforcement (expected behavior from policy rules). No unexpected violations.

</details>