### PR TITLE
feat(issue-177): deny actions with no registered adapter

### DIFF
--- a/src/kernel/kernel.ts
+++ b/src/kernel/kernel.ts
@@ -411,6 +411,73 @@ export function createKernel(config: KernelConfig = {}): Kernel {
             });
             allEvents.push(failedEvent);
           }
+        } else {
+          // Deny actions with no registered adapter — close the audit trail gap
+          const adapterReason = !actionClass
+            ? `No action class for type: ${action.type}`
+            : `No adapter registered for action class: ${actionClass}`;
+
+          const noAdapterDeniedEvent = createEvent(ACTION_DENIED, {
+            actionType: action.type,
+            target: action.target,
+            reason: `no_registered_adapter: ${adapterReason}`,
+            actionId: action.id,
+            metadata: { runId, noAdapter: true },
+          });
+          allEvents.push(noAdapterDeniedEvent);
+          sinkEvents(allEvents);
+
+          const noAdapterSimSummary = simulationResult
+            ? {
+                predictedChanges: simulationResult.predictedChanges,
+                blastRadius: simulationResult.blastRadius,
+                riskLevel: simulationResult.riskLevel,
+                simulatorId: simulationResult.simulatorId,
+                durationMs: simulationResult.durationMs,
+                forecast: forecast || undefined,
+              }
+            : null;
+
+          const noAdapterDecisionRecord = buildDecisionRecord({
+            runId,
+            decision: {
+              ...decision,
+              allowed: false,
+              decision: {
+                ...decision.decision,
+                reason: `no_registered_adapter: ${adapterReason}`,
+              },
+            },
+            execution: null,
+            executionDurationMs: null,
+            simulation: noAdapterSimSummary,
+          });
+          sinkDecision(noAdapterDecisionRecord);
+
+          const noAdapterDecisionEvent = createEvent(DECISION_RECORDED, {
+            recordId: noAdapterDecisionRecord.recordId,
+            outcome: 'deny',
+            actionType: noAdapterDecisionRecord.action.type,
+            target: noAdapterDecisionRecord.action.target,
+            reason: `no_registered_adapter`,
+          });
+          sinkEvent(noAdapterDecisionEvent);
+
+          const noAdapterResult: KernelResult = {
+            allowed: false,
+            executed: false,
+            decision: {
+              ...decision,
+              allowed: false,
+            },
+            execution: null,
+            action,
+            events: allEvents,
+            runId,
+            decisionRecord: noAdapterDecisionRecord,
+          };
+          actionLog.push(noAdapterResult);
+          return noAdapterResult;
         }
       }
 

--- a/tests/ts/kernel.test.ts
+++ b/tests/ts/kernel.test.ts
@@ -205,6 +205,113 @@ describe('Kernel with seeded RNG', () => {
   });
 });
 
+describe('Kernel denies actions with no registered adapter', () => {
+  it('denies when no adapter is registered for the action class', async () => {
+    // Use an empty adapter registry (no adapters registered at all)
+    const { createAdapterRegistry } = await import('../../src/core/adapters.js');
+    const emptyRegistry = createAdapterRegistry();
+
+    const sunkEvents: DomainEvent[] = [];
+    const testSink: EventSink = {
+      write(event) {
+        sunkEvents.push(event);
+      },
+    };
+
+    const kernel = createKernel({
+      adapters: emptyRegistry,
+      sinks: [testSink],
+    });
+
+    // file.read is allowed by default policy, but 'file' class has no adapter
+    const result = await kernel.propose({
+      tool: 'Read',
+      file: 'src/index.ts',
+      agent: 'test-agent',
+    });
+
+    expect(result.allowed).toBe(false);
+    expect(result.executed).toBe(false);
+    expect(result.action).not.toBeNull();
+
+    // Should have an ActionDenied event with no_registered_adapter reason
+    const deniedEvents = result.events.filter((e) => e.kind === 'ActionDenied');
+    expect(deniedEvents.length).toBe(1);
+    expect((deniedEvents[0] as Record<string, unknown>).reason).toContain('no_registered_adapter');
+  });
+
+  it('sinks denial events to configured sinks', async () => {
+    const { createAdapterRegistry } = await import('../../src/core/adapters.js');
+    const emptyRegistry = createAdapterRegistry();
+
+    const sunkEvents: DomainEvent[] = [];
+    const testSink: EventSink = {
+      write(event) {
+        sunkEvents.push(event);
+      },
+    };
+
+    const kernel = createKernel({
+      adapters: emptyRegistry,
+      sinks: [testSink],
+    });
+
+    await kernel.propose({
+      tool: 'Read',
+      file: 'src/index.ts',
+      agent: 'test-agent',
+    });
+
+    // Should have sunk ActionDenied and DecisionRecorded events
+    const deniedSunk = sunkEvents.filter((e) => e.kind === 'ActionDenied');
+    const decisionSunk = sunkEvents.filter((e) => e.kind === 'DecisionRecorded');
+    expect(deniedSunk.length).toBe(1);
+    expect(decisionSunk.length).toBe(1);
+    expect((decisionSunk[0] as Record<string, unknown>).outcome).toBe('deny');
+    expect((decisionSunk[0] as Record<string, unknown>).reason).toBe('no_registered_adapter');
+  });
+
+  it('includes decision record in kernel result', async () => {
+    const { createAdapterRegistry } = await import('../../src/core/adapters.js');
+    const emptyRegistry = createAdapterRegistry();
+
+    const kernel = createKernel({ adapters: emptyRegistry });
+
+    const result = await kernel.propose({
+      tool: 'Write',
+      file: 'test.txt',
+      agent: 'test-agent',
+    });
+
+    expect(result.allowed).toBe(false);
+    expect(result.decisionRecord).toBeDefined();
+    expect(result.decisionRecord?.outcome).toBe('deny');
+  });
+
+  it('records no-adapter denial in action log', async () => {
+    const { createAdapterRegistry } = await import('../../src/core/adapters.js');
+    const emptyRegistry = createAdapterRegistry();
+
+    const kernel = createKernel({ adapters: emptyRegistry });
+
+    await kernel.propose({
+      tool: 'Read',
+      file: 'a.ts',
+      agent: 'test',
+    });
+    await kernel.propose({
+      tool: 'Write',
+      file: 'b.ts',
+      agent: 'test',
+    });
+
+    const log = kernel.getActionLog();
+    expect(log.length).toBe(2);
+    expect(log[0].allowed).toBe(false);
+    expect(log[1].allowed).toBe(false);
+  });
+});
+
 describe('Kernel with policies', () => {
   const strictPolicy: KernelConfig = {
     dryRun: true,


### PR DESCRIPTION
## Summary
- Add explicit denial when the kernel encounters an action whose class has no registered adapter, closing an audit trail gap where allowed-but-unexecutable actions were silently skipped
- Emits `ActionDenied` event with reason `no_registered_adapter` and builds a `GovernanceDecisionRecord` for full traceability
- Closes #177

## Changes
- `src/kernel/kernel.ts` — Added else branch in the adapter execution check (line ~414) to deny and return early when no adapter is found for the action class, with full event and decision record emission
- `tests/ts/kernel.test.ts` — Added 4 tests in new `Kernel denies actions with no registered adapter` describe block covering denial behavior, event sinking, decision records, and action log tracking

## Test Plan
- [x] TypeScript build passes (`npm run build:ts`)
- [x] Vitest tests pass (`npm run ts:test`) — 1047/1047
- [x] JS tests pass (`npm test`) — 210/210
- [x] ESLint clean (`npm run lint`) — 0 errors
- [x] Prettier clean (`npm run format`)

## Governance Report

| Metric | Count |
|--------|-------|
| Total events | 450 |
| Actions allowed | 124 |
| Actions denied | 4 |
| Policy denials | 4 |
| Invariant violations | 2 |

<details>
<summary>Telemetry details</summary>

Source: `.agentguard/events/` and `logs/runtime-events.jsonl`

No notable denials or violations related to this implementation — all denials were from prior sessions.

</details>