### PR TITLE
feat(issue-130): GitHub Actions reusable governance workflow

### DIFF
--- a/.github/workflows/agentguard-governance.yml
+++ b/.github/workflows/agentguard-governance.yml
@@ -1,0 +1,130 @@
+# AgentGuard Governance — Reusable GitHub Actions workflow
+#
+# Verifies governance session data in CI. Can be called from other repositories
+# to enforce AgentGuard governance policies as a CI gate.
+#
+# Usage (from another repo's workflow):
+#
+#   jobs:
+#     governance:
+#       uses: jpleva91/agent-guard/.github/workflows/agentguard-governance.yml@main
+#       with:
+#         session-file: .agentguard/exports/session.agentguard.jsonl
+#         fail-on-violation: true
+#
+# Usage (from the same repo):
+#
+#   jobs:
+#     governance:
+#       uses: ./.github/workflows/agentguard-governance.yml
+#       with:
+#         session-file: .agentguard/exports/session.agentguard.jsonl
+
+name: AgentGuard Governance
+
+on:
+  workflow_call:
+    inputs:
+      session-file:
+        description: >
+          Path to an exported governance session file (.agentguard.jsonl).
+          Created by running `agentguard export --last -o <path>`.
+          If omitted, the workflow will look for the most recent local run.
+        required: false
+        type: string
+        default: ''
+      policy-file:
+        description: >
+          Path to the governance policy file (YAML or JSON).
+          Used for policy validation. Defaults to agentguard.yaml.
+        required: false
+        type: string
+        default: 'agentguard.yaml'
+      fail-on-violation:
+        description: 'Fail the workflow if invariant violations are found.'
+        required: false
+        type: boolean
+        default: true
+      fail-on-denial:
+        description: 'Fail the workflow if any governance actions were denied.'
+        required: false
+        type: boolean
+        default: false
+      agentguard-version:
+        description: >
+          Version of @red-codes/agentguard to install.
+          Use "latest" for the most recent release, or pin a specific version.
+        required: false
+        type: string
+        default: 'latest'
+      node-version:
+        description: 'Node.js version to use.'
+        required: false
+        type: string
+        default: '20'
+
+jobs:
+  governance-check:
+    name: Governance Verification
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: 'npm'
+
+      - name: Install AgentGuard
+        run: npm install -g @red-codes/agentguard@${{ inputs.agentguard-version }}
+
+      - name: Validate policy file
+        run: |
+          if [ -f "${{ inputs.policy-file }}" ]; then
+            echo "::notice title=Policy File::Found governance policy: ${{ inputs.policy-file }}"
+          else
+            echo "::warning title=No Policy File::Governance policy not found at ${{ inputs.policy-file }}. Running in fail-open mode."
+          fi
+
+      - name: Run governance check
+        id: ci-check
+        run: |
+          ARGS=""
+
+          # Determine session source
+          if [ -n "${{ inputs.session-file }}" ] && [ -f "${{ inputs.session-file }}" ]; then
+            ARGS="${{ inputs.session-file }}"
+          elif [ -d ".agentguard/events" ] && [ "$(ls -A .agentguard/events/ 2>/dev/null)" ]; then
+            ARGS="--last"
+          else
+            echo "::notice title=No Session Data::No governance session file or local runs found. Skipping governance check."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Add failure mode flags
+          if [ "${{ inputs.fail-on-violation }}" = "true" ]; then
+            ARGS="$ARGS --fail-on-violation"
+          fi
+          if [ "${{ inputs.fail-on-denial }}" = "true" ]; then
+            ARGS="$ARGS --fail-on-denial"
+          fi
+
+          # Run the check with JSON output for structured data
+          agentguard ci-check $ARGS --json > governance-result.json 2>&1 || true
+
+          # Display the result
+          cat governance-result.json
+
+          # Run again for terminal output and annotations (GITHUB_ACTIONS is set automatically)
+          agentguard ci-check $ARGS
+
+      - name: Upload governance report
+        if: steps.ci-check.outputs.skip != 'true' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: governance-report
+          path: governance-result.json
+          retention-days: 30

--- a/src/cli/bin.ts
+++ b/src/cli/bin.ts
@@ -108,6 +108,23 @@ const COMMANDS: Record<string, CommandHelp> = {
       'agentguard import ./exports/run.agentguard.jsonl --as custom_run_id',
     ],
   },
+  'ci-check': {
+    name: 'agentguard ci-check',
+    description: 'CI governance verification — check a session for violations',
+    usage: 'agentguard ci-check <session-file> [flags]',
+    flags: [
+      { flag: '--fail-on-violation', description: 'Exit 1 if invariant violations found' },
+      { flag: '--fail-on-denial', description: 'Exit 1 if any actions were denied' },
+      { flag: '--json', description: 'Output result as JSON' },
+      { flag: '--last', description: 'Use the most recent local run' },
+      { flag: '--base-dir, -d <dir>', description: 'Base directory for event storage' },
+    ],
+    examples: [
+      'agentguard ci-check session.agentguard.jsonl --fail-on-violation',
+      'agentguard ci-check --last --fail-on-denial --json',
+      'agentguard ci-check session.jsonl --fail-on-violation --fail-on-denial',
+    ],
+  },
   simulate: {
     name: 'agentguard simulate',
     description: 'Simulate an action and display predicted impact without executing',
@@ -212,6 +229,17 @@ async function main() {
       break;
     }
 
+    case 'ci-check': {
+      if (wantsHelp) {
+        console.log(formatHelp(COMMANDS['ci-check']));
+        break;
+      }
+      const { ciCheck } = await import('./commands/ci-check.js');
+      const code = await ciCheck(args.slice(1));
+      process.exit(code);
+      break;
+    }
+
     case 'simulate': {
       if (wantsHelp) {
         console.log(formatHelp(COMMANDS.simulate));
@@ -307,6 +335,10 @@ function printHelp(): void {
     agentguard plugin install <path>          Install a plugin from a local path
     agentguard plugin remove <id>             Remove a plugin by ID
     agentguard plugin search [query]          Search for plugins on npm
+
+  \x1b[1mCI/CD:\x1b[0m
+    agentguard ci-check <session>             Verify governance session in CI
+    agentguard ci-check --last                Check most recent run locally
 
   \x1b[1mIntegration:\x1b[0m
     agentguard claude-init                    Set up Claude Code hook integration

--- a/src/cli/commands/ci-check.ts
+++ b/src/cli/commands/ci-check.ts
@@ -1,0 +1,227 @@
+// CLI command: agentguard ci-check — CI governance verification.
+//
+// Reads an exported governance session (or the most recent local run),
+// summarises governance outcomes, and exits with code 1 when violations
+// or denials exceed the configured threshold. Designed for CI pipelines.
+
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { parseArgs } from '../args.js';
+import {
+  loadReplaySession,
+  getLatestRunId,
+  buildReplaySession,
+} from '../../kernel/replay-engine.js';
+import type { ReplaySession } from '../../kernel/replay-engine.js';
+import type { DomainEvent } from '../../core/types.js';
+import type { GovernanceExportHeader } from './export.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CiCheckResult {
+  readonly runId: string;
+  readonly totalActions: number;
+  readonly allowed: number;
+  readonly denied: number;
+  readonly violations: number;
+  readonly escalations: number;
+  readonly denialReasons: readonly string[];
+  readonly pass: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Session Loading
+// ---------------------------------------------------------------------------
+
+/**
+ * Load a replay session from an exported `.agentguard.jsonl` file.
+ * Parses the header, extracts events, and builds a ReplaySession.
+ */
+function loadSessionFromExport(filePath: string): ReplaySession | null {
+  const content = readFileSync(filePath, 'utf8');
+  const lines = content.split('\n').filter((l) => l.trim());
+
+  if (lines.length === 0) return null;
+
+  let header: GovernanceExportHeader;
+  try {
+    header = JSON.parse(lines[0]) as GovernanceExportHeader;
+  } catch {
+    return null;
+  }
+
+  if (header.__agentguard_export !== true || header.version !== 1) {
+    return null;
+  }
+
+  const eventLines = lines.slice(1, 1 + header.eventCount);
+  const events: DomainEvent[] = [];
+  for (const line of eventLines) {
+    try {
+      events.push(JSON.parse(line) as DomainEvent);
+    } catch {
+      // Skip malformed lines
+    }
+  }
+
+  if (events.length === 0) return null;
+
+  return buildReplaySession(header.runId, events);
+}
+
+// ---------------------------------------------------------------------------
+// Core Logic
+// ---------------------------------------------------------------------------
+
+function evaluateSession(
+  session: ReplaySession,
+  options: { failOnViolation: boolean; failOnDenial: boolean }
+): CiCheckResult {
+  const { summary } = session;
+
+  let pass = true;
+  if (options.failOnDenial && summary.denied > 0) {
+    pass = false;
+  }
+  if (options.failOnViolation && summary.violations > 0) {
+    pass = false;
+  }
+
+  return {
+    runId: session.runId,
+    totalActions: summary.totalActions,
+    allowed: summary.allowed,
+    denied: summary.denied,
+    violations: summary.violations,
+    escalations: summary.escalations,
+    denialReasons: summary.denialReasons,
+    pass,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Output Formatting
+// ---------------------------------------------------------------------------
+
+function formatTerminal(result: CiCheckResult): string {
+  const icon = result.pass ? '\x1b[32m\u2713\x1b[0m' : '\x1b[31m\u2717\x1b[0m';
+  const verdict = result.pass ? '\x1b[32mPASS\x1b[0m' : '\x1b[31mFAIL\x1b[0m';
+
+  const lines: string[] = [];
+  lines.push('');
+  lines.push(`  ${icon} Governance CI Check — ${verdict}`);
+  lines.push(`  Run: ${result.runId}`);
+  lines.push('');
+  lines.push(`  Actions:     ${result.totalActions}`);
+  lines.push(`  Allowed:     ${result.allowed}`);
+  lines.push(`  Denied:      ${result.denied}`);
+  lines.push(`  Violations:  ${result.violations}`);
+  lines.push(`  Escalations: ${result.escalations}`);
+
+  if (result.denialReasons.length > 0) {
+    lines.push('');
+    lines.push('  Denial reasons:');
+    for (const reason of result.denialReasons) {
+      lines.push(`    - ${reason}`);
+    }
+  }
+
+  lines.push('');
+  return lines.join('\n');
+}
+
+function formatGitHubAnnotation(result: CiCheckResult): string {
+  const lines: string[] = [];
+
+  if (!result.pass) {
+    const reasons = result.denialReasons.join('; ');
+    lines.push(
+      `::error title=Governance Check Failed::${result.denied} action(s) denied, ${result.violations} violation(s). ${reasons}`
+    );
+  }
+
+  // Always output summary as a notice
+  lines.push(
+    `::notice title=Governance Summary::Actions: ${result.totalActions} | Allowed: ${result.allowed} | Denied: ${result.denied} | Violations: ${result.violations} | Escalations: ${result.escalations}`
+  );
+
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// CLI Entry Point
+// ---------------------------------------------------------------------------
+
+export async function ciCheck(args: string[]): Promise<number> {
+  const parsed = parseArgs(args, {
+    boolean: ['--fail-on-violation', '--fail-on-denial', '--json', '--last'],
+    string: ['--base-dir'],
+    alias: { '-d': '--base-dir' },
+  });
+
+  const failOnViolation = !!parsed.flags['fail-on-violation'];
+  const failOnDenial = !!parsed.flags['fail-on-denial'];
+  const jsonOutput = !!parsed.flags.json;
+  const useLast = !!parsed.flags.last;
+  const baseDir = (parsed.flags['base-dir'] as string) || '.agentguard';
+  const sessionFile = parsed.positional[0];
+  const isGitHubActions = !!process.env.GITHUB_ACTIONS;
+
+  // Resolve the session
+  let session: ReplaySession | null = null;
+
+  if (sessionFile) {
+    const resolvedPath = resolve(sessionFile);
+    if (!existsSync(resolvedPath)) {
+      process.stderr.write(`\n  \x1b[31mError:\x1b[0m Session file not found: ${resolvedPath}\n\n`);
+      return 1;
+    }
+    session = loadSessionFromExport(resolvedPath);
+    if (!session) {
+      process.stderr.write(
+        `\n  \x1b[31mError:\x1b[0m Could not parse session file: ${resolvedPath}\n\n`
+      );
+      return 1;
+    }
+  } else if (useLast) {
+    const runId = getLatestRunId(baseDir);
+    if (!runId) {
+      process.stderr.write('\n  \x1b[31mError:\x1b[0m No governance runs found.\n\n');
+      return 1;
+    }
+    session = loadReplaySession(runId, { baseDir });
+    if (!session) {
+      process.stderr.write(`\n  \x1b[31mError:\x1b[0m Could not load run: ${runId}\n\n`);
+      return 1;
+    }
+  } else {
+    process.stderr.write('\n  Usage: agentguard ci-check <session-file> [flags]\n');
+    process.stderr.write('         agentguard ci-check --last [flags]\n\n');
+    process.stderr.write('  Flags:\n');
+    process.stderr.write('    --fail-on-violation   Exit 1 if invariant violations found\n');
+    process.stderr.write('    --fail-on-denial      Exit 1 if any actions were denied\n');
+    process.stderr.write('    --json                Output as JSON\n');
+    process.stderr.write('    --last                Use the most recent local run\n');
+    process.stderr.write('    --base-dir, -d <dir>  Base directory for events\n\n');
+    return 1;
+  }
+
+  // Evaluate
+  const result = evaluateSession(session, { failOnViolation, failOnDenial });
+
+  // Output
+  if (jsonOutput) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+  } else {
+    process.stderr.write(formatTerminal(result));
+  }
+
+  // GitHub Actions annotations
+  if (isGitHubActions) {
+    process.stdout.write(formatGitHubAnnotation(result) + '\n');
+  }
+
+  return result.pass ? 0 : 1;
+}

--- a/tests/ts/cli-ci-check.test.ts
+++ b/tests/ts/cli-ci-check.test.ts
@@ -1,0 +1,270 @@
+// Tests for the agentguard ci-check CLI command
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('node:fs', () => ({
+  readFileSync: vi.fn(),
+  existsSync: vi.fn(),
+  readdirSync: vi.fn(),
+}));
+
+vi.mock('../../src/kernel/replay-engine.js', () => ({
+  loadReplaySession: vi.fn(),
+  getLatestRunId: vi.fn(),
+  buildReplaySession: vi.fn(),
+}));
+
+import { ciCheck } from '../../src/cli/commands/ci-check.js';
+import { readFileSync, existsSync } from 'node:fs';
+import {
+  loadReplaySession,
+  getLatestRunId,
+  buildReplaySession,
+} from '../../src/kernel/replay-engine.js';
+
+function makeReplaySession(overrides: Record<string, unknown> = {}) {
+  return {
+    runId: 'run_test_123',
+    events: [],
+    actions: [],
+    startEvent: null,
+    endEvent: null,
+    summary: {
+      totalActions: 10,
+      allowed: 8,
+      denied: 2,
+      executed: 8,
+      failed: 0,
+      violations: 1,
+      escalations: 0,
+      simulationsRun: 0,
+      durationMs: 5000,
+      actionTypes: { 'file.write': 5, 'git.push': 3, 'shell.exec': 2 },
+      denialReasons: ['Protected branch violation', 'Blast radius exceeded'],
+      ...overrides,
+    },
+  };
+}
+
+function makeExportFile(eventCount = 2, runId = 'run_export_1') {
+  const header = {
+    __agentguard_export: true,
+    version: 1,
+    runId,
+    exportedAt: Date.now(),
+    eventCount,
+    decisionCount: 0,
+  };
+
+  const events = Array.from({ length: eventCount }, (_, i) => ({
+    id: `evt_${i}`,
+    kind: i === 0 ? 'ActionRequested' : 'ActionAllowed',
+    timestamp: 1700000000000 + i * 1000,
+    fingerprint: `fp_${i}`,
+    actionType: 'file.write',
+    target: 'src/test.ts',
+    justification: 'testing',
+  }));
+
+  return [JSON.stringify(header), ...events.map((e) => JSON.stringify(e))].join('\n') + '\n';
+}
+
+let stderrOutput: string[];
+let stdoutOutput: string[];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  stderrOutput = [];
+  stdoutOutput = [];
+  vi.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
+    stderrOutput.push(String(chunk));
+    return true;
+  });
+  vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+    stdoutOutput.push(String(chunk));
+    return true;
+  });
+  // Ensure GITHUB_ACTIONS is not set during tests
+  delete process.env.GITHUB_ACTIONS;
+});
+
+describe('ciCheck CLI', () => {
+  it('shows usage when no arguments provided', async () => {
+    const code = await ciCheck([]);
+
+    expect(code).toBe(1);
+    expect(stderrOutput.join('')).toContain('Usage:');
+  });
+
+  it('loads a session from exported file', async () => {
+    const session = makeReplaySession({ denied: 0, violations: 0 });
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(makeExportFile());
+    vi.mocked(buildReplaySession).mockReturnValue(session as never);
+
+    const code = await ciCheck(['session.agentguard.jsonl']);
+
+    expect(code).toBe(0);
+    expect(buildReplaySession).toHaveBeenCalledWith('run_export_1', expect.any(Array));
+    expect(stderrOutput.join('')).toContain('PASS');
+  });
+
+  it('errors when session file not found', async () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    const code = await ciCheck(['missing.jsonl']);
+
+    expect(code).toBe(1);
+    expect(stderrOutput.join('')).toContain('Session file not found');
+  });
+
+  it('errors when session file is invalid', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue('not-json\n');
+
+    const code = await ciCheck(['bad.jsonl']);
+
+    expect(code).toBe(1);
+    expect(stderrOutput.join('')).toContain('Could not parse');
+  });
+
+  it('uses --last to load most recent local run', async () => {
+    const session = makeReplaySession({ denied: 0, violations: 0 });
+    vi.mocked(getLatestRunId).mockReturnValue('run_latest_1');
+    vi.mocked(loadReplaySession).mockReturnValue(session as never);
+
+    const code = await ciCheck(['--last']);
+
+    expect(code).toBe(0);
+    expect(getLatestRunId).toHaveBeenCalledWith('.agentguard');
+    expect(loadReplaySession).toHaveBeenCalledWith('run_latest_1', { baseDir: '.agentguard' });
+  });
+
+  it('errors when --last and no runs found', async () => {
+    vi.mocked(getLatestRunId).mockReturnValue(undefined as never);
+
+    const code = await ciCheck(['--last']);
+
+    expect(code).toBe(1);
+    expect(stderrOutput.join('')).toContain('No governance runs found');
+  });
+
+  it('passes when no violations and --fail-on-violation set', async () => {
+    const session = makeReplaySession({ denied: 0, violations: 0 });
+    vi.mocked(getLatestRunId).mockReturnValue('run_clean');
+    vi.mocked(loadReplaySession).mockReturnValue(session as never);
+
+    const code = await ciCheck(['--last', '--fail-on-violation']);
+
+    expect(code).toBe(0);
+    expect(stderrOutput.join('')).toContain('PASS');
+  });
+
+  it('fails when violations exist and --fail-on-violation set', async () => {
+    const session = makeReplaySession({ violations: 3 });
+    vi.mocked(getLatestRunId).mockReturnValue('run_bad');
+    vi.mocked(loadReplaySession).mockReturnValue(session as never);
+
+    const code = await ciCheck(['--last', '--fail-on-violation']);
+
+    expect(code).toBe(1);
+    expect(stderrOutput.join('')).toContain('FAIL');
+  });
+
+  it('passes when violations exist but --fail-on-violation not set', async () => {
+    const session = makeReplaySession({ violations: 3, denied: 0 });
+    vi.mocked(getLatestRunId).mockReturnValue('run_violations');
+    vi.mocked(loadReplaySession).mockReturnValue(session as never);
+
+    const code = await ciCheck(['--last']);
+
+    expect(code).toBe(0);
+  });
+
+  it('fails when denials exist and --fail-on-denial set', async () => {
+    const session = makeReplaySession({ denied: 5, violations: 0 });
+    vi.mocked(getLatestRunId).mockReturnValue('run_denied');
+    vi.mocked(loadReplaySession).mockReturnValue(session as never);
+
+    const code = await ciCheck(['--last', '--fail-on-denial']);
+
+    expect(code).toBe(1);
+  });
+
+  it('passes when no denials and --fail-on-denial set', async () => {
+    const session = makeReplaySession({ denied: 0, violations: 0 });
+    vi.mocked(getLatestRunId).mockReturnValue('run_clean');
+    vi.mocked(loadReplaySession).mockReturnValue(session as never);
+
+    const code = await ciCheck(['--last', '--fail-on-denial']);
+
+    expect(code).toBe(0);
+  });
+
+  it('outputs JSON when --json flag set', async () => {
+    const session = makeReplaySession();
+    vi.mocked(getLatestRunId).mockReturnValue('run_json');
+    vi.mocked(loadReplaySession).mockReturnValue(session as never);
+
+    const code = await ciCheck(['--last', '--json']);
+
+    const output = stdoutOutput.join('');
+    const result = JSON.parse(output);
+    expect(result.runId).toBe('run_test_123');
+    expect(result.totalActions).toBe(10);
+    expect(result.allowed).toBe(8);
+    expect(result.denied).toBe(2);
+    expect(result.violations).toBe(1);
+    expect(result.pass).toBe(true); // no --fail flags
+    expect(code).toBe(0);
+  });
+
+  it('outputs GitHub Actions annotations when GITHUB_ACTIONS is set', async () => {
+    process.env.GITHUB_ACTIONS = 'true';
+    const session = makeReplaySession({ denied: 1, violations: 1 });
+    vi.mocked(getLatestRunId).mockReturnValue('run_ci');
+    vi.mocked(loadReplaySession).mockReturnValue(session as never);
+
+    const code = await ciCheck(['--last', '--fail-on-violation']);
+
+    const output = stdoutOutput.join('');
+    expect(output).toContain('::error title=Governance Check Failed');
+    expect(output).toContain('::notice title=Governance Summary');
+    expect(code).toBe(1);
+
+    delete process.env.GITHUB_ACTIONS;
+  });
+
+  it('shows denial reasons in terminal output', async () => {
+    const session = makeReplaySession();
+    vi.mocked(getLatestRunId).mockReturnValue('run_reasons');
+    vi.mocked(loadReplaySession).mockReturnValue(session as never);
+
+    await ciCheck(['--last']);
+
+    const output = stderrOutput.join('');
+    expect(output).toContain('Protected branch violation');
+    expect(output).toContain('Blast radius exceeded');
+  });
+
+  it('uses custom --base-dir', async () => {
+    const session = makeReplaySession({ denied: 0, violations: 0 });
+    vi.mocked(getLatestRunId).mockReturnValue('run_custom');
+    vi.mocked(loadReplaySession).mockReturnValue(session as never);
+
+    await ciCheck(['--last', '--base-dir', '/custom/path']);
+
+    expect(getLatestRunId).toHaveBeenCalledWith('/custom/path');
+    expect(loadReplaySession).toHaveBeenCalledWith('run_custom', { baseDir: '/custom/path' });
+  });
+
+  it('combines --fail-on-violation and --fail-on-denial', async () => {
+    // Violations but no denials — should still fail
+    const session = makeReplaySession({ denied: 0, violations: 2 });
+    vi.mocked(getLatestRunId).mockReturnValue('run_combo');
+    vi.mocked(loadReplaySession).mockReturnValue(session as never);
+
+    const code = await ciCheck(['--last', '--fail-on-violation', '--fail-on-denial']);
+
+    expect(code).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `agentguard ci-check` CLI command for CI governance verification of exported sessions
- Create reusable GitHub Actions workflow (`.github/workflows/agentguard-governance.yml`) that other repos can reference via `workflow_call`
- Closes #130

## Changes
- `src/cli/commands/ci-check.ts` — New CI check command: loads exported sessions or local runs, evaluates governance outcomes, outputs terminal/JSON/GitHub Actions annotations
- `src/cli/bin.ts` — Register `ci-check` command in CLI router and help output
- `.github/workflows/agentguard-governance.yml` — Reusable workflow with configurable inputs (policy file, session file, fail-on-violation, fail-on-denial, agentguard version, node version)
- `tests/ts/cli-ci-check.test.ts` — 16 comprehensive tests covering all flags, error paths, and output modes

## Test Plan
- [x] TypeScript build passes (`npm run build:ts`)
- [x] Vitest tests pass (`npm run ts:test`) — 980 pass / 0 fail
- [x] JS tests pass (`npm test`) — 210 pass / 0 fail
- [x] ESLint clean (`npm run lint`) — 0 errors
- [x] Type-check clean (`npm run ts:check`)

## Governance Report

| Metric | Count |
|--------|-------|
| Total events | 380 |
| Actions allowed | 108 |
| Actions denied | 3 |
| Policy denials | 3 |
| Invariant violations | 2 |

<details>
<summary>Telemetry details</summary>

Source: `.agentguard/events/` and `logs/runtime-events.jsonl`

No notable denials for this session — all denials were from prior governance sessions in the event store.

</details>