### PR TITLE
docs: sync documentation with codebase state

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ src/
 │   ├── aggregator.ts       # Violation aggregation across sessions
 │   ├── cluster.ts          # Violation clustering by dimension
 │   ├── engine.ts           # Analytics engine orchestrator
+│   ├── index.ts            # Module re-exports
 │   ├── reporter.ts         # Output formatters (terminal, JSON, markdown)
 │   ├── risk-scorer.ts      # Per-run risk scoring engine
 │   ├── trends.ts           # Violation trend computation


### PR DESCRIPTION
## Summary

- Automated documentation sync detected drift between codebase and docs
- README.md analytics directory tree was missing `index.ts` (Module re-exports) — present in codebase and listed in CLAUDE.md but omitted from README

## Changes

- **README.md**: Added `index.ts` entry to the analytics directory tree, consistent with how other directories (plugins, renderers) list their `index.ts` re-export files

## Source

Auto-generated by the **Scheduled Docs Sync** skill.

---
*Run: 2026-03-11*