### PR TITLE
feat(issue-261): enhance diff command with SQLite, escalation & violations

### DIFF
--- a/src/cli/bin.ts
+++ b/src/cli/bin.ts
@@ -182,11 +182,13 @@ const COMMANDS: Record<string, CommandHelp> = {
       { flag: '--json', description: 'Output as JSON' },
       { flag: '--last', description: 'Compare the two most recent runs' },
       { flag: '--dir, -d <path>', description: 'Base directory for event data' },
+      { flag: '--store <backend>', description: 'Storage backend: jsonl (default) or sqlite' },
     ],
     examples: [
       'agentguard diff run_abc123 run_def456',
       'agentguard diff --last',
       'agentguard diff --last --json',
+      'agentguard diff --last --store sqlite',
     ],
   },
   init: {
@@ -366,7 +368,7 @@ async function main() {
         break;
       }
       const { diff: diffCmd } = await import('./commands/diff.js');
-      await diffCmd(args.slice(1));
+      await diffCmd(args.slice(1), resolveStorageConfig(args.slice(1)));
       break;
     }
 

--- a/src/cli/commands/diff.ts
+++ b/src/cli/commands/diff.ts
@@ -1,13 +1,16 @@
 // CLI command: agentguard diff — compare two governance sessions side-by-side.
 //
 // Loads two sessions by run ID, compares action sequences, policy decisions,
-// and invariant evaluations, and outputs a structured diff report.
+// escalation levels, invariant violations, and outputs a structured diff report.
+// Supports both JSONL (default) and SQLite storage backends via --store flag.
 
 import { parseArgs } from '../args.js';
 import { BOLD, RESET, DIM, FG, bold, dim, color, padVis } from '../colors.js';
-import { compareRunIds } from '../../kernel/replay-comparator.js';
-import { listRunIds } from '../../kernel/replay-engine.js';
+import { compareRunIds, compareReplaySessions } from '../../kernel/replay-comparator.js';
+import { listRunIds, loadReplaySession, buildReplaySession } from '../../kernel/replay-engine.js';
+import type { ReplaySession, ReplayAction } from '../../kernel/replay-engine.js';
 import type { ComparisonReport, ActionComparison } from '../../kernel/replay-comparator.js';
+import type { StorageConfig } from '../../storage/types.js';
 
 // ---------------------------------------------------------------------------
 // Terminal rendering
@@ -41,10 +44,67 @@ function statusLabel(status: ActionComparison['status']): string {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Session-level analysis helpers
+// ---------------------------------------------------------------------------
+
+/** Escalation level ordering for comparison. */
+const ESCALATION_LEVELS = ['NORMAL', 'ELEVATED', 'HIGH', 'LOCKDOWN'] as const;
+
+/** Extract the maximum escalation level observed in a session. */
+function getMaxEscalationLevel(session: ReplaySession): string {
+  let maxLevel = 0;
+  for (const action of session.actions) {
+    if (action.escalationEvent) {
+      const level = (action.escalationEvent.escalationLevel as string) || '';
+      const idx = ESCALATION_LEVELS.indexOf(level as (typeof ESCALATION_LEVELS)[number]);
+      if (idx > maxLevel) maxLevel = idx;
+    }
+  }
+  return ESCALATION_LEVELS[maxLevel];
+}
+
+/** Extract invariant violations from a session, grouped by invariant name. */
+function getInvariantViolations(session: ReplaySession): Map<string, number> {
+  const violations = new Map<string, number>();
+  for (const action of session.actions) {
+    for (const gov of action.governanceEvents) {
+      if (gov.kind === 'InvariantViolation') {
+        const name = (gov.invariant as string) || 'unknown';
+        violations.set(name, (violations.get(name) || 0) + 1);
+      }
+    }
+  }
+  return violations;
+}
+
+/** Get per-action governance detail strings for display. */
+function getActionGovernanceDetail(action: ReplayAction): string[] {
+  const details: string[] = [];
+  if (action.escalationEvent) {
+    const level = (action.escalationEvent.escalationLevel as string) || 'unknown';
+    details.push(`escalation: ${level}`);
+  }
+  for (const gov of action.governanceEvents) {
+    if (gov.kind === 'InvariantViolation') {
+      const inv = (gov.invariant as string) || 'unknown';
+      details.push(`violation: ${inv}`);
+    } else if (gov.kind === 'PolicyDenied') {
+      const reason = (gov.reason as string) || '';
+      details.push(`policy: ${reason}`);
+    }
+  }
+  return details;
+}
+
 /**
  * Render a comparison report with ANSI colors for terminal display.
  */
-function renderDiffReport(report: ComparisonReport): string {
+function renderDiffReport(
+  report: ComparisonReport,
+  sessionA?: ReplaySession,
+  sessionB?: ReplaySession
+): string {
   const lines: string[] = [];
 
   // Header
@@ -106,12 +166,38 @@ function renderDiffReport(report: ComparisonReport): string {
         }
       }
 
+      // Show governance details (escalation, violations) for divergent actions
+      if (comp.status === 'divergent') {
+        const origDetails = comp.original ? getActionGovernanceDetail(comp.original) : [];
+        const replayDetails = comp.replayed ? getActionGovernanceDetail(comp.replayed) : [];
+        if (origDetails.length > 0 || replayDetails.length > 0) {
+          if (origDetails.length > 0) {
+            for (const d of origDetails) {
+              lines.push(`       ${dim('A:')} ${color(d, 'red')}`);
+            }
+          }
+          if (replayDetails.length > 0) {
+            for (const d of replayDetails) {
+              lines.push(`       ${dim('B:')} ${color(d, 'green')}`);
+            }
+          }
+        }
+      }
+
       if (comp.status === 'missing' && comp.original) {
         lines.push(`       ${dim('Only in Session A')}`);
+        const details = getActionGovernanceDetail(comp.original);
+        for (const d of details) {
+          lines.push(`       ${dim('\u2514')} ${color(d, 'yellow')}`);
+        }
       }
 
       if (comp.status === 'extra' && comp.replayed) {
         lines.push(`       ${dim('Only in Session B')}`);
+        const details = getActionGovernanceDetail(comp.replayed);
+        for (const d of details) {
+          lines.push(`       ${dim('\u2514')} ${color(d, 'yellow')}`);
+        }
       }
     }
     lines.push('');
@@ -132,6 +218,52 @@ function renderDiffReport(report: ComparisonReport): string {
     lines.push('');
   }
 
+  // Escalation level comparison
+  if (sessionA && sessionB) {
+    const levelA = getMaxEscalationLevel(sessionA);
+    const levelB = getMaxEscalationLevel(sessionB);
+
+    if (levelA !== levelB) {
+      lines.push(`  ${BOLD}Escalation Levels${RESET}`);
+      lines.push(`  ${DIM}${'─'.repeat(50)}${RESET}`);
+      const colorA = levelA === 'NORMAL' ? 'green' : levelA === 'LOCKDOWN' ? 'red' : 'yellow';
+      const colorB = levelB === 'NORMAL' ? 'green' : levelB === 'LOCKDOWN' ? 'red' : 'yellow';
+      lines.push(
+        `  ${padVis('Max escalation', 20)} ${color(levelA, colorA)} ${dim('\u2192')} ${color(levelB, colorB)}`
+      );
+      lines.push('');
+    }
+
+    // Invariant violation comparison
+    const violationsA = getInvariantViolations(sessionA);
+    const violationsB = getInvariantViolations(sessionB);
+    const allInvariants = new Set([...violationsA.keys(), ...violationsB.keys()]);
+
+    if (allInvariants.size > 0) {
+      const changedInvariants: Array<[string, number, number]> = [];
+      for (const inv of allInvariants) {
+        const countA = violationsA.get(inv) || 0;
+        const countB = violationsB.get(inv) || 0;
+        if (countA !== countB) {
+          changedInvariants.push([inv, countA, countB]);
+        }
+      }
+
+      if (changedInvariants.length > 0) {
+        lines.push(`  ${BOLD}Invariant Violations${RESET}`);
+        lines.push(`  ${DIM}${'─'.repeat(50)}${RESET}`);
+        for (const [inv, countA, countB] of changedInvariants) {
+          const colorA = countA === 0 ? 'green' : 'red';
+          const colorB = countB === 0 ? 'green' : 'red';
+          lines.push(
+            `  ${padVis(inv, 30)} ${color(String(countA), colorA)} ${dim('\u2192')} ${color(String(countB), colorB)}`
+          );
+        }
+        lines.push('');
+      }
+    }
+  }
+
   return lines.join('\n') + '\n';
 }
 
@@ -139,15 +271,57 @@ function renderDiffReport(report: ComparisonReport): string {
 // CLI command
 // ---------------------------------------------------------------------------
 
-export async function diff(args: string[]): Promise<void> {
+// ---------------------------------------------------------------------------
+// SQLite helpers
+// ---------------------------------------------------------------------------
+
+async function loadSessionSqlite(
+  runId: string,
+  storageConfig: StorageConfig
+): Promise<ReplaySession | null> {
+  const { createStorageBundle } = await import('../../storage/factory.js');
+  const { loadRunEvents } = await import('../../storage/sqlite-store.js');
+  const storage = await createStorageBundle(storageConfig);
+  if (!storage.db) {
+    process.stderr.write(`  ${FG.red}Error:${RESET} SQLite storage backend did not initialize.\n`);
+    return null;
+  }
+  const db = storage.db as import('better-sqlite3').Database;
+  const events = loadRunEvents(db, runId);
+  storage.close();
+  if (events.length === 0) return null;
+  return buildReplaySession(runId, events);
+}
+
+async function listRunIdsSqlite(storageConfig: StorageConfig): Promise<string[]> {
+  const { createStorageBundle } = await import('../../storage/factory.js');
+  const { listRunIds: listSqliteRunIds } = await import('../../storage/sqlite-store.js');
+  const storage = await createStorageBundle(storageConfig);
+  if (!storage.db) return [];
+  const db = storage.db as import('better-sqlite3').Database;
+  const runs = listSqliteRunIds(db);
+  storage.close();
+  return runs;
+}
+
+// ---------------------------------------------------------------------------
+// CLI command
+// ---------------------------------------------------------------------------
+
+export async function diff(args: string[], storageConfig?: StorageConfig): Promise<void> {
   const parsed = parseArgs(args, {
     boolean: ['--json', '--last'],
-    string: ['--dir', '-d'],
+    string: ['--dir', '-d', '--store'],
     alias: { '-d': '--dir' },
   });
 
   const baseDir = (parsed.flags.dir as string) || undefined;
   const wantJson = !!parsed.flags.json;
+  const useSqlite = storageConfig?.backend === 'sqlite' || parsed.flags.store === 'sqlite';
+  const resolvedConfig: StorageConfig = storageConfig || {
+    backend: useSqlite ? 'sqlite' : 'jsonl',
+    baseDir,
+  };
 
   // Resolve run IDs
   let runIdA: string | undefined;
@@ -155,7 +329,7 @@ export async function diff(args: string[]): Promise<void> {
 
   if (parsed.flags.last) {
     // --last: compare the two most recent runs
-    const runs = listRunIds(baseDir);
+    const runs = useSqlite ? await listRunIdsSqlite(resolvedConfig) : listRunIds(baseDir);
     if (runs.length < 2) {
       process.stderr.write(
         `\n  ${FG.red}Error:${RESET} Need at least 2 recorded runs for --last comparison.\n`
@@ -180,18 +354,36 @@ export async function diff(args: string[]): Promise<void> {
     --json          Output as JSON
     --last          Compare the two most recent runs
     --dir, -d       Base directory for event data
+    --store         Storage backend: jsonl (default) or sqlite
 
   ${BOLD}Examples:${RESET}
     agentguard diff run_abc123 run_def456
     agentguard diff --last
     agentguard diff --last --json
+    agentguard diff --last --store sqlite
 `);
     process.exitCode = 1;
     return;
   }
 
-  // Compare
-  const report = compareRunIds(runIdA, runIdB, { baseDir });
+  // Load sessions and compare
+  let report: ComparisonReport | null;
+  let sessionA: ReplaySession | null = null;
+  let sessionB: ReplaySession | null = null;
+
+  if (useSqlite) {
+    sessionA = await loadSessionSqlite(runIdA, resolvedConfig);
+    sessionB = await loadSessionSqlite(runIdB, resolvedConfig);
+    if (sessionA && sessionB) {
+      report = compareReplaySessions(sessionA, sessionB);
+    } else {
+      report = null;
+    }
+  } else {
+    sessionA = loadReplaySession(runIdA, { baseDir });
+    sessionB = loadReplaySession(runIdB, { baseDir });
+    report = compareRunIds(runIdA, runIdB, { baseDir });
+  }
 
   if (!report) {
     process.stderr.write(`\n  ${FG.red}Error:${RESET} Could not load one or both sessions.\n`);
@@ -203,13 +395,43 @@ export async function diff(args: string[]): Promise<void> {
 
   // Output
   if (wantJson) {
-    process.stdout.write(JSON.stringify(report, null, 2) + '\n');
+    // Enrich JSON output with escalation and violation details
+    const enriched = enrichJsonReport(report, sessionA, sessionB);
+    process.stdout.write(JSON.stringify(enriched, null, 2) + '\n');
   } else {
-    process.stderr.write(renderDiffReport(report));
+    process.stderr.write(renderDiffReport(report, sessionA ?? undefined, sessionB ?? undefined));
   }
 
   // Exit with non-zero if sessions diverge
   if (!report.identical) {
     process.exitCode = 1;
   }
+}
+
+/** Enrich a ComparisonReport with escalation and violation metadata for JSON output. */
+function enrichJsonReport(
+  report: ComparisonReport,
+  sessionA: ReplaySession | null,
+  sessionB: ReplaySession | null
+): Record<string, unknown> {
+  const base = report as unknown as Record<string, unknown>;
+  if (!sessionA || !sessionB) return base;
+
+  const levelA = getMaxEscalationLevel(sessionA);
+  const levelB = getMaxEscalationLevel(sessionB);
+  const violationsA = Object.fromEntries(getInvariantViolations(sessionA));
+  const violationsB = Object.fromEntries(getInvariantViolations(sessionB));
+
+  return {
+    ...base,
+    escalation: {
+      sessionA: levelA,
+      sessionB: levelB,
+      changed: levelA !== levelB,
+    },
+    invariantViolations: {
+      sessionA: violationsA,
+      sessionB: violationsB,
+    },
+  };
 }

--- a/tests/ts/diff-command.test.ts
+++ b/tests/ts/diff-command.test.ts
@@ -295,4 +295,118 @@ describe('diff command', () => {
       expect(stderrOutput).toContain('Summary Differences');
     });
   });
+
+  // ── Escalation Level Comparison ──
+
+  describe('escalation level comparison', () => {
+    it('shows escalation level changes between sessions', async () => {
+      const origEvents = createAllowedActionEvents('file.write', 'a.ts', 1000);
+      const replayEvents = [
+        testEvent('ActionRequested', { actionType: 'file.write', target: 'a.ts', agentId: 'test' }, 1000),
+        testEvent('ActionEscalated', { actionType: 'file.write', target: 'a.ts', escalationLevel: 'ELEVATED' }, 1001),
+        testEvent('ActionAllowed', { actionType: 'file.write', target: 'a.ts', reason: 'Allowed after escalation' }, 1002),
+        testEvent('ActionExecuted', { actionType: 'file.write', target: 'a.ts', result: 'success' }, 1003),
+      ];
+
+      writeTestJsonl('run-a', origEvents);
+      writeTestJsonl('run-b', replayEvents);
+
+      await runDiff(['run-a', 'run-b', '--dir', TEST_BASE_DIR]);
+      expect(stderrOutput).toContain('Escalation Levels');
+      expect(stderrOutput).toContain('NORMAL');
+      expect(stderrOutput).toContain('ELEVATED');
+    });
+
+    it('does not show escalation section when levels are the same', async () => {
+      const events = createAllowedActionEvents('file.write', 'a.ts', 1000);
+      writeTestJsonl('run-a', events);
+      writeTestJsonl('run-b', events);
+
+      await runDiff(['run-a', 'run-b', '--dir', TEST_BASE_DIR]);
+      expect(stderrOutput).not.toContain('Escalation Levels');
+    });
+  });
+
+  // ── Invariant Violation Highlighting ──
+
+  describe('invariant violation highlighting', () => {
+    it('shows invariant violations that differ between sessions', async () => {
+      const origEvents = createAllowedActionEvents('file.write', 'a.ts', 1000);
+      const replayEvents = [
+        testEvent('ActionRequested', { actionType: 'file.write', target: 'a.ts', agentId: 'test' }, 1000),
+        testEvent('InvariantViolation', { invariant: 'secret-exposure', action: 'file.write', reason: 'Secrets detected' }, 1001),
+        testEvent('ActionDenied', { actionType: 'file.write', target: 'a.ts', reason: 'Invariant violation' }, 1002),
+      ];
+
+      writeTestJsonl('run-a', origEvents);
+      writeTestJsonl('run-b', replayEvents);
+
+      await runDiff(['run-a', 'run-b', '--dir', TEST_BASE_DIR]);
+      expect(stderrOutput).toContain('Invariant Violations');
+      expect(stderrOutput).toContain('secret-exposure');
+    });
+
+    it('shows per-action governance details for divergent actions', async () => {
+      const origEvents = createAllowedActionEvents('file.write', 'a.ts', 1000);
+      const replayEvents = [
+        testEvent('ActionRequested', { actionType: 'file.write', target: 'a.ts', agentId: 'test' }, 1000),
+        testEvent('InvariantViolation', { invariant: 'blast-radius', action: 'file.write', reason: 'Too many files' }, 1001),
+        testEvent('ActionDenied', { actionType: 'file.write', target: 'a.ts', reason: 'blast-radius violation' }, 1002),
+      ];
+
+      writeTestJsonl('run-a', origEvents);
+      writeTestJsonl('run-b', replayEvents);
+
+      await runDiff(['run-a', 'run-b', '--dir', TEST_BASE_DIR]);
+      expect(stderrOutput).toContain('violation: blast-radius');
+    });
+  });
+
+  // ── Enriched JSON Output ──
+
+  describe('enriched JSON output', () => {
+    it('includes escalation metadata in JSON output', async () => {
+      const origEvents = createAllowedActionEvents('file.write', 'a.ts', 1000);
+      const replayEvents = [
+        testEvent('ActionRequested', { actionType: 'file.write', target: 'a.ts', agentId: 'test' }, 1000),
+        testEvent('ActionEscalated', { actionType: 'file.write', target: 'a.ts', escalationLevel: 'HIGH' }, 1001),
+        testEvent('ActionAllowed', { actionType: 'file.write', target: 'a.ts', reason: 'Allowed' }, 1002),
+        testEvent('ActionExecuted', { actionType: 'file.write', target: 'a.ts', result: 'success' }, 1003),
+      ];
+
+      writeTestJsonl('run-a', origEvents);
+      writeTestJsonl('run-b', replayEvents);
+
+      await runDiff(['run-a', 'run-b', '--json', '--dir', TEST_BASE_DIR]);
+      const parsed = JSON.parse(stdoutOutput);
+      expect(parsed.escalation).toBeDefined();
+      expect(parsed.escalation.sessionA).toBe('NORMAL');
+      expect(parsed.escalation.sessionB).toBe('HIGH');
+      expect(parsed.escalation.changed).toBe(true);
+    });
+
+    it('includes invariant violations in JSON output', async () => {
+      const origEvents = createAllowedActionEvents('file.write', 'a.ts', 1000);
+      const replayEvents = [
+        testEvent('ActionRequested', { actionType: 'file.write', target: 'a.ts', agentId: 'test' }, 1000),
+        testEvent('InvariantViolation', { invariant: 'no-force-push', reason: 'Force push detected' }, 1001),
+        testEvent('ActionDenied', { actionType: 'file.write', target: 'a.ts', reason: 'Violation' }, 1002),
+      ];
+
+      writeTestJsonl('run-a', origEvents);
+      writeTestJsonl('run-b', replayEvents);
+
+      await runDiff(['run-a', 'run-b', '--json', '--dir', TEST_BASE_DIR]);
+      const parsed = JSON.parse(stdoutOutput);
+      expect(parsed.invariantViolations).toBeDefined();
+      expect(parsed.invariantViolations.sessionA).toEqual({});
+      expect(parsed.invariantViolations.sessionB).toEqual({ 'no-force-push': 1 });
+    });
+
+    it('shows store flag in usage help', async () => {
+      await runDiff([]);
+      expect(stderrOutput).toContain('--store');
+      expect(stderrOutput).toContain('sqlite');
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Enhances the `agentguard diff` command with SQLite backend support, escalation level comparison, and invariant violation highlighting
- Adds `--store sqlite` flag for parity with other CLI commands (inspect, replay, export, ci-check)
- Enriches both terminal and JSON output with governance-specific diff detail
- Closes #261

## Changes
- `src/cli/commands/diff.ts` — Added SQLite backend loading (dynamic import pattern), escalation level extraction/comparison, invariant violation grouping, per-action governance detail rendering, enriched JSON output with `escalation` and `invariantViolations` metadata
- `src/cli/bin.ts` — Pass `storageConfig` to diff command, add `--store` flag to help text
- `tests/ts/diff-command.test.ts` — Added 7 new tests: escalation level comparison (present/absent), invariant violation highlighting, per-action governance details, enriched JSON output with escalation and violation metadata, usage help includes --store flag

## Test Plan
- [x] TypeScript build passes (`npm run build:ts`)
- [x] Vitest tests pass (`npm run ts:test`) — 1415 pass / 0 fail
- [x] JS tests pass (`npm test`) — 210 pass / 0 fail
- [x] ESLint clean (`npm run lint`) — 0 errors
- [x] Prettier clean (`npm run format`)
- [x] Type-check passes (`npm run ts:check`)

## Risk Assessment

| Metric | Value |
|--------|-------|
| Risk level | low |
| Risk score | 12/100 |
| Blast radius | 0 (weighted) |
| Simulation result | not applicable (feature branch) |

## Governance Report

| Metric | Count |
|--------|-------|
| Total events | 2401 |
| Actions allowed | 432 |
| Actions denied | 43 |
| Policy denials | 17 |
| Invariant violations | 33 |
| Escalation events | 2 |
| Decision records | 472 |

<details>
<summary>Governance details</summary>

**Source**: `.agentguard/events/`, `.agentguard/decisions/`, `logs/runtime-events.jsonl`

**Decision Records**: 472 total, 41 denials
**Escalation levels observed**: NORMAL only (session-level)
**Pre-push simulation**: low risk, blast radius 0

Note: governance telemetry spans multiple sessions sharing the same `.agentguard/` directory. Denials and violations are from prior sessions, not this implementation.

</details>