### PR TITLE
feat(issue-104): structured impact forecasts

### DIFF
--- a/src/kernel/kernel.ts
+++ b/src/kernel/kernel.ts
@@ -23,7 +23,8 @@ import {
 import { simpleHash } from '../core/hash.js';
 import type { GovernanceDecisionRecord, DecisionSink } from './decisions/types.js';
 import { buildDecisionRecord } from './decisions/factory.js';
-import type { SimulatorRegistry } from './simulation/types.js';
+import type { SimulatorRegistry, ImpactForecast } from './simulation/types.js';
+import { buildImpactForecast } from './simulation/forecast.js';
 import type { SeededRng } from '../core/rng.js';
 import { generateSeed, createSeededRng } from '../core/rng.js';
 
@@ -204,19 +205,25 @@ export function createKernel(config: KernelConfig = {}): Kernel {
 
       // 5b. ALLOWED — run simulation if available, then re-check
       let simulationResult = null;
+      let forecast: ImpactForecast | null = null;
 
       if (simulators && simulators.find(decision.intent)) {
         const simulator = simulators.find(decision.intent)!;
         try {
           simulationResult = await simulator.simulate(decision.intent, systemContext);
 
-          // Emit simulation event
+          // Build structured impact forecast
+          forecast = buildImpactForecast(decision.intent, simulationResult, blastRadiusThreshold);
+          simulationResult.forecast = forecast;
+
+          // Emit simulation event with forecast data
           const simEvent = createEvent(SIMULATION_COMPLETED, {
             simulatorId: simulationResult.simulatorId,
             riskLevel: simulationResult.riskLevel,
             blastRadius: simulationResult.blastRadius,
             predictedChanges: simulationResult.predictedChanges,
             durationMs: simulationResult.durationMs,
+            forecast,
           });
           allEvents.push(simEvent);
           sinkEvent(simEvent);
@@ -280,6 +287,7 @@ export function createKernel(config: KernelConfig = {}): Kernel {
                 riskLevel: simulationResult.riskLevel,
                 simulatorId: simulationResult.simulatorId,
                 durationMs: simulationResult.durationMs,
+                forecast: forecast || undefined,
               };
 
               const decisionRecord = buildDecisionRecord({
@@ -416,6 +424,7 @@ export function createKernel(config: KernelConfig = {}): Kernel {
             riskLevel: simulationResult.riskLevel,
             simulatorId: simulationResult.simulatorId,
             durationMs: simulationResult.durationMs,
+            forecast: forecast || undefined,
           }
         : null;
 

--- a/src/kernel/simulation/forecast.ts
+++ b/src/kernel/simulation/forecast.ts
@@ -1,0 +1,171 @@
+// Impact forecast builder — composes structured forecasts from simulation results.
+// Post-processes SimulationResult + NormalizedIntent into a typed ImpactForecast
+// suitable for predictive policy rules and governance reporting.
+
+import type { NormalizedIntent } from '../../policy/evaluator.js';
+import { computeBlastRadius } from '../blast-radius.js';
+import type { ImpactForecast, SimulationResult } from './types.js';
+
+/** Known module directories and their downstream dependents */
+const MODULE_DEPENDENCY_MAP: Record<string, string[]> = {
+  'src/kernel': ['src/cli', 'src/adapters'],
+  'src/events': ['src/kernel', 'src/cli', 'src/adapters', 'src/plugins', 'src/renderers'],
+  'src/policy': ['src/kernel', 'src/cli'],
+  'src/invariants': ['src/kernel'],
+  'src/adapters': ['src/cli'],
+  'src/core': [
+    'src/kernel',
+    'src/events',
+    'src/policy',
+    'src/invariants',
+    'src/adapters',
+    'src/cli',
+    'src/plugins',
+    'src/renderers',
+  ],
+  'src/plugins': ['src/cli'],
+  'src/renderers': ['src/cli'],
+  'src/telemetry': ['src/cli'],
+  'src/cli': [],
+};
+
+/** Test-relevant path patterns that increase test risk */
+const TEST_SENSITIVE_PATTERNS = [
+  { pattern: 'test', weight: 20 },
+  { pattern: '.test.', weight: 15 },
+  { pattern: '.spec.', weight: 15 },
+  { pattern: 'src/core/', weight: 15 },
+  { pattern: 'src/kernel/', weight: 12 },
+  { pattern: 'src/events/', weight: 10 },
+  { pattern: 'src/policy/', weight: 10 },
+  { pattern: 'src/invariants/', weight: 10 },
+  { pattern: 'package.json', weight: 8 },
+  { pattern: 'tsconfig', weight: 5 },
+];
+
+/** Extract predicted file paths from a simulation result and intent */
+function extractPredictedFiles(intent: NormalizedIntent, result: SimulationResult): string[] {
+  const files: string[] = [];
+
+  // The target is the primary predicted file
+  if (intent.target) {
+    files.push(intent.target);
+  }
+
+  // Extract additional paths from simulation details
+  if (result.details.affectedPackages && Array.isArray(result.details.affectedPackages)) {
+    files.push('package.json', 'package-lock.json');
+  }
+
+  // For git merges, diff-stat may have indicated file count
+  if (result.details.mergeFiles && Array.isArray(result.details.mergeFiles)) {
+    files.push(...(result.details.mergeFiles as string[]));
+  }
+
+  return [...new Set(files)];
+}
+
+/** Identify downstream modules affected by changes to the given file paths */
+function identifyDependencies(filePaths: string[]): string[] {
+  const affected = new Set<string>();
+
+  for (const filePath of filePaths) {
+    // Normalize to forward slashes for matching
+    const normalized = filePath.replace(/\\/g, '/');
+
+    for (const [moduleDir, dependents] of Object.entries(MODULE_DEPENDENCY_MAP)) {
+      if (normalized.startsWith(moduleDir) || normalized.includes(`/${moduleDir}`)) {
+        // The module itself is affected
+        affected.add(moduleDir);
+        // All dependents are downstream-affected
+        for (const dep of dependents) {
+          affected.add(dep);
+        }
+      }
+    }
+
+    // Package changes affect the entire dependency tree
+    if (normalized.includes('package.json') || normalized.includes('package-lock.json')) {
+      affected.add('node_modules');
+    }
+  }
+
+  return [...affected].sort();
+}
+
+/** Compute a test risk score (0–100) based on the predicted changes */
+function computeTestRisk(
+  filePaths: string[],
+  dependenciesAffected: string[],
+  blastRadius: number
+): number {
+  let score = 0;
+
+  // Base score from blast radius (clamped to 0-40 range)
+  score += Math.min(40, Math.round((blastRadius / 50) * 40));
+
+  // Path sensitivity contribution
+  for (const filePath of filePaths) {
+    const lower = filePath.toLowerCase().replace(/\\/g, '/');
+    for (const { pattern, weight } of TEST_SENSITIVE_PATTERNS) {
+      if (lower.includes(pattern)) {
+        score += weight;
+        break; // Only apply the highest-weight pattern per file
+      }
+    }
+  }
+
+  // Dependency breadth contribution (more modules affected = higher risk)
+  score += Math.min(15, dependenciesAffected.length * 3);
+
+  return Math.min(100, score);
+}
+
+/**
+ * Build a structured impact forecast from a simulation result.
+ *
+ * Composes the SimulationResult with blast-radius computation and
+ * dependency analysis to produce a typed ImpactForecast.
+ *
+ * @param intent  The normalized action intent
+ * @param result  The simulation result from an ActionSimulator
+ * @param threshold  Blast radius threshold for score computation (default: 50)
+ */
+export function buildImpactForecast(
+  intent: NormalizedIntent,
+  result: SimulationResult,
+  threshold = 50
+): ImpactForecast {
+  // 1. Predicted files
+  const predictedFiles = extractPredictedFiles(intent, result);
+
+  // 2. Dependencies affected
+  const dependenciesAffected = identifyDependencies(predictedFiles);
+
+  // 3. Blast radius score via the existing computation engine
+  const brResult = computeBlastRadius(intent, threshold);
+
+  // 4. Test risk score
+  const testRiskScore = computeTestRisk(predictedFiles, dependenciesAffected, result.blastRadius);
+
+  // 5. Risk level — take the worst of simulation and blast radius assessment
+  const riskLevels: Array<'low' | 'medium' | 'high'> = [result.riskLevel, brResult.riskLevel];
+  const riskLevel = riskLevels.includes('high')
+    ? 'high'
+    : riskLevels.includes('medium')
+      ? 'medium'
+      : 'low';
+
+  return {
+    predictedFiles,
+    dependenciesAffected,
+    testRiskScore,
+    blastRadiusScore: brResult.weightedScore,
+    riskLevel,
+    blastRadiusFactors: brResult.factors.map((f) => ({
+      name: f.name,
+      multiplier: f.multiplier,
+      reason: f.reason,
+    })),
+  };
+}

--- a/src/kernel/simulation/types.ts
+++ b/src/kernel/simulation/types.ts
@@ -3,6 +3,22 @@
 
 import type { NormalizedIntent } from '../../policy/evaluator.js';
 
+/** Structured impact forecast for predictive governance */
+export interface ImpactForecast {
+  /** File paths predicted to be changed by this action */
+  predictedFiles: string[];
+  /** Downstream modules or packages impacted by the change */
+  dependenciesAffected: string[];
+  /** Likelihood of test failure (0–100) based on scope and sensitivity of changes */
+  testRiskScore: number;
+  /** Weighted blast radius score from the blast-radius computation engine */
+  blastRadiusScore: number;
+  /** Risk level derived from the combined forecast assessment */
+  riskLevel: 'low' | 'medium' | 'high';
+  /** Factors that contributed to the blast radius score */
+  blastRadiusFactors: Array<{ name: string; multiplier: number; reason: string }>;
+}
+
 /** Result of simulating an action before execution */
 export interface SimulationResult {
   /** Human-readable list of predicted changes */
@@ -17,6 +33,8 @@ export interface SimulationResult {
   simulatorId: string;
   /** How long the simulation took (ms) */
   durationMs: number;
+  /** Structured impact forecast (populated by buildImpactForecast) */
+  forecast?: ImpactForecast;
 }
 
 /** An action simulator predicts the impact of an action before execution */

--- a/tests/ts/impact-forecast.test.ts
+++ b/tests/ts/impact-forecast.test.ts
@@ -1,0 +1,217 @@
+// Tests for structured impact forecast builder
+import { describe, it, expect } from 'vitest';
+import { buildImpactForecast } from '../../src/kernel/simulation/forecast.js';
+import type { NormalizedIntent } from '../../src/policy/evaluator.js';
+import type { SimulationResult } from '../../src/kernel/simulation/types.js';
+
+function makeIntent(overrides: Partial<NormalizedIntent> = {}): NormalizedIntent {
+  return {
+    action: 'file.write',
+    target: 'src/helper.ts',
+    agent: 'test',
+    destructive: false,
+    ...overrides,
+  };
+}
+
+function makeSimResult(overrides: Partial<SimulationResult> = {}): SimulationResult {
+  return {
+    predictedChanges: ['Write: src/helper.ts'],
+    blastRadius: 1,
+    riskLevel: 'low',
+    details: {},
+    simulatorId: 'test-sim',
+    durationMs: 2,
+    ...overrides,
+  };
+}
+
+describe('buildImpactForecast', () => {
+  it('produces a complete ImpactForecast with all required fields', () => {
+    const forecast = buildImpactForecast(makeIntent(), makeSimResult());
+
+    expect(forecast).toHaveProperty('predictedFiles');
+    expect(forecast).toHaveProperty('dependenciesAffected');
+    expect(forecast).toHaveProperty('testRiskScore');
+    expect(forecast).toHaveProperty('blastRadiusScore');
+    expect(forecast).toHaveProperty('riskLevel');
+    expect(forecast).toHaveProperty('blastRadiusFactors');
+  });
+
+  it('includes the target path in predictedFiles', () => {
+    const forecast = buildImpactForecast(
+      makeIntent({ target: 'src/events/bus.ts' }),
+      makeSimResult()
+    );
+
+    expect(forecast.predictedFiles).toContain('src/events/bus.ts');
+  });
+
+  it('deduplicates predicted files', () => {
+    const forecast = buildImpactForecast(
+      makeIntent({ target: 'src/core/types.ts' }),
+      makeSimResult()
+    );
+
+    const unique = new Set(forecast.predictedFiles);
+    expect(forecast.predictedFiles.length).toBe(unique.size);
+  });
+
+  it('identifies downstream dependencies for kernel files', () => {
+    const forecast = buildImpactForecast(
+      makeIntent({ target: 'src/kernel/monitor.ts' }),
+      makeSimResult()
+    );
+
+    expect(forecast.dependenciesAffected).toContain('src/kernel');
+    expect(forecast.dependenciesAffected).toContain('src/cli');
+    expect(forecast.dependenciesAffected).toContain('src/adapters');
+  });
+
+  it('identifies broad dependencies for core files', () => {
+    const forecast = buildImpactForecast(
+      makeIntent({ target: 'src/core/types.ts' }),
+      makeSimResult()
+    );
+
+    // src/core affects almost everything
+    expect(forecast.dependenciesAffected).toContain('src/core');
+    expect(forecast.dependenciesAffected).toContain('src/kernel');
+    expect(forecast.dependenciesAffected).toContain('src/events');
+    expect(forecast.dependenciesAffected).toContain('src/policy');
+  });
+
+  it('adds package.json to predicted files for package changes', () => {
+    const forecast = buildImpactForecast(
+      makeIntent({ action: 'shell.exec', target: '' }),
+      makeSimResult({
+        details: { affectedPackages: ['lodash@4.17.21'] },
+      })
+    );
+
+    expect(forecast.predictedFiles).toContain('package.json');
+    expect(forecast.predictedFiles).toContain('package-lock.json');
+  });
+
+  it('computes test risk score in valid range (0–100)', () => {
+    const forecast = buildImpactForecast(makeIntent(), makeSimResult());
+
+    expect(forecast.testRiskScore).toBeGreaterThanOrEqual(0);
+    expect(forecast.testRiskScore).toBeLessThanOrEqual(100);
+  });
+
+  it('assigns higher test risk for test file modifications', () => {
+    const testFileForecast = buildImpactForecast(
+      makeIntent({ target: 'tests/ts/kernel.test.ts' }),
+      makeSimResult()
+    );
+
+    const regularForecast = buildImpactForecast(
+      makeIntent({ target: 'src/cli/tui.ts' }),
+      makeSimResult()
+    );
+
+    expect(testFileForecast.testRiskScore).toBeGreaterThan(regularForecast.testRiskScore);
+  });
+
+  it('assigns higher test risk for larger blast radius', () => {
+    const highBlastForecast = buildImpactForecast(makeIntent(), makeSimResult({ blastRadius: 50 }));
+
+    const lowBlastForecast = buildImpactForecast(makeIntent(), makeSimResult({ blastRadius: 1 }));
+
+    expect(highBlastForecast.testRiskScore).toBeGreaterThan(lowBlastForecast.testRiskScore);
+  });
+
+  it('computes blast radius score using the blast-radius engine', () => {
+    const forecast = buildImpactForecast(
+      makeIntent({ action: 'file.delete', target: '.env', filesAffected: 1 }),
+      makeSimResult({ riskLevel: 'high', blastRadius: 10 })
+    );
+
+    // file.delete on .env should have a high weighted score due to
+    // delete multiplier (3.0) * sensitive path multiplier (5.0)
+    expect(forecast.blastRadiusScore).toBeGreaterThan(10);
+    expect(forecast.blastRadiusFactors.length).toBeGreaterThan(0);
+  });
+
+  it('includes blast radius factors with name, multiplier, and reason', () => {
+    const forecast = buildImpactForecast(
+      makeIntent({ action: 'file.write', target: 'package.json', filesAffected: 1 }),
+      makeSimResult()
+    );
+
+    for (const factor of forecast.blastRadiusFactors) {
+      expect(factor).toHaveProperty('name');
+      expect(factor).toHaveProperty('multiplier');
+      expect(factor).toHaveProperty('reason');
+      expect(typeof factor.name).toBe('string');
+      expect(typeof factor.multiplier).toBe('number');
+      expect(typeof factor.reason).toBe('string');
+    }
+  });
+
+  it('takes the worst risk level from simulation and blast radius', () => {
+    // Simulation says low, but blast radius on a sensitive delete should be high
+    const forecast = buildImpactForecast(
+      makeIntent({ action: 'file.delete', target: '.env.production', filesAffected: 5 }),
+      makeSimResult({ riskLevel: 'low' })
+    );
+
+    // The blast radius engine should produce at least medium/high for sensitive deletes
+    expect(['medium', 'high']).toContain(forecast.riskLevel);
+  });
+
+  it('handles empty target gracefully', () => {
+    const forecast = buildImpactForecast(makeIntent({ target: '' }), makeSimResult());
+
+    expect(forecast.predictedFiles).toEqual([]);
+    expect(forecast.dependenciesAffected).toEqual([]);
+    expect(forecast.testRiskScore).toBeGreaterThanOrEqual(0);
+  });
+
+  it('uses custom threshold for blast radius computation', () => {
+    const lowThreshold = buildImpactForecast(
+      makeIntent({ filesAffected: 10 }),
+      makeSimResult(),
+      10
+    );
+
+    const highThreshold = buildImpactForecast(
+      makeIntent({ filesAffected: 10 }),
+      makeSimResult(),
+      100
+    );
+
+    // Both should have the same blast radius score (threshold doesn't affect score)
+    expect(lowThreshold.blastRadiusScore).toBe(highThreshold.blastRadiusScore);
+  });
+
+  it('identifies node_modules as affected for package.json changes', () => {
+    const forecast = buildImpactForecast(makeIntent({ target: 'package.json' }), makeSimResult());
+
+    expect(forecast.dependenciesAffected).toContain('node_modules');
+  });
+
+  it('returns sorted dependencies', () => {
+    const forecast = buildImpactForecast(
+      makeIntent({ target: 'src/core/types.ts' }),
+      makeSimResult()
+    );
+
+    const sorted = [...forecast.dependenciesAffected].sort();
+    expect(forecast.dependenciesAffected).toEqual(sorted);
+  });
+});
+
+describe('buildImpactForecast — kernel integration', () => {
+  it('forecast is attached to simulation result when computed', () => {
+    const simResult = makeSimResult();
+    const forecast = buildImpactForecast(makeIntent(), simResult);
+
+    // The kernel attaches the forecast to the simulation result
+    simResult.forecast = forecast;
+
+    expect(simResult.forecast).toBeDefined();
+    expect(simResult.forecast!.predictedFiles).toEqual(forecast.predictedFiles);
+  });
+});


### PR DESCRIPTION
## Summary
- Add structured impact forecasts to the simulation engine, producing typed `ImpactForecast` objects with predicted files, dependency analysis, test risk scoring, and blast radius computation
- Forecasts are automatically computed after simulation and included in `SimulationCompleted` events and decision records
- Closes #104

## Changes
- `src/kernel/simulation/types.ts` — Added `ImpactForecast` interface and optional `forecast` field on `SimulationResult`
- `src/kernel/simulation/forecast.ts` — New module: `buildImpactForecast()` composes simulation results with blast-radius engine and dependency graph analysis
- `src/kernel/kernel.ts` — Integrated forecast computation into the simulation flow; forecast data included in events and decision records
- `tests/ts/impact-forecast.test.ts` — 17 tests covering forecast generation, dependency detection, test risk scoring, edge cases

## Test Plan
- [x] TypeScript build passes (`npm run build:ts`)
- [x] Vitest tests pass (`npm run ts:test`) — 899 pass / 0 fail
- [x] JS tests pass (`npm test`) — 210 pass / 0 fail
- [x] ESLint clean (`npm run lint`) — 0 errors
- [x] Type-check clean (`npm run ts:check`)
- [x] Coverage passes (`npm run test:coverage`) — 84.29% lines (threshold: 50%)

## Governance Report

| Metric | Count |
|--------|-------|
| Total events | 215 |
| Actions allowed | 68 |
| Actions denied | 2 |
| Policy denials | 2 |
| Invariant violations | 2 |

<details>
<summary>Telemetry details</summary>

Source: `.agentguard/events/` and `logs/runtime-events.jsonl`

Denials are from prior governance sessions and are not related to this implementation.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)