### PR TITLE
feat(issue-189): add policy templates for common scenarios

### DIFF
--- a/.events.json
+++ b/.events.json
@@ -1,5 +1,5 @@
 {
-  "commits": 7,
+  "commits": 8,
   "prs_merged": 1,
   "bugs_fixed": 1,
   "tests_passing": 0,
@@ -8,5 +8,5 @@
   "conflicts_resolved": 0,
   "ci_passes": 0,
   "deploys": 0,
-  "docs_written": 1
+  "docs_written": 2
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "files": [
     "dist/",
     "hooks/",
+    "templates/",
     "LICENSE",
     "README.md"
   ],

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -1,4 +1,4 @@
-// CLI command: agentguard init — scaffold new governance extensions.
+// CLI command: agentguard init — scaffold new governance extensions or policy templates.
 //
 // Generates boilerplate for extension types:
 //   invariant          Custom invariant pack
@@ -6,9 +6,16 @@
 //   adapter            Custom execution adapter
 //   renderer           Custom governance renderer
 //   replay-processor   Custom replay processor
+//
+// Or scaffold a policy template:
+//   --template strict       Maximum guardrails
+//   --template permissive   Default-allow with safety nets
+//   --template ci-only      Read-only CI pipeline mode
+//   --template development  Balanced for active development
 
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { parseArgs } from '../args.js';
 import { bold, color, dim } from '../colors.js';
 
@@ -22,6 +29,10 @@ const EXTENSION_TYPES = [
 
 type ExtensionType = (typeof EXTENSION_TYPES)[number];
 
+const TEMPLATE_NAMES = ['strict', 'permissive', 'ci-only', 'development'] as const;
+
+type TemplateName = (typeof TEMPLATE_NAMES)[number];
+
 interface ScaffoldFile {
   path: string;
   content: string;
@@ -32,9 +43,16 @@ interface ScaffoldFile {
  */
 export async function init(args: string[]): Promise<number> {
   const parsed = parseArgs(args, {
-    string: ['--extension', '--name', '--dir'],
-    alias: { '-e': '--extension', '-n': '--name', '-d': '--dir' },
+    string: ['--extension', '--name', '--dir', '--template'],
+    alias: { '-e': '--extension', '-n': '--name', '-d': '--dir', '-t': '--template' },
   });
+
+  const templateName = parsed.flags.template as string | undefined;
+
+  // Template mode: scaffold an agentguard.yaml from a built-in template
+  if (templateName) {
+    return initTemplate(templateName, parsed.flags.dir as string | undefined);
+  }
 
   const extensionType = (parsed.flags.extension as string) ?? parsed.positional[0];
   const name = parsed.flags.name as string | undefined;
@@ -95,6 +113,69 @@ export async function init(args: string[]): Promise<number> {
   console.log(`    npm install`);
   console.log(`    # Edit src/index.ts to implement your extension`);
   console.log(`    agentguard plugin install .\n`);
+
+  return 0;
+}
+
+function isValidTemplateName(name: string): name is TemplateName {
+  return (TEMPLATE_NAMES as readonly string[]).includes(name);
+}
+
+/**
+ * Resolve the templates directory. Uses the bundled templates/ directory
+ * relative to the project root (works both in dev and dist builds).
+ */
+function resolveTemplatesDir(): string {
+  // Walk up from this file to find the project root (where templates/ lives)
+  const thisFile = fileURLToPath(import.meta.url);
+  let dir = dirname(thisFile);
+  for (let i = 0; i < 5; i++) {
+    const candidate = join(dir, 'templates');
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+    dir = dirname(dir);
+  }
+  return join(dirname(thisFile), '..', '..', '..', 'templates');
+}
+
+/**
+ * Scaffold an agentguard.yaml from a built-in policy template.
+ */
+function initTemplate(templateName: string, targetDir?: string): number {
+  if (!isValidTemplateName(templateName)) {
+    console.error(`\n  ${color('Error', 'red')}: Unknown template "${templateName}".`);
+    console.error(`  Available templates: ${TEMPLATE_NAMES.join(', ')}\n`);
+    return 1;
+  }
+
+  const templatesDir = resolveTemplatesDir();
+  const templatePath = join(templatesDir, `${templateName}.yaml`);
+
+  if (!existsSync(templatePath)) {
+    console.error(`\n  ${color('Error', 'red')}: Template file not found: ${templatePath}`);
+    console.error(`  Ensure the templates/ directory is present in the AgentGuard installation.\n`);
+    return 1;
+  }
+
+  const outputDir = resolve(targetDir ?? '.');
+  const outputPath = join(outputDir, 'agentguard.yaml');
+
+  if (existsSync(outputPath)) {
+    console.error(`\n  ${color('Error', 'red')}: ${outputPath} already exists.`);
+    console.error(`  Remove or rename the existing file before scaffolding a template.\n`);
+    return 1;
+  }
+
+  const content = readFileSync(templatePath, 'utf8');
+  writeFileSync(outputPath, content, 'utf8');
+
+  console.log(`\n  ${color('✓', 'green')} Scaffolded ${bold(templateName)} policy template\n`);
+  console.log(`  ${bold('File created:')}`);
+  console.log(`    ${dim(outputPath)}\n`);
+  console.log(`  ${bold('Next steps:')}`);
+  console.log(`    # Review and customize the policy rules`);
+  console.log(`    agentguard guard --policy agentguard.yaml --dry-run\n`);
 
   return 0;
 }
@@ -859,10 +940,11 @@ agentguard plugin install .
 
 function printInitHelp(): void {
   console.log(`
-  ${bold('agentguard init')} — Scaffold a new governance extension
+  ${bold('agentguard init')} — Scaffold a new governance extension or policy template
 
   ${bold('Usage:')}
     agentguard init --extension <type> [--name <name>] [--dir <path>]
+    agentguard init --template <name> [--dir <path>]
     agentguard init <type> [--name <name>] [--dir <path>]
 
   ${bold('Extension types:')}
@@ -872,16 +954,23 @@ function printInitHelp(): void {
     renderer           Custom governance renderer
     replay-processor   Custom replay processor
 
+  ${bold('Policy templates:')}
+    strict             Maximum guardrails — deny all destructive ops
+    permissive         Default-allow with safety nets for dangerous ops
+    ci-only            Read-only CI pipeline mode — build and test only
+    development        Balanced guardrails for active development
+
   ${bold('Flags:')}
-    --extension, -e    Extension type (required)
+    --extension, -e    Extension type
+    --template, -t     Policy template name (creates agentguard.yaml)
     --name, -n         Extension name (default: my-<type>)
-    --dir, -d          Output directory (default: ./<name>)
+    --dir, -d          Output directory (default: ./<name> or . for templates)
 
   ${bold('Examples:')}
+    agentguard init --template strict
+    agentguard init --template development --dir ./my-project
     agentguard init --extension renderer --name json-renderer
     agentguard init invariant --name vendor-guard
     agentguard init policy-pack --name strict-policy
-    agentguard init adapter --name docker-adapter
-    agentguard init replay-processor --name denial-counter
 `);
 }

--- a/templates/ci-only.yaml
+++ b/templates/ci-only.yaml
@@ -1,0 +1,103 @@
+# AgentGuard Policy — CI-Only
+#
+# Read-only filesystem with test execution allowed. No git mutations, no file
+# writes, no deploys. Designed for CI/CD pipelines where the agent should only
+# build, test, and report — never modify source code or push changes.
+#
+# Best for: CI pipelines, automated review bots, read-only analysis.
+#
+# Scaffolded by: agentguard init --template ci-only
+# Docs: https://github.com/jpleva91/agent-guard#policy
+
+id: ci-only-policy
+name: CI-Only Safety Policy
+description: Read-only with test execution — no mutations, no pushes, no deploys
+severity: 4
+
+rules:
+  # ─── No git mutations ─────────────────────────────────────────────────
+  - action: git.push
+    effect: deny
+    reason: CI pipelines must not push directly
+
+  - action: git.force-push
+    effect: deny
+    reason: Force push prohibited in CI
+
+  - action: git.commit
+    effect: deny
+    reason: CI pipelines must not create commits
+
+  - action: git.reset
+    effect: deny
+    reason: Git reset prohibited in CI
+
+  - action: git.branch.create
+    effect: deny
+    reason: CI pipelines must not create branches
+
+  - action: git.branch.delete
+    effect: deny
+    reason: CI pipelines must not delete branches
+
+  - action: git.merge
+    effect: deny
+    reason: CI pipelines must not merge branches
+
+  # ─── No file mutations ────────────────────────────────────────────────
+  - action: file.write
+    effect: deny
+    reason: CI pipelines must not modify source files
+
+  - action: file.delete
+    effect: deny
+    reason: CI pipelines must not delete files
+
+  - action: file.move
+    effect: deny
+    reason: CI pipelines must not move files
+
+  # ─── No publishing or deployment ──────────────────────────────────────
+  - action: npm.publish
+    effect: deny
+    reason: Publishing must use a dedicated release pipeline
+
+  - action: deploy.trigger
+    effect: deny
+    reason: Deployment must use a dedicated deploy pipeline
+
+  - action: infra.apply
+    effect: deny
+    reason: Infrastructure changes prohibited in CI
+
+  - action: infra.destroy
+    effect: deny
+    reason: Infrastructure destruction prohibited in CI
+
+  # ─── Allowed: read-only and test operations ────────────────────────────
+  - action: file.read
+    effect: allow
+
+  - action: git.diff
+    effect: allow
+
+  - action: git.checkout
+    effect: allow
+
+  - action:
+      - test.run
+      - test.run.unit
+      - test.run.integration
+    effect: allow
+
+  - action: shell.exec
+    effect: allow
+
+  - action: npm.install
+    effect: allow
+
+  - action: npm.script.run
+    effect: allow
+
+  - action: http.request
+    effect: allow

--- a/templates/development.yaml
+++ b/templates/development.yaml
@@ -1,0 +1,107 @@
+# AgentGuard Policy — Development
+#
+# Balanced policy for active development. Allows most operations while denying
+# destructive git actions and protecting secrets. A good starting point for
+# teams that want guardrails without excessive restrictions.
+#
+# Best for: team development, feature branches, day-to-day coding with agents.
+#
+# Scaffolded by: agentguard init --template development
+# Docs: https://github.com/jpleva91/agent-guard#policy
+
+id: development-policy
+name: Development Safety Policy
+description: Balanced guardrails for active development — protect branches and secrets
+severity: 3
+
+rules:
+  # ─── Branch protection ────────────────────────────────────────────────
+  # Protect main/master from direct pushes — use feature branches and PRs.
+  - action: git.push
+    effect: deny
+    branches: [main, master, release, production]
+    reason: Direct push to protected branch — use a feature branch
+
+  # Force push is never safe on shared branches.
+  - action: git.force-push
+    effect: deny
+    reason: Force push rewrites shared history
+
+  # ─── Secrets protection ───────────────────────────────────────────────
+  - action: file.write
+    effect: deny
+    target: .env
+    reason: Secrets file must not be modified by agents
+
+  - action: file.write
+    effect: deny
+    target: "*.pem"
+    reason: Certificate files are protected
+
+  - action: file.write
+    effect: deny
+    target: "*.key"
+    reason: Private key files are protected
+
+  # ─── Destructive command protection ────────────────────────────────────
+  - action: shell.exec
+    effect: deny
+    target: rm -rf
+    reason: Recursive delete blocked
+
+  - action: infra.destroy
+    effect: deny
+    reason: Infrastructure destruction requires manual confirmation
+
+  # ─── Blast radius ─────────────────────────────────────────────────────
+  # Limit the scope of changes to prevent runaway modifications.
+  - action: file.write
+    effect: deny
+    limit: 20
+    reason: Blast radius exceeded — max 20 files per action
+
+  # ─── Allowed operations ───────────────────────────────────────────────
+  # Reading is always safe.
+  - action: file.read
+    effect: allow
+
+  # File writes are allowed (subject to blast radius limit above).
+  - action: file.write
+    effect: allow
+
+  # Git operations on non-protected branches.
+  - action: git.push
+    effect: allow
+
+  - action: git.commit
+    effect: allow
+
+  - action: git.diff
+    effect: allow
+
+  - action: git.checkout
+    effect: allow
+
+  - action: git.branch.create
+    effect: allow
+
+  - action: git.merge
+    effect: allow
+
+  # Testing is encouraged.
+  - action:
+      - test.run
+      - test.run.unit
+      - test.run.integration
+    effect: allow
+
+  # Shell commands for builds and scripts.
+  - action: shell.exec
+    effect: allow
+
+  # NPM operations.
+  - action: npm.install
+    effect: allow
+
+  - action: npm.script.run
+    effect: allow

--- a/templates/permissive.yaml
+++ b/templates/permissive.yaml
@@ -1,0 +1,87 @@
+# AgentGuard Policy — Permissive
+#
+# Default-allow with deny rules only for dangerous operations. Gives agents
+# freedom to work while guarding against the most destructive actions.
+#
+# Best for: personal projects, prototyping, trusted development environments.
+#
+# Scaffolded by: agentguard init --template permissive
+# Docs: https://github.com/jpleva91/agent-guard#policy
+
+id: permissive-policy
+name: Permissive Safety Policy
+description: Default-allow with guardrails for dangerous operations only
+severity: 2
+
+rules:
+  # ─── Critical safety only ─────────────────────────────────────────────
+  # These rules catch the most destructive operations that are almost never
+  # intentional when performed by an AI coding agent.
+
+  # Protect main/master from direct pushes.
+  - action: git.push
+    effect: deny
+    branches: [main, master]
+    reason: Direct push to protected branch — use a feature branch
+
+  # Force push rewrites shared history.
+  - action: git.force-push
+    effect: deny
+    reason: Force push rewrites shared history
+
+  # Secrets must never be touched.
+  - action: file.write
+    effect: deny
+    target: .env
+    reason: Secrets file must not be modified
+
+  # Block recursive deletion.
+  - action: shell.exec
+    effect: deny
+    target: rm -rf
+    reason: Recursive delete blocked
+
+  # Block infrastructure destruction.
+  - action: infra.destroy
+    effect: deny
+    reason: Infrastructure destruction requires manual confirmation
+
+  # ─── Everything else is allowed ────────────────────────────────────────
+  - action: file.read
+    effect: allow
+
+  - action: file.write
+    effect: allow
+
+  - action: file.delete
+    effect: allow
+
+  - action: git.push
+    effect: allow
+
+  - action: git.commit
+    effect: allow
+
+  - action: git.diff
+    effect: allow
+
+  - action: git.checkout
+    effect: allow
+
+  - action: git.branch.create
+    effect: allow
+
+  - action: shell.exec
+    effect: allow
+
+  - action:
+      - test.run
+      - test.run.unit
+      - test.run.integration
+    effect: allow
+
+  - action: npm.install
+    effect: allow
+
+  - action: npm.script.run
+    effect: allow

--- a/templates/strict.yaml
+++ b/templates/strict.yaml
@@ -1,0 +1,112 @@
+# AgentGuard Policy — Strict
+#
+# Maximum guardrails for high-risk environments. Default-deny for all
+# destructive operations. Only read and test operations are allowed by default.
+#
+# Best for: production codebases, security-sensitive projects, regulated environments.
+#
+# Scaffolded by: agentguard init --template strict
+# Docs: https://github.com/jpleva91/agent-guard#policy
+
+id: strict-policy
+name: Strict Safety Policy
+description: Maximum guardrails — deny destructive ops, enforce test-before-push
+severity: 5
+
+rules:
+  # ─── Git safety ───────────────────────────────────────────────────────
+  # All pushes denied — use pull requests instead.
+  - action: git.push
+    effect: deny
+    reason: All pushes denied in strict mode — use pull requests
+
+  # Force push rewrites shared history and is never safe.
+  - action: git.force-push
+    effect: deny
+    reason: Force push rewrites shared history
+
+  # Hard resets discard work; prefer git stash or revert.
+  - action: git.reset
+    effect: deny
+    reason: Git reset is destructive — use revert instead
+
+  # Branch deletion can lose unmerged work.
+  - action: git.branch.delete
+    effect: deny
+    reason: Branch deletion denied in strict mode
+
+  # ─── File safety ──────────────────────────────────────────────────────
+  # Prevent deletion of any files by the agent.
+  - action: file.delete
+    effect: deny
+    reason: File deletion denied in strict mode
+
+  # Secrets and credentials must never be touched.
+  - action: file.write
+    effect: deny
+    target: .env
+    reason: Secrets file modification denied
+
+  - action: file.write
+    effect: deny
+    target: "*.pem"
+    reason: Certificate file modification denied
+
+  - action: file.write
+    effect: deny
+    target: "*.key"
+    reason: Private key file modification denied
+
+  # ─── Shell safety ─────────────────────────────────────────────────────
+  # Block known destructive commands.
+  - action: shell.exec
+    effect: deny
+    target: rm -rf
+    reason: Recursive delete blocked
+
+  - action: shell.exec
+    effect: deny
+    target: "chmod 777"
+    reason: Overly permissive chmod denied
+
+  # ─── Blast radius ─────────────────────────────────────────────────────
+  # Limit the number of files modified in a single action.
+  - action: file.write
+    effect: deny
+    limit: 10
+    reason: Blast radius exceeded — max 10 files per action
+
+  # ─── Package safety ───────────────────────────────────────────────────
+  - action: npm.publish
+    effect: deny
+    reason: Package publishing denied in strict mode
+
+  # ─── Infrastructure ───────────────────────────────────────────────────
+  - action: infra.destroy
+    effect: deny
+    reason: Infrastructure destruction denied
+
+  - action: infra.apply
+    effect: deny
+    reason: Infrastructure changes denied in strict mode
+
+  # ─── Deploy ───────────────────────────────────────────────────────────
+  - action: deploy.trigger
+    effect: deny
+    reason: Deployments denied in strict mode
+
+  # ─── Allowed operations ───────────────────────────────────────────────
+  # Reading files is always safe.
+  - action: file.read
+    effect: allow
+
+  # Running tests is encouraged.
+  - action:
+      - test.run
+      - test.run.unit
+      - test.run.integration
+    effect: allow
+
+  # Viewing diffs is safe.
+  - action: git.diff
+    effect: allow

--- a/tests/ts/cli-init.test.ts
+++ b/tests/ts/cli-init.test.ts
@@ -1,7 +1,7 @@
 // Tests for CLI init command — scaffold governance extensions
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { sep } from 'node:path';
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 
 vi.mock('node:fs', () => ({
   existsSync: vi.fn(),
@@ -267,6 +267,112 @@ describe('init command', () => {
         const code = await init(['--extension', type, '--name', `valid-${type}`]);
         expect(code, `Extension type "${type}" should be valid`).toBe(0);
       }
+    });
+  });
+
+  describe('policy templates', () => {
+    const MOCK_TEMPLATE = `# Mock template\nid: mock-policy\nrules: []\n`;
+
+    function setupTemplateMocks() {
+      vi.mocked(existsSync).mockImplementation((p: unknown) => {
+        const path = String(p);
+        // The templates directory must exist (for resolveTemplatesDir)
+        if (path.endsWith('templates')) return true;
+        // The template YAML file must exist
+        if (path.endsWith('.yaml') && path.includes('templates')) return true;
+        // The output agentguard.yaml must NOT exist
+        if (path.endsWith('agentguard.yaml')) return false;
+        return false;
+      });
+      vi.mocked(readFileSync).mockReturnValue(MOCK_TEMPLATE);
+    }
+
+    it('should scaffold a template when --template is provided', async () => {
+      setupTemplateMocks();
+      const code = await init(['--template', 'strict']);
+      expect(code).toBe(0);
+      expect(writeFileSync).toHaveBeenCalled();
+
+      const writeCalls = vi.mocked(writeFileSync).mock.calls;
+      const yamlCall = writeCalls.find(
+        (call) => typeof call[0] === 'string' && (call[0] as string).endsWith('agentguard.yaml')
+      );
+      expect(yamlCall).toBeDefined();
+      expect(yamlCall?.[1]).toBe(MOCK_TEMPLATE);
+    });
+
+    it('should accept -t alias for --template', async () => {
+      setupTemplateMocks();
+      const code = await init(['-t', 'development']);
+      expect(code).toBe(0);
+    });
+
+    it('should accept all four template names', async () => {
+      const templates = ['strict', 'permissive', 'ci-only', 'development'];
+      for (const tmpl of templates) {
+        vi.clearAllMocks();
+        vi.spyOn(console, 'log').mockImplementation(() => {});
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+        setupTemplateMocks();
+
+        const code = await init(['--template', tmpl]);
+        expect(code, `Template "${tmpl}" should be valid`).toBe(0);
+      }
+    });
+
+    it('should return 1 for unknown template name', async () => {
+      const code = await init(['--template', 'nonexistent']);
+      expect(code).toBe(1);
+      expect(console.error).toHaveBeenCalled();
+    });
+
+    it('should return 1 if agentguard.yaml already exists', async () => {
+      vi.mocked(existsSync).mockImplementation((p: unknown) => {
+        const path = String(p);
+        if (path.endsWith('templates')) return true;
+        if (path.endsWith('.yaml') && path.includes('templates')) return true;
+        // Output file already exists
+        if (path.endsWith('agentguard.yaml')) return true;
+        return false;
+      });
+      vi.mocked(readFileSync).mockReturnValue(MOCK_TEMPLATE);
+
+      const code = await init(['--template', 'strict']);
+      expect(code).toBe(1);
+      expect(console.error).toHaveBeenCalled();
+    });
+
+    it('should write to custom directory when --dir is provided', async () => {
+      setupTemplateMocks();
+      const code = await init(['--template', 'permissive', '--dir', '/tmp/my-project']);
+      expect(code).toBe(0);
+
+      const writeCalls = vi.mocked(writeFileSync).mock.calls;
+      const yamlCall = writeCalls.find(
+        (call) => typeof call[0] === 'string' && (call[0] as string).includes('my-project')
+      );
+      expect(yamlCall).toBeDefined();
+    });
+
+    it('should display success message with template name', async () => {
+      setupTemplateMocks();
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      await init(['--template', 'development']);
+
+      const allOutput = consoleSpy.mock.calls.flat().join('\n');
+      expect(allOutput).toContain('development');
+    });
+
+    it('should include template info in help output', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      await init([]);
+
+      const allOutput = consoleSpy.mock.calls.flat().join('\n');
+      expect(allOutput).toContain('--template');
+      expect(allOutput).toContain('strict');
+      expect(allOutput).toContain('permissive');
+      expect(allOutput).toContain('ci-only');
+      expect(allOutput).toContain('development');
     });
   });
 });


### PR DESCRIPTION
## Summary
- Add 4 policy templates (strict, permissive, ci-only, development) as well-documented YAML starter configurations in `templates/`
- Add `--template`/`-t` flag to `agentguard init` for scaffolding `agentguard.yaml` from a built-in template
- Closes #189

## Changes
- `templates/strict.yaml` — Maximum guardrails, default-deny for destructive ops
- `templates/permissive.yaml` — Default-allow with safety nets for dangerous ops only
- `templates/ci-only.yaml` — Read-only CI pipeline mode (build/test only, no mutations)
- `templates/development.yaml` — Balanced guardrails for active development
- `src/cli/commands/init.ts` — Added `--template` flag, `initTemplate()` function, `resolveTemplatesDir()`, updated help text
- `tests/ts/cli-init.test.ts` — Added 8 test cases for template scaffolding
- `package.json` — Added `templates/` to npm package files

## Test Plan
- [x] TypeScript build passes (`npm run build:ts`)
- [x] Vitest tests pass (`npm run ts:test`) — 1493 pass / 0 fail
- [x] JS tests pass (`npm test`) — 210 pass / 0 fail
- [x] ESLint clean (`npm run lint`) — 0 errors
- [x] Prettier clean (`npm run format`)
- [x] Coverage passes (`npm run test:coverage`) — 81.45% lines

## Risk Assessment

| Metric | Value |
|--------|-------|
| Risk level | low |
| Risk score | 5/100 |
| Blast radius | 7 files (low) |
| Simulation result | not applicable (feature branch) |

## Governance Report

| Metric | Count |
|--------|-------|
| Total events | 4095 |
| Actions allowed | 735 |
| Actions denied | 78 |
| Policy denials | 26 |
| Invariant violations | 64 |
| Escalation events | 8 |
| Decision records | 803 |

<details>
<summary>Governance details</summary>

**Source**: `.agentguard/events/`, `.agentguard/decisions/`, `logs/runtime-events.jsonl`

**Decision Records**: 803 total, 73 denials (accumulated across all sessions)
**Escalation levels observed**: NORMAL only (this session)
**Pre-push simulation**: low risk, blast radius 0 (simulation flagged false positive due to missing remote tracking)

Note: Event counts reflect accumulated telemetry from all governance sessions, not just this implementation run.

</details>