### PR TITLE
feat: add dedicated policy evaluation traces CLI command

### DIFF
--- a/.events.json
+++ b/.events.json
@@ -1,5 +1,5 @@
 {
-  "commits": 5,
+  "commits": 6,
   "prs_merged": 1,
   "bugs_fixed": 1,
   "tests_passing": 0,
@@ -8,5 +8,5 @@
   "conflicts_resolved": 0,
   "ci_passes": 0,
   "deploys": 0,
-  "docs_written": 0
+  "docs_written": 1
 }

--- a/src/cli/bin.ts
+++ b/src/cli/bin.ts
@@ -207,6 +207,31 @@ const COMMANDS: Record<string, CommandHelp> = {
       'agentguard init policy-pack --name strict-policy',
     ],
   },
+  traces: {
+    name: 'agentguard traces',
+    description: 'Display policy evaluation traces for a governance run',
+    usage: 'agentguard traces [runId] [flags]',
+    flags: [
+      { flag: '--last', description: 'Show traces for the most recent run' },
+      { flag: '--list', description: 'List all recorded runs' },
+      { flag: '--action, -a <type>', description: 'Filter by action type (e.g., git, file.write)' },
+      {
+        flag: '--decision, -d <allow|deny>',
+        description: 'Filter by decision outcome',
+      },
+      { flag: '--summary, -s', description: 'Show summary statistics only' },
+      { flag: '--json', description: 'Output as JSON' },
+      { flag: '--store <backend>', description: 'Storage backend: jsonl (default) or sqlite' },
+    ],
+    examples: [
+      'agentguard traces --last',
+      'agentguard traces --last --summary',
+      'agentguard traces --last --action git',
+      'agentguard traces --last --decision deny',
+      'agentguard traces --last --json',
+      'agentguard traces run_1234567890_abc',
+    ],
+  },
   'evidence-pr': {
     name: 'agentguard evidence-pr',
     description: 'Attach governance evidence report to a pull request',
@@ -393,6 +418,17 @@ async function main() {
       break;
     }
 
+    case 'traces': {
+      if (wantsHelp) {
+        console.log(formatHelp(COMMANDS.traces));
+        break;
+      }
+      const { traces: tracesCmd } = await import('./commands/traces.js');
+      const code = await tracesCmd(args.slice(1), resolveStorageConfig(args.slice(1)));
+      process.exit(code);
+      break;
+    }
+
     case 'init': {
       if (wantsHelp) {
         console.log(formatHelp(COMMANDS.init));
@@ -454,6 +490,12 @@ function printHelp(): void {
     agentguard inspect [runId]                Inspect action graph and decisions
     agentguard events [runId]                 Show raw event stream for a run
     agentguard analytics                      Analyze violation patterns across sessions
+
+  \x1b[1mTraces:\x1b[0m
+    agentguard traces --last                  Show policy traces for most recent run
+    agentguard traces --last --summary        Show summary statistics only
+    agentguard traces --last --action git     Filter traces by action type
+    agentguard traces --last --decision deny  Filter traces by decision
 
   [1mComparison:[0m
     agentguard diff <runA> <runB>              Compare two governance sessions

--- a/src/cli/commands/traces.ts
+++ b/src/cli/commands/traces.ts
@@ -1,0 +1,403 @@
+// CLI command: agentguard traces — display policy evaluation traces for a run.
+// Supports filtering by action type and decision, summary statistics, and JSON output.
+// Works with both JSONL (default) and SQLite storage backends.
+
+import { readFileSync, existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { parseArgs } from '../args.js';
+import { renderPolicyTraces } from '../tui.js';
+import type { PolicyTraceEvent } from '../tui.js';
+import { getEventFilePath } from '../../events/jsonl.js';
+import type { DomainEvent } from '../../core/types.js';
+import type { StorageConfig } from '../../storage/types.js';
+
+const BASE_DIR = '.agentguard';
+const EVENTS_DIR = join(BASE_DIR, 'events');
+
+function isPolicyTraceEvent(e: DomainEvent): e is PolicyTraceEvent & DomainEvent {
+  return e.kind === 'PolicyTraceRecorded';
+}
+
+// ---------------------------------------------------------------------------
+// JSONL helpers
+// ---------------------------------------------------------------------------
+
+function loadEventsJsonl(runId: string): DomainEvent[] {
+  const filePath = getEventFilePath(runId);
+  if (!existsSync(filePath)) return [];
+
+  const content = readFileSync(filePath, 'utf8');
+  const events: DomainEvent[] = [];
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      events.push(JSON.parse(trimmed) as DomainEvent);
+    } catch {
+      // Skip malformed lines
+    }
+  }
+  return events;
+}
+
+function listRunsJsonl(): string[] {
+  if (!existsSync(EVENTS_DIR)) return [];
+  return readdirSync(EVENTS_DIR)
+    .filter((f) => f.endsWith('.jsonl'))
+    .map((f) => f.replace('.jsonl', ''))
+    .sort()
+    .reverse();
+}
+
+// ---------------------------------------------------------------------------
+// Trace filtering
+// ---------------------------------------------------------------------------
+
+function filterTraces(
+  traces: PolicyTraceEvent[],
+  actionFilter?: string,
+  decisionFilter?: string
+): PolicyTraceEvent[] {
+  let result = traces;
+
+  if (actionFilter) {
+    const pattern = actionFilter.toLowerCase();
+    result = result.filter((t) => {
+      const actionType = t.actionType.toLowerCase();
+      // Support prefix matching (e.g., "git" matches "git.push", "git.commit")
+      return actionType === pattern || actionType.startsWith(pattern + '.');
+    });
+  }
+
+  if (decisionFilter) {
+    const decision = decisionFilter.toLowerCase();
+    result = result.filter((t) => t.decision.toLowerCase() === decision);
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// JSON output
+// ---------------------------------------------------------------------------
+
+function formatTracesJson(traces: PolicyTraceEvent[]): string {
+  const summary = computeSummary(traces);
+  return JSON.stringify(
+    {
+      totalEvaluations: traces.length,
+      summary,
+      traces: traces.map((t) => ({
+        actionType: t.actionType,
+        target: t.target,
+        decision: t.decision,
+        phaseThatMatched: t.phaseThatMatched,
+        totalRulesChecked: t.totalRulesChecked,
+        durationMs: t.durationMs,
+        rulesEvaluated: t.rulesEvaluated,
+      })),
+    },
+    null,
+    2
+  );
+}
+
+interface TraceSummary {
+  totalEvaluations: number;
+  allowed: number;
+  denied: number;
+  avgDurationMs: number | null;
+  actionTypes: Record<string, { allowed: number; denied: number }>;
+  topMatchedRules: Array<{ rule: string; policy: string; matchCount: number }>;
+  phaseBreakdown: Record<string, number>;
+}
+
+function computeSummary(traces: PolicyTraceEvent[]): TraceSummary {
+  let allowed = 0;
+  let denied = 0;
+  let totalDuration = 0;
+  let durationCount = 0;
+  const actionTypes: Record<string, { allowed: number; denied: number }> = {};
+  const ruleMatchCounts: Record<string, { rule: string; policy: string; count: number }> = {};
+  const phaseBreakdown: Record<string, number> = {};
+
+  for (const trace of traces) {
+    if (trace.decision === 'allow') allowed++;
+    else denied++;
+
+    if (trace.durationMs !== undefined) {
+      totalDuration += trace.durationMs;
+      durationCount++;
+    }
+
+    // Action type breakdown
+    if (!actionTypes[trace.actionType]) {
+      actionTypes[trace.actionType] = { allowed: 0, denied: 0 };
+    }
+    if (trace.decision === 'allow') actionTypes[trace.actionType].allowed++;
+    else actionTypes[trace.actionType].denied++;
+
+    // Phase breakdown
+    const phase = trace.phaseThatMatched || 'none';
+    phaseBreakdown[phase] = (phaseBreakdown[phase] || 0) + 1;
+
+    // Rule match counting
+    const rules = trace.rulesEvaluated || [];
+    for (const rule of rules) {
+      if (rule.outcome === 'match') {
+        const key = `${rule.policyName}#${rule.ruleIndex}`;
+        if (!ruleMatchCounts[key]) {
+          const pattern = Array.isArray(rule.actionPattern)
+            ? rule.actionPattern.join(', ')
+            : rule.actionPattern;
+          ruleMatchCounts[key] = { rule: `[${rule.effect}] ${pattern}`, policy: key, count: 0 };
+        }
+        ruleMatchCounts[key].count++;
+      }
+    }
+  }
+
+  const topMatchedRules = Object.values(ruleMatchCounts)
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 5)
+    .map((r) => ({ rule: r.rule, policy: r.policy, matchCount: r.count }));
+
+  return {
+    totalEvaluations: traces.length,
+    allowed,
+    denied,
+    avgDurationMs: durationCount > 0 ? totalDuration / durationCount : null,
+    actionTypes,
+    topMatchedRules,
+    phaseBreakdown,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Summary rendering
+// ---------------------------------------------------------------------------
+
+const ANSI = {
+  reset: '\x1b[0m',
+  bold: '\x1b[1m',
+  dim: '\x1b[2m',
+  red: '\x1b[31m',
+  green: '\x1b[32m',
+  gray: '\x1b[90m',
+};
+
+const ICONS = {
+  allowed: '\u2713', // ✓
+  denied: '\u2717', // ✗
+};
+
+export function renderTracesSummary(summary: TraceSummary): string {
+  const lines: string[] = [];
+  lines.push('');
+  lines.push(
+    `  ${ANSI.bold}Trace Summary${ANSI.reset} ${ANSI.dim}(${summary.totalEvaluations} evaluations)${ANSI.reset}`
+  );
+  lines.push(`  ${ANSI.dim}${'─'.repeat(60)}${ANSI.reset}`);
+
+  // Decision breakdown
+  const allowPct =
+    summary.totalEvaluations > 0
+      ? ((summary.allowed / summary.totalEvaluations) * 100).toFixed(0)
+      : '0';
+  const denyPct =
+    summary.totalEvaluations > 0
+      ? ((summary.denied / summary.totalEvaluations) * 100).toFixed(0)
+      : '0';
+
+  lines.push(
+    `  ${ANSI.green}${ICONS.allowed} Allowed:${ANSI.reset} ${summary.allowed} (${allowPct}%)  ${ANSI.red}${ICONS.denied} Denied:${ANSI.reset} ${summary.denied} (${denyPct}%)`
+  );
+
+  if (summary.avgDurationMs !== null) {
+    lines.push(
+      `  ${ANSI.dim}Avg evaluation time: ${summary.avgDurationMs.toFixed(2)}ms${ANSI.reset}`
+    );
+  }
+
+  // Phase breakdown
+  const phases = Object.entries(summary.phaseBreakdown);
+  if (phases.length > 0) {
+    lines.push('');
+    lines.push(`  ${ANSI.bold}Phase Breakdown${ANSI.reset}`);
+    for (const [phase, count] of phases) {
+      const phaseColor = phase === 'deny' ? ANSI.red : phase === 'allow' ? ANSI.green : ANSI.gray;
+      lines.push(`    ${phaseColor}${phase}${ANSI.reset}: ${count}`);
+    }
+  }
+
+  // Action type breakdown
+  const actionEntries = Object.entries(summary.actionTypes);
+  if (actionEntries.length > 0) {
+    lines.push('');
+    lines.push(`  ${ANSI.bold}Action Types${ANSI.reset}`);
+    for (const [actionType, counts] of actionEntries) {
+      const parts: string[] = [];
+      if (counts.allowed > 0) parts.push(`${ANSI.green}${counts.allowed} allowed${ANSI.reset}`);
+      if (counts.denied > 0) parts.push(`${ANSI.red}${counts.denied} denied${ANSI.reset}`);
+      lines.push(`    ${actionType}: ${parts.join(', ')}`);
+    }
+  }
+
+  // Top matched rules
+  if (summary.topMatchedRules.length > 0) {
+    lines.push('');
+    lines.push(`  ${ANSI.bold}Top Matched Rules${ANSI.reset}`);
+    for (const entry of summary.topMatchedRules) {
+      lines.push(
+        `    ${entry.matchCount}x  ${entry.rule} ${ANSI.dim}(${entry.policy})${ANSI.reset}`
+      );
+    }
+  }
+
+  lines.push('');
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Public command
+// ---------------------------------------------------------------------------
+
+export { computeSummary };
+export type { TraceSummary };
+
+export async function traces(args: string[], storageConfig?: StorageConfig): Promise<number> {
+  const parsed = parseArgs(args, {
+    boolean: ['--last', '--list', '--summary', '--json', '--help', '-h'],
+    string: ['--action', '--decision', '--store'],
+    alias: { '-a': '--action', '-d': '--decision', '-s': '--summary' },
+  });
+
+  const showList = parsed.flags['list'] === true;
+  const showLast = parsed.flags['last'] === true;
+  const summaryOnly = parsed.flags['summary'] === true;
+  const jsonOutput = parsed.flags['json'] === true;
+  const actionFilter = parsed.flags['action'] as string | undefined;
+  const decisionFilter = parsed.flags['decision'] as string | undefined;
+  const targetArg = parsed.positional[0];
+
+  const useSqlite = storageConfig?.backend === 'sqlite';
+
+  // List runs
+  if (showList || (!targetArg && !showLast)) {
+    let runs: string[];
+
+    if (useSqlite) {
+      const { createStorageBundle } = await import('../../storage/factory.js');
+      const storage = await createStorageBundle(storageConfig!);
+      if (!storage.db) {
+        process.stderr.write('  Error: SQLite storage backend did not initialize database.\n');
+        return 1;
+      }
+      const { listRunIds } = await import('../../storage/sqlite-store.js');
+      const db = storage.db as import('better-sqlite3').Database;
+      runs = listRunIds(db);
+      storage.close();
+    } else {
+      runs = listRunsJsonl();
+    }
+
+    if (runs.length === 0) {
+      process.stderr.write('\n  \x1b[2mNo runs recorded yet.\x1b[0m\n');
+      process.stderr.write('  Run \x1b[1magentguard guard\x1b[0m to start recording.\n\n');
+      return 0;
+    }
+
+    process.stderr.write('\n  \x1b[1mRecorded Runs\x1b[0m\n');
+    process.stderr.write(`  \x1b[2m${'─'.repeat(50)}\x1b[0m\n`);
+    for (const id of runs.slice(0, 20)) {
+      process.stderr.write(`  ${id}\n`);
+    }
+    process.stderr.write('\n  Use: agentguard traces <runId> or agentguard traces --last\n\n');
+    return 0;
+  }
+
+  // Resolve run ID
+  let runId: string | undefined;
+  if (showLast) {
+    if (useSqlite) {
+      const { createStorageBundle } = await import('../../storage/factory.js');
+      const storage = await createStorageBundle(storageConfig!);
+      if (!storage.db) {
+        process.stderr.write('  Error: SQLite storage backend did not initialize database.\n');
+        return 1;
+      }
+      const { getLatestRunId } = await import('../../storage/sqlite-store.js');
+      const db = storage.db as import('better-sqlite3').Database;
+      runId = getLatestRunId(db) ?? undefined;
+      storage.close();
+    } else {
+      runId = listRunsJsonl()[0];
+    }
+  } else {
+    runId = targetArg;
+  }
+
+  if (!runId) {
+    process.stderr.write('\n  \x1b[2mNo runs recorded yet.\x1b[0m\n\n');
+    return 0;
+  }
+
+  // Load events
+  let eventList: DomainEvent[];
+  if (useSqlite) {
+    const { createStorageBundle } = await import('../../storage/factory.js');
+    const storage = await createStorageBundle(storageConfig!);
+    if (!storage.db) {
+      process.stderr.write('  Error: SQLite storage backend did not initialize database.\n');
+      return 1;
+    }
+    const { loadRunEvents } = await import('../../storage/sqlite-store.js');
+    const db = storage.db as import('better-sqlite3').Database;
+    eventList = loadRunEvents(db, runId);
+    storage.close();
+  } else {
+    eventList = loadEventsJsonl(runId);
+  }
+
+  // Extract and filter traces
+  let traceEvents: PolicyTraceEvent[] = eventList.filter(isPolicyTraceEvent);
+
+  if (traceEvents.length === 0) {
+    if (jsonOutput) {
+      process.stdout.write(JSON.stringify({ totalEvaluations: 0, traces: [] }, null, 2) + '\n');
+    } else {
+      process.stderr.write(`\n  \x1b[1mRun:\x1b[0m ${runId}\n`);
+      process.stderr.write('\n  \x1b[2mNo policy evaluation traces found for this run.\x1b[0m\n\n');
+    }
+    return 0;
+  }
+
+  traceEvents = filterTraces(traceEvents, actionFilter, decisionFilter);
+
+  // JSON output
+  if (jsonOutput) {
+    process.stdout.write(formatTracesJson(traceEvents) + '\n');
+    return 0;
+  }
+
+  // Terminal output
+  process.stderr.write(`\n  \x1b[1mRun:\x1b[0m ${runId}\n`);
+
+  if (actionFilter || decisionFilter) {
+    const filters: string[] = [];
+    if (actionFilter) filters.push(`action=${actionFilter}`);
+    if (decisionFilter) filters.push(`decision=${decisionFilter}`);
+    process.stderr.write(`  \x1b[2mFilters: ${filters.join(', ')}\x1b[0m\n`);
+  }
+
+  // Summary
+  const summary = computeSummary(traceEvents);
+  process.stderr.write(renderTracesSummary(summary));
+
+  // Detailed traces (unless --summary)
+  if (!summaryOnly) {
+    process.stderr.write(renderPolicyTraces(traceEvents));
+  }
+
+  return 0;
+}

--- a/tests/ts/traces-command.test.ts
+++ b/tests/ts/traces-command.test.ts
@@ -1,0 +1,333 @@
+// Tests for the traces CLI command and renderTracesSummary
+import { describe, it, expect } from 'vitest';
+import { renderPolicyTraces } from '../../src/cli/tui.js';
+import type { PolicyTraceEvent } from '../../src/cli/tui.js';
+import {
+  computeSummary,
+  renderTracesSummary,
+} from '../../src/cli/commands/traces.js';
+import type { TraceSummary } from '../../src/cli/commands/traces.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTraceEvent(overrides: Partial<PolicyTraceEvent> = {}): PolicyTraceEvent {
+  return {
+    kind: 'PolicyTraceRecorded',
+    timestamp: Date.now(),
+    actionType: 'file.write',
+    target: 'src/index.ts',
+    decision: 'allow',
+    totalRulesChecked: 3,
+    phaseThatMatched: 'allow',
+    durationMs: 0.5,
+    rulesEvaluated: [
+      {
+        policyId: 'default',
+        policyName: 'default',
+        ruleIndex: 0,
+        effect: 'deny',
+        actionPattern: 'file.delete',
+        actionMatched: false,
+        conditionsMatched: false,
+        conditionDetails: {},
+        outcome: 'no-match' as const,
+      },
+      {
+        policyId: 'default',
+        policyName: 'default',
+        ruleIndex: 1,
+        effect: 'allow',
+        actionPattern: 'file.*',
+        actionMatched: true,
+        conditionsMatched: true,
+        conditionDetails: { scopeMatched: true },
+        outcome: 'match' as const,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function makeDeniedTraceEvent(overrides: Partial<PolicyTraceEvent> = {}): PolicyTraceEvent {
+  return makeTraceEvent({
+    actionType: 'git.push',
+    target: 'origin/main',
+    decision: 'deny',
+    phaseThatMatched: 'deny',
+    rulesEvaluated: [
+      {
+        policyId: 'protect-main',
+        policyName: 'protect-main',
+        ruleIndex: 0,
+        effect: 'deny',
+        actionPattern: 'git.push',
+        actionMatched: true,
+        conditionsMatched: true,
+        conditionDetails: { branchMatched: true },
+        outcome: 'match' as const,
+      },
+    ],
+    ...overrides,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// computeSummary
+// ---------------------------------------------------------------------------
+
+describe('computeSummary', () => {
+  it('returns zeroed summary for empty traces', () => {
+    const summary = computeSummary([]);
+    expect(summary.totalEvaluations).toBe(0);
+    expect(summary.allowed).toBe(0);
+    expect(summary.denied).toBe(0);
+    expect(summary.avgDurationMs).toBeNull();
+    expect(Object.keys(summary.actionTypes)).toHaveLength(0);
+    expect(summary.topMatchedRules).toHaveLength(0);
+  });
+
+  it('counts allowed and denied correctly', () => {
+    const traces = [makeTraceEvent(), makeDeniedTraceEvent(), makeTraceEvent()];
+    const summary = computeSummary(traces);
+    expect(summary.totalEvaluations).toBe(3);
+    expect(summary.allowed).toBe(2);
+    expect(summary.denied).toBe(1);
+  });
+
+  it('computes average duration', () => {
+    const traces = [
+      makeTraceEvent({ durationMs: 1.0 }),
+      makeTraceEvent({ durationMs: 3.0 }),
+    ];
+    const summary = computeSummary(traces);
+    expect(summary.avgDurationMs).toBe(2.0);
+  });
+
+  it('handles traces without duration', () => {
+    const traces = [makeTraceEvent({ durationMs: undefined })];
+    const summary = computeSummary(traces);
+    expect(summary.avgDurationMs).toBeNull();
+  });
+
+  it('breaks down action types', () => {
+    const traces = [
+      makeTraceEvent({ actionType: 'file.write' }),
+      makeTraceEvent({ actionType: 'file.write' }),
+      makeDeniedTraceEvent({ actionType: 'git.push' }),
+    ];
+    const summary = computeSummary(traces);
+    expect(summary.actionTypes['file.write']).toEqual({ allowed: 2, denied: 0 });
+    expect(summary.actionTypes['git.push']).toEqual({ allowed: 0, denied: 1 });
+  });
+
+  it('tracks phase breakdown', () => {
+    const traces = [
+      makeTraceEvent({ phaseThatMatched: 'allow' }),
+      makeDeniedTraceEvent({ phaseThatMatched: 'deny' }),
+      makeTraceEvent({ phaseThatMatched: 'default' }),
+    ];
+    const summary = computeSummary(traces);
+    expect(summary.phaseBreakdown).toEqual({ allow: 1, deny: 1, default: 1 });
+  });
+
+  it('aggregates top matched rules', () => {
+    const rule = {
+      policyId: 'default',
+      policyName: 'default',
+      ruleIndex: 1,
+      effect: 'allow',
+      actionPattern: 'file.*',
+      actionMatched: true,
+      conditionsMatched: true,
+      conditionDetails: {},
+      outcome: 'match' as const,
+    };
+    const traces = [
+      makeTraceEvent({ rulesEvaluated: [rule] }),
+      makeTraceEvent({ rulesEvaluated: [rule] }),
+      makeTraceEvent({ rulesEvaluated: [rule] }),
+    ];
+    const summary = computeSummary(traces);
+    expect(summary.topMatchedRules).toHaveLength(1);
+    expect(summary.topMatchedRules[0].matchCount).toBe(3);
+    expect(summary.topMatchedRules[0].policy).toBe('default#1');
+  });
+
+  it('limits top matched rules to 5', () => {
+    const rules = Array.from({ length: 8 }, (_, i) => ({
+      policyId: `p${i}`,
+      policyName: `policy-${i}`,
+      ruleIndex: 0,
+      effect: 'allow',
+      actionPattern: `action.${i}`,
+      actionMatched: true,
+      conditionsMatched: true,
+      conditionDetails: {},
+      outcome: 'match' as const,
+    }));
+    const traces = rules.map((rule) => makeTraceEvent({ rulesEvaluated: [rule] }));
+    const summary = computeSummary(traces);
+    expect(summary.topMatchedRules.length).toBeLessThanOrEqual(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderTracesSummary
+// ---------------------------------------------------------------------------
+
+describe('renderTracesSummary', () => {
+  it('renders summary header with evaluation count', () => {
+    const summary: TraceSummary = {
+      totalEvaluations: 5,
+      allowed: 3,
+      denied: 2,
+      avgDurationMs: 1.5,
+      actionTypes: {},
+      topMatchedRules: [],
+      phaseBreakdown: {},
+    };
+    const output = renderTracesSummary(summary);
+    expect(output).toContain('Trace Summary');
+    expect(output).toContain('5 evaluations');
+  });
+
+  it('shows allowed and denied counts with percentages', () => {
+    const summary: TraceSummary = {
+      totalEvaluations: 4,
+      allowed: 3,
+      denied: 1,
+      avgDurationMs: null,
+      actionTypes: {},
+      topMatchedRules: [],
+      phaseBreakdown: {},
+    };
+    const output = renderTracesSummary(summary);
+    expect(output).toContain('Allowed:');
+    expect(output).toContain('3');
+    expect(output).toContain('Denied:');
+    expect(output).toContain('1');
+    expect(output).toContain('75%');
+    expect(output).toContain('25%');
+  });
+
+  it('shows average duration when available', () => {
+    const summary: TraceSummary = {
+      totalEvaluations: 2,
+      allowed: 2,
+      denied: 0,
+      avgDurationMs: 2.35,
+      actionTypes: {},
+      topMatchedRules: [],
+      phaseBreakdown: {},
+    };
+    const output = renderTracesSummary(summary);
+    expect(output).toContain('2.35ms');
+  });
+
+  it('omits duration when null', () => {
+    const summary: TraceSummary = {
+      totalEvaluations: 1,
+      allowed: 1,
+      denied: 0,
+      avgDurationMs: null,
+      actionTypes: {},
+      topMatchedRules: [],
+      phaseBreakdown: {},
+    };
+    const output = renderTracesSummary(summary);
+    expect(output).not.toContain('Avg evaluation time');
+  });
+
+  it('renders phase breakdown', () => {
+    const summary: TraceSummary = {
+      totalEvaluations: 3,
+      allowed: 2,
+      denied: 1,
+      avgDurationMs: null,
+      actionTypes: {},
+      topMatchedRules: [],
+      phaseBreakdown: { allow: 2, deny: 1 },
+    };
+    const output = renderTracesSummary(summary);
+    expect(output).toContain('Phase Breakdown');
+    expect(output).toContain('allow');
+    expect(output).toContain('deny');
+  });
+
+  it('renders action type breakdown', () => {
+    const summary: TraceSummary = {
+      totalEvaluations: 3,
+      allowed: 2,
+      denied: 1,
+      avgDurationMs: null,
+      actionTypes: {
+        'file.write': { allowed: 2, denied: 0 },
+        'git.push': { allowed: 0, denied: 1 },
+      },
+      topMatchedRules: [],
+      phaseBreakdown: {},
+    };
+    const output = renderTracesSummary(summary);
+    expect(output).toContain('Action Types');
+    expect(output).toContain('file.write');
+    expect(output).toContain('git.push');
+    expect(output).toContain('2 allowed');
+    expect(output).toContain('1 denied');
+  });
+
+  it('renders top matched rules', () => {
+    const summary: TraceSummary = {
+      totalEvaluations: 5,
+      allowed: 5,
+      denied: 0,
+      avgDurationMs: null,
+      actionTypes: {},
+      topMatchedRules: [
+        { rule: '[allow] file.*', policy: 'default#1', matchCount: 5 },
+      ],
+      phaseBreakdown: {},
+    };
+    const output = renderTracesSummary(summary);
+    expect(output).toContain('Top Matched Rules');
+    expect(output).toContain('5x');
+    expect(output).toContain('[allow] file.*');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderPolicyTraces (existing, verify integration)
+// ---------------------------------------------------------------------------
+
+describe('renderPolicyTraces with trace events', () => {
+  it('renders a single allowed trace', () => {
+    const output = renderPolicyTraces([makeTraceEvent()]);
+    expect(output).toContain('Policy Evaluation Traces');
+    expect(output).toContain('file.write');
+    expect(output).toContain('ALLOW');
+  });
+
+  it('renders a denied trace', () => {
+    const output = renderPolicyTraces([makeDeniedTraceEvent()]);
+    expect(output).toContain('git.push');
+    expect(output).toContain('DENY');
+  });
+
+  it('renders multiple traces with numbering', () => {
+    const traces = [makeTraceEvent(), makeDeniedTraceEvent()];
+    const output = renderPolicyTraces(traces);
+    expect(output).toContain('2 evaluations');
+  });
+
+  it('shows rule evaluation details', () => {
+    const output = renderPolicyTraces([makeTraceEvent()]);
+    expect(output).toContain('file.*');
+    expect(output).toContain('match');
+  });
+
+  it('shows condition details for matched rules', () => {
+    const output = renderPolicyTraces([makeTraceEvent()]);
+    expect(output).toContain('scope');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds new `agentguard traces` CLI command for viewing and analyzing policy evaluation traces from governance sessions
- Supports filtering by action type (`--action git`) and decision outcome (`--decision deny`)
- Includes summary statistics with decision breakdown, phase analysis, action type distribution, and top matched rules
- Supports `--json` output for machine-readable trace data and `--summary` flag for stats-only view
- Works with both JSONL (default) and SQLite storage backends

## New Files
- `src/cli/commands/traces.ts` — Traces command implementation with filtering, summary computation, and rendering
- `tests/ts/traces-command.test.ts` — 20 tests covering `computeSummary()`, `renderTracesSummary()`, and `renderPolicyTraces()` integration

## Modified Files
- `src/cli/bin.ts` — Register `traces` command (help definition, switch case handler, help text section)

## Test plan
- [x] All 20 new traces tests pass (`computeSummary`, `renderTracesSummary`, `renderPolicyTraces` integration)
- [x] All 1428 TypeScript tests pass (74 files)
- [x] All 210 JS tests pass
- [x] TypeScript type-check passes (`tsc --noEmit`)
- [x] ESLint passes (0 errors)
- [x] Prettier formatting clean

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)