### PR TITLE
docs: sync documentation with codebase state

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -43,6 +43,7 @@ Each top-level directory under `src/` maps to a single architectural concept:
 
 ```
 src/
+├── analytics/     Cross-session violation analytics (aggregation, clustering, trends)
 ├── kernel/        Governed action kernel (orchestrate, normalize, decide, escalate)
 ├── events/        Canonical event model (schema, bus, store, JSONL persistence)
 ├── policy/        Policy system (evaluator, loaders, pack loader)
@@ -66,7 +67,8 @@ vscode-extension/  VS Code extension (sidebar panels, notifications, event reade
 - **adapters/** may import from core/, kernel/ only
 - **plugins/** may import from core/, events/, kernel/ only
 - **renderers/** may import from core/, events/ only
-- **cli/** may import from kernel/, events/, policy/, plugins/, renderers/, core/
+- **analytics/** may import from events/, core/ only
+- **cli/** may import from analytics/, kernel/, events/, policy/, plugins/, renderers/, core/
 - **telemetry/** may import from core/ only
 - **core/** has no project imports (leaf layer)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ src/
 │       ├── filesystem-simulator.ts  # File system impact simulation
 │       ├── git-simulator.ts         # Git operation simulation
 │       ├── package-simulator.ts     # Package change simulation
+│       ├── forecast.ts              # Impact forecast builder
 │       ├── registry.ts              # Simulator registry
 │       └── types.ts                 # Simulation type definitions
 ├── events/                 # Canonical event model
@@ -70,6 +71,14 @@ src/
 ├── invariants/             # Invariant system
 │   ├── definitions.ts      # 8 built-in invariant definitions
 │   └── checker.ts          # Invariant evaluation engine
+├── analytics/              # Cross-session violation analytics
+│   ├── aggregator.ts       # Violation aggregation across sessions
+│   ├── cluster.ts          # Violation clustering by dimension
+│   ├── engine.ts           # Analytics engine orchestrator
+│   ├── index.ts            # Module re-exports
+│   ├── reporter.ts         # Output formatters (terminal, JSON, markdown)
+│   ├── trends.ts           # Violation trend computation
+│   └── types.ts            # Analytics type definitions
 ├── adapters/               # Execution adapters
 │   ├── registry.ts         # Adapter registry (action class → handler)
 │   ├── file.ts, shell.ts, git.ts  # Action handlers
@@ -84,7 +93,7 @@ src/
 │   ├── replay.ts           # Session replay logic
 │   ├── session-store.ts    # Session management
 │   ├── file-event-store.ts # File-based event persistence
-│   └── commands/           # guard, inspect, replay, export, import, plugin, claude-hook, claude-init
+│   └── commands/           # analytics, guard, inspect, replay, export, import, plugin, claude-hook, claude-init
 ├── plugins/                # Plugin ecosystem
 │   ├── discovery.ts        # Plugin discovery mechanism
 │   ├── registry.ts         # Plugin registry
@@ -117,7 +126,7 @@ src/
 vscode-extension/              # VS Code extension
 ├── src/
 │   ├── extension.ts           # Extension entry point (sidebar panels, file watcher)
-│   ├── providers/             # Tree data providers (run status, run history)
+│   ├── providers/             # Tree data providers (run status, run history, recent events)
 │   └── services/              # Event reader, notification formatter, notification service
 ├── package.json               # Extension manifest (activation, views, configuration)
 └── tsconfig.json              # Extension TypeScript config
@@ -173,6 +182,7 @@ See `docs/unified-architecture.md` for the full model.
 
 ### Directory Layout
 Each top-level directory maps to a single architectural concept:
+- **src/analytics/** — Cross-session violation analytics (aggregation, clustering, trends, reporting)
 - **src/kernel/** — Governed action kernel, escalation, evidence, decisions, simulation
 - **src/events/** — Canonical event model (schema, bus, store, persistence)
 - **src/policy/** — Policy evaluator + loaders (YAML/JSON, pack loader)
@@ -185,6 +195,7 @@ Each top-level directory maps to a single architectural concept:
 - **src/telemetry/** — Runtime telemetry and logging
 
 ### CLI Commands
+- `agentguard analytics` — Analyze violation patterns across governance sessions
 - `agentguard guard` — Start the governed action runtime (policy + invariant enforcement)
 - `agentguard guard --policy <file>` — Use a specific policy file (YAML or JSON)
 - `agentguard guard --dry-run` — Evaluate without executing actions
@@ -260,8 +271,8 @@ npm run test:coverage      # Run with coverage (c8, 50% line threshold)
 
 **Test structure:**
 - **JS tests** (`tests/*.test.js`): 14 files using a custom zero-dependency harness (`tests/run.js` with `node:assert`)
-- **TypeScript tests** (`tests/ts/*.test.ts`): 51 files using vitest
-- **Coverage areas**: adapters, kernel (AAB, engine, monitor, blast radius, integration, e2e pipeline), CLI commands, decision records, domain models, events, evidence packs, execution log, invariants, JSONL persistence, notification formatter, plugins (discovery, registry, validation), policy evaluation (including pack loader), renderers, replay (engine, comparator, processor), simulation, telemetry, TUI renderer, VS Code event reader, YAML loading
+- **TypeScript tests** (`tests/ts/*.test.ts`): 53 files using vitest
+- **Coverage areas**: adapters, analytics, kernel (AAB, engine, monitor, blast radius, integration, e2e pipeline), CLI commands, decision records, domain models, events, evidence packs, execution log, impact forecast, invariants, JSONL persistence, notification formatter, plugins (discovery, registry, validation), policy evaluation (including pack loader), renderers, replay (engine, comparator, processor), simulation, telemetry, TUI renderer, VS Code event reader, YAML loading
 
 ## CI/CD & Automation
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ agentguard guard --dry-run                # Evaluate without executing actions
 agentguard inspect [runId]                # Show action graph and decisions for a run
 agentguard inspect --last                 # Inspect most recent run
 agentguard events [runId]                 # Show raw event stream for a run
+agentguard analytics                      # Analyze violation patterns across sessions
 
 # === Portability ===
 agentguard export <runId>                 # Export a governance session to JSONL
@@ -232,6 +233,13 @@ src/
 ├── invariants/             # Invariant system
 │   ├── definitions.ts      # 8 built-in invariants
 │   └── checker.ts          # Invariant evaluation engine
+├── analytics/              # Cross-session violation analytics
+│   ├── aggregator.ts       # Violation aggregation across sessions
+│   ├── cluster.ts          # Violation clustering by dimension
+│   ├── engine.ts           # Analytics engine orchestrator
+│   ├── reporter.ts         # Output formatters (terminal, JSON, markdown)
+│   ├── trends.ts           # Violation trend computation
+│   └── types.ts            # Analytics type definitions
 ├── adapters/               # Execution adapters
 │   ├── file.ts, shell.ts, git.ts  # Action handlers
 │   ├── claude-code.ts      # Claude Code hook adapter
@@ -250,14 +258,14 @@ src/
 │   └── index.ts            # Module re-exports
 ├── cli/                    # CLI entry point + commands
 │   ├── bin.ts              # Main entry
-│   └── commands/           # guard, inspect, replay, export, import, plugin, claude-hook, claude-init
+│   └── commands/           # analytics, guard, inspect, replay, export, import, plugin, claude-hook, claude-init
 ├── telemetry/              # Runtime telemetry and logging
 └── core/                   # Shared utilities (types, actions, hash, rng, execution-log)
 
 vscode-extension/              # VS Code extension
 ├── src/
 │   ├── extension.ts           # Sidebar panels, file watcher, notifications
-│   ├── providers/             # Tree data providers (run status, run history)
+│   ├── providers/             # Tree data providers (run status, run history, recent events)
 │   └── services/              # Event reader, notification formatter + service
 └── package.json               # Extension manifest
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -134,7 +134,7 @@ AI features are intentionally placed last. The system must be useful without AI 
 
 Extend the simulation engine from risk assessment to predictive governance — evaluate policies and invariants against predicted system state before actions execute.
 
-- [ ] Structured impact forecasts (predicted files changed, dependencies affected, test risk, blast radius score)
+- [x] Structured impact forecasts (predicted files changed, dependencies affected, test risk, blast radius score)
 - [ ] Predictive policy rules (`deny if predicted_test_failures > 0`, `deny if predicted_files_changed > 10`)
 - [ ] Plan-level simulation — simulate a sequence of actions as a batch before allowing execution
 - [ ] Simulator plugin interface — community-contributed simulators via plugin registry
@@ -164,7 +164,7 @@ Surface governance activity through dashboards, traces, and metrics.
 
 - [ ] Timeline viewer for governance sessions (`agentguard replay --ui`)
 - [ ] Policy evaluation traces (which rule matched, why)
-- [ ] Invariant violation analytics (frequency, clustering)
+- [x] Invariant violation analytics (frequency, clustering)
 - [ ] Metrics export (Prometheus / OpenTelemetry)
 - [ ] Session comparison (diff two governance runs side-by-side)
 


### PR DESCRIPTION
## Summary

Automated documentation sync detected drift between codebase and docs after recent additions:

- **New `src/analytics/` module** (7 files) not documented in any structure tree
- **New `src/kernel/simulation/forecast.ts`** (impact forecasting) not listed in CLAUDE.md
- **New `agentguard analytics` CLI command** missing from CLI docs
- **New VS Code `recent-events-provider.ts`** not mentioned in providers
- **TS test count stale** — docs said 51, actual is 53
- **ROADMAP items implemented but not checked off** — impact forecasts (Phase 7) and violation analytics (Phase 9)

## Changes

- **CLAUDE.md** — Added analytics module to structure tree, added forecast.ts, added analytics CLI command, updated directory layout, updated test count (51→53), updated coverage areas, updated VS Code providers comment
- **README.md** — Added analytics module to repository structure, added analytics CLI command, updated VS Code providers comment, updated commands list
- **ARCHITECTURE.md** — Added analytics directory to layout, added analytics layer rule
- **ROADMAP.md** — Marked Phase 7 "Structured impact forecasts" as done, marked Phase 9 "Invariant violation analytics" as done

## Source

Auto-generated by the **Scheduled Docs Sync** skill.

---
*Run: 2026-03-10*