### PR TITLE
feat: enable SQLite storage for governance hooks

### DIFF
--- a/.claude/skills/start-governance-runtime.md
+++ b/.claude/skills/start-governance-runtime.md
@@ -6,23 +6,23 @@ Ensure the AgentGuard kernel is active and intercepting all tool calls before an
 
 ### 1. Check Hook Registration
 
-Read the local Claude Code settings and verify the PreToolUse governance hook is installed:
+Read the local Claude Code settings and verify the PreToolUse governance hook is installed with SQLite storage:
 
 ```bash
 cat .claude/settings.json 2>/dev/null
 ```
 
-Look for a `PreToolUse` entry whose command contains `claude-hook`. If the file does not exist or does not contain the hook, proceed to step 2. If it does, skip to step 3.
+Look for a `PreToolUse` entry whose command contains `claude-hook` and `--store sqlite`. If the file does not exist, does not contain the hook, or the hook is missing `--store sqlite`, proceed to step 2. If it does, skip to step 3.
 
 ### 2. Install Hooks
 
-Run the AgentGuard hook installer:
+Run the AgentGuard hook installer with SQLite storage:
 
 ```bash
-npx agentguard claude-init
+npx agentguard claude-init --remove 2>/dev/null; npx agentguard claude-init --store sqlite
 ```
 
-This writes both PreToolUse (governance enforcement for all tools) and PostToolUse (Bash error monitoring) hooks into `.claude/settings.json`. The command is idempotent — if hooks already exist it reports "Already configured."
+This writes both PreToolUse (governance enforcement for all tools) and PostToolUse (Bash error monitoring) hooks into `.claude/settings.json`, configured to persist governance data to SQLite (`.agentguard/agentguard.db`). The `--remove` ensures any existing hooks without SQLite are replaced.
 
 If installation fails, STOP. Do not proceed with development work without governance.
 
@@ -31,11 +31,11 @@ If installation fails, STOP. Do not proceed with development work without govern
 Ensure the telemetry output paths exist:
 
 ```bash
-mkdir -p .agentguard/events logs
+mkdir -p .agentguard logs
 ```
 
 These directories are used by:
-- `.agentguard/events/<runId>.jsonl` — per-run governance event logs
+- `.agentguard/agentguard.db` — SQLite governance database (events, decisions, sessions)
 - `logs/runtime-events.jsonl` — aggregated telemetry records
 
 ### 4. Verify Policy File
@@ -55,6 +55,7 @@ Report the status:
 ```
 Governance runtime active.
 PreToolUse hooks: registered
+Storage: SQLite (.agentguard/agentguard.db)
 Telemetry paths: ready
 Policy: <filename or "none (fail-open)">
 ```

--- a/src/cli/bin.ts
+++ b/src/cli/bin.ts
@@ -359,7 +359,7 @@ async function main() {
 
     case 'claude-hook': {
       const { claudeHook } = await import('./commands/claude-hook.js');
-      await claudeHook(args[1]); // 'pre' or 'post'
+      await claudeHook(args[1], args.slice(2)); // 'pre' or 'post', then remaining flags (e.g., --store sqlite)
       break;
     }
 

--- a/src/cli/commands/claude-hook.ts
+++ b/src/cli/commands/claude-hook.ts
@@ -2,11 +2,11 @@
 // PreToolUse: routes actions through the kernel for policy/invariant enforcement.
 // PostToolUse: reports Bash stderr errors (informational only).
 // Always exits 0 — hooks must never fail.
-// Supports both JSONL (default) and SQLite storage backends via AGENTGUARD_STORE env var.
+// Supports both JSONL (default) and SQLite storage backends via --store flag or AGENTGUARD_STORE env var.
 
 import type { ClaudeCodeHookPayload } from '../../adapters/claude-code.js';
 
-export async function claudeHook(hookType?: string): Promise<void> {
+export async function claudeHook(hookType?: string, extraArgs: string[] = []): Promise<void> {
   try {
     const input = await readStdin();
     if (!input) process.exit(0);
@@ -28,7 +28,7 @@ export async function claudeHook(hookType?: string): Promise<void> {
       const sessionId =
         (data.session_id as string | undefined) || process.env.CLAUDE_SESSION_ID || undefined;
       const payload = { ...data, session_id: sessionId } as unknown as ClaudeCodeHookPayload;
-      await handlePreToolUse(payload);
+      await handlePreToolUse(payload, extraArgs);
     } else {
       handlePostToolUse(data);
     }
@@ -38,7 +38,7 @@ export async function claudeHook(hookType?: string): Promise<void> {
   process.exit(0);
 }
 
-async function handlePreToolUse(payload: ClaudeCodeHookPayload): Promise<void> {
+async function handlePreToolUse(payload: ClaudeCodeHookPayload, cliArgs: string[]): Promise<void> {
   const { processClaudeCodeHook, formatHookResponse } =
     await import('../../adapters/claude-code.js');
   const { createKernel } = await import('../../kernel/kernel.js');
@@ -63,8 +63,8 @@ async function handlePreToolUse(payload: ClaudeCodeHookPayload): Promise<void> {
   // Generate run ID
   const runId = `hook_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
 
-  // Resolve storage backend from env/CLI args and create sinks via factory
-  const storageConfig = resolveStorageConfig([]);
+  // Resolve storage backend from CLI args (e.g. --store sqlite) or AGENTGUARD_STORE env var
+  const storageConfig = resolveStorageConfig(cliArgs);
   let storage: Awaited<ReturnType<typeof createStorageBundle>> | null = null;
   let eventSink: import('../../kernel/kernel.js').EventSink | undefined;
   let decisionSink: import('../../kernel/decisions/types.js').DecisionSink | undefined;
@@ -79,7 +79,9 @@ async function handlePreToolUse(payload: ClaudeCodeHookPayload): Promise<void> {
     // Sink creation failure is non-fatal
   }
 
-  // Build kernel — dryRun: true because Claude Code handles execution
+  // Build kernel — dryRun: true = evaluate policies/invariants only (no adapter execution).
+  // Claude Code handles actual tool execution; the hook only governs (allow/deny).
+  // Events and decision records are still emitted and persisted to the configured storage backend.
   const kernel = createKernel({
     runId,
     policyDefs,

--- a/src/cli/commands/claude-init.ts
+++ b/src/cli/commands/claude-init.ts
@@ -31,6 +31,11 @@ export async function claudeInit(args: string[] = []): Promise<void> {
   const isGlobal = args.includes('--global') || args.includes('-g');
   const isRemove = args.includes('--remove') || args.includes('--uninstall');
 
+  // Parse --store flag for storage backend (embedded into hook commands)
+  const storeIdx = args.findIndex((a) => a === '--store');
+  const storeBackend = storeIdx !== -1 ? args[storeIdx + 1] : undefined;
+  const storeSuffix = storeBackend ? ` --store ${storeBackend}` : '';
+
   // Resolve hook script path — handles both tsc output (commands/) and esbuild bundle (cli/)
   let hookScript = resolve(__dirname, 'claude-hook.js');
   if (!existsSync(hookScript)) {
@@ -81,7 +86,7 @@ export async function claudeInit(args: string[] = []): Promise<void> {
     hooks: [
       {
         type: 'command',
-        command: `node ${hookScript} pre`,
+        command: `node ${hookScript} pre${storeSuffix}`,
       },
     ],
   });
@@ -93,7 +98,7 @@ export async function claudeInit(args: string[] = []): Promise<void> {
     hooks: [
       {
         type: 'command',
-        command: `node ${hookScript} post`,
+        command: `node ${hookScript} post${storeSuffix}`,
       },
     ],
   });
@@ -104,7 +109,11 @@ export async function claudeInit(args: string[] = []): Promise<void> {
     `  ${FG.green}✓${RESET}  Hooks installed in ${FG.cyan}${settingsLabel}${RESET}\n`
   );
   process.stderr.write(`  ${DIM}PreToolUse:  governance enforcement (all tools)${RESET}\n`);
-  process.stderr.write(`  ${DIM}PostToolUse: error monitoring (Bash)${RESET}\n\n`);
+  process.stderr.write(`  ${DIM}PostToolUse: error monitoring (Bash)${RESET}\n`);
+  if (storeBackend) {
+    process.stderr.write(`  ${DIM}Storage:     ${storeBackend}${RESET}\n`);
+  }
+  process.stderr.write('\n');
   // Set core.hooksPath so git uses the repo's hooks/ directory
   // (pre-commit auto-stages telemetry, post-commit tracks dev activity)
   try {

--- a/src/kernel/kernel.ts
+++ b/src/kernel/kernel.ts
@@ -49,6 +49,11 @@ export interface KernelConfig extends MonitorConfig {
   runId?: string;
   sinks?: EventSink[];
   adapters?: AdapterRegistry;
+  /**
+   * When true, the kernel evaluates policies and invariants but skips adapter execution.
+   * Events and decision records are still emitted and persisted.
+   * Used by the Claude Code hook where Claude Code handles actual tool execution.
+   */
   dryRun?: boolean;
   /** Optional decision sinks for persisting GovernanceDecisionRecords */
   decisionSinks?: DecisionSink[];

--- a/tests/ts/cli-claude-hook.test.ts
+++ b/tests/ts/cli-claude-hook.test.ts
@@ -180,6 +180,38 @@ describe('claudeHook', () => {
     }
   });
 
+  // --- extraArgs forwarding ---
+
+  it('accepts extraArgs parameter without error', async () => {
+    const input = JSON.stringify({
+      hook: 'PreToolUse',
+      tool_name: 'Read',
+      tool_input: { file_path: '/tmp/test.ts' },
+    });
+    const restore = mockStdin(input);
+    try {
+      await claudeHook('pre', ['--store', 'sqlite']);
+      expect(process.exit).toHaveBeenCalledWith(0);
+    } finally {
+      restore();
+    }
+  });
+
+  it('defaults extraArgs to empty array when not provided', async () => {
+    const input = JSON.stringify({
+      hook: 'PreToolUse',
+      tool_name: 'Read',
+      tool_input: { file_path: '/tmp/test.ts' },
+    });
+    const restore = mockStdin(input);
+    try {
+      await claudeHook('pre');
+      expect(process.exit).toHaveBeenCalledWith(0);
+    } finally {
+      restore();
+    }
+  });
+
   // --- PreToolUse (kernel governance) ---
 
   it('routes PreToolUse Read action through kernel and allows it (no stdout)', async () => {

--- a/tests/ts/cli-claude-init.test.ts
+++ b/tests/ts/cli-claude-init.test.ts
@@ -208,6 +208,57 @@ describe('claudeInit', () => {
     );
   });
 
+  // --- --store flag ---
+
+  it('embeds --store sqlite in hook commands when --store flag is provided', async () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    await claudeInit(['--store', 'sqlite']);
+
+    expect(writeFileSync).toHaveBeenCalledTimes(1);
+    const written = JSON.parse(vi.mocked(writeFileSync).mock.calls[0][1] as string);
+
+    // PreToolUse command should include --store sqlite
+    expect(written.hooks.PreToolUse[0].hooks[0].command).toContain('pre --store sqlite');
+
+    // PostToolUse command should include --store sqlite
+    expect(written.hooks.PostToolUse[0].hooks[0].command).toContain('post --store sqlite');
+  });
+
+  it('does not include --store suffix when no --store flag is provided', async () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    await claudeInit([]);
+
+    const written = JSON.parse(vi.mocked(writeFileSync).mock.calls[0][1] as string);
+
+    // Commands should end with just 'pre' and 'post', no trailing flags
+    expect(written.hooks.PreToolUse[0].hooks[0].command).not.toContain('--store');
+    expect(written.hooks.PostToolUse[0].hooks[0].command).not.toContain('--store');
+  });
+
+  it('combines --store with --global flag', async () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    await claudeInit(['--global', '--store', 'sqlite']);
+
+    expect(writeFileSync).toHaveBeenCalledWith(
+      expect.stringContaining(join('/mock-home', '.claude', 'settings.json')),
+      expect.any(String),
+      'utf8'
+    );
+    const written = JSON.parse(vi.mocked(writeFileSync).mock.calls[0][1] as string);
+    expect(written.hooks.PreToolUse[0].hooks[0].command).toContain('--store sqlite');
+  });
+
+  it('outputs storage backend info when --store is specified', async () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    await claudeInit(['--store', 'sqlite']);
+
+    expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('sqlite'));
+  });
+
   it('preserves other hooks when removing', async () => {
     vi.mocked(existsSync).mockReturnValue(true);
     vi.mocked(readFileSync).mockReturnValue(


### PR DESCRIPTION
## Changes

- **CLI hook support**: `claudeHook()` now accepts `extraArgs` parameter to forward CLI flags (e.g., `--store sqlite`) from `claude-init` to the kernel
- **Storage backend configuration**: `claude-init` command now supports `--store` flag to embed storage backend specification into hook commands
- **Kernel documentation**: Clarified `dryRun` mode behavior — policies/invariants are evaluated but adapter execution is skipped; events and decision records are still persisted
- **Governance runtime docs**: Updated `.claude/skills/start-governance-runtime.md` to reference SQLite storage backend and provide updated setup instructions
- **Test coverage**: Added 6 new tests covering `--store` flag parsing, hook command generation, and storage backend output

## Details

- PreToolUse and PostToolUse hooks now embed `--store sqlite` (or other backends) in their command invocations
- Storage configuration resolved from CLI args or `AGENTGUARD_STORE` env var (CLI args take precedence)
- Non-breaking: existing hooks without `--store` flag continue to work with default JSONL backend
- Example: `npx agentguard claude-init --store sqlite` generates hooks that persist to `.agentguard/agentguard.db`