### PR TITLE
docs: sync documentation with codebase

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -52,6 +52,7 @@ src/
 ├── plugins/       Plugin ecosystem (discovery, registry, validation, sandboxing)
 ├── renderers/     Renderer plugin system (registry, TUI renderer)
 ├── cli/           CLI entry point and commands
+├── storage/       SQLite storage backend (opt-in alternative to JSONL)
 ├── telemetry/     Runtime telemetry and logging
 └── core/          Shared utilities (types, actions, hash, execution-log)
 
@@ -70,7 +71,8 @@ policies/          Policy packs (YAML: ci-safe, enterprise, open-source, strict)
 - **plugins/** may import from core/, events/, kernel/ only
 - **renderers/** may import from core/, events/ only
 - **analytics/** may import from events/, core/ only
-- **cli/** may import from analytics/, kernel/, events/, policy/, plugins/, renderers/, core/
+- **storage/** may import from events/, core/ only
+- **cli/** may import from analytics/, kernel/, events/, policy/, plugins/, renderers/, storage/, core/
 - **telemetry/** may import from core/ only
 - **core/** has no project imports (leaf layer)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ The system has one architectural spine: the **canonical event model**. All syste
 - JSONL event persistence for audit trail and replay
 - Claude Code adapter for PreToolUse/PostToolUse hooks
 - TypeScript source (`src/`), compiled to `dist/` via tsc + esbuild
-- CLI has runtime dependencies (`chokidar`, `commander`, `pino`)
+- CLI has runtime dependencies (`chokidar`, `commander`, `pino`); optional `better-sqlite3` for SQLite storage backend
 - Build tooling: tsc + esbuild + vitest (dev dependencies only)
 
 ## Quick Start
@@ -47,6 +47,7 @@ src/
 │   ├── replay-comparator.ts # Replay outcome comparison
 │   ├── replay-engine.ts    # Deterministic replay engine
 │   ├── replay-processor.ts # Replay event processor
+│   ├── heartbeat.ts        # Agent heartbeat monitor
 │   ├── decisions/          # Typed decision records
 │   │   ├── factory.ts      # Decision record factory
 │   │   └── types.ts        # Decision record type definitions
@@ -95,7 +96,7 @@ src/
 │   ├── replay.ts           # Session replay logic
 │   ├── session-store.ts    # Session management
 │   ├── file-event-store.ts # File-based event persistence
-│   └── commands/           # analytics, guard, inspect, replay, export, import, simulate, ci-check, plugin, policy, claude-hook, claude-init
+│   └── commands/           # analytics, guard, inspect, replay, export, import, simulate, ci-check, plugin, policy, claude-hook, claude-init, init
 ├── plugins/                # Plugin ecosystem
 │   ├── discovery.ts        # Plugin discovery mechanism
 │   ├── registry.ts         # Plugin registry
@@ -108,6 +109,14 @@ src/
 │   ├── tui-renderer.ts     # TUI renderer implementation
 │   ├── types.ts            # Renderer type definitions
 │   └── index.ts            # Module re-exports
+├── storage/                # SQLite storage backend (opt-in)
+│   ├── factory.ts          # Storage bundle factory
+│   ├── index.ts            # Module re-exports
+│   ├── migrations.ts       # Schema migrations (version-based)
+│   ├── sqlite-analytics.ts # SQLite-backed analytics queries
+│   ├── sqlite-sink.ts      # SQLite event/decision sink
+│   ├── sqlite-store.ts     # SQLite event store implementation
+│   └── types.ts            # Storage type definitions
 ├── telemetry/              # Runtime telemetry
 │   ├── index.ts            # Module re-exports
 │   ├── runtimeLogger.ts    # Runtime logging implementation
@@ -137,7 +146,7 @@ vscode-extension/              # VS Code extension
 
 tests/
 ├── *.test.js               # 14 JS test files (custom zero-dependency harness)
-└── ts/*.test.ts            # 62 TS test files (vitest)
+└── ts/*.test.ts            # 71 TS test files (vitest)
 policy/                     # Policy configuration (JSON: action_rules, capabilities)
 policies/                   # Policy packs (YAML: ci-safe, enterprise, open-source, strict)
 docs/                       # System documentation (architecture, event model, specs)
@@ -197,6 +206,7 @@ Each top-level directory maps to a single architectural concept:
 - **src/renderers/** — Renderer plugin system (registry, TUI renderer)
 - **src/cli/** — CLI entry point and commands
 - **src/core/** — Shared utilities (types, actions, hash, execution-log)
+- **src/storage/** — SQLite storage backend (opt-in alternative to JSONL, indexed queries)
 - **src/telemetry/** — Runtime telemetry and logging
 
 ### CLI Commands
@@ -215,6 +225,7 @@ Each top-level directory maps to a single architectural concept:
 - `agentguard policy validate <file>` — Validate a policy file (YAML/JSON)
 - `agentguard claude-hook` — Handle Claude Code PreToolUse/PostToolUse hook events
 - `agentguard claude-init` — Set up Claude Code hook integration
+- `agentguard init <type>` — Scaffold governance extensions (invariant, policy-pack, adapter, renderer, replay-processor)
 
 ### Event Model
 The canonical event model is the architectural spine. Event kinds defined in `src/events/schema.ts`:
@@ -227,6 +238,7 @@ The canonical event model is the architectural spine. Event kinds defined in `sr
 - **Policy Traces**: `PolicyTraceRecorded`
 - **Pipeline**: `PipelineStarted`, `StageCompleted`, `StageFailed`, `PipelineCompleted`, `PipelineFailed`, `FileScopeViolation`
 - **Dev activity**: `FileSaved`, `TestCompleted`, `BuildCompleted`, `CommitCreated`, `CodeReviewed`, `DeployCompleted`, `LintCompleted`
+- **Heartbeat**: `HeartbeatEmitted`, `HeartbeatMissed`, `AgentUnresponsive`
 - **Battle lifecycle**: `ENCOUNTER_STARTED`, `MOVE_USED`, `DAMAGE_DEALT`, `HEALING_APPLIED`, `PASSIVE_ACTIVATED`, `BUGMON_FAINTED`, `CACHE_ATTEMPTED`, `CACHE_SUCCESS`, `BATTLE_ENDED`
 - **Ingestion**: `ErrorObserved`, `BugClassified`, `ActivityRecorded`, `EvolutionTriggered`
 
@@ -281,7 +293,7 @@ npm run test:coverage      # Run with coverage (c8, 50% line threshold)
 
 **Test structure:**
 - **JS tests** (`tests/*.test.js`): 14 files using a custom zero-dependency harness (`tests/run.js` with `node:assert`)
-- **TypeScript tests** (`tests/ts/*.test.ts`): 62 files using vitest
+- **TypeScript tests** (`tests/ts/*.test.ts`): 71 files using vitest
 - **Coverage areas**: adapters, analytics (including risk scorer), kernel (AAB, engine, monitor, blast radius, integration, e2e pipeline), CLI commands (args, guard, inspect, simulate, ci-check, claude-hook, claude-init, export/import, policy-validate), decision records, domain models, events, evidence packs, execution log, impact forecast, invariants, JSONL persistence, notification formatter, plugins (discovery, registry, validation), policy evaluation (including pack loader, policy packs, evaluation trace), renderers, replay (engine, comparator, processor), simulation, telemetry (including tracepoint), TUI renderer, violation mapper, VS Code event reader, YAML loading
 
 ## CI/CD & Automation

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ agentguard ci-check --last                # Check most recent run locally
 
 # === Integration ===
 agentguard claude-init                    # Set up Claude Code hook integration
+agentguard init <type>                    # Scaffold governance extensions
 agentguard help                           # Show all commands
 ```
 
@@ -229,6 +230,7 @@ src/
 │   ├── replay-comparator.ts # Replay outcome comparison
 │   ├── replay-engine.ts    # Deterministic replay engine
 │   ├── replay-processor.ts # Replay event processor
+│   ├── heartbeat.ts        # Agent heartbeat monitor
 │   ├── decisions/          # Typed decision records
 │   └── simulation/         # Pre-execution impact simulation
 ├── events/                 # Canonical event model
@@ -272,7 +274,8 @@ src/
 │   └── index.ts            # Module re-exports
 ├── cli/                    # CLI entry point + commands
 │   ├── bin.ts              # Main entry
-│   └── commands/           # analytics, guard, inspect, replay, export, import, simulate, ci-check, plugin, policy, claude-hook, claude-init
+│   └── commands/           # analytics, guard, inspect, replay, export, import, simulate, ci-check, plugin, policy, claude-hook, claude-init, init
+├── storage/                # SQLite storage backend (opt-in alternative to JSONL)
 ├── telemetry/              # Runtime telemetry and logging
 └── core/                   # Shared utilities (types, actions, hash, rng, execution-log)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -60,7 +60,7 @@ A comprehensive codebase audit assessed the current system against the strategic
 | Action Authorization Boundary (AAB) | Implemented (2 bypass vectors) | `src/kernel/aab.ts` |
 | Policy Evaluator (two-phase deny/allow) | Implemented | `src/policy/evaluator.ts` |
 | 8 Built-in Invariants | Fully Implemented | `src/invariants/definitions.ts`, `src/invariants/checker.ts` |
-| Event Model (46 event kinds) | Comprehensive | `src/events/schema.ts` |
+| Event Model (49 event kinds) | Comprehensive | `src/events/schema.ts` |
 | JSONL Persistence | Implemented | `src/events/jsonl.ts` |
 | Simulation Engine (3 simulators + impact forecast) | Fully Implemented | `src/kernel/simulation/` |
 | Blast Radius Computation | Implemented | `src/kernel/blast-radius.ts` |
@@ -76,7 +76,7 @@ A comprehensive codebase audit assessed the current system against the strategic
 | Cross-session Analytics (aggregation, clustering, trends) | Implemented | `src/analytics/` |
 | Plugin Ecosystem (discovery, registry, validation) | Implemented | `src/plugins/` |
 | Renderer Plugin System | Implemented | `src/renderers/` |
-| CLI (guard, inspect, events, replay, export, import, simulate, ci-check, analytics, plugin, claude-hook, claude-init) | Implemented | `src/cli/` |
+| CLI (guard, inspect, events, replay, export, import, simulate, ci-check, analytics, plugin, claude-hook, claude-init, init) | Implemented | `src/cli/` |
 | Claude Code Hook Integration | Implemented | `src/adapters/claude-code.ts` |
 | VS Code Extension (sidebar panels, event reader, inline diagnostics) | Implemented | `vscode-extension/` |
 | Policy Pack Loader | Implemented | `src/policy/pack-loader.ts` |
@@ -105,7 +105,7 @@ A comprehensive codebase audit assessed the current system against the strategic
 | AAB Reference Monitor | Implemented | 1 bypass vector to close (missing-adapter fixed) |
 | Policy Evaluator | Implemented | Production |
 | 8 Built-in Invariants | Fully Implemented | Production |
-| Event Model (46 kinds) | Comprehensive | Production |
+| Event Model (49 kinds) | Comprehensive | Production |
 | Simulation & Forecasting | Fully Implemented | Production |
 | Escalation State Machine | Implemented | Functional (events persisted as StateChanged) |
 | Cross-session Analytics | Implemented | Functional (forensic only) |
@@ -115,7 +115,7 @@ A comprehensive codebase audit assessed the current system against the strategic
 | P-1b Transactional Protocol | Not Started | Aspirational |
 | Confidence-Based HITL | Partial | Labels only |
 | Multi-Agent Identity | Aspirational | Types exist, no enforcement |
-| Shared State & Heartbeat | Not Started | Aspirational |
+| Shared State & Heartbeat | Partial | Heartbeat implemented (`src/kernel/heartbeat.ts`) |
 | Formal Verification (Z3) | Not Started | Aspirational |
 | Automated Invariant Learning | Not Started | Aspirational |
 
@@ -209,7 +209,7 @@ Monitor escalation state transitions are now persisted as `StateChanged` DomainE
 - [x] Deterministic replay with seeded RNG (`src/core/rng.ts`, `src/kernel/replay-engine.ts`)
 - [x] Replay comparator (verify original vs replayed outcomes) (`src/kernel/replay-comparator.ts`)
 - [x] Event export/import for sharing sessions (`src/cli/commands/export.ts`, `src/cli/commands/import.ts`)
-- [ ] SQLite storage backend (opt-in alternative to JSONL with indexed queries) (`src/storage/`)
+- [x] SQLite storage backend (opt-in alternative to JSONL with indexed queries) (`src/storage/`)
 
 ### Phase 4 — Plugin Ecosystem `STABLE`
 
@@ -281,21 +281,21 @@ This is the architectural hinge. These changes transform the AAB from advisory i
 - [ ] Deep Claude Code integration (auto-install, configuration management)
 - [ ] Cursor integration
 
-### Phase 10 — Structured Storage Backend `PLANNED`
+### Phase 10 — Structured Storage Backend `IN PROGRESS`
 
 > **Theme:** Replace flat-file JSONL with embedded database for fast queries and audit at scale
 
 The JSONL persistence layer was the right starting point — append-only, human-readable, zero dependencies. But it doesn't scale: every query requires filesystem enumeration + full file parsing, and hundreds of `.jsonl` files accumulate in `.agentguard/`.
 
-- [ ] SQLite storage adapter implementing existing `EventStore` interface
-- [ ] Schema design: `events`, `decisions`, `sessions` tables with JSON payload columns
-- [ ] Indexed columns: `kind`, `timestamp`, `runId`, `actionType`, `fingerprint`
+- [x] SQLite storage adapter implementing existing `EventStore` interface
+- [x] Schema design: `events`, `decisions`, `sessions` tables with JSON payload columns
+- [x] Indexed columns: `kind`, `timestamp`, `runId`, `actionType`, `fingerprint`
 - [ ] Migration utility: bulk-import existing `.jsonl` files into SQLite (`agentguard migrate`)
-- [ ] Query API: filter by time range, event kind, action type, run ID without loading all events
-- [ ] Aggregation queries for analytics (replace in-memory `loadAllEvents()` pattern)
-- [ ] JSONL export compatibility — `agentguard export` still produces portable JSONL
+- [x] Query API: filter by time range, event kind, action type, run ID without loading all events
+- [x] Aggregation queries for analytics (replace in-memory `loadAllEvents()` pattern)
+- [x] JSONL export compatibility — `agentguard export` still produces portable JSONL
 - [ ] Storage location: `~/.agentguard/agentguard.db` (home directory, out of repo tree)
-- [ ] Retain JSONL as optional fallback/streaming sink for real-time tailing
+- [x] Retain JSONL as optional fallback/streaming sink for real-time tailing
 
 ### Phase 11 — Runtime Tracing & Observability `PLANNED`
 
@@ -340,7 +340,7 @@ The JSONL persistence layer was the right starting point — append-only, human-
 - [ ] PID-bound capability tokens for privilege separation
 - [ ] Cross-agent policy definitions
 - [ ] Shared state contracts with provenance tracking
-- [ ] Heartbeat mechanism for agent liveness
+- [x] Heartbeat mechanism for agent liveness (`src/kernel/heartbeat.ts`)
 - [ ] Multi-agent pipeline orchestration (implement `docs/multi-agent-pipeline.md`)
 - [ ] Multi-agent escalation coordination
 


### PR DESCRIPTION
## Summary
- Added `src/storage/` (SQLite backend) module to project structure trees in CLAUDE.md, ARCHITECTURE.md, README.md
- Added `src/kernel/heartbeat.ts` to kernel file listings across all docs
- Added `agentguard init` command to CLI sections in CLAUDE.md and README.md
- Updated TS test count from 62 to 71 in CLAUDE.md
- Added `better-sqlite3` optional dependency note in CLAUDE.md
- Added `HeartbeatEmitted`, `HeartbeatMissed`, `AgentUnresponsive` event kinds to CLAUDE.md
- Updated event model count from 46 to 49 in ROADMAP.md
- Checked 7 implemented Phase 10 (SQLite) items and Phase 14 heartbeat item in ROADMAP.md
- Updated Phase 10 status from `PLANNED` to `IN PROGRESS` in ROADMAP.md
- Added `storage/` layer rules in ARCHITECTURE.md

## Test plan
- [ ] Verify all 4 doc files render correctly in GitHub markdown preview
- [ ] Confirm no code changes are included (docs-only PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)