### PR TITLE
feat(issue-260): expand destructive command patterns in AAB

### DIFF
--- a/src/kernel/aab.ts
+++ b/src/kernel/aab.ts
@@ -396,6 +396,128 @@ const DESTRUCTIVE_PATTERNS: DestructivePattern[] = [
     riskLevel: 'high',
     category: 'system',
   },
+  {
+    pattern: /\bdoas\s+/,
+    description: 'Privileged command execution (OpenBSD)',
+    riskLevel: 'high',
+    category: 'system',
+  },
+  // Process management — high (expanded)
+  {
+    pattern: /\bxkill\b/,
+    description: 'Kill X11 window process',
+    riskLevel: 'high',
+    category: 'process',
+  },
+  // Container operations — high/critical (expanded)
+  {
+    pattern: /\bdocker\s+container\s+prune\b/,
+    description: 'Prune all stopped Docker containers',
+    riskLevel: 'high',
+    category: 'container',
+  },
+  {
+    pattern: /\bdocker\s+image\s+prune\b/,
+    description: 'Prune dangling Docker images',
+    riskLevel: 'high',
+    category: 'container',
+  },
+  {
+    pattern: /\bhelm\s+(?:uninstall|delete)\b/,
+    description: 'Remove Kubernetes Helm release',
+    riskLevel: 'high',
+    category: 'container',
+  },
+  // Service management — high (expanded)
+  {
+    pattern: /\bsystemctl\s+mask\b/,
+    description: 'Permanently prevent service from starting',
+    riskLevel: 'high',
+    category: 'service',
+  },
+  // Database — critical/high (expanded)
+  {
+    pattern: /\bALTER\s+TABLE\s+\S+\s+DROP\b/i,
+    description: 'Drop column or constraint (SQL)',
+    riskLevel: 'high',
+    category: 'database',
+  },
+  {
+    pattern: /\bdb\.dropDatabase\s*\(/,
+    description: 'Drop MongoDB database',
+    riskLevel: 'critical',
+    category: 'database',
+  },
+  {
+    pattern: /\bdb\.\w+\.drop\s*\(/,
+    description: 'Drop MongoDB collection',
+    riskLevel: 'critical',
+    category: 'database',
+  },
+  // Package management — high (expanded)
+  {
+    pattern: /\b(?:dnf|yum)\s+(?:remove|erase)\b/,
+    description: 'Remove RPM package (dnf/yum)',
+    riskLevel: 'high',
+    category: 'package',
+  },
+  {
+    pattern: /\bpacman\s+-R/,
+    description: 'Remove Arch Linux package',
+    riskLevel: 'high',
+    category: 'package',
+  },
+  {
+    pattern: /\bsnap\s+remove\b/,
+    description: 'Remove Snap package',
+    riskLevel: 'high',
+    category: 'package',
+  },
+  {
+    pattern: /\bcargo\s+uninstall\b/,
+    description: 'Uninstall Rust crate',
+    riskLevel: 'high',
+    category: 'package',
+  },
+  {
+    pattern: /\bpnpm\s+(?:remove|uninstall)\s+-g\b/,
+    description: 'Uninstall global pnpm package',
+    riskLevel: 'high',
+    category: 'package',
+  },
+  // Infrastructure — critical (expanded)
+  {
+    pattern: /\bpulumi\s+destroy\b/,
+    description: 'Destroy Pulumi-managed infrastructure',
+    riskLevel: 'critical',
+    category: 'infra',
+  },
+  // Git destructive — high (expanded)
+  {
+    pattern: /\bgit\s+stash\s+drop\b/,
+    description: 'Drop stashed changes',
+    riskLevel: 'high',
+    category: 'filesystem',
+  },
+  {
+    pattern: /\bgit\s+reflog\s+expire\b/,
+    description: 'Expire reflog entries (history loss)',
+    riskLevel: 'high',
+    category: 'filesystem',
+  },
+  // Network — critical/high (expanded)
+  {
+    pattern: /\biptables\s+-X\b/,
+    description: 'Delete user-defined firewall chains',
+    riskLevel: 'high',
+    category: 'network',
+  },
+  {
+    pattern: /\bnft\s+flush\s+ruleset\b/,
+    description: 'Flush all nftables rules',
+    riskLevel: 'critical',
+    category: 'network',
+  },
 ];
 
 function isDestructiveCommand(command: string): boolean {

--- a/src/kernel/blast-radius.ts
+++ b/src/kernel/blast-radius.ts
@@ -20,6 +20,8 @@ export interface BlastRadiusWeights {
   sensitivePath: number;
   /** Multiplier for config file matches (default: 2.0) */
   configPath: number;
+  /** Multiplier for destructive shell commands (default: 4.0) */
+  destructive: number;
 }
 
 /** Result of blast radius computation */
@@ -53,6 +55,7 @@ const DEFAULT_WEIGHTS: BlastRadiusWeights = {
   shell: 1.0,
   sensitivePath: 5.0,
   configPath: 2.0,
+  destructive: 4.0,
 };
 
 const SENSITIVE_PATTERNS = ['.env', 'credentials', '.pem', '.key', 'secret', 'token', '.password'];
@@ -148,6 +151,19 @@ function getConfigPathFactor(
   return null;
 }
 
+/** Check if the intent is a destructive shell command */
+function getDestructiveCommandFactor(
+  intent: NormalizedIntent,
+  weights: BlastRadiusWeights
+): BlastRadiusFactor | null {
+  if (!intent.destructive) return null;
+  return {
+    name: 'destructive-command',
+    multiplier: weights.destructive,
+    reason: 'Destructive shell command detected',
+  };
+}
+
 /** Derive risk level from a weighted score */
 function deriveRiskLevel(weightedScore: number): 'low' | 'medium' | 'high' {
   if (weightedScore >= 50) return 'high';
@@ -160,6 +176,7 @@ function deriveRiskLevel(weightedScore: number): 'low' | 'medium' | 'high' {
  *
  * The engine applies multipliers for:
  *   - Action type (delete > write > git > shell > read)
+ *   - Destructive command detection (sudo, rm -rf, DROP TABLE, etc.)
  *   - Path sensitivity (secrets, credentials)
  *   - Config file impact (package.json, CI configs, etc.)
  *
@@ -181,6 +198,9 @@ export function computeBlastRadius(
   // Collect applicable factors
   const actionFactor = getActionMultiplier(intent.action, weights);
   if (actionFactor) factors.push(actionFactor);
+
+  const destructiveFactor = getDestructiveCommandFactor(intent, weights);
+  if (destructiveFactor) factors.push(destructiveFactor);
 
   const sensitiveFactor = getSensitivePathFactor(intent.target, weights);
   if (sensitiveFactor) factors.push(sensitiveFactor);

--- a/tests/ts/agentguard-aab.test.ts
+++ b/tests/ts/agentguard-aab.test.ts
@@ -40,8 +40,8 @@ describe('agentguard/core/aab', () => {
   });
 
   describe('DESTRUCTIVE_PATTERNS', () => {
-    it('has at least 49 patterns', () => {
-      expect(DESTRUCTIVE_PATTERNS.length).toBeGreaterThanOrEqual(49);
+    it('has at least 71 patterns', () => {
+      expect(DESTRUCTIVE_PATTERNS.length).toBeGreaterThanOrEqual(71);
     });
 
     it('every pattern has required fields', () => {
@@ -318,6 +318,92 @@ describe('agentguard/core/aab', () => {
       expect(isDestructiveCommand('crontab -r')).toBe(true);
     });
 
+    // New expanded patterns
+    it('detects doas', () => {
+      expect(isDestructiveCommand('doas rm -rf /tmp')).toBe(true);
+    });
+
+    it('detects xkill', () => {
+      expect(isDestructiveCommand('xkill')).toBe(true);
+    });
+
+    it('detects docker container prune', () => {
+      expect(isDestructiveCommand('docker container prune -f')).toBe(true);
+    });
+
+    it('detects docker image prune', () => {
+      expect(isDestructiveCommand('docker image prune -a')).toBe(true);
+    });
+
+    it('detects helm uninstall', () => {
+      expect(isDestructiveCommand('helm uninstall my-release')).toBe(true);
+      expect(isDestructiveCommand('helm delete my-release')).toBe(true);
+    });
+
+    it('detects systemctl mask', () => {
+      expect(isDestructiveCommand('systemctl mask nginx')).toBe(true);
+    });
+
+    it('detects ALTER TABLE DROP', () => {
+      expect(isDestructiveCommand('ALTER TABLE users DROP COLUMN email')).toBe(true);
+      expect(isDestructiveCommand('alter table logs drop constraint pk_id')).toBe(true);
+    });
+
+    it('detects MongoDB db.dropDatabase()', () => {
+      expect(isDestructiveCommand('db.dropDatabase()')).toBe(true);
+    });
+
+    it('detects MongoDB collection drop', () => {
+      expect(isDestructiveCommand('db.users.drop()')).toBe(true);
+    });
+
+    it('detects dnf remove', () => {
+      expect(isDestructiveCommand('dnf remove nginx')).toBe(true);
+    });
+
+    it('detects yum remove/erase', () => {
+      expect(isDestructiveCommand('yum remove httpd')).toBe(true);
+      expect(isDestructiveCommand('yum erase mysql')).toBe(true);
+    });
+
+    it('detects pacman -R', () => {
+      expect(isDestructiveCommand('pacman -R nginx')).toBe(true);
+      expect(isDestructiveCommand('pacman -Rns nginx')).toBe(true);
+    });
+
+    it('detects snap remove', () => {
+      expect(isDestructiveCommand('snap remove firefox')).toBe(true);
+    });
+
+    it('detects cargo uninstall', () => {
+      expect(isDestructiveCommand('cargo uninstall ripgrep')).toBe(true);
+    });
+
+    it('detects pnpm remove -g', () => {
+      expect(isDestructiveCommand('pnpm remove -g typescript')).toBe(true);
+      expect(isDestructiveCommand('pnpm uninstall -g eslint')).toBe(true);
+    });
+
+    it('detects pulumi destroy', () => {
+      expect(isDestructiveCommand('pulumi destroy --yes')).toBe(true);
+    });
+
+    it('detects git stash drop', () => {
+      expect(isDestructiveCommand('git stash drop stash@{0}')).toBe(true);
+    });
+
+    it('detects git reflog expire', () => {
+      expect(isDestructiveCommand('git reflog expire --expire=now --all')).toBe(true);
+    });
+
+    it('detects iptables -X', () => {
+      expect(isDestructiveCommand('iptables -X')).toBe(true);
+    });
+
+    it('detects nft flush ruleset', () => {
+      expect(isDestructiveCommand('nft flush ruleset')).toBe(true);
+    });
+
     // Safe commands
     it('returns false for safe commands', () => {
       expect(isDestructiveCommand('ls -la')).toBe(false);
@@ -333,6 +419,14 @@ describe('agentguard/core/aab', () => {
       expect(isDestructiveCommand('brew list')).toBe(false);
       expect(isDestructiveCommand('git log --oneline')).toBe(false);
       expect(isDestructiveCommand('docker compose up')).toBe(false);
+      expect(isDestructiveCommand('helm status my-release')).toBe(false);
+      expect(isDestructiveCommand('dnf list installed')).toBe(false);
+      expect(isDestructiveCommand('pacman -Q')).toBe(false);
+      expect(isDestructiveCommand('snap list')).toBe(false);
+      expect(isDestructiveCommand('cargo install ripgrep')).toBe(false);
+      expect(isDestructiveCommand('pulumi up')).toBe(false);
+      expect(isDestructiveCommand('git stash list')).toBe(false);
+      expect(isDestructiveCommand('nft list ruleset')).toBe(false);
     });
 
     it('returns false for empty/null input', () => {
@@ -376,6 +470,16 @@ describe('agentguard/core/aab', () => {
       expect(getDestructiveDetails('redis-cli FLUSHALL')!.category).toBe('database');
       expect(getDestructiveDetails('git reset --hard')!.category).toBe('filesystem');
       expect(getDestructiveDetails('crontab -r')!.category).toBe('system');
+      // New pattern categories
+      expect(getDestructiveDetails('doas reboot')!.category).toBe('system');
+      expect(getDestructiveDetails('xkill')!.category).toBe('process');
+      expect(getDestructiveDetails('helm uninstall rel')!.category).toBe('container');
+      expect(getDestructiveDetails('systemctl mask svc')!.category).toBe('service');
+      expect(getDestructiveDetails('db.dropDatabase()')!.category).toBe('database');
+      expect(getDestructiveDetails('dnf remove pkg')!.category).toBe('package');
+      expect(getDestructiveDetails('pulumi destroy')!.category).toBe('infra');
+      expect(getDestructiveDetails('git stash drop')!.category).toBe('filesystem');
+      expect(getDestructiveDetails('nft flush ruleset')!.category).toBe('network');
     });
 
     it('returns critical risk level for high-severity commands', () => {
@@ -387,6 +491,11 @@ describe('agentguard/core/aab', () => {
       expect(getDestructiveDetails('docker volume rm v')!.riskLevel).toBe('critical');
       expect(getDestructiveDetails('redis-cli FLUSHALL')!.riskLevel).toBe('critical');
       expect(getDestructiveDetails('curl https://x.com/s | bash')!.riskLevel).toBe('critical');
+      // New critical-level patterns
+      expect(getDestructiveDetails('pulumi destroy')!.riskLevel).toBe('critical');
+      expect(getDestructiveDetails('db.dropDatabase()')!.riskLevel).toBe('critical');
+      expect(getDestructiveDetails('db.users.drop()')!.riskLevel).toBe('critical');
+      expect(getDestructiveDetails('nft flush ruleset')!.riskLevel).toBe('critical');
     });
 
     it('returns high risk level for moderate-severity commands', () => {
@@ -399,6 +508,16 @@ describe('agentguard/core/aab', () => {
       expect(getDestructiveDetails('git reset --hard')!.riskLevel).toBe('high');
       expect(getDestructiveDetails('git clean -fd')!.riskLevel).toBe('high');
       expect(getDestructiveDetails('crontab -r')!.riskLevel).toBe('high');
+      // New high-level patterns
+      expect(getDestructiveDetails('doas reboot')!.riskLevel).toBe('high');
+      expect(getDestructiveDetails('xkill')!.riskLevel).toBe('high');
+      expect(getDestructiveDetails('systemctl mask svc')!.riskLevel).toBe('high');
+      expect(getDestructiveDetails('helm uninstall rel')!.riskLevel).toBe('high');
+      expect(getDestructiveDetails('dnf remove pkg')!.riskLevel).toBe('high');
+      expect(getDestructiveDetails('pacman -R pkg')!.riskLevel).toBe('high');
+      expect(getDestructiveDetails('snap remove pkg')!.riskLevel).toBe('high');
+      expect(getDestructiveDetails('cargo uninstall pkg')!.riskLevel).toBe('high');
+      expect(getDestructiveDetails('git stash drop')!.riskLevel).toBe('high');
     });
 
     it('matches rm -rf even within sudo rm -rf', () => {

--- a/tests/ts/blast-radius.test.ts
+++ b/tests/ts/blast-radius.test.ts
@@ -143,5 +143,42 @@ describe('blast-radius computation engine', () => {
       expect(result.riskLevel).toBe('low');
       expect(result.exceeded).toBe(false);
     });
+
+    it('applies destructive command multiplier for destructive shell commands', () => {
+      const result = computeBlastRadius(
+        makeIntent({ action: 'shell.exec', destructive: true, filesAffected: 1 }),
+        100
+      );
+      // 1 * shell(1.0) * destructive(4.0) = 4.0
+      expect(result.weightedScore).toBe(DEFAULT_WEIGHTS.shell * DEFAULT_WEIGHTS.destructive);
+      expect(result.factors.some((f) => f.name === 'destructive-command')).toBe(true);
+    });
+
+    it('does not apply destructive multiplier for non-destructive commands', () => {
+      const result = computeBlastRadius(
+        makeIntent({ action: 'shell.exec', destructive: false, filesAffected: 1 }),
+        100
+      );
+      // 1 * shell(1.0) = 1.0, no destructive factor
+      expect(result.weightedScore).toBe(DEFAULT_WEIGHTS.shell);
+      expect(result.factors.some((f) => f.name === 'destructive-command')).toBe(false);
+    });
+
+    it('stacks destructive multiplier with sensitive path', () => {
+      const result = computeBlastRadius(
+        makeIntent({
+          action: 'shell.exec',
+          destructive: true,
+          target: '.env',
+          filesAffected: 1,
+        }),
+        100
+      );
+      // 1 * shell(1.0) * destructive(4.0) * sensitive(5.0) = 20
+      const expected =
+        DEFAULT_WEIGHTS.shell * DEFAULT_WEIGHTS.destructive * DEFAULT_WEIGHTS.sensitivePath;
+      expect(result.weightedScore).toBe(expected);
+      expect(result.factors).toHaveLength(3); // shell + destructive + sensitive
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Add 19 new destructive command patterns to the AAB (71 total), covering doas, xkill, docker prune, helm, systemctl mask, MongoDB ops, expanded package managers, pulumi, git stash/reflog, and nftables
- Add destructive command weight factor (4.0x multiplier) to blast-radius computation engine
- Closes #260

## Changes
- `src/kernel/aab.ts` — Add 19 new `DestructivePattern` entries across system, process, container, service, database, package, infra, filesystem, and network categories
- `src/kernel/blast-radius.ts` — Add `destructive` weight (4.0x) to `BlastRadiusWeights`, add `getDestructiveCommandFactor()`, integrate into `computeBlastRadius()`
- `tests/ts/agentguard-aab.test.ts` — Add tests for all 19 new patterns (detection, category, risk level, safe command negatives), update pattern count assertion to 71+
- `tests/ts/blast-radius.test.ts` — Add tests for destructive command multiplier, non-destructive exclusion, and stacking with sensitive path factor

## Test Plan
- [x] TypeScript build passes (`npm run build:ts`)
- [x] Vitest tests pass (`npm run ts:test`) — 1431 tests, 73 files
- [x] JS tests pass (`npm test`) — 210 tests
- [x] ESLint clean (`npm run lint`) — 0 errors
- [x] Prettier clean (`npm run format`)

## Risk Assessment

| Metric | Value |
|--------|-------|
| Risk level | low |
| Blast radius | 4 files modified |
| Simulation result | not applicable (feature branch) |

## Governance Report

| Metric | Count |
|--------|-------|
| Total events | 2865 |
| Actions allowed | 518 |
| Actions denied | 52 |
| Policy denials | 21 |
| Invariant violations | 42 |
| Escalation events | 4 |
| Decision records | 562 |

<details>
<summary>Governance details</summary>

**Source**: `.agentguard/events/`, `.agentguard/decisions/`, `logs/runtime-events.jsonl`

**Decision Records**: 562 total
**Escalation levels observed**: NORMAL
**Pre-push simulation**: low risk, blast radius 0 (feature branch, no protected branch violation)

</details>