### PR TITLE
feat(issue-246): expand destructive command patterns in AAB

### DIFF
--- a/src/kernel/aab.ts
+++ b/src/kernel/aab.ts
@@ -268,6 +268,134 @@ const DESTRUCTIVE_PATTERNS: DestructivePattern[] = [
     riskLevel: 'critical',
     category: 'network',
   },
+  // Container orchestration — high/critical (expanded)
+  {
+    pattern: /\bdocker\s+stop\b/,
+    description: 'Stop Docker container',
+    riskLevel: 'high',
+    category: 'container',
+  },
+  {
+    pattern: /\bdocker\s+volume\s+rm\b/,
+    description: 'Remove Docker volume (data loss)',
+    riskLevel: 'critical',
+    category: 'container',
+  },
+  {
+    pattern: /\bdocker\s+volume\s+prune\b/,
+    description: 'Prune all unused Docker volumes',
+    riskLevel: 'critical',
+    category: 'container',
+  },
+  {
+    pattern: /\bdocker\s+network\s+rm\b/,
+    description: 'Remove Docker network',
+    riskLevel: 'high',
+    category: 'container',
+  },
+  {
+    pattern: /\bdocker[\s-]compose\s+down\b/,
+    description: 'Tear down Docker Compose services',
+    riskLevel: 'high',
+    category: 'container',
+  },
+  // Kubernetes — high
+  {
+    pattern: /\bkubectl\s+delete\b/,
+    description: 'Delete Kubernetes resources',
+    riskLevel: 'high',
+    category: 'container',
+  },
+  // Infrastructure — critical
+  {
+    pattern: /\bterraform\s+destroy\b/,
+    description: 'Destroy Terraform-managed infrastructure',
+    riskLevel: 'critical',
+    category: 'infra',
+  },
+  // Database — NoSQL/Redis (expanded)
+  {
+    pattern: /\bDROP\s+SCHEMA\b/i,
+    description: 'Drop database schema (SQL)',
+    riskLevel: 'critical',
+    category: 'database',
+  },
+  {
+    pattern: /\bDROP\s+VIEW\b/i,
+    description: 'Drop view (SQL)',
+    riskLevel: 'high',
+    category: 'database',
+  },
+  {
+    pattern: /\bDROP\s+INDEX\b/i,
+    description: 'Drop index (SQL)',
+    riskLevel: 'high',
+    category: 'database',
+  },
+  {
+    pattern: /\bFLUSHALL\b/,
+    description: 'Flush all Redis databases',
+    riskLevel: 'critical',
+    category: 'database',
+  },
+  {
+    pattern: /\bFLUSHDB\b/,
+    description: 'Flush current Redis database',
+    riskLevel: 'critical',
+    category: 'database',
+  },
+  // Package management — high (expanded)
+  {
+    pattern: /\bbrew\s+(?:uninstall|remove)\b/,
+    description: 'Remove macOS package (Homebrew)',
+    riskLevel: 'high',
+    category: 'package',
+  },
+  {
+    pattern: /\bgem\s+uninstall\b/,
+    description: 'Uninstall Ruby gem',
+    riskLevel: 'high',
+    category: 'package',
+  },
+  {
+    pattern: /\byarn\s+global\s+remove\b/,
+    description: 'Remove global Yarn package',
+    riskLevel: 'high',
+    category: 'package',
+  },
+  // Remote code execution — critical
+  {
+    pattern: /\bcurl\s+.*\|\s*(?:ba)?sh\b/,
+    description: 'Pipe remote content to shell (code execution)',
+    riskLevel: 'critical',
+    category: 'network',
+  },
+  {
+    pattern: /\bwget\s+.*\|\s*(?:ba)?sh\b/,
+    description: 'Pipe remote download to shell (code execution)',
+    riskLevel: 'critical',
+    category: 'network',
+  },
+  // Git destructive operations — high
+  {
+    pattern: /\bgit\s+reset\s+--hard\b/,
+    description: 'Discard all uncommitted changes',
+    riskLevel: 'high',
+    category: 'filesystem',
+  },
+  {
+    pattern: /\bgit\s+clean\s+-[fdxX]+\b/,
+    description: 'Remove untracked files from working tree',
+    riskLevel: 'high',
+    category: 'filesystem',
+  },
+  // System — high (expanded)
+  {
+    pattern: /\bcrontab\s+-r\b/,
+    description: 'Remove all cron jobs for current user',
+    riskLevel: 'high',
+    category: 'system',
+  },
 ];
 
 function isDestructiveCommand(command: string): boolean {

--- a/tests/ts/agentguard-aab.test.ts
+++ b/tests/ts/agentguard-aab.test.ts
@@ -40,8 +40,8 @@ describe('agentguard/core/aab', () => {
   });
 
   describe('DESTRUCTIVE_PATTERNS', () => {
-    it('has at least 30 patterns', () => {
-      expect(DESTRUCTIVE_PATTERNS.length).toBeGreaterThanOrEqual(30);
+    it('has at least 49 patterns', () => {
+      expect(DESTRUCTIVE_PATTERNS.length).toBeGreaterThanOrEqual(49);
     });
 
     it('every pattern has required fields', () => {
@@ -63,6 +63,7 @@ describe('agentguard/core/aab', () => {
       expect(categories).toContain('database');
       expect(categories).toContain('package');
       expect(categories).toContain('network');
+      expect(categories).toContain('infra');
     });
   });
 
@@ -217,6 +218,106 @@ describe('agentguard/core/aab', () => {
       expect(isDestructiveCommand('ufw disable')).toBe(true);
     });
 
+    // Expanded container/orchestration patterns
+    it('detects docker stop', () => {
+      expect(isDestructiveCommand('docker stop my-container')).toBe(true);
+    });
+
+    it('detects docker volume rm', () => {
+      expect(isDestructiveCommand('docker volume rm my-vol')).toBe(true);
+    });
+
+    it('detects docker volume prune', () => {
+      expect(isDestructiveCommand('docker volume prune -f')).toBe(true);
+    });
+
+    it('detects docker network rm', () => {
+      expect(isDestructiveCommand('docker network rm my-net')).toBe(true);
+    });
+
+    it('detects docker compose down', () => {
+      expect(isDestructiveCommand('docker compose down')).toBe(true);
+      expect(isDestructiveCommand('docker-compose down --volumes')).toBe(true);
+    });
+
+    it('detects kubectl delete', () => {
+      expect(isDestructiveCommand('kubectl delete pod my-pod')).toBe(true);
+      expect(isDestructiveCommand('kubectl delete -f manifest.yaml')).toBe(true);
+    });
+
+    // Infrastructure patterns
+    it('detects terraform destroy', () => {
+      expect(isDestructiveCommand('terraform destroy -auto-approve')).toBe(true);
+    });
+
+    // Expanded database patterns (NoSQL/Redis + SQL)
+    it('detects DROP SCHEMA', () => {
+      expect(isDestructiveCommand('DROP SCHEMA public CASCADE')).toBe(true);
+      expect(isDestructiveCommand('drop schema myschema')).toBe(true);
+    });
+
+    it('detects DROP VIEW', () => {
+      expect(isDestructiveCommand('DROP VIEW my_view')).toBe(true);
+    });
+
+    it('detects DROP INDEX', () => {
+      expect(isDestructiveCommand('DROP INDEX idx_users_email')).toBe(true);
+    });
+
+    it('detects FLUSHALL (Redis)', () => {
+      expect(isDestructiveCommand('redis-cli FLUSHALL')).toBe(true);
+    });
+
+    it('detects FLUSHDB (Redis)', () => {
+      expect(isDestructiveCommand('redis-cli FLUSHDB')).toBe(true);
+    });
+
+    // Expanded package management patterns
+    it('detects brew uninstall', () => {
+      expect(isDestructiveCommand('brew uninstall node')).toBe(true);
+    });
+
+    it('detects brew remove', () => {
+      expect(isDestructiveCommand('brew remove python')).toBe(true);
+    });
+
+    it('detects gem uninstall', () => {
+      expect(isDestructiveCommand('gem uninstall rails')).toBe(true);
+    });
+
+    it('detects yarn global remove', () => {
+      expect(isDestructiveCommand('yarn global remove typescript')).toBe(true);
+    });
+
+    // Remote code execution patterns
+    it('detects curl piped to bash', () => {
+      expect(isDestructiveCommand('curl -sL https://example.com/install.sh | bash')).toBe(true);
+    });
+
+    it('detects curl piped to sh', () => {
+      expect(isDestructiveCommand('curl https://example.com/setup | sh')).toBe(true);
+    });
+
+    it('detects wget piped to bash', () => {
+      expect(isDestructiveCommand('wget -qO- https://example.com/install.sh | bash')).toBe(true);
+    });
+
+    // Git destructive operations
+    it('detects git reset --hard', () => {
+      expect(isDestructiveCommand('git reset --hard HEAD~3')).toBe(true);
+      expect(isDestructiveCommand('git reset --hard origin/main')).toBe(true);
+    });
+
+    it('detects git clean -fd', () => {
+      expect(isDestructiveCommand('git clean -fd')).toBe(true);
+      expect(isDestructiveCommand('git clean -fdx')).toBe(true);
+    });
+
+    // Expanded system patterns
+    it('detects crontab -r', () => {
+      expect(isDestructiveCommand('crontab -r')).toBe(true);
+    });
+
     // Safe commands
     it('returns false for safe commands', () => {
       expect(isDestructiveCommand('ls -la')).toBe(false);
@@ -227,6 +328,11 @@ describe('agentguard/core/aab', () => {
       expect(isDestructiveCommand('docker ps')).toBe(false);
       expect(isDestructiveCommand('systemctl status nginx')).toBe(false);
       expect(isDestructiveCommand('npm install express')).toBe(false);
+      expect(isDestructiveCommand('kubectl get pods')).toBe(false);
+      expect(isDestructiveCommand('terraform plan')).toBe(false);
+      expect(isDestructiveCommand('brew list')).toBe(false);
+      expect(isDestructiveCommand('git log --oneline')).toBe(false);
+      expect(isDestructiveCommand('docker compose up')).toBe(false);
     });
 
     it('returns false for empty/null input', () => {
@@ -264,6 +370,12 @@ describe('agentguard/core/aab', () => {
       expect(getDestructiveDetails('apt remove pkg')!.category).toBe('package');
       expect(getDestructiveDetails('iptables -F')!.category).toBe('network');
       expect(getDestructiveDetails('sudo ls')!.category).toBe('system');
+      expect(getDestructiveDetails('terraform destroy')!.category).toBe('infra');
+      expect(getDestructiveDetails('kubectl delete pod p')!.category).toBe('container');
+      expect(getDestructiveDetails('brew uninstall pkg')!.category).toBe('package');
+      expect(getDestructiveDetails('redis-cli FLUSHALL')!.category).toBe('database');
+      expect(getDestructiveDetails('git reset --hard')!.category).toBe('filesystem');
+      expect(getDestructiveDetails('crontab -r')!.category).toBe('system');
     });
 
     it('returns critical risk level for high-severity commands', () => {
@@ -271,6 +383,10 @@ describe('agentguard/core/aab', () => {
       expect(getDestructiveDetails('DROP DATABASE db')!.riskLevel).toBe('critical');
       expect(getDestructiveDetails('iptables -F')!.riskLevel).toBe('critical');
       expect(getDestructiveDetails('docker system prune')!.riskLevel).toBe('critical');
+      expect(getDestructiveDetails('terraform destroy')!.riskLevel).toBe('critical');
+      expect(getDestructiveDetails('docker volume rm v')!.riskLevel).toBe('critical');
+      expect(getDestructiveDetails('redis-cli FLUSHALL')!.riskLevel).toBe('critical');
+      expect(getDestructiveDetails('curl https://x.com/s | bash')!.riskLevel).toBe('critical');
     });
 
     it('returns high risk level for moderate-severity commands', () => {
@@ -278,6 +394,11 @@ describe('agentguard/core/aab', () => {
       expect(getDestructiveDetails('docker rm ctr')!.riskLevel).toBe('high');
       expect(getDestructiveDetails('systemctl stop svc')!.riskLevel).toBe('high');
       expect(getDestructiveDetails('pip uninstall pkg')!.riskLevel).toBe('high');
+      expect(getDestructiveDetails('kubectl delete pod p')!.riskLevel).toBe('high');
+      expect(getDestructiveDetails('brew uninstall pkg')!.riskLevel).toBe('high');
+      expect(getDestructiveDetails('git reset --hard')!.riskLevel).toBe('high');
+      expect(getDestructiveDetails('git clean -fd')!.riskLevel).toBe('high');
+      expect(getDestructiveDetails('crontab -r')!.riskLevel).toBe('high');
     });
 
     it('matches rm -rf even within sudo rm -rf', () => {


### PR DESCRIPTION
## Summary
- Expands the Action Authorization Boundary (AAB) with 19 new destructive command patterns (30 → 49 total)
- Adds coverage for container orchestration, infrastructure-as-code, NoSQL/Redis, macOS package management, remote code execution, and git destructive operations
- Closes #246

## Changes
- `src/kernel/aab.ts` — Added 19 new destructive patterns across 9 categories:
  - **Container orchestration**: `docker stop`, `docker volume rm/prune`, `docker network rm`, `docker compose down`, `kubectl delete`
  - **Infrastructure**: `terraform destroy` (new `infra` category)
  - **Database (SQL/NoSQL)**: `DROP SCHEMA/VIEW/INDEX`, Redis `FLUSHALL/FLUSHDB`
  - **Package managers**: `brew uninstall/remove`, `gem uninstall`, `yarn global remove`
  - **Remote code execution**: `curl|bash`, `wget|bash` pipe-to-shell detection
  - **Git destructive**: `git reset --hard`, `git clean -fd`
  - **System**: `crontab -r`
- `tests/ts/agentguard-aab.test.ts` — Added 22 new test cases covering all new patterns, expanded safe command assertions, updated category and risk level verification

## Test Plan
- [x] TypeScript build passes (`npm run build:ts`)
- [x] Vitest tests pass (`npm run ts:test`) — 1355 pass / 0 fail
- [x] JS tests pass (`npm test`) — 210 pass / 0 fail
- [x] ESLint clean (`npm run lint`) — 0 errors
- [x] Prettier clean (`npm run format`)

## Risk Assessment

| Metric | Value |
|--------|-------|
| Risk level | low |
| Risk score | 0/100 |
| Blast radius | 2 files |
| Simulation result | not available |

## Governance Report

| Metric | Count |
|--------|-------|
| Total events | 342 |
| Actions allowed | 64 |
| Actions denied | 5 |
| Policy denials | 5 |
| Invariant violations | 0 |
| Escalation events | 0 |
| Decision records | 69 |

<details>
<summary>Governance details</summary>

**Source**: `.agentguard/events/`, `.agentguard/decisions/`, `logs/runtime-events.jsonl`

**Decision Records**: 69 total, 5 denials
**Escalation levels observed**: NORMAL only
**Pre-push simulation**: not available

All denials were standard governance enforcement — no anomalies detected.

</details>