### PR TITLE
fix: resolve claude-init hook path for esbuild bundle

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node C:\\Users\\jplev\\Documents\\GitHub\\agent-guard\\dist\\cli\\claude-hook.js pre"
+            "command": "node C:\\Users\\jplev\\Documents\\GitHub\\agent-guard\\dist\\cli\\commands\\claude-hook.js pre"
           }
         ]
       }
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node C:\\Users\\jplev\\Documents\\GitHub\\agent-guard\\dist\\cli\\claude-hook.js post"
+            "command": "node C:\\Users\\jplev\\Documents\\GitHub\\agent-guard\\dist\\cli\\commands\\claude-hook.js post"
           }
         ]
       }

--- a/src/cli/commands/claude-init.ts
+++ b/src/cli/commands/claude-init.ts
@@ -31,7 +31,11 @@ export async function claudeInit(args: string[] = []): Promise<void> {
   const isGlobal = args.includes('--global') || args.includes('-g');
   const isRemove = args.includes('--remove') || args.includes('--uninstall');
 
-  const hookScript = resolve(__dirname, 'claude-hook.js');
+  // Resolve hook script path — handles both tsc output (commands/) and esbuild bundle (cli/)
+  let hookScript = resolve(__dirname, 'claude-hook.js');
+  if (!existsSync(hookScript)) {
+    hookScript = resolve(__dirname, 'commands', 'claude-hook.js');
+  }
 
   const settingsDir = isGlobal ? join(homedir(), '.claude') : join(process.cwd(), '.claude');
   const settingsPath = join(settingsDir, 'settings.json');


### PR DESCRIPTION
## Summary
- **Bug**: `claude-init` generates a hook path (`dist/cli/claude-hook.js`) that doesn't exist when run from the esbuild bundle, because `__dirname` resolves to `dist/cli/` instead of `dist/cli/commands/`
- **Impact**: PreToolUse/PostToolUse hooks silently fail (MODULE_NOT_FOUND), leaving **no governance enforcement active** during Claude Code sessions
- **Fix**: Added fallback path resolution — checks `dist/cli/commands/claude-hook.js` when the initial `__dirname`-relative path doesn't exist. Also updated `.claude/settings.json` with the correct path.

## Test plan
- [x] `cli-claude-init.test.ts` — 11 tests pass
- [x] `cli-claude-hook.test.ts` — 12 tests pass
- [ ] Manual verification: restart Claude Code session and confirm `.agentguard/decisions/hook_*.jsonl` files are created on tool calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)