### PR TITLE
docs: sync documentation with codebase state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ src/
 │   ├── replay.ts           # Session replay logic
 │   ├── session-store.ts    # Session management
 │   ├── file-event-store.ts # File-based event persistence
-│   └── commands/           # analytics, guard, inspect, replay, export, import, simulate, plugin, claude-hook, claude-init
+│   └── commands/           # analytics, guard, inspect, replay, export, import, simulate, ci-check, plugin, claude-hook, claude-init
 ├── plugins/                # Plugin ecosystem
 │   ├── discovery.ts        # Plugin discovery mechanism
 │   ├── registry.ts         # Plugin registry
@@ -133,7 +133,7 @@ vscode-extension/              # VS Code extension
 
 tests/
 ├── *.test.js               # 14 JS test files (custom zero-dependency harness)
-└── ts/*.test.ts            # 57 TS test files (vitest)
+└── ts/*.test.ts            # 58 TS test files (vitest)
 policy/                     # Policy configuration (JSON: action_rules, capabilities)
 policies/                   # Policy packs (YAML: ci-safe, enterprise, open-source, strict)
 docs/                       # System documentation (architecture, event model, specs)
@@ -207,6 +207,7 @@ Each top-level directory maps to a single architectural concept:
 - `agentguard replay` — Replay a governance session timeline
 - `agentguard plugin list|install|remove|search` — Manage plugins
 - `agentguard simulate <action-json>` — Simulate an action and display predicted impact without executing
+- `agentguard ci-check <session-file>` — CI governance verification (check a session for violations)
 - `agentguard claude-hook` — Handle Claude Code PreToolUse/PostToolUse hook events
 - `agentguard claude-init` — Set up Claude Code hook integration
 
@@ -274,8 +275,8 @@ npm run test:coverage      # Run with coverage (c8, 50% line threshold)
 
 **Test structure:**
 - **JS tests** (`tests/*.test.js`): 14 files using a custom zero-dependency harness (`tests/run.js` with `node:assert`)
-- **TypeScript tests** (`tests/ts/*.test.ts`): 57 files using vitest
-- **Coverage areas**: adapters, analytics, kernel (AAB, engine, monitor, blast radius, integration, e2e pipeline), CLI commands (args, guard, inspect, simulate, claude-hook, claude-init, export/import), decision records, domain models, events, evidence packs, execution log, impact forecast, invariants, JSONL persistence, notification formatter, plugins (discovery, registry, validation), policy evaluation (including pack loader, policy packs, evaluation trace), renderers, replay (engine, comparator, processor), simulation, telemetry, TUI renderer, violation mapper, VS Code event reader, YAML loading
+- **TypeScript tests** (`tests/ts/*.test.ts`): 58 files using vitest
+- **Coverage areas**: adapters, analytics, kernel (AAB, engine, monitor, blast radius, integration, e2e pipeline), CLI commands (args, guard, inspect, simulate, ci-check, claude-hook, claude-init, export/import), decision records, domain models, events, evidence packs, execution log, impact forecast, invariants, JSONL persistence, notification formatter, plugins (discovery, registry, validation), policy evaluation (including pack loader, policy packs, evaluation trace), renderers, replay (engine, comparator, processor), simulation, telemetry, TUI renderer, violation mapper, VS Code event reader, YAML loading
 
 ## CI/CD & Automation
 
@@ -285,4 +286,5 @@ npm run test:coverage      # Run with coverage (c8, 50% line threshold)
 |----------|---------|---------|
 | `size-check.yml` | PR (ignoring docs/markdown) | Runs linting, type-checking, tests, and size checks |
 | `publish.yml` | GitHub Release published | Validates version, runs tests, publishes npm package with provenance |
+| `agentguard-governance.yml` | Reusable workflow (called from other repos) | CI governance verification for sessions |
 | `codeql.yml` | PR to `main`/`master` + weekly schedule | CodeQL security analysis |

--- a/README.md
+++ b/README.md
@@ -153,6 +153,10 @@ agentguard plugin search [query]          # Search for plugins on npm
 agentguard simulate <action-json>         # Simulate action and show predicted impact
 agentguard simulate --action <type>       # Simulate by action type and flags
 
+# === CI/CD ===
+agentguard ci-check <session>             # Verify governance session for violations
+agentguard ci-check --last                # Check most recent run locally
+
 # === Integration ===
 agentguard claude-init                    # Set up Claude Code hook integration
 agentguard help                           # Show all commands
@@ -262,7 +266,7 @@ src/
 │   └── index.ts            # Module re-exports
 ├── cli/                    # CLI entry point + commands
 │   ├── bin.ts              # Main entry
-│   └── commands/           # analytics, guard, inspect, replay, export, import, simulate, plugin, claude-hook, claude-init
+│   └── commands/           # analytics, guard, inspect, replay, export, import, simulate, ci-check, plugin, claude-hook, claude-init
 ├── telemetry/              # Runtime telemetry and logging
 └── core/                   # Shared utilities (types, actions, hash, rng, execution-log)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -76,7 +76,7 @@ A comprehensive codebase audit assessed the current system against the strategic
 | Cross-session Analytics (aggregation, clustering, trends) | Implemented | `src/analytics/` |
 | Plugin Ecosystem (discovery, registry, validation) | Implemented | `src/plugins/` |
 | Renderer Plugin System | Implemented | `src/renderers/` |
-| CLI (guard, inspect, events, replay, export, import, simulate, analytics, plugin, claude-hook, claude-init) | Implemented | `src/cli/` |
+| CLI (guard, inspect, events, replay, export, import, simulate, ci-check, analytics, plugin, claude-hook, claude-init) | Implemented | `src/cli/` |
 | Claude Code Hook Integration | Implemented | `src/adapters/claude-code.ts` |
 | VS Code Extension (sidebar panels, event reader, inline diagnostics) | Implemented | `vscode-extension/` |
 | Policy Pack Loader | Implemented | `src/policy/pack-loader.ts` |
@@ -102,7 +102,7 @@ A comprehensive codebase audit assessed the current system against the strategic
 | Item | Status | Maturity |
 |---|---|---|
 | Canonical Action Representation | Implemented | Production |
-| AAB Reference Monitor | Implemented | 2 bypass vectors to close |
+| AAB Reference Monitor | Implemented | 1 bypass vector to close (missing-adapter fixed) |
 | Policy Evaluator | Implemented | Production |
 | 8 Built-in Invariants | Fully Implemented | Production |
 | Event Model (45 kinds) | Comprehensive | Production |
@@ -243,7 +243,7 @@ Phases are ordered to prioritize **effect-path closure and mandatory mediation**
 This is the architectural hinge. These changes transform the AAB from advisory interception to mandatory execution control.
 
 - [ ] Default-deny unknown actions in `src/policy/evaluator.ts` (change fallback from `allowed: true` to `allowed: false`)
-- [ ] Deny actions with no registered adapter in `src/kernel/kernel.ts` (emit `ActionDenied` instead of silently skipping)
+- [x] Deny actions with no registered adapter in `src/kernel/kernel.ts` (emit `ActionDenied` instead of silently skipping)
 - [ ] Persist escalation state changes as `StateChanged` DomainEvents in `src/kernel/monitor.ts`
 - [ ] Expand destructive command patterns in `src/kernel/aab.ts` (add 15+ patterns covering sudo, pkill, docker, systemctl, database commands)
 - [ ] Enforce intervention types beyond DENY (implement PAUSE and ROLLBACK behaviors in kernel execution)
@@ -314,7 +314,7 @@ The JSONL persistence layer was the right starting point — append-only, human-
 
 > **Theme:** Governance gates in the delivery pipeline
 
-- [ ] GitHub Actions integration (reusable workflow)
+- [x] GitHub Actions integration (reusable workflow)
 - [ ] Pre-merge policy validation (block PRs that violate policy)
 - [ ] CI replay verification (replay governance session in CI)
 - [ ] Evidence packs attached to pull requests


### PR DESCRIPTION
## Summary

- Add `ci-check` CLI command documentation to CLAUDE.md, README.md, and ROADMAP.md
- Update TypeScript test file count from 57 to 58
- Add `agentguard-governance.yml` workflow to CI/CD table in CLAUDE.md
- Mark Phase 6 item "deny actions with no registered adapter" as completed (PR #194)
- Mark Phase 12 item "GitHub Actions reusable workflow" as completed (PR #174)
- Update maturity matrix: 1 bypass vector remaining (missing-adapter vector fixed)
- Add `cli-ci-check` to coverage areas list

## Changes

- **CLAUDE.md** — Updated test counts, CLI commands list, CI/CD table, coverage areas
- **README.md** — Added CI/CD subsection to CLI reference, updated commands list in repo structure
- **ROADMAP.md** — Marked 2 implemented items as done, updated CLI component list, updated maturity matrix

## Source

Auto-generated by the **Scheduled Docs Sync** skill.

---
*Run: 2026-03-10*