### PR TITLE
docs: sync documentation with codebase state

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -46,7 +46,7 @@ src/
 ├── analytics/     Cross-session violation analytics (aggregation, clustering, trends, risk scoring)
 ├── kernel/        Governed action kernel (orchestrate, normalize, decide, escalate)
 ├── events/        Canonical event model (schema, bus, store, JSONL persistence)
-├── policy/        Policy system (evaluator, loaders, pack loader)
+├── policy/        Policy system (composer, evaluator, loaders, pack loader)
 ├── invariants/    Invariant system (8 built-in definitions, checker)
 ├── adapters/      Execution adapters (file, shell, git, claude-code)
 ├── plugins/       Plugin ecosystem (discovery, registry, validation, sandboxing)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,7 @@ src/
 │   ├── jsonl.ts            # JSONL event persistence (audit trail)
 │   └── decision-jsonl.ts   # Decision record persistence
 ├── policy/                 # Policy system
+│   ├── composer.ts         # Policy composition (multi-file merging)
 │   ├── evaluator.ts        # Rule matching engine
 │   ├── loader.ts           # Policy validation + loading
 │   ├── pack-loader.ts      # Policy pack loader (community policy sets)
@@ -136,7 +137,7 @@ vscode-extension/              # VS Code extension
 
 tests/
 ├── *.test.js               # 14 JS test files (custom zero-dependency harness)
-└── ts/*.test.ts            # 61 TS test files (vitest)
+└── ts/*.test.ts            # 62 TS test files (vitest)
 policy/                     # Policy configuration (JSON: action_rules, capabilities)
 policies/                   # Policy packs (YAML: ci-safe, enterprise, open-source, strict)
 docs/                       # System documentation (architecture, event model, specs)
@@ -278,7 +279,7 @@ npm run test:coverage      # Run with coverage (c8, 50% line threshold)
 
 **Test structure:**
 - **JS tests** (`tests/*.test.js`): 14 files using a custom zero-dependency harness (`tests/run.js` with `node:assert`)
-- **TypeScript tests** (`tests/ts/*.test.ts`): 61 files using vitest
+- **TypeScript tests** (`tests/ts/*.test.ts`): 62 files using vitest
 - **Coverage areas**: adapters, analytics (including risk scorer), kernel (AAB, engine, monitor, blast radius, integration, e2e pipeline), CLI commands (args, guard, inspect, simulate, ci-check, claude-hook, claude-init, export/import, policy-validate), decision records, domain models, events, evidence packs, execution log, impact forecast, invariants, JSONL persistence, notification formatter, plugins (discovery, registry, validation), policy evaluation (including pack loader, policy packs, evaluation trace), renderers, replay (engine, comparator, processor), simulation, telemetry (including tracepoint), TUI renderer, violation mapper, VS Code event reader, YAML loading
 
 ## CI/CD & Automation

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ AgentGuard tracks repeated denials and invariant violations. If an agent repeate
 # === Governance ===
 agentguard guard                          # Start governed action runtime
 agentguard guard --policy <file>          # Use a specific policy file (YAML/JSON)
+agentguard guard --policy a --policy b   # Compose multiple policies with precedence
 agentguard guard --dry-run                # Evaluate without executing actions
 agentguard inspect [runId]                # Show action graph and decisions for a run
 agentguard inspect --last                 # Inspect most recent run
@@ -237,6 +238,7 @@ src/
 │   ├── jsonl.ts            # JSONL event persistence (audit trail)
 │   └── decision-jsonl.ts   # Decision record persistence
 ├── policy/                 # Policy system
+│   ├── composer.ts         # Policy composition (multi-file merging)
 │   ├── evaluator.ts        # Rule matching engine
 │   ├── loader.ts           # Policy validation + loading
 │   ├── pack-loader.ts      # Policy pack loader (community policy sets)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -60,7 +60,7 @@ A comprehensive codebase audit assessed the current system against the strategic
 | Action Authorization Boundary (AAB) | Implemented (2 bypass vectors) | `src/kernel/aab.ts` |
 | Policy Evaluator (two-phase deny/allow) | Implemented | `src/policy/evaluator.ts` |
 | 8 Built-in Invariants | Fully Implemented | `src/invariants/definitions.ts`, `src/invariants/checker.ts` |
-| Event Model (45 event kinds) | Comprehensive | `src/events/schema.ts` |
+| Event Model (46 event kinds) | Comprehensive | `src/events/schema.ts` |
 | JSONL Persistence | Implemented | `src/events/jsonl.ts` |
 | Simulation Engine (3 simulators + impact forecast) | Fully Implemented | `src/kernel/simulation/` |
 | Blast Radius Computation | Implemented | `src/kernel/blast-radius.ts` |
@@ -105,7 +105,7 @@ A comprehensive codebase audit assessed the current system against the strategic
 | AAB Reference Monitor | Implemented | 1 bypass vector to close (missing-adapter fixed) |
 | Policy Evaluator | Implemented | Production |
 | 8 Built-in Invariants | Fully Implemented | Production |
-| Event Model (45 kinds) | Comprehensive | Production |
+| Event Model (46 kinds) | Comprehensive | Production |
 | Simulation & Forecasting | Fully Implemented | Production |
 | Escalation State Machine | Implemented | Functional (events not persisted) |
 | Cross-session Analytics | Implemented | Functional (forensic only) |
@@ -264,8 +264,8 @@ This is the architectural hinge. These changes transform the AAB from advisory i
 > **Theme:** Shareable, composable, discoverable policies
 
 - [x] Policy templates for common scenarios (`policies/strict`, `policies/ci-safe`, `policies/enterprise`, `policies/open-source`)
-- [ ] Policy composition (multiple policy files merged with precedence)
-- [ ] Policy validation CLI (`agentguard policy validate <file>`)
+- [x] Policy composition (multiple policy files merged with precedence) (`src/policy/composer.ts`, `guard --policy a --policy b`)
+- [x] Policy validation CLI (`agentguard policy validate <file>`)
 - [ ] Community policy packs (SOC2, HIPAA, internal engineering standards)
 - [ ] Policy pack versioning and compatibility
 


### PR DESCRIPTION
## Summary

Automated documentation sync detected drift between codebase and docs after the policy composition feature (issue-190) was merged.

- Event kind count updated from 45 to 46 (`PolicyComposed` event added)
- New file `src/policy/composer.ts` added to structure trees across docs
- TS test file count updated from 61 to 62
- ROADMAP Phase 8 items marked complete (policy composition, policy validation CLI)
- Multi-policy composition (`--policy a --policy b`) added to README CLI section
- ARCHITECTURE.md policy directory description updated

## Changes

- **ROADMAP.md** — Event count 45→46 (2 places), Phase 8 checkboxes updated
- **CLAUDE.md** — Test count 61→62, `composer.ts` added to structure tree
- **README.md** — `composer.ts` added to structure tree, multi-policy CLI line added
- **ARCHITECTURE.md** — Policy directory description updated to include composer

## Source

Auto-generated by the **Scheduled Docs Sync** skill.

---
*Run: 2026-03-10*