### PR TITLE
docs: sync documentation with codebase state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ src/
 │   ├── session-store.ts    # Session management
 │   ├── file-event-store.ts # File-based event persistence
 │   ├── evidence-summary.ts # Evidence summary generator for PR reports
-│   └── commands/           # analytics, guard, inspect, replay, export, import, simulate, ci-check, plugin, policy, claude-hook, claude-init, init, diff, evidence-pr
+│   └── commands/           # analytics, guard, inspect, replay, export, import, simulate, ci-check, plugin, policy, claude-hook, claude-init, init, diff, evidence-pr, traces
 ├── plugins/                # Plugin ecosystem
 │   ├── discovery.ts        # Plugin discovery mechanism
 │   ├── registry.ts         # Plugin registry
@@ -147,7 +147,7 @@ vscode-extension/              # VS Code extension
 
 tests/
 ├── *.test.js               # 14 JS test files (custom zero-dependency harness)
-└── ts/*.test.ts            # 73 TS test files (vitest)
+└── ts/*.test.ts            # 74 TS test files (vitest)
 policy/                     # Policy configuration (JSON: action_rules, capabilities)
 policies/                   # Policy packs (YAML: ci-safe, enterprise, open-source, strict)
 docs/                       # System documentation (architecture, event model, specs)
@@ -228,6 +228,7 @@ Each top-level directory maps to a single architectural concept:
 - `agentguard claude-init` — Set up Claude Code hook integration
 - `agentguard diff <run1> <run2>` — Compare two governance sessions side-by-side
 - `agentguard evidence-pr` — Attach governance evidence summary to a pull request
+- `agentguard traces [runId]` — Display policy evaluation traces for a run
 - `agentguard init <type>` — Scaffold governance extensions (invariant, policy-pack, adapter, renderer, replay-processor)
 
 ### Event Model
@@ -296,8 +297,8 @@ npm run test:coverage      # Run with coverage (c8, 50% line threshold)
 
 **Test structure:**
 - **JS tests** (`tests/*.test.js`): 14 files using a custom zero-dependency harness (`tests/run.js` with `node:assert`)
-- **TypeScript tests** (`tests/ts/*.test.ts`): 73 files using vitest
-- **Coverage areas**: adapters, analytics (including risk scorer), kernel (AAB, engine, monitor, blast radius, heartbeat, integration, e2e pipeline), CLI commands (args, guard, inspect, init, simulate, ci-check, claude-hook, claude-init, export/import, policy-validate, diff, evidence-pr), decision records, domain models, events, evidence packs, evidence summary, execution log, export-import roundtrip, impact forecast, invariants, JSONL persistence, notification formatter, plugins (discovery, registry, validation), policy evaluation (including composer, pack loader, policy packs, evaluation trace), renderers, replay (engine, comparator, processor), simulation, SQLite storage (analytics, commands, migrations, sink, store, factory), telemetry (including tracepoint), TUI renderer, violation mapper, VS Code event reader, YAML loading
+- **TypeScript tests** (`tests/ts/*.test.ts`): 74 files using vitest
+- **Coverage areas**: adapters, analytics (including risk scorer), kernel (AAB, engine, monitor, blast radius, heartbeat, integration, e2e pipeline), CLI commands (args, guard, inspect, init, simulate, ci-check, claude-hook, claude-init, export/import, policy-validate, diff, evidence-pr, traces), decision records, domain models, events, evidence packs, evidence summary, execution log, export-import roundtrip, impact forecast, invariants, JSONL persistence, notification formatter, plugins (discovery, registry, validation), policy evaluation (including composer, pack loader, policy packs, evaluation trace), renderers, replay (engine, comparator, processor), simulation, SQLite storage (analytics, commands, migrations, sink, store, factory), telemetry (including tracepoint), TUI renderer, violation mapper, VS Code event reader, YAML loading
 
 ## CI/CD & Automation
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,12 @@ agentguard evidence-pr                    # Attach governance evidence summary t
 agentguard evidence-pr --pr <number>     # Post evidence to a specific PR
 agentguard evidence-pr --dry-run         # Preview evidence report
 
+# === Traces ===
+agentguard traces [runId]                 # Display policy evaluation traces for a run
+agentguard traces --last                  # Show traces for the most recent run
+agentguard traces --last --summary       # Summary statistics only
+agentguard traces --last --json          # JSON output
+
 # === Integration ===
 agentguard claude-init                    # Set up Claude Code hook integration
 agentguard init <type>                    # Scaffold governance extensions
@@ -286,7 +292,7 @@ src/
 ├── cli/                    # CLI entry point + commands
 │   ├── bin.ts              # Main entry
 │   ├── evidence-summary.ts # Evidence summary generator for PR reports
-│   └── commands/           # analytics, guard, inspect, replay, export, import, simulate, ci-check, plugin, policy, claude-hook, claude-init, init, diff, evidence-pr
+│   └── commands/           # analytics, guard, inspect, replay, export, import, simulate, ci-check, plugin, policy, claude-hook, claude-init, init, diff, evidence-pr, traces
 ├── storage/                # SQLite storage backend (opt-in alternative to JSONL)
 ├── telemetry/              # Runtime telemetry and logging
 └── core/                   # Shared utilities (types, actions, hash, rng, execution-log)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -76,7 +76,7 @@ A comprehensive codebase audit assessed the current system against the strategic
 | Cross-session Analytics (aggregation, clustering, trends) | Implemented | `src/analytics/` |
 | Plugin Ecosystem (discovery, registry, validation) | Implemented | `src/plugins/` |
 | Renderer Plugin System | Implemented | `src/renderers/` |
-| CLI (guard, inspect, events, replay, export, import, simulate, ci-check, analytics, plugin, policy, claude-hook, claude-init, init, diff, evidence-pr) | Implemented | `src/cli/` |
+| CLI (guard, inspect, events, replay, export, import, simulate, ci-check, analytics, plugin, policy, claude-hook, claude-init, init, diff, evidence-pr, traces) | Implemented | `src/cli/` |
 | Claude Code Hook Integration | Implemented | `src/adapters/claude-code.ts` |
 | VS Code Extension (sidebar panels, event reader, inline diagnostics) | Implemented | `vscode-extension/` |
 | Policy Pack Loader | Implemented | `src/policy/pack-loader.ts` |
@@ -306,7 +306,7 @@ The JSONL persistence layer was the right starting point — append-only, human-
 - [x] Risk scoring per agent run
 - [ ] Failure clustering and trend detection (extend `src/analytics/`)
 - [ ] Timeline viewer for governance sessions (`agentguard replay --ui`)
-- [ ] Policy evaluation traces visualization
+- [x] Policy evaluation traces CLI (`agentguard traces`)
 - [ ] Metrics export (Prometheus / OpenTelemetry)
 - [x] Foundation for kernel-level tracing (define tracepoint interface)
 - [ ] Application-level process and network monitoring (Node.js-based, pre-eBPF)


### PR DESCRIPTION
## Summary

- Automated documentation sync detected drift between codebase and docs
- New `traces` CLI command (`src/cli/commands/traces.ts`) was not documented
- TS test count was stale (73 → 74, `traces-command.test.ts` added)

## Changes

- **CLAUDE.md**: Updated TS test count (73→74), added `traces` to CLI commands list, commands directory listing, and test coverage areas
- **README.md**: Added `traces` command section under CLI, updated commands directory listing
- **ROADMAP.md**: Updated CLI list to include `traces`, marked policy evaluation traces CLI as completed

## Source

Auto-generated by the **Scheduled Docs Sync** skill.

---
*Run: 2026-03-11*