### PR TITLE
feat(issue-122): init scaffolding, hook fixes, and plugin validation

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node C:\\Users\\jplev\\Documents\\GitHub\\agent-guard\\dist\\cli\\commands\\claude-hook.js pre"
+            "command": "node C:/Users/jplev/Documents/GitHub/agent-guard/dist/cli/commands/claude-hook.js pre"
           }
         ]
       }
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node C:\\Users\\jplev\\Documents\\GitHub\\agent-guard\\dist\\cli\\commands\\claude-hook.js post"
+            "command": "node C:/Users/jplev/Documents/GitHub/agent-guard/dist/cli/commands/claude-hook.js post"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- **`agentguard init --extension`** scaffolding command for invariants, policy packs, adapters, renderers, and replay processors
- **Hook entry-point shim** so `claude-hook.js` works when run directly (not just via CLI bundle)
- **Path normalization** — backslash → forward slash in hook commands for Windows/Git Bash compatibility
- **Plugin validation fixes** — sync `VALID_PLUGIN_TYPES` runtime allowlist with `PluginType` union; stricter name validation
- **CI/format fixes** — remove duplicate `init` property, Prettier formatting

## Test plan
- [ ] `npm run ts:test` passes (includes new `cli-init.test.ts` and updated `plugin-validation.test.ts`)
- [ ] `npm run ts:check` — no type errors
- [ ] `npm run lint && npm run format` — clean
- [ ] Manual: `npx agentguard init invariant` scaffolds correctly
- [ ] Manual: hook invocation works on Windows (`node .../claude-hook.js pre`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)