### PR TITLE
feat(issue-262): integrate evidence packs with CI pipeline

### DIFF
--- a/.events.json
+++ b/.events.json
@@ -1,5 +1,5 @@
 {
-  "commits": 6,
+  "commits": 7,
   "prs_merged": 1,
   "bugs_fixed": 1,
   "tests_passing": 0,
@@ -8,5 +8,5 @@
   "conflicts_resolved": 0,
   "ci_passes": 0,
   "deploys": 0,
-  "docs_written": 1
+  "docs_written": 2
 }

--- a/.github/workflows/agentguard-governance.yml
+++ b/.github/workflows/agentguard-governance.yml
@@ -50,6 +50,13 @@ on:
         required: false
         type: boolean
         default: false
+      post-evidence:
+        description: >
+          Post a governance evidence report as a PR comment.
+          Requires the workflow to have write permissions on pull-requests.
+        required: false
+        type: boolean
+        default: false
       agentguard-version:
         description: >
           Version of @red-codes/agentguard to install.
@@ -67,6 +74,9 @@ jobs:
   governance-check:
     name: Governance Verification
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -118,8 +128,31 @@ jobs:
           # Display the result
           cat governance-result.json
 
-          # Run again for terminal output and annotations (GITHUB_ACTIONS is set automatically)
-          agentguard ci-check $ARGS
+          # Build evidence posting flags
+          EVIDENCE_ARGS=""
+          if [ "${{ inputs.post-evidence }}" = "true" ]; then
+            EVIDENCE_ARGS="--post-evidence"
+          fi
+
+          # Run again for terminal output, annotations, and evidence posting
+          agentguard ci-check $ARGS $EVIDENCE_ARGS
+
+      - name: Export full session
+        id: export-session
+        if: steps.ci-check.outputs.skip != 'true' && always()
+        run: |
+          SESSION_FILE="governance-session.agentguard.jsonl"
+          if [ -n "${{ inputs.session-file }}" ] && [ -f "${{ inputs.session-file }}" ]; then
+            cp "${{ inputs.session-file }}" "$SESSION_FILE"
+          else
+            agentguard export --last -o "$SESSION_FILE" 2>/dev/null || true
+          fi
+
+          if [ -f "$SESSION_FILE" ]; then
+            echo "exported=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exported=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Upload governance report
         if: steps.ci-check.outputs.skip != 'true' && always()
@@ -128,3 +161,11 @@ jobs:
           name: governance-report
           path: governance-result.json
           retention-days: 30
+
+      - name: Upload full governance session
+        if: steps.export-session.outputs.exported == 'true' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: governance-session
+          path: governance-session.agentguard.jsonl
+          retention-days: 90

--- a/src/cli/bin.ts
+++ b/src/cli/bin.ts
@@ -163,6 +163,9 @@ const COMMANDS: Record<string, CommandHelp> = {
       { flag: '--fail-on-denial', description: 'Exit 1 if any actions were denied' },
       { flag: '--json', description: 'Output result as JSON' },
       { flag: '--last', description: 'Use the most recent local run' },
+      { flag: '--post-evidence', description: 'Post evidence report as PR comment' },
+      { flag: '--pr, -n <number>', description: 'Target PR number (auto-detected if omitted)' },
+      { flag: '--artifact-url <url>', description: 'Link to full session artifact' },
       { flag: '--base-dir, -d <dir>', description: 'Base directory for event storage' },
       { flag: '--store <backend>', description: 'Storage backend: jsonl (default) or sqlite' },
       {
@@ -174,6 +177,7 @@ const COMMANDS: Record<string, CommandHelp> = {
       'agentguard ci-check session.agentguard.jsonl --fail-on-violation',
       'agentguard ci-check --last --fail-on-denial --json',
       'agentguard ci-check --last --store sqlite --fail-on-violation',
+      'agentguard ci-check --last --post-evidence --pr 42',
     ],
   },
   policy: {

--- a/src/cli/commands/ci-check.ts
+++ b/src/cli/commands/ci-check.ts
@@ -7,6 +7,7 @@
 
 import { readFileSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { execSync } from 'node:child_process';
 import { parseArgs } from '../args.js';
 import {
   loadReplaySession,
@@ -17,6 +18,8 @@ import type { ReplaySession } from '../../kernel/replay-engine.js';
 import type { DomainEvent } from '../../core/types.js';
 import type { GovernanceExportHeader } from './export.js';
 import type { StorageConfig } from '../../storage/types.js';
+import { aggregateEvents, formatEvidenceMarkdown } from '../evidence-summary.js';
+import type { EvidenceMarkdownOptions } from '../evidence-summary.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -183,21 +186,80 @@ function formatGitHubAnnotation(result: CiCheckResult): string {
 }
 
 // ---------------------------------------------------------------------------
+// Evidence Posting
+// ---------------------------------------------------------------------------
+
+const COMMENT_MARKER = '<!-- agentguard-evidence-report -->';
+
+function detectPrNumber(): string | null {
+  try {
+    const result = execSync('gh pr view --json number --jq .number 2>/dev/null', {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    return result || null;
+  } catch {
+    return null;
+  }
+}
+
+function postEvidenceComment(prNumber: string, markdown: string): boolean {
+  const body = `${COMMENT_MARKER}\n${markdown}`;
+
+  // Delete any existing evidence comments
+  try {
+    const commentsJson = execSync(
+      `gh pr view ${prNumber} --json comments --jq '.comments[] | select(.body | startswith("${COMMENT_MARKER}")) | .id'`,
+      { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }
+    ).trim();
+
+    if (commentsJson) {
+      const commentIds = commentsJson.split('\n').filter((id) => /^\d+$/.test(id));
+      for (const id of commentIds) {
+        try {
+          execSync(`gh api repos/{owner}/{repo}/issues/comments/${id} -X DELETE`, {
+            stdio: ['pipe', 'pipe', 'pipe'],
+          });
+        } catch {
+          // Ignore delete failures
+        }
+      }
+    }
+  } catch {
+    // No existing comments
+  }
+
+  try {
+    execSync(`gh pr comment ${prNumber} --body -`, {
+      input: body,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // CLI Entry Point
 // ---------------------------------------------------------------------------
 
 export async function ciCheck(args: string[], storageConfig?: StorageConfig): Promise<number> {
   const parsed = parseArgs(args, {
-    boolean: ['--fail-on-violation', '--fail-on-denial', '--json', '--last'],
-    string: ['--base-dir'],
-    alias: { '-d': '--base-dir' },
+    boolean: ['--fail-on-violation', '--fail-on-denial', '--json', '--last', '--post-evidence'],
+    string: ['--base-dir', '--pr', '--artifact-url'],
+    alias: { '-d': '--base-dir', '-n': '--pr' },
   });
 
   const failOnViolation = !!parsed.flags['fail-on-violation'];
   const failOnDenial = !!parsed.flags['fail-on-denial'];
   const jsonOutput = !!parsed.flags.json;
   const useLast = !!parsed.flags.last;
+  const postEvidence = !!parsed.flags['post-evidence'];
   const baseDir = (parsed.flags['base-dir'] as string) || '.agentguard';
+  const prNumberFlag = (parsed.flags.pr as string) || null;
+  const artifactUrl = (parsed.flags['artifact-url'] as string) || undefined;
   const sessionFile = parsed.positional[0];
   const isGitHubActions = !!process.env.GITHUB_ACTIONS;
 
@@ -239,13 +301,18 @@ export async function ciCheck(args: string[], storageConfig?: StorageConfig): Pr
     process.stderr.write('\n  Usage: agentguard ci-check <session-file> [flags]\n');
     process.stderr.write('         agentguard ci-check --last [flags]\n\n');
     process.stderr.write('  Flags:\n');
-    process.stderr.write('    --fail-on-violation   Exit 1 if invariant violations found\n');
-    process.stderr.write('    --fail-on-denial      Exit 1 if any actions were denied\n');
-    process.stderr.write('    --json                Output as JSON\n');
-    process.stderr.write('    --last                Use the most recent local run\n');
-    process.stderr.write('    --base-dir, -d <dir>  Base directory for events\n');
+    process.stderr.write('    --fail-on-violation      Exit 1 if invariant violations found\n');
+    process.stderr.write('    --fail-on-denial         Exit 1 if any actions were denied\n');
+    process.stderr.write('    --json                   Output as JSON\n');
+    process.stderr.write('    --last                   Use the most recent local run\n');
+    process.stderr.write('    --post-evidence          Post evidence report as PR comment\n');
     process.stderr.write(
-      '    --store <backend>     Storage backend: jsonl (default) or sqlite\n\n'
+      '    --pr, -n <number>        Target PR number (auto-detected if omitted)\n'
+    );
+    process.stderr.write('    --artifact-url <url>     Link to full session artifact\n');
+    process.stderr.write('    --base-dir, -d <dir>     Base directory for events\n');
+    process.stderr.write(
+      '    --store <backend>        Storage backend: jsonl (default) or sqlite\n\n'
     );
     return 1;
   }
@@ -263,6 +330,35 @@ export async function ciCheck(args: string[], storageConfig?: StorageConfig): Pr
   // GitHub Actions annotations
   if (isGitHubActions) {
     process.stdout.write(formatGitHubAnnotation(result) + '\n');
+  }
+
+  // Post evidence report to PR
+  if (postEvidence) {
+    const prNumber = prNumberFlag || detectPrNumber();
+    if (!prNumber) {
+      process.stderr.write(
+        '\n  \x1b[33mWarning:\x1b[0m --post-evidence: could not determine PR number. ' +
+          'Use --pr <number> or run from a branch with an open PR.\n\n'
+      );
+    } else if (!/^\d+$/.test(prNumber)) {
+      process.stderr.write(
+        '\n  \x1b[33mWarning:\x1b[0m --post-evidence: PR number must be numeric.\n\n'
+      );
+    } else {
+      const evidenceSummary = aggregateEvents([...session.events]);
+      const markdownOptions: EvidenceMarkdownOptions = { artifactUrl };
+      const markdown = formatEvidenceMarkdown(evidenceSummary, markdownOptions);
+      const posted = postEvidenceComment(prNumber, markdown);
+      if (posted) {
+        process.stderr.write(
+          `  \x1b[32m\u2713\x1b[0m Evidence report posted to PR #${prNumber}\n\n`
+        );
+      } else {
+        process.stderr.write(
+          `\n  \x1b[33mWarning:\x1b[0m Failed to post evidence report to PR #${prNumber}.\n\n`
+        );
+      }
+    }
   }
 
   return result.pass ? 0 : 1;

--- a/src/cli/evidence-summary.ts
+++ b/src/cli/evidence-summary.ts
@@ -13,10 +13,17 @@ export interface EvidenceSummary {
   readonly escalations: number;
   readonly blastRadiusExceeded: number;
   readonly evidencePacksGenerated: number;
+  readonly maxEscalationLevel: string;
   readonly actionTypeBreakdown: Record<string, { allowed: number; denied: number }>;
   readonly denialReasons: string[];
   readonly violationDetails: string[];
   readonly runIds: string[];
+}
+
+/** Options for formatting the evidence markdown report. */
+export interface EvidenceMarkdownOptions {
+  /** URL to the full session artifact (e.g., GitHub Actions artifact link). */
+  readonly artifactUrl?: string;
 }
 
 const GOVERNANCE_KINDS = new Set([
@@ -34,6 +41,13 @@ const GOVERNANCE_KINDS = new Set([
   'SimulationCompleted',
 ]);
 
+const ESCALATION_ORDER: Record<string, number> = {
+  NORMAL: 0,
+  ELEVATED: 1,
+  HIGH: 2,
+  LOCKDOWN: 3,
+};
+
 /**
  * Aggregate raw governance events into a structured summary.
  * Only counts governance-related events in the metrics.
@@ -46,6 +60,7 @@ export function aggregateEvents(events: DomainEvent[]): EvidenceSummary {
   let escalations = 0;
   let blastRadiusExceeded = 0;
   let evidencePacksGenerated = 0;
+  let maxEscalationOrdinal = 0;
   const actionTypeBreakdown: Record<string, { allowed: number; denied: number }> = {};
   const denialReasons: string[] = [];
   const violationDetails: string[] = [];
@@ -107,8 +122,20 @@ export function aggregateEvents(events: DomainEvent[]): EvidenceSummary {
         evidencePacksGenerated++;
         break;
       }
+      case 'StateChanged': {
+        const to = (event.to as string) || '';
+        const ordinal = ESCALATION_ORDER[to] ?? 0;
+        if (ordinal > maxEscalationOrdinal) {
+          maxEscalationOrdinal = ordinal;
+        }
+        break;
+      }
     }
   }
+
+  const escalationNames = Object.entries(ESCALATION_ORDER);
+  const maxEscalationLevel =
+    escalationNames.find(([, v]) => v === maxEscalationOrdinal)?.[0] ?? 'NORMAL';
 
   return {
     totalEvents: governanceEvents.length,
@@ -119,6 +146,7 @@ export function aggregateEvents(events: DomainEvent[]): EvidenceSummary {
     escalations,
     blastRadiusExceeded,
     evidencePacksGenerated,
+    maxEscalationLevel,
     actionTypeBreakdown,
     denialReasons,
     violationDetails,
@@ -129,12 +157,15 @@ export function aggregateEvents(events: DomainEvent[]): EvidenceSummary {
 /**
  * Format an evidence summary as PR-ready markdown.
  */
-export function formatEvidenceMarkdown(summary: EvidenceSummary): string {
+export function formatEvidenceMarkdown(
+  summary: EvidenceSummary,
+  options?: EvidenceMarkdownOptions
+): string {
   const lines: string[] = [];
 
   lines.push('## Governance Evidence Report');
   lines.push('');
-  lines.push('| Metric | Count |');
+  lines.push('| Metric | Value |');
   lines.push('|--------|-------|');
   lines.push(`| Total governance events | ${summary.totalEvents} |`);
   lines.push(`| Actions allowed | ${summary.actionsAllowed} |`);
@@ -143,6 +174,7 @@ export function formatEvidenceMarkdown(summary: EvidenceSummary): string {
   lines.push(`| Invariant violations | ${summary.invariantViolations} |`);
   lines.push(`| Escalations | ${summary.escalations} |`);
   lines.push(`| Blast radius exceeded | ${summary.blastRadiusExceeded} |`);
+  lines.push(`| Escalation level | ${summary.maxEscalationLevel} |`);
 
   // Verdict line
   if (summary.actionsDenied === 0 && summary.invariantViolations === 0) {
@@ -202,6 +234,12 @@ export function formatEvidenceMarkdown(summary: EvidenceSummary): string {
   if (summary.runIds.length > 0) {
     lines.push('');
     lines.push(`*Sessions: ${summary.runIds.map((id) => `\`${id}\``).join(', ')}*`);
+  }
+
+  // Link to full session artifact
+  if (options?.artifactUrl) {
+    lines.push('');
+    lines.push(`**Full session data:** [Download governance session](${options.artifactUrl})`);
   }
 
   lines.push('');

--- a/tests/ts/evidence-summary.test.ts
+++ b/tests/ts/evidence-summary.test.ts
@@ -17,6 +17,7 @@ describe('evidence-summary', () => {
       expect(summary.invariantViolations).toBe(0);
       expect(summary.escalations).toBe(0);
       expect(summary.blastRadiusExceeded).toBe(0);
+      expect(summary.maxEscalationLevel).toBe('NORMAL');
       expect(summary.denialReasons).toEqual([]);
       expect(summary.violationDetails).toEqual([]);
       expect(summary.runIds).toEqual([]);
@@ -171,6 +172,36 @@ describe('evidence-summary', () => {
       // Only ActionAllowed is a governance event; RunStarted and FileSaved are not
       expect(summary.totalEvents).toBe(1);
     });
+
+    it('tracks max escalation level from StateChanged events', () => {
+      const events = [
+        makeEvent('StateChanged', { from: 'NORMAL', to: 'ELEVATED', trigger: 'denial' }),
+        makeEvent('StateChanged', { from: 'ELEVATED', to: 'HIGH', trigger: 'violation' }),
+      ];
+      const summary = aggregateEvents(events);
+      expect(summary.maxEscalationLevel).toBe('HIGH');
+    });
+
+    it('defaults to NORMAL when no StateChanged events exist', () => {
+      const events = [
+        makeEvent('ActionAllowed', {
+          actionType: 'file.read',
+          target: 'a.ts',
+          capability: 'read',
+        }),
+      ];
+      const summary = aggregateEvents(events);
+      expect(summary.maxEscalationLevel).toBe('NORMAL');
+    });
+
+    it('tracks highest escalation even if later de-escalated', () => {
+      const events = [
+        makeEvent('StateChanged', { from: 'NORMAL', to: 'LOCKDOWN', trigger: 'violation' }),
+        makeEvent('StateChanged', { from: 'LOCKDOWN', to: 'NORMAL', trigger: 'manual-reset' }),
+      ];
+      const summary = aggregateEvents(events);
+      expect(summary.maxEscalationLevel).toBe('LOCKDOWN');
+    });
   });
 
   describe('formatEvidenceMarkdown', () => {
@@ -256,6 +287,41 @@ describe('evidence-summary', () => {
       const summary = aggregateEvents([]);
       const md = formatEvidenceMarkdown(summary);
       expect(md).toContain('AgentGuard');
+    });
+
+    it('includes escalation level in the report', () => {
+      const events = [
+        makeEvent('StateChanged', { from: 'NORMAL', to: 'ELEVATED', trigger: 'denial' }),
+        makeEvent('ActionAllowed', {
+          actionType: 'file.read',
+          target: 'a.ts',
+          capability: 'read',
+        }),
+      ];
+      const summary = aggregateEvents(events);
+      const md = formatEvidenceMarkdown(summary);
+      expect(md).toContain('| Escalation level | ELEVATED |');
+    });
+
+    it('includes artifact URL when provided', () => {
+      const summary = aggregateEvents([]);
+      const md = formatEvidenceMarkdown(summary, {
+        artifactUrl: 'https://github.com/org/repo/actions/runs/123/artifacts/456',
+      });
+      expect(md).toContain('Full session data');
+      expect(md).toContain('https://github.com/org/repo/actions/runs/123/artifacts/456');
+    });
+
+    it('omits artifact link when no URL provided', () => {
+      const summary = aggregateEvents([]);
+      const md = formatEvidenceMarkdown(summary);
+      expect(md).not.toContain('Full session data');
+    });
+
+    it('omits artifact link when options is undefined', () => {
+      const summary = aggregateEvents([]);
+      const md = formatEvidenceMarkdown(summary, undefined);
+      expect(md).not.toContain('Full session data');
     });
   });
 });


### PR DESCRIPTION
## Summary
- Integrate evidence report posting directly into `ci-check` command via `--post-evidence` flag
- Add escalation level tracking and session artifact links to governance evidence reports
- Update GitHub Actions workflow to export full session files and optionally post evidence to PRs
- Closes #262

## Changes
- `src/cli/evidence-summary.ts` — Add `maxEscalationLevel` field to `EvidenceSummary`, `EvidenceMarkdownOptions` interface with `artifactUrl`, and escalation level row in markdown report
- `src/cli/commands/ci-check.ts` — Add `--post-evidence`, `--pr`, `--artifact-url` flags with evidence posting logic (reuses evidence-summary formatting)
- `src/cli/bin.ts` — Register new ci-check flags in help text and examples
- `.github/workflows/agentguard-governance.yml` — Add `post-evidence` input, `pull-requests: write` permission, full session export step, and session artifact upload
- `tests/ts/evidence-summary.test.ts` — Add tests for escalation level tracking, artifact URL formatting, and edge cases

## Test Plan
- [x] TypeScript build passes (`npm run build:ts`)
- [x] Vitest tests pass (`npm run ts:test`) — 1427 pass / 0 fail
- [x] JS tests pass (`npm test`) — 210 pass / 0 fail
- [x] ESLint clean (`npm run lint`) — 0 errors
- [x] Prettier clean (`npm run format`)
- [x] Coverage passes (`npm run test:coverage`) — 80.91% lines

## Risk Assessment

| Metric | Value |
|--------|-------|
| Risk level | low |
| Blast radius | 0 (weighted) |
| Simulation result | low risk |

## Governance Report

| Metric | Count |
|--------|-------|
| Total events | 4044 |
| Actions allowed | 726 |
| Actions denied | 77 |
| Policy denials | 25 |
| Invariant violations | 64 |
| Escalation events | 8 |
| Decision records | 793 |

<details>
<summary>Governance details</summary>

**Source**: `.agentguard/events/`, `.agentguard/decisions/`, `logs/runtime-events.jsonl`

**Decision Records**: 793 total, 72 denials
**Escalation levels observed**: cumulative across all sessions
**Pre-push simulation**: risk level low, blast radius 0

Note: Telemetry counts are cumulative across all governance sessions in this repository, not just this PR's session.

</details>