### PR TITLE
fix: remove invalid game data validation from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,10 +21,11 @@ jobs:
 
       - run: npm ci
 
+      - run: npm run build:ts
+
       - run: npm test
 
-      - name: Validate game data
-        run: node .github/scripts/validate-data.mjs
+      - run: npm run ts:test
 
       - name: Verify package version matches tag
         run: |


### PR DESCRIPTION
The publish workflow referenced ecosystem/data/ files that don't exist,
which would cause every publish attempt to fail. Removed the invalid
validate-data step and added build:ts and ts:test steps so TypeScript
compilation and tests run before publishing.

https://claude.ai/code/session_01SaHNp5qubMTwtnZpehcyhS