### PR TITLE
docs: sync documentation with codebase state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,7 +252,7 @@ npm run test:coverage      # Run with coverage (c8, 50% line threshold)
 
 **Test structure:**
 - **JS tests** (`tests/*.test.js`): 14 files using a custom zero-dependency harness (`tests/run.js` with `node:assert`)
-- **TypeScript tests** (`tests/ts/*.test.ts`): 49 files using vitest
+- **TypeScript tests** (`tests/ts/*.test.ts`): 50 files using vitest
 - **Coverage areas**: adapters, kernel (AAB, engine, monitor, blast radius), CLI commands, decision records, domain models, events, evidence packs, execution log, invariants, JSONL persistence, plugins (discovery, registry, validation), policy evaluation (including pack loader), renderers, replay (engine, comparator, processor), simulation, telemetry, TUI renderer, YAML loading
 
 ## CI/CD & Automation

--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ src/
 ├── kernel/                 # Governed action kernel
 │   ├── kernel.ts           # Orchestrator (propose → evaluate → execute → emit)
 │   ├── aab.ts              # Action Authorization Boundary (normalization)
+│   ├── blast-radius.ts     # Weighted blast radius computation engine
 │   ├── decision.ts         # Runtime assurance engine
 │   ├── monitor.ts          # Escalation state machine
 │   ├── evidence.ts         # Evidence pack generation


### PR DESCRIPTION
## Summary

- Automated documentation sync detected drift between codebase and docs
- **CLAUDE.md**: TS test file count was 49, actual is 50 (new `vscode-event-reader.test.ts`)
- **README.md**: `blast-radius.ts` was missing from the kernel/ directory structure listing

## Changes

- `CLAUDE.md` — Updated TypeScript test count from 49 to 50
- `README.md` — Added `blast-radius.ts` to kernel/ structure tree

## Source

Auto-generated by the **Scheduled Docs Sync** skill.

---
*Run: 2026-03-10*