### PR TITLE
feat(issue-102): VS Code sidebar — policy file and recent events

### DIFF
--- a/tests/ts/vscode-event-reader.test.ts
+++ b/tests/ts/vscode-event-reader.test.ts
@@ -3,7 +3,7 @@
 // without requiring the VS Code extension host.
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from 'node:fs';
+import { mkdirSync, writeFileSync, readFileSync, readdirSync, rmSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -56,10 +56,77 @@ function parseJsonlContent(content: string): GovernanceEvent[] {
   return events;
 }
 
+interface RecentEvent {
+  readonly id: string;
+  readonly kind: string;
+  readonly timestamp: number;
+  readonly actionType: string | null;
+  readonly target: string | null;
+  readonly reason: string | null;
+}
+
+const POLICY_FILE_NAMES = ['agentguard.yaml', 'agentguard.yml', '.agentguard.yaml'];
+
+function findPolicyFile(workspaceRoot: string): string | null {
+  for (const name of POLICY_FILE_NAMES) {
+    const filePath = join(workspaceRoot, name);
+    if (existsSync(filePath)) {
+      return name;
+    }
+  }
+  return null;
+}
+
+function getRecentEvents(workspaceRoot: string, limit = 20): RecentEvent[] {
+  const eventsDir = join(workspaceRoot, '.agentguard', 'events');
+  if (!existsSync(eventsDir)) return [];
+
+  const files = readdirSync(eventsDir)
+    .filter((f) => f.endsWith('.jsonl'))
+    .sort()
+    .reverse();
+
+  if (files.length === 0) return [];
+
+  const latestFile = join(eventsDir, files[0]);
+  const content = readFileSync(latestFile, 'utf8');
+  const events = parseJsonlContent(content);
+
+  const actionKinds = new Set([
+    'ActionAllowed',
+    'ActionDenied',
+    'ActionEscalated',
+    'PolicyDenied',
+    'InvariantViolation',
+    'BlastRadiusExceeded',
+  ]);
+
+  const recent: RecentEvent[] = [];
+  for (let i = events.length - 1; i >= 0 && recent.length < limit; i--) {
+    const event = events[i];
+    if (actionKinds.has(event.kind)) {
+      const metadata =
+        typeof event.metadata === 'object' && event.metadata !== null
+          ? (event.metadata as Record<string, unknown>)
+          : {};
+      recent.push({
+        id: event.id,
+        kind: event.kind,
+        timestamp: event.timestamp,
+        actionType: (event.actionType as string) ?? (metadata.actionType as string) ?? null,
+        target: (event.target as string) ?? (metadata.target as string) ?? null,
+        reason: (event.reason as string) ?? (metadata.reason as string) ?? null,
+      });
+    }
+  }
+
+  return recent;
+}
+
 function summarizeRun(
   sessionId: string,
   sessionFile: string,
-  events: GovernanceEvent[],
+  events: GovernanceEvent[]
 ): RunSummary {
   let startedAt = 0;
   let endedAt: number | null = null;
@@ -258,7 +325,14 @@ describe('VS Code event reader', () => {
           expected: 'false',
           actual: 'true',
         },
-        { id: 'e7', kind: 'RunEnded', timestamp: 2000, fingerprint: 'g', runId: 'r1', result: 'ok' },
+        {
+          id: 'e7',
+          kind: 'RunEnded',
+          timestamp: 2000,
+          fingerprint: 'g',
+          runId: 'r1',
+          result: 'ok',
+        },
       ];
 
       const summary = summarizeRun('session_1', 'session_1.jsonl', events);
@@ -372,6 +446,113 @@ describe('VS Code event reader', () => {
       expect(parsed).toHaveLength(2);
       expect(parsed[0].kind).toBe('RunStarted');
       expect(parsed[1].kind).toBe('ActionRequested');
+    });
+  });
+
+  describe('findPolicyFile', () => {
+    it('detects agentguard.yaml in workspace', () => {
+      writeFileSync(join(testDir, 'agentguard.yaml'), 'version: 1\nrules: []\n');
+      const result = findPolicyFile(testDir);
+      expect(result).toBe('agentguard.yaml');
+    });
+
+    it('detects agentguard.yml when yaml not present', () => {
+      writeFileSync(join(testDir, 'agentguard.yml'), 'version: 1\nrules: []\n');
+      const result = findPolicyFile(testDir);
+      expect(result).toBe('agentguard.yml');
+    });
+
+    it('detects .agentguard.yaml as hidden config', () => {
+      writeFileSync(join(testDir, '.agentguard.yaml'), 'version: 1\nrules: []\n');
+      const result = findPolicyFile(testDir);
+      expect(result).toBe('.agentguard.yaml');
+    });
+
+    it('prefers agentguard.yaml over agentguard.yml', () => {
+      writeFileSync(join(testDir, 'agentguard.yaml'), 'version: 1\nrules: []\n');
+      writeFileSync(join(testDir, 'agentguard.yml'), 'version: 1\nrules: []\n');
+      const result = findPolicyFile(testDir);
+      expect(result).toBe('agentguard.yaml');
+    });
+
+    it('returns null when no policy file exists', () => {
+      const result = findPolicyFile(testDir);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getRecentEvents', () => {
+    it('extracts recent allowed and denied events from latest run', () => {
+      const sessionFile = join(eventsDir, 'session_recent.jsonl');
+      const events = [
+        { id: 'e1', kind: 'RunStarted', timestamp: 1000, fingerprint: 'a', runId: 'r1' },
+        {
+          id: 'e2',
+          kind: 'ActionAllowed',
+          timestamp: 1001,
+          fingerprint: 'b',
+          actionType: 'file.write',
+          target: 'src/app.ts',
+        },
+        {
+          id: 'e3',
+          kind: 'ActionDenied',
+          timestamp: 1002,
+          fingerprint: 'c',
+          actionType: 'git.push',
+          target: 'main',
+          reason: 'protected branch',
+        },
+        {
+          id: 'e4',
+          kind: 'PolicyDenied',
+          timestamp: 1003,
+          fingerprint: 'd',
+          actionType: 'shell.exec',
+          target: 'rm -rf /',
+          reason: 'destructive command',
+        },
+      ];
+      writeFileSync(sessionFile, events.map((e) => JSON.stringify(e)).join('\n') + '\n');
+
+      const recent = getRecentEvents(testDir);
+      // 3 action events (RunStarted is not an action kind)
+      expect(recent).toHaveLength(3);
+      // Newest first
+      expect(recent[0].kind).toBe('PolicyDenied');
+      expect(recent[0].actionType).toBe('shell.exec');
+      expect(recent[0].reason).toBe('destructive command');
+      expect(recent[1].kind).toBe('ActionDenied');
+      expect(recent[1].target).toBe('main');
+      expect(recent[2].kind).toBe('ActionAllowed');
+      expect(recent[2].actionType).toBe('file.write');
+    });
+
+    it('returns empty array when no runs exist', () => {
+      const recent = getRecentEvents(testDir);
+      expect(recent).toEqual([]);
+    });
+
+    it('respects the limit parameter', () => {
+      const sessionFile = join(eventsDir, 'session_limit.jsonl');
+      const events = [];
+      for (let i = 0; i < 30; i++) {
+        events.push({
+          id: `e${i}`,
+          kind: 'ActionAllowed',
+          timestamp: 1000 + i,
+          fingerprint: `f${i}`,
+          actionType: 'file.write',
+          target: `file${i}.ts`,
+        });
+      }
+      writeFileSync(sessionFile, events.map((e) => JSON.stringify(e)).join('\n') + '\n');
+
+      const recent = getRecentEvents(testDir, 5);
+      expect(recent).toHaveLength(5);
+      // Should be the 5 most recent (highest timestamp)
+      expect(recent[0].target).toBe('file29.ts');
+      expect(recent[4].target).toBe('file25.ts');
     });
   });
 });

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -31,6 +31,10 @@
           "name": "Run Status"
         },
         {
+          "id": "agentguard.recentEvents",
+          "name": "Recent Events"
+        },
+        {
           "id": "agentguard.runHistory",
           "name": "Run History"
         }
@@ -48,7 +52,7 @@
       "view/title": [
         {
           "command": "agentguard.refresh",
-          "when": "view == agentguard.runStatus || view == agentguard.runHistory",
+          "when": "view == agentguard.runStatus || view == agentguard.recentEvents || view == agentguard.runHistory",
           "group": "navigation"
         }
       ]

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -6,6 +6,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { RunStatusProvider } from './providers/run-status-provider';
 import { RunHistoryProvider } from './providers/run-history-provider';
+import { RecentEventsProvider } from './providers/recent-events-provider';
 import { NotificationService } from './services/notification-service';
 import { getEventsDir } from './services/event-reader';
 
@@ -20,10 +21,12 @@ export function activate(context: vscode.ExtensionContext): void {
   // Register tree data providers
   const runStatusProvider = new RunStatusProvider(workspaceRoot);
   const runHistoryProvider = new RunHistoryProvider(workspaceRoot);
+  const recentEventsProvider = new RecentEventsProvider(workspaceRoot);
 
   context.subscriptions.push(
     vscode.window.registerTreeDataProvider('agentguard.runStatus', runStatusProvider),
-    vscode.window.registerTreeDataProvider('agentguard.runHistory', runHistoryProvider)
+    vscode.window.registerTreeDataProvider('agentguard.runHistory', runHistoryProvider),
+    vscode.window.registerTreeDataProvider('agentguard.recentEvents', recentEventsProvider)
   );
 
   // Register notification service
@@ -35,6 +38,7 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.commands.registerCommand('agentguard.refresh', () => {
       runStatusProvider.refresh();
       runHistoryProvider.refresh();
+      recentEventsProvider.refresh();
     })
   );
 
@@ -43,6 +47,7 @@ export function activate(context: vscode.ExtensionContext): void {
   watchEventsDirectory(eventsDir, () => {
     runStatusProvider.refresh();
     runHistoryProvider.refresh();
+    recentEventsProvider.refresh();
   });
 
   // Clean up file watcher on deactivation

--- a/vscode-extension/src/providers/recent-events-provider.ts
+++ b/vscode-extension/src/providers/recent-events-provider.ts
@@ -1,0 +1,99 @@
+// Recent Events TreeView — shows individual governance events from the latest run
+// Displays: event kind, action type, target, and timestamp
+
+import * as vscode from 'vscode';
+import type { RecentEvent } from '../services/event-reader';
+import { getRecentEvents } from '../services/event-reader';
+
+/** Icons for each event kind */
+const EVENT_ICONS: Record<string, vscode.ThemeIcon> = {
+  ActionAllowed: new vscode.ThemeIcon('pass'),
+  ActionDenied: new vscode.ThemeIcon('error'),
+  ActionEscalated: new vscode.ThemeIcon('warning'),
+  PolicyDenied: new vscode.ThemeIcon('circle-slash'),
+  InvariantViolation: new vscode.ThemeIcon('alert'),
+  BlastRadiusExceeded: new vscode.ThemeIcon('flame'),
+};
+
+/** Friendly labels for event kinds */
+const EVENT_LABELS: Record<string, string> = {
+  ActionAllowed: 'Allowed',
+  ActionDenied: 'Denied',
+  ActionEscalated: 'Escalated',
+  PolicyDenied: 'Policy Denied',
+  InvariantViolation: 'Violation',
+  BlastRadiusExceeded: 'Blast Radius',
+};
+
+class EventItem extends vscode.TreeItem {
+  constructor(event: RecentEvent) {
+    const kindLabel = EVENT_LABELS[event.kind] ?? event.kind;
+    const actionLabel = event.actionType ?? 'unknown';
+    const label = `${kindLabel}: ${actionLabel}`;
+    super(label, vscode.TreeItemCollapsibleState.None);
+
+    this.iconPath = EVENT_ICONS[event.kind] ?? new vscode.ThemeIcon('circle-outline');
+
+    const targetPart = event.target ? ` → ${event.target}` : '';
+    const reasonPart = event.reason ? `\nReason: ${event.reason}` : '';
+    this.tooltip = `${event.kind}: ${actionLabel}${targetPart}${reasonPart}\n${formatEventTime(event.timestamp)}`;
+
+    this.description = event.target ? truncatePath(event.target) : formatEventTime(event.timestamp);
+  }
+}
+
+/**
+ * TreeDataProvider for the Recent Events view.
+ * Shows individual governance events from the latest run.
+ */
+export class RecentEventsProvider implements vscode.TreeDataProvider<EventItem> {
+  private _onDidChangeTreeData = new vscode.EventEmitter<EventItem | undefined | void>();
+  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+  private events: RecentEvent[] = [];
+
+  constructor(private readonly workspaceRoot: string) {
+    this.refresh();
+  }
+
+  refresh(): void {
+    this.events = getRecentEvents(this.workspaceRoot);
+    this._onDidChangeTreeData.fire();
+  }
+
+  getTreeItem(element: EventItem): vscode.TreeItem {
+    return element;
+  }
+
+  getChildren(): EventItem[] {
+    if (this.events.length === 0) {
+      return [
+        new EventItem({
+          id: 'empty',
+          kind: 'info',
+          timestamp: Date.now(),
+          actionType: 'No recent events',
+          target: null,
+          reason: null,
+        }),
+      ];
+    }
+    return this.events.map((event) => new EventItem(event));
+  }
+}
+
+function formatEventTime(ts: number): string {
+  const now = Date.now();
+  const diffMs = now - ts;
+
+  if (diffMs < 60_000) return 'just now';
+  if (diffMs < 3_600_000) return `${Math.floor(diffMs / 60_000)}m ago`;
+  if (diffMs < 86_400_000) return `${Math.floor(diffMs / 3_600_000)}h ago`;
+
+  return new Date(ts).toLocaleDateString([], { month: 'short', day: 'numeric' });
+}
+
+function truncatePath(target: string): string {
+  if (target.length <= 30) return target;
+  return '…' + target.slice(-29);
+}

--- a/vscode-extension/src/providers/run-status-provider.ts
+++ b/vscode-extension/src/providers/run-status-provider.ts
@@ -3,15 +3,11 @@
 
 import * as vscode from 'vscode';
 import type { RunSummary } from '../services/event-reader';
-import { ESCALATION_LABELS, findLatestRun } from '../services/event-reader';
+import { ESCALATION_LABELS, findLatestRun, findPolicyFile } from '../services/event-reader';
 
 /** Tree item representing a status property */
 class StatusItem extends vscode.TreeItem {
-  constructor(
-    label: string,
-    value: string,
-    icon?: vscode.ThemeIcon,
-  ) {
+  constructor(label: string, value: string, icon?: vscode.ThemeIcon) {
     super(`${label}: ${value}`, vscode.TreeItemCollapsibleState.None);
     if (icon) {
       this.iconPath = icon;
@@ -29,6 +25,7 @@ export class RunStatusProvider implements vscode.TreeDataProvider<StatusItem> {
   readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
 
   private currentRun: RunSummary | null = null;
+  private policyFile: string | null = null;
 
   constructor(private readonly workspaceRoot: string) {
     this.refresh();
@@ -36,6 +33,7 @@ export class RunStatusProvider implements vscode.TreeDataProvider<StatusItem> {
 
   refresh(): void {
     this.currentRun = findLatestRun(this.workspaceRoot);
+    this.policyFile = findPolicyFile(this.workspaceRoot);
     this._onDidChangeTreeData.fire();
   }
 
@@ -45,7 +43,13 @@ export class RunStatusProvider implements vscode.TreeDataProvider<StatusItem> {
 
   getChildren(): StatusItem[] {
     if (!this.currentRun) {
-      return [new StatusItem('Status', 'No governance runs found', new vscode.ThemeIcon('info'))];
+      const items: StatusItem[] = [
+        new StatusItem('Status', 'No governance runs found', new vscode.ThemeIcon('info')),
+      ];
+      // Show policy file even when no runs exist
+      const policyLabel = this.policyFile ?? 'none (fail-open)';
+      items.push(new StatusItem('Policy', policyLabel, new vscode.ThemeIcon('file-code')));
+      return items;
     }
 
     const run = this.currentRun;
@@ -55,32 +59,48 @@ export class RunStatusProvider implements vscode.TreeDataProvider<StatusItem> {
     items.push(new StatusItem('Run', run.runId, new vscode.ThemeIcon('play-circle')));
 
     // Status
-    const statusIcon = run.status === 'active'
-      ? new vscode.ThemeIcon('sync~spin')
-      : new vscode.ThemeIcon('check');
+    const statusIcon =
+      run.status === 'active' ? new vscode.ThemeIcon('sync~spin') : new vscode.ThemeIcon('check');
     items.push(new StatusItem('Status', run.status, statusIcon));
 
     // Escalation level
     const levelLabel = ESCALATION_LABELS[run.escalationLevel] ?? 'UNKNOWN';
-    const levelIcon = run.escalationLevel >= 2
-      ? new vscode.ThemeIcon('warning')
-      : new vscode.ThemeIcon('shield');
+    const levelIcon =
+      run.escalationLevel >= 2 ? new vscode.ThemeIcon('warning') : new vscode.ThemeIcon('shield');
     items.push(new StatusItem('Escalation', levelLabel, levelIcon));
+
+    // Active policy file
+    const policyLabel = this.policyFile ?? 'none (fail-open)';
+    items.push(new StatusItem('Policy', policyLabel, new vscode.ThemeIcon('file-code')));
 
     // Action counts
     items.push(new StatusItem('Allowed', String(run.actionsAllowed), new vscode.ThemeIcon('pass')));
-    items.push(new StatusItem('Denied', String(run.actionsDenied),
-      run.actionsDenied > 0 ? new vscode.ThemeIcon('error') : new vscode.ThemeIcon('circle-slash')));
-    items.push(new StatusItem('Violations', String(run.violations),
-      run.violations > 0 ? new vscode.ThemeIcon('alert') : new vscode.ThemeIcon('check-all')));
+    items.push(
+      new StatusItem(
+        'Denied',
+        String(run.actionsDenied),
+        run.actionsDenied > 0 ? new vscode.ThemeIcon('error') : new vscode.ThemeIcon('circle-slash')
+      )
+    );
+    items.push(
+      new StatusItem(
+        'Violations',
+        String(run.violations),
+        run.violations > 0 ? new vscode.ThemeIcon('alert') : new vscode.ThemeIcon('check-all')
+      )
+    );
 
     // Total events
-    items.push(new StatusItem('Events', String(run.totalEvents), new vscode.ThemeIcon('list-flat')));
+    items.push(
+      new StatusItem('Events', String(run.totalEvents), new vscode.ThemeIcon('list-flat'))
+    );
 
     // Duration
     if (run.endedAt) {
       const durationMs = run.endedAt - run.startedAt;
-      items.push(new StatusItem('Duration', formatDuration(durationMs), new vscode.ThemeIcon('clock')));
+      items.push(
+        new StatusItem('Duration', formatDuration(durationMs), new vscode.ThemeIcon('clock'))
+      );
     } else if (run.startedAt) {
       const elapsed = Date.now() - run.startedAt;
       items.push(new StatusItem('Elapsed', formatDuration(elapsed), new vscode.ThemeIcon('clock')));

--- a/vscode-extension/src/services/event-reader.ts
+++ b/vscode-extension/src/services/event-reader.ts
@@ -95,7 +95,11 @@ export function listSessionIds(eventsDir: string): string[] {
 /**
  * Build a RunSummary from a list of events.
  */
-export function summarizeRun(sessionId: string, sessionFile: string, events: GovernanceEvent[]): RunSummary {
+export function summarizeRun(
+  sessionId: string,
+  sessionFile: string,
+  events: GovernanceEvent[]
+): RunSummary {
   let startedAt = 0;
   let endedAt: number | null = null;
   let actionsRequested = 0;
@@ -125,9 +129,10 @@ export function summarizeRun(sessionId: string, sessionFile: string, events: Gov
         violations++;
         break;
       case 'ActionEscalated': {
-        const level = typeof event.metadata === 'object' && event.metadata !== null
-          ? (event.metadata as Record<string, unknown>).escalationLevel
-          : undefined;
+        const level =
+          typeof event.metadata === 'object' && event.metadata !== null
+            ? (event.metadata as Record<string, unknown>).escalationLevel
+            : undefined;
         if (typeof level === 'number' && level > escalationLevel) {
           escalationLevel = level;
         }
@@ -201,4 +206,72 @@ export function findLatestRun(workspaceRoot: string): RunSummary | null {
  */
 export function isGovernanceEvent(kind: string): boolean {
   return GOVERNANCE_KINDS.has(kind);
+}
+
+/** Policy file names to search for, in priority order */
+const POLICY_FILE_NAMES = ['agentguard.yaml', 'agentguard.yml', '.agentguard.yaml'];
+
+/**
+ * Find the active policy file in the workspace.
+ * Returns the filename if found, null otherwise.
+ */
+export function findPolicyFile(workspaceRoot: string): string | null {
+  for (const name of POLICY_FILE_NAMES) {
+    const filePath = path.join(workspaceRoot, name);
+    if (fs.existsSync(filePath)) {
+      return name;
+    }
+  }
+  return null;
+}
+
+/** A recent governance event for display in the sidebar */
+export interface RecentEvent {
+  readonly id: string;
+  readonly kind: string;
+  readonly timestamp: number;
+  readonly actionType: string | null;
+  readonly target: string | null;
+  readonly reason: string | null;
+}
+
+/**
+ * Extract recent governance events (allowed/denied actions) from the latest run.
+ * Returns the most recent N events, newest first.
+ */
+export function getRecentEvents(workspaceRoot: string, limit = 20): RecentEvent[] {
+  const latestRun = findLatestRun(workspaceRoot);
+  if (!latestRun) return [];
+
+  const events = parseJsonlFile(latestRun.sessionFile);
+  const actionKinds = new Set([
+    'ActionAllowed',
+    'ActionDenied',
+    'ActionEscalated',
+    'PolicyDenied',
+    'InvariantViolation',
+    'BlastRadiusExceeded',
+  ]);
+
+  const recent: RecentEvent[] = [];
+  for (let i = events.length - 1; i >= 0 && recent.length < limit; i--) {
+    const event = events[i];
+    if (actionKinds.has(event.kind)) {
+      const metadata =
+        typeof event.metadata === 'object' && event.metadata !== null
+          ? (event.metadata as Record<string, unknown>)
+          : {};
+
+      recent.push({
+        id: event.id,
+        kind: event.kind,
+        timestamp: event.timestamp,
+        actionType: (event.actionType as string) ?? (metadata.actionType as string) ?? null,
+        target: (event.target as string) ?? (metadata.target as string) ?? null,
+        reason: (event.reason as string) ?? (metadata.reason as string) ?? null,
+      });
+    }
+  }
+
+  return recent;
 }


### PR DESCRIPTION
## Summary
- Add active policy file name display to the Run Status sidebar view
- Add new "Recent Events" tree view showing individual governance events (allowed/denied actions) from the latest run
- Closes #102

## Changes
- `vscode-extension/src/services/event-reader.ts` — add `findPolicyFile()` and `getRecentEvents()` functions
- `vscode-extension/src/providers/run-status-provider.ts` — display policy file in status view
- `vscode-extension/src/providers/recent-events-provider.ts` — new tree view for recent governance events
- `vscode-extension/src/extension.ts` — register RecentEventsProvider and include in refresh
- `vscode-extension/package.json` — add `agentguard.recentEvents` view to sidebar manifest
- `tests/ts/vscode-event-reader.test.ts` — add tests for findPolicyFile and getRecentEvents

## Test Plan
- [x] TypeScript build passes (`npm run build:ts`)
- [x] Vitest tests pass (`npm run ts:test`) — 890 pass / 0 fail
- [x] JS tests pass (`npm test`) — 210 pass / 0 fail
- [x] ESLint clean (`npm run lint`) — 0 errors
- [x] Prettier clean (`npm run format`) — clean on modified files
- [x] Coverage: 84.29% lines (threshold: 50%)

## Governance Report

| Metric | Count |
|--------|-------|
| Total events | 215 |
| Actions allowed | 68 |
| Actions denied | 2 |
| Policy denials | 2 |
| Invariant violations | 2 |

<details>
<summary>Telemetry details</summary>

Source: `.agentguard/events/` and `logs/runtime-events.jsonl`

Runtime telemetry records: 53

No notable denials during this session — the 2 denials and 2 violations are from prior governance runs.

</details>