### PR TITLE
docs: sync documentation with codebase state

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -45,9 +45,11 @@ Each top-level directory under `src/` maps to a single architectural concept:
 src/
 ├── kernel/        Governed action kernel (orchestrate, normalize, decide, escalate)
 ├── events/        Canonical event model (schema, bus, store, JSONL persistence)
-├── policy/        Policy system (evaluator, loaders)
-├── invariants/    Invariant system (7 built-in definitions, checker)
+├── policy/        Policy system (evaluator, loaders, pack loader)
+├── invariants/    Invariant system (8 built-in definitions, checker)
 ├── adapters/      Execution adapters (file, shell, git, claude-code)
+├── plugins/       Plugin ecosystem (discovery, registry, validation, sandboxing)
+├── renderers/     Renderer plugin system (registry, TUI renderer)
 ├── cli/           CLI entry point and commands
 ├── telemetry/     Runtime telemetry and logging
 └── core/          Shared utilities (types, actions, hash, execution-log)
@@ -60,7 +62,9 @@ src/
 - **policy/** may import from core/ only
 - **invariants/** may import from core/, events/ only
 - **adapters/** may import from core/, kernel/ only
-- **cli/** may import from kernel/, events/, policy/, core/
+- **plugins/** may import from core/, events/, kernel/ only
+- **renderers/** may import from core/, events/ only
+- **cli/** may import from kernel/, events/, policy/, plugins/, renderers/, core/
 - **telemetry/** may import from core/ only
 - **core/** has no project imports (leaf layer)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ The system has one architectural spine: the **canonical event model**. All syste
 
 **Key characteristics:**
 - Governed action kernel: propose → normalize → evaluate → execute → emit
-- 7 built-in invariants (secret exposure, protected branches, blast radius, test-before-push, no force push, no skill modification, lockfile integrity)
+- 8 built-in invariants (secret exposure, protected branches, blast radius, test-before-push, no force push, no skill modification, no scheduled task modification, lockfile integrity)
 - YAML/JSON policy format with pattern matching, scopes, and branch conditions
 - Escalation tracking: NORMAL → ELEVATED → HIGH → LOCKDOWN
 - JSONL event persistence for audit trail and replay
@@ -46,6 +46,7 @@ src/
 │   ├── evidence.ts         # Evidence pack generation
 │   ├── replay-comparator.ts # Replay outcome comparison
 │   ├── replay-engine.ts    # Deterministic replay engine
+│   ├── replay-processor.ts # Replay event processor
 │   ├── decisions/          # Typed decision records
 │   │   ├── factory.ts      # Decision record factory
 │   │   └── types.ts        # Decision record type definitions
@@ -64,9 +65,10 @@ src/
 ├── policy/                 # Policy system
 │   ├── evaluator.ts        # Rule matching engine
 │   ├── loader.ts           # Policy validation + loading
+│   ├── pack-loader.ts      # Policy pack loader (community policy sets)
 │   └── yaml-loader.ts      # YAML policy parser
 ├── invariants/             # Invariant system
-│   ├── definitions.ts      # 7 built-in invariant definitions
+│   ├── definitions.ts      # 8 built-in invariant definitions
 │   └── checker.ts          # Invariant evaluation engine
 ├── adapters/               # Execution adapters
 │   ├── registry.ts         # Adapter registry (action class → handler)
@@ -82,7 +84,23 @@ src/
 │   ├── replay.ts           # Session replay logic
 │   ├── session-store.ts    # Session management
 │   ├── file-event-store.ts # File-based event persistence
-│   └── commands/           # guard, inspect, replay, claude-hook, claude-init
+│   └── commands/           # guard, inspect, replay, export, import, plugin, claude-hook, claude-init
+├── plugins/                # Plugin ecosystem
+│   ├── discovery.ts        # Plugin discovery mechanism
+│   ├── registry.ts         # Plugin registry
+│   ├── sandbox.ts          # Plugin sandboxing
+│   ├── validator.ts        # Plugin validation
+│   ├── types.ts            # Plugin type definitions
+│   └── index.ts            # Module re-exports
+├── renderers/              # Renderer plugin system
+│   ├── registry.ts         # Renderer registry
+│   ├── tui-renderer.ts     # TUI renderer implementation
+│   ├── types.ts            # Renderer type definitions
+│   └── index.ts            # Module re-exports
+├── telemetry/              # Runtime telemetry
+│   ├── index.ts            # Module re-exports
+│   ├── runtimeLogger.ts    # Runtime logging implementation
+│   └── types.ts            # Telemetry type definitions
 └── core/                   # Shared utilities
     ├── types.ts            # Shared TypeScript type definitions
     ├── actions.ts          # 23 canonical action types across 8 classes
@@ -95,14 +113,10 @@ src/
         ├── event-projections.ts # Event projections
         ├── event-schema.ts # Event schema definitions
         └── index.ts        # Module re-exports
-├── telemetry/              # Runtime telemetry
-│   ├── index.ts            # Module re-exports
-│   ├── runtimeLogger.ts    # Runtime logging implementation
-│   └── types.ts            # Telemetry type definitions
 
 tests/
 ├── *.test.js               # 14 JS test files (custom zero-dependency harness)
-└── ts/*.test.ts            # 41 TS test files (vitest)
+└── ts/*.test.ts            # 49 TS test files (vitest)
 policy/                     # Policy configuration (JSON: action_rules, capabilities)
 docs/                       # System documentation (architecture, event model, specs)
 hooks/                      # Git hooks (post-commit, post-merge)
@@ -141,7 +155,7 @@ The kernel loop is the core of AgentGuard. Every agent action passes through it:
 1. Agent proposes action (Claude Code tool call → `RawAgentAction`)
 2. AAB normalizes intent (tool → action type, detect git/destructive commands)
 3. Policy evaluator matches rules (deny/allow with scopes, branches, limits)
-4. Invariant checker verifies system state (7 defaults)
+4. Invariant checker verifies system state (8 defaults)
 5. If allowed: execute via adapter (file/shell/git handlers)
 6. Emit lifecycle events: `ACTION_REQUESTED` → `ACTION_ALLOWED/DENIED` → `ACTION_EXECUTED/FAILED`
 7. Sink all events to JSONL for audit trail
@@ -153,9 +167,11 @@ See `docs/unified-architecture.md` for the full model.
 Each top-level directory maps to a single architectural concept:
 - **src/kernel/** — Governed action kernel, escalation, evidence, decisions, simulation
 - **src/events/** — Canonical event model (schema, bus, store, persistence)
-- **src/policy/** — Policy evaluator + loaders (YAML/JSON)
+- **src/policy/** — Policy evaluator + loaders (YAML/JSON, pack loader)
 - **src/invariants/** — Invariant definitions + checker
 - **src/adapters/** — Execution adapters (file, shell, git, claude-code)
+- **src/plugins/** — Plugin ecosystem (discovery, registry, validation, sandboxing)
+- **src/renderers/** — Renderer plugin system (registry, TUI renderer)
 - **src/cli/** — CLI entry point and commands
 - **src/core/** — Shared utilities (types, actions, hash, execution-log)
 - **src/telemetry/** — Runtime telemetry and logging
@@ -166,7 +182,10 @@ Each top-level directory maps to a single architectural concept:
 - `agentguard guard --dry-run` — Evaluate without executing actions
 - `agentguard inspect [runId]` — Show action graph and decisions for a run
 - `agentguard events [runId]` — Show raw event stream for a run
+- `agentguard export <runId>` — Export a governance session to a portable JSONL file
+- `agentguard import <file>` — Import a governance session from a portable JSONL file
 - `agentguard replay` — Replay a governance session timeline
+- `agentguard plugin list|install|remove|search` — Manage plugins
 - `agentguard claude-hook` — Handle Claude Code PreToolUse/PostToolUse hook events
 - `agentguard claude-init` — Set up Claude Code hook integration
 
@@ -233,8 +252,8 @@ npm run test:coverage      # Run with coverage (c8, 50% line threshold)
 
 **Test structure:**
 - **JS tests** (`tests/*.test.js`): 14 files using a custom zero-dependency harness (`tests/run.js` with `node:assert`)
-- **TypeScript tests** (`tests/ts/*.test.ts`): 41 files using vitest
-- **Coverage areas**: adapters, kernel (AAB, engine, monitor, blast radius), CLI commands, decision records, domain models, events, evidence packs, execution log, invariants, JSONL persistence, policy evaluation, simulation, telemetry, TUI renderer, YAML loading
+- **TypeScript tests** (`tests/ts/*.test.ts`): 49 files using vitest
+- **Coverage areas**: adapters, kernel (AAB, engine, monitor, blast radius), CLI commands, decision records, domain models, events, evidence packs, execution log, invariants, JSONL persistence, plugins (discovery, registry, validation), policy evaluation (including pack loader), renderers, replay (engine, comparator, processor), simulation, telemetry, TUI renderer, YAML loading
 
 ## CI/CD & Automation
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Expected output:
 
 ```
   AgentGuard Runtime Active
-  policy: Demo Safety Policy | invariants: 7 active
+  policy: Demo Safety Policy | invariants: 8 active
 
   ✓ file.read src/auth/service.ts (dry-run)
   ✓ file.write src/auth/service.ts (dry-run)
@@ -62,7 +62,7 @@ AI coding agents execute file writes, shell commands, and git operations autonom
 AgentGuard adds a **deterministic decision point** between proposal and execution:
 
 - **Safety policies** — declare what agents can and cannot do in YAML
-- **Invariant enforcement** — 7 built-in checks (secrets, protected branches, blast radius, skill protection) run on every action
+- **Invariant enforcement** — 8 built-in checks (secrets, protected branches, blast radius, skill/task protection) run on every action
 - **Audit trail** — every decision is recorded as structured JSONL, inspectable after the fact
 - **Session debugging** — replay any agent session to see exactly what happened and why
 
@@ -72,7 +72,7 @@ AgentGuard evaluates every agent action through a **governed action kernel**:
 
 1. **Normalize** — Claude Code tool calls (Bash, Write, Edit, Read) are mapped to canonical action types (shell.exec, file.write, file.read)
 2. **Evaluate** — policies match against the action (deny git.push to main, deny destructive commands, enforce scope limits)
-3. **Check invariants** — 7 built-in safety checks run on every action
+3. **Check invariants** — 8 built-in safety checks run on every action
 4. **Execute** — if allowed, the action runs via adapters (file, shell, git handlers)
 5. **Emit events** — full lifecycle events sunk to JSONL for audit trail
 
@@ -80,7 +80,7 @@ AgentGuard evaluates every agent action through a **governed action kernel**:
 
 ```
   AgentGuard Runtime Active
-  policy: agentguard.yaml | invariants: 7 active
+  policy: agentguard.yaml | invariants: 8 active
 
   ✓ file.write src/auth/service.ts
   ✓ shell.exec npm test
@@ -120,7 +120,7 @@ Drop an `agentguard.yaml` in your repo root — the CLI picks it up automaticall
 
 ## Built-in Invariants
 
-7 safety invariants run on every action evaluation:
+8 safety invariants run on every action evaluation:
 
 | Invariant | Severity | Description |
 |-----------|----------|-------------|
@@ -128,6 +128,7 @@ Drop an `agentguard.yaml` in your repo root — the CLI picks it up automaticall
 | **protected-branch** | 4 (high) | Prevents direct push to main/master |
 | **no-force-push** | 4 (high) | Forbids force push |
 | **no-skill-modification** | 4 (high) | Prevents modification of .claude/skills/ files |
+| **no-scheduled-task-modification** | 4 (high) | Prevents modification of scheduled task files |
 | **blast-radius-limit** | 3 (medium) | Enforces file modification limit (default 20) |
 | **test-before-push** | 3 (medium) | Requires tests pass before push |
 | **lockfile-integrity** | 2 (low) | Ensures package.json changes sync with lockfiles |
@@ -147,9 +148,20 @@ agentguard inspect [runId]                # Show action graph and decisions for 
 agentguard inspect --last                 # Inspect most recent run
 agentguard events [runId]                 # Show raw event stream for a run
 
+# === Portability ===
+agentguard export <runId>                 # Export a governance session to JSONL
+agentguard export --last                  # Export the most recent run
+agentguard import <file>                  # Import a governance session from JSONL
+
 # === Replay ===
 agentguard replay --last                  # Replay a governance session timeline
 agentguard replay --last --step           # Step through events interactively
+
+# === Plugins ===
+agentguard plugin list                    # List installed plugins
+agentguard plugin install <path>          # Install a plugin from a local path
+agentguard plugin remove <id>            # Remove a plugin by ID
+agentguard plugin search [query]          # Search for plugins on npm
 
 # === Integration ===
 agentguard claude-init                    # Set up Claude Code hook integration
@@ -217,6 +229,7 @@ src/
 │   ├── evidence.ts         # Evidence pack generation
 │   ├── replay-comparator.ts # Replay outcome comparison
 │   ├── replay-engine.ts    # Deterministic replay engine
+│   ├── replay-processor.ts # Replay event processor
 │   ├── decisions/          # Typed decision records
 │   └── simulation/         # Pre-execution impact simulation
 ├── events/                 # Canonical event model
@@ -228,17 +241,30 @@ src/
 ├── policy/                 # Policy system
 │   ├── evaluator.ts        # Rule matching engine
 │   ├── loader.ts           # Policy validation + loading
+│   ├── pack-loader.ts      # Policy pack loader (community policy sets)
 │   └── yaml-loader.ts      # YAML policy parser
 ├── invariants/             # Invariant system
-│   ├── definitions.ts      # 7 built-in invariants
+│   ├── definitions.ts      # 8 built-in invariants
 │   └── checker.ts          # Invariant evaluation engine
 ├── adapters/               # Execution adapters
 │   ├── file.ts, shell.ts, git.ts  # Action handlers
 │   ├── claude-code.ts      # Claude Code hook adapter
 │   └── registry.ts         # Adapter registry
+├── plugins/                # Plugin ecosystem
+│   ├── discovery.ts        # Plugin discovery mechanism
+│   ├── registry.ts         # Plugin registry
+│   ├── sandbox.ts          # Plugin sandboxing
+│   ├── validator.ts        # Plugin validation
+│   ├── types.ts            # Plugin type definitions
+│   └── index.ts            # Module re-exports
+├── renderers/              # Renderer plugin system
+│   ├── registry.ts         # Renderer registry
+│   ├── tui-renderer.ts     # TUI renderer implementation
+│   ├── types.ts            # Renderer type definitions
+│   └── index.ts            # Module re-exports
 ├── cli/                    # CLI entry point + commands
 │   ├── bin.ts              # Main entry
-│   └── commands/           # guard, inspect, replay, claude-hook, claude-init
+│   └── commands/           # guard, inspect, replay, export, import, plugin, claude-hook, claude-init
 ├── telemetry/              # Runtime telemetry and logging
 └── core/                   # Shared utilities (types, actions, hash, rng, execution-log)
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -70,7 +70,7 @@ Build the governance runtime that evaluates agent actions against policies and i
 - [x] Governance event emission into canonical event model
 - [x] Integration with Claude Code hook (`src/adapters/claude-code.ts`, `src/cli/commands/claude-hook.ts`)
 
-## Phase 3 — Event Persistence + Replay `MOSTLY COMPLETE`
+## Phase 3 — Event Persistence + Replay `COMPLETE`
 
 > **Theme:** Every session is replayable
 
@@ -83,19 +83,19 @@ Implement durable event storage and deterministic replay.
 - [x] CLI replay command (`agentguard replay`)
 - [x] Deterministic replay with seeded RNG (`src/core/rng.ts`, `src/kernel/replay-engine.ts`)
 - [x] Replay comparator (verify original vs replayed outcomes) (`src/kernel/replay-comparator.ts`)
-- [ ] Event export/import for sharing sessions
+- [x] Event export/import for sharing sessions (`src/cli/commands/export.ts`, `src/cli/commands/import.ts`)
 
-## Phase 4 — Plugin Ecosystem
+## Phase 4 — Plugin Ecosystem `COMPLETE`
 
 > **Theme:** Extensible by design
 
 Formalize the plugin system for third-party extensions.
 
-- [ ] Policy pack loading system (community policy sets)
-- [ ] Renderer plugin interface
-- [ ] Replay processor interface
-- [ ] Plugin validation and sandboxing
-- [ ] Plugin registry / discovery mechanism
+- [x] Policy pack loading system (community policy sets) (`src/policy/pack-loader.ts`)
+- [x] Renderer plugin interface (`src/renderers/`)
+- [x] Replay processor interface (`src/kernel/replay-processor.ts`)
+- [x] Plugin validation and sandboxing (`src/plugins/validator.ts`, `src/plugins/sandbox.ts`)
+- [x] Plugin registry / discovery mechanism (`src/plugins/registry.ts`, `src/plugins/discovery.ts`)
 
 ## Phase 5 — Editor Integrations
 


### PR DESCRIPTION
## Summary

- Updated invariant count from 7 to 8 across all docs (added `no-scheduled-task-modification`)
- Added `src/plugins/` directory (discovery, registry, sandbox, validator) to structure trees
- Added `src/renderers/` directory (registry, TUI renderer) to structure trees
- Added missing CLI commands: `export`, `import`, `plugin`
- Added `src/policy/pack-loader.ts` and `src/kernel/replay-processor.ts` to CLAUDE.md
- Updated TS test file count from 41 to 49
- Marked Phase 3 as COMPLETE (export/import now implemented)
- Marked Phase 4 as COMPLETE (full plugin ecosystem now implemented)
- Updated ARCHITECTURE.md layer rules for `plugins/` and `renderers/`
- Fixed telemetry directory placement in CLAUDE.md structure tree

## Changes

- `README.md` — invariant count, invariant table, CLI section, structure tree
- `CLAUDE.md` — invariant count, structure tree, directory layout, CLI commands, test counts
- `ARCHITECTURE.md` — directory layout, layer rules
- `ROADMAP.md` — Phase 3 and Phase 4 status updates

## Source

Auto-generated by the **Scheduled Docs Sync** skill.

---
*Run: 2026-03-09*