### PR TITLE
feat(issue-275): add real-time policy trace visualization

### DIFF
--- a/src/cli/bin.ts
+++ b/src/cli/bin.ts
@@ -52,6 +52,7 @@ const COMMANDS: Record<string, CommandHelp> = {
       },
       { flag: '--dry-run', description: 'Evaluate without executing actions' },
       { flag: '--verbose, -v', description: 'Show detailed output' },
+      { flag: '--trace, -t', description: 'Show policy evaluation traces inline' },
       { flag: '--store <backend>', description: 'Storage backend: jsonl (default) or sqlite' },
       {
         flag: '--db-path <path>',
@@ -316,6 +317,7 @@ async function main() {
 
       const dryRun = flags.includes('--dry-run');
       const verbose = flags.includes('--verbose') || flags.includes('-v');
+      const trace = flags.includes('--trace') || flags.includes('-t');
 
       const { guard } = await import('./commands/guard.js');
       const storageConfig = resolveStorageConfig(flags);
@@ -324,6 +326,7 @@ async function main() {
         policies: policyFiles.length > 1 ? policyFiles : undefined,
         dryRun,
         verbose,
+        trace,
         stdin: true,
         store: storageConfig,
       });
@@ -521,6 +524,7 @@ function printHelp(): void {
     agentguard guard --policy <file>          Use a specific policy file (YAML/JSON)
     agentguard guard --policy a --policy b    Compose multiple policies with precedence
     agentguard guard --dry-run                Evaluate without executing actions
+    agentguard guard --trace                  Show policy evaluation traces inline
     agentguard inspect [runId]                Inspect action graph and decisions
     agentguard events [runId]                 Show raw event stream for a run
     agentguard analytics                      Analyze violation patterns across sessions

--- a/src/cli/commands/guard.ts
+++ b/src/cli/commands/guard.ts
@@ -18,10 +18,11 @@ import { simpleHash } from '../../core/hash.js';
 import { createRendererRegistry } from '../../renderers/registry.js';
 import type { RendererRegistry } from '../../renderers/registry.js';
 import { createTuiRenderer } from '../../renderers/tui-renderer.js';
-import { createEvent, POLICY_COMPOSED } from '../../events/schema.js';
+import { createEvent, POLICY_COMPOSED, POLICY_TRACE_RECORDED } from '../../events/schema.js';
 
 import { createStorageBundle } from '../../storage/factory.js';
 import type { StorageConfig } from '../../storage/types.js';
+import type { PolicyTracePayload } from '../../renderers/types.js';
 
 export interface GuardOptions {
   /** Single policy path (backwards compatible) */
@@ -30,6 +31,7 @@ export interface GuardOptions {
   policies?: string[];
   dryRun?: boolean;
   verbose?: boolean;
+  trace?: boolean;
   stdin?: boolean;
   simulate?: boolean;
   /** Optional pre-configured renderer registry (for custom renderers) */
@@ -111,7 +113,7 @@ export async function guard(_args: string[], options: GuardOptions = {}): Promis
   // Set up renderer registry — use provided registry or create default with TUI
   const renderers = options.renderers ?? createRendererRegistry();
   if (!options.renderers) {
-    renderers.register(createTuiRenderer({ verbose: options.verbose }));
+    renderers.register(createTuiRenderer({ verbose: options.verbose, trace: options.trace }));
   }
 
   // Notify renderers: run started
@@ -123,6 +125,7 @@ export async function guard(_args: string[], options: GuardOptions = {}): Promis
     verbose: options.verbose,
     dryRun: options.dryRun,
     simulatorCount: simCount,
+    trace: options.trace,
   });
 
   if (!options.stdin) {
@@ -171,6 +174,13 @@ async function processStdin(
 
           // Dispatch to all registered renderers
           renderers.notifyActionResult(result);
+
+          // Dispatch policy trace events for real-time visualization
+          for (const event of result.events) {
+            if (event.kind === POLICY_TRACE_RECORDED) {
+              renderers.notifyPolicyTrace(event as unknown as PolicyTracePayload);
+            }
+          }
 
           if (result.decisionRecord) {
             renderers.notifyDecisionRecord(result.decisionRecord);

--- a/src/renderers/index.ts
+++ b/src/renderers/index.ts
@@ -1,6 +1,11 @@
 // Renderer plugin system — re-exports for public API.
 
-export type { GovernanceRenderer, RendererConfig, RunSummary } from './types.js';
+export type {
+  GovernanceRenderer,
+  PolicyTracePayload,
+  RendererConfig,
+  RunSummary,
+} from './types.js';
 
 export { createRendererRegistry } from './registry.js';
 export type { RendererRegistry } from './registry.js';

--- a/src/renderers/registry.ts
+++ b/src/renderers/registry.ts
@@ -1,7 +1,12 @@
 // Renderer registry — manages multiple governance renderers.
 // Dispatches lifecycle events to all registered renderers.
 
-import type { GovernanceRenderer, RendererConfig, RunSummary } from './types.js';
+import type {
+  GovernanceRenderer,
+  PolicyTracePayload,
+  RendererConfig,
+  RunSummary,
+} from './types.js';
 import type { KernelResult } from '../kernel/kernel.js';
 import type { MonitorDecision } from '../kernel/monitor.js';
 import type { GovernanceDecisionRecord } from '../kernel/decisions/types.js';
@@ -37,6 +42,9 @@ export interface RendererRegistry {
 
   /** Dispatch: decision record */
   notifyDecisionRecord(record: GovernanceDecisionRecord): void;
+
+  /** Dispatch: policy trace */
+  notifyPolicyTrace(trace: PolicyTracePayload): void;
 
   /** Dispatch: run ended */
   notifyRunEnded(summary: RunSummary): void;
@@ -128,6 +136,14 @@ export function createRendererRegistry(): RendererRegistry {
       for (const renderer of renderers.values()) {
         if (renderer.onDecisionRecord) {
           safeCall(() => renderer.onDecisionRecord!(record));
+        }
+      }
+    },
+
+    notifyPolicyTrace(trace) {
+      for (const renderer of renderers.values()) {
+        if (renderer.onPolicyTrace) {
+          safeCall(() => renderer.onPolicyTrace!(trace));
         }
       }
     },

--- a/src/renderers/tui-renderer.ts
+++ b/src/renderers/tui-renderer.ts
@@ -1,7 +1,12 @@
 // TUI governance renderer — wraps the existing tui.ts render functions
 // into a GovernanceRenderer plugin. Writes ANSI-colored output to a stream.
 
-import type { GovernanceRenderer, RendererConfig, RunSummary } from './types.js';
+import type {
+  GovernanceRenderer,
+  PolicyTracePayload,
+  RendererConfig,
+  RunSummary,
+} from './types.js';
 import type { KernelResult } from '../kernel/kernel.js';
 import type { MonitorDecision } from '../kernel/monitor.js';
 import type { GovernanceDecisionRecord } from '../kernel/decisions/types.js';
@@ -12,6 +17,7 @@ import {
   renderMonitorStatus,
   renderDecisionRecord,
   renderSimulation,
+  renderPolicyTraces,
 } from '../cli/tui.js';
 
 export interface TuiRendererOptions {
@@ -19,6 +25,8 @@ export interface TuiRendererOptions {
   output?: { write(s: string): boolean };
   /** Show verbose output (decision records, reasons) */
   verbose?: boolean;
+  /** Show policy evaluation traces inline */
+  trace?: boolean;
 }
 
 /**
@@ -31,12 +39,16 @@ export interface TuiRendererOptions {
 export function createTuiRenderer(options: TuiRendererOptions = {}): GovernanceRenderer {
   const output = options.output ?? process.stderr;
   const verbose = options.verbose ?? false;
+  let traceEnabled = options.trace ?? false;
 
   return {
     id: 'tui',
     name: 'Terminal UI Renderer',
 
     onRunStarted(config: RendererConfig) {
+      if (config.trace !== undefined) {
+        traceEnabled = config.trace;
+      }
       output.write(
         renderBanner({
           policyName: config.policyName,
@@ -70,6 +82,27 @@ export function createTuiRenderer(options: TuiRendererOptions = {}): GovernanceR
       if (verbose) {
         output.write(renderDecisionRecord(record) + '\n');
       }
+    },
+
+    onPolicyTrace(trace: PolicyTracePayload) {
+      if (!traceEnabled) return;
+      output.write(
+        renderPolicyTraces([
+          {
+            kind: 'PolicyTraceRecorded',
+            timestamp: Date.now(),
+            actionType: trace.actionType,
+            target: trace.target,
+            decision: trace.decision,
+            totalRulesChecked: trace.totalRulesChecked,
+            phaseThatMatched: trace.phaseThatMatched,
+            rulesEvaluated: trace.rulesEvaluated as Parameters<
+              typeof renderPolicyTraces
+            >[0][0]['rulesEvaluated'],
+            durationMs: trace.durationMs,
+          },
+        ]) + '\n'
+      );
     },
 
     onRunEnded(summary: RunSummary) {

--- a/src/renderers/types.ts
+++ b/src/renderers/types.ts
@@ -14,6 +14,32 @@ export interface RendererConfig {
   readonly verbose?: boolean;
   readonly dryRun?: boolean;
   readonly simulatorCount?: number;
+  readonly trace?: boolean;
+}
+
+/** A single policy trace event for real-time rendering */
+export interface PolicyTracePayload {
+  readonly actionType: string;
+  readonly target?: string;
+  readonly decision: string;
+  readonly totalRulesChecked: number;
+  readonly phaseThatMatched?: string | null;
+  readonly rulesEvaluated?: ReadonlyArray<{
+    readonly policyId: string;
+    readonly policyName: string;
+    readonly ruleIndex: number;
+    readonly effect: string;
+    readonly actionPattern: string | string[];
+    readonly actionMatched: boolean;
+    readonly conditionsMatched: boolean;
+    readonly conditionDetails: {
+      readonly scopeMatched?: boolean;
+      readonly limitExceeded?: boolean;
+      readonly branchMatched?: boolean;
+    };
+    readonly outcome: 'match' | 'no-match' | 'skipped';
+  }>;
+  readonly durationMs?: number;
 }
 
 /** Summary provided to renderers at run end */
@@ -56,6 +82,9 @@ export interface GovernanceRenderer {
 
   /** Called when a governance decision record is persisted */
   onDecisionRecord?(record: GovernanceDecisionRecord): void;
+
+  /** Called when a policy evaluation trace is recorded */
+  onPolicyTrace?(trace: PolicyTracePayload): void;
 
   /** Called when a governance run ends */
   onRunEnded?(summary: RunSummary): void;

--- a/tests/ts/renderer-registry.test.ts
+++ b/tests/ts/renderer-registry.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi } from 'vitest';
 import { createRendererRegistry } from '../../src/renderers/registry.js';
-import type { GovernanceRenderer, RendererConfig, RunSummary } from '../../src/renderers/types.js';
+import type {
+  GovernanceRenderer,
+  PolicyTracePayload,
+  RendererConfig,
+  RunSummary,
+} from '../../src/renderers/types.js';
 import type { KernelResult } from '../../src/kernel/kernel.js';
 
 function makeRenderer(id: string, overrides: Partial<GovernanceRenderer> = {}): GovernanceRenderer {
@@ -120,6 +125,27 @@ describe('RendererRegistry', () => {
       registry.notifyRunEnded(summary);
 
       expect(onRunEnded).toHaveBeenCalledWith(summary);
+    });
+
+    it('dispatches onPolicyTrace to all renderers', () => {
+      const registry = createRendererRegistry();
+      const onPolicyTrace1 = vi.fn();
+      const onPolicyTrace2 = vi.fn();
+      registry.register(makeRenderer('r1', { onPolicyTrace: onPolicyTrace1 }));
+      registry.register(makeRenderer('r2', { onPolicyTrace: onPolicyTrace2 }));
+
+      const trace: PolicyTracePayload = {
+        actionType: 'file.write',
+        target: 'src/index.ts',
+        decision: 'allow',
+        totalRulesChecked: 2,
+        phaseThatMatched: 'allow',
+        durationMs: 0.5,
+      };
+      registry.notifyPolicyTrace(trace);
+
+      expect(onPolicyTrace1).toHaveBeenCalledWith(trace);
+      expect(onPolicyTrace2).toHaveBeenCalledWith(trace);
     });
 
     it('skips renderers without the hook', () => {

--- a/tests/ts/tui-renderer-plugin.test.ts
+++ b/tests/ts/tui-renderer-plugin.test.ts
@@ -1,7 +1,7 @@
 // Tests for TUI governance renderer plugin (GovernanceRenderer implementation)
 import { describe, it, expect, vi } from 'vitest';
 import { createTuiRenderer } from '../../src/renderers/tui-renderer.js';
-import type { RendererConfig, RunSummary } from '../../src/renderers/types.js';
+import type { PolicyTracePayload, RendererConfig, RunSummary } from '../../src/renderers/types.js';
 import type { KernelResult } from '../../src/kernel/kernel.js';
 import type { MonitorDecision } from '../../src/kernel/monitor.js';
 
@@ -220,6 +220,102 @@ describe('TuiRenderer plugin', () => {
     });
   });
 
+  describe('onPolicyTrace', () => {
+    function makeTrace(overrides: Partial<PolicyTracePayload> = {}): PolicyTracePayload {
+      return {
+        actionType: 'file.write',
+        target: 'src/index.ts',
+        decision: 'allow',
+        totalRulesChecked: 3,
+        phaseThatMatched: 'allow',
+        durationMs: 1.25,
+        rulesEvaluated: [
+          {
+            policyId: 'default',
+            policyName: 'default-policy',
+            ruleIndex: 0,
+            effect: 'deny',
+            actionPattern: 'shell.exec',
+            actionMatched: false,
+            conditionsMatched: false,
+            conditionDetails: {},
+            outcome: 'no-match',
+          },
+          {
+            policyId: 'default',
+            policyName: 'default-policy',
+            ruleIndex: 1,
+            effect: 'allow',
+            actionPattern: 'file.*',
+            actionMatched: true,
+            conditionsMatched: true,
+            conditionDetails: { scopeMatched: true },
+            outcome: 'match',
+          },
+        ],
+        ...overrides,
+      };
+    }
+
+    it('renders trace when trace option is enabled', () => {
+      const output = makeOutput();
+      const renderer = createTuiRenderer({ output, trace: true });
+      renderer.onPolicyTrace!(makeTrace());
+
+      const text = output.text();
+      expect(text).toContain('Policy Evaluation Traces');
+      expect(text).toContain('file.write');
+      expect(text).toContain('ALLOW');
+    });
+
+    it('suppresses trace when trace option is disabled', () => {
+      const output = makeOutput();
+      const renderer = createTuiRenderer({ output, trace: false });
+      renderer.onPolicyTrace!(makeTrace());
+
+      expect(output.write).not.toHaveBeenCalled();
+    });
+
+    it('suppresses trace by default', () => {
+      const output = makeOutput();
+      const renderer = createTuiRenderer({ output });
+      renderer.onPolicyTrace!(makeTrace());
+
+      expect(output.write).not.toHaveBeenCalled();
+    });
+
+    it('enables trace via config.trace in onRunStarted', () => {
+      const output = makeOutput();
+      const renderer = createTuiRenderer({ output });
+      renderer.onRunStarted!(makeConfig({ trace: true }));
+      output.chunks.length = 0; // clear banner output
+
+      renderer.onPolicyTrace!(makeTrace());
+
+      const text = output.text();
+      expect(text).toContain('Policy Evaluation Traces');
+    });
+
+    it('renders denied trace with DENY indicator', () => {
+      const output = makeOutput();
+      const renderer = createTuiRenderer({ output, trace: true });
+      renderer.onPolicyTrace!(makeTrace({ decision: 'deny', phaseThatMatched: 'deny' }));
+
+      const text = output.text();
+      expect(text).toContain('DENY');
+    });
+
+    it('shows rule evaluation details', () => {
+      const output = makeOutput();
+      const renderer = createTuiRenderer({ output, trace: true });
+      renderer.onPolicyTrace!(makeTrace());
+
+      const text = output.text();
+      expect(text).toContain('default-policy');
+      expect(text).toContain('file.*');
+    });
+  });
+
   describe('implements GovernanceRenderer contract', () => {
     it('has all optional lifecycle hooks', () => {
       const renderer = createTuiRenderer();
@@ -228,6 +324,7 @@ describe('TuiRenderer plugin', () => {
       expect(renderer.onMonitorStatus).toBeDefined();
       expect(renderer.onSimulation).toBeDefined();
       expect(renderer.onDecisionRecord).toBeDefined();
+      expect(renderer.onPolicyTrace).toBeDefined();
       expect(renderer.onRunEnded).toBeDefined();
     });
   });


### PR DESCRIPTION
## Summary
- Add `--trace`/`-t` flag to `agentguard guard` for real-time policy evaluation trace rendering
- Extend the `GovernanceRenderer` plugin interface with `onPolicyTrace` lifecycle hook
- Integrate trace visualization into the TUI renderer using existing `renderPolicyTraces` engine
- Closes #275

## Changes
- `src/renderers/types.ts` — Add `PolicyTracePayload` type, `trace` field to `RendererConfig`, `onPolicyTrace` hook to `GovernanceRenderer`
- `src/renderers/registry.ts` — Add `notifyPolicyTrace` dispatch method to `RendererRegistry`
- `src/renderers/tui-renderer.ts` — Implement `onPolicyTrace` handler with `trace` enable/disable toggle
- `src/renderers/index.ts` — Export new `PolicyTracePayload` type
- `src/cli/commands/guard.ts` — Add `trace` option, extract `PolicyTraceRecorded` events and dispatch to renderers
- `src/cli/bin.ts` — Add `--trace`/`-t` flag parsing, help text
- `tests/ts/tui-renderer-plugin.test.ts` — 6 new tests for trace rendering behavior
- `tests/ts/renderer-registry.test.ts` — 1 new test for `notifyPolicyTrace` dispatch

## Test Plan
- [x] TypeScript build passes (`npm run build:ts`)
- [x] Vitest tests pass (`npm run ts:test`) — 1492 pass / 0 fail
- [x] JS tests pass (`npm test`) — 210 pass / 0 fail
- [x] ESLint clean (`npm run lint`) — 0 errors
- [x] Prettier clean (`npm run format`)

## Risk Assessment

| Metric | Value |
|--------|-------|
| Risk level | low |
| Risk score | 10/100 |
| Blast radius | 8 files (weighted) |
| Simulation result | not available |

## Governance Report

| Metric | Count |
|--------|-------|
| Total events | 4375 |
| Actions allowed | 793 |
| Actions denied | 80 |
| Policy denials | 28 |
| Invariant violations | 66 |
| Escalation events | 10 |
| Decision records | 860 |

<details>
<summary>Governance details</summary>

**Source**: `.agentguard/events/`, `.agentguard/decisions/`, `logs/runtime-events.jsonl`

**Decision Records**: 860 total, 73 denials
**Escalation levels observed**: NORMAL (session-level telemetry from prior runs)
**Pre-push simulation**: not available

</details>