### PR TITLE
feat: expand AAB destructive command patterns

### DIFF
--- a/src/kernel/aab.ts
+++ b/src/kernel/aab.ts
@@ -627,6 +627,41 @@ const DESTRUCTIVE_PATTERNS: DestructivePattern[] = [
     riskLevel: 'critical',
     category: 'filesystem',
   },
+  // Process management — high (bare kill with PID)
+  {
+    pattern: /\bkill\s+\d/,
+    description: 'Kill process by PID',
+    riskLevel: 'high',
+    category: 'process',
+  },
+  // Service management — high (restart causes downtime)
+  {
+    pattern: /\bsystemctl\s+restart\b/,
+    description: 'Restart system service',
+    riskLevel: 'high',
+    category: 'service',
+  },
+  // System — high (recursive permission changes)
+  {
+    pattern: /\bchmod\s+-R\b/,
+    description: 'Recursive permission change',
+    riskLevel: 'high',
+    category: 'system',
+  },
+  // Package management — high (irreversible publication)
+  {
+    pattern: /\bnpm\s+publish\b/,
+    description: 'Publish npm package (irreversible public release)',
+    riskLevel: 'high',
+    category: 'package',
+  },
+  // Container operations — high (force kill container)
+  {
+    pattern: /\bdocker\s+kill\b/,
+    description: 'Force kill Docker container',
+    riskLevel: 'high',
+    category: 'container',
+  },
 ];
 
 function isDestructiveCommand(command: string): boolean {

--- a/tests/ts/agentguard-aab.test.ts
+++ b/tests/ts/agentguard-aab.test.ts
@@ -40,8 +40,8 @@ describe('agentguard/core/aab', () => {
   });
 
   describe('DESTRUCTIVE_PATTERNS', () => {
-    it('has at least 87 patterns', () => {
-      expect(DESTRUCTIVE_PATTERNS.length).toBeGreaterThanOrEqual(87);
+    it('has at least 92 patterns', () => {
+      expect(DESTRUCTIVE_PATTERNS.length).toBeGreaterThanOrEqual(92);
     });
 
     it('every pattern has required fields', () => {
@@ -482,6 +482,35 @@ describe('agentguard/core/aab', () => {
       expect(isDestructiveCommand('git filter-branch --tree-filter "rm -rf secrets"')).toBe(true);
     });
 
+    // Bare kill (process termination)
+    it('detects bare kill with PID', () => {
+      expect(isDestructiveCommand('kill 1234')).toBe(true);
+      expect(isDestructiveCommand('kill 42')).toBe(true);
+    });
+
+    // systemctl restart
+    it('detects systemctl restart', () => {
+      expect(isDestructiveCommand('systemctl restart nginx')).toBe(true);
+      expect(isDestructiveCommand('systemctl restart sshd')).toBe(true);
+    });
+
+    // chmod -R (recursive permission changes)
+    it('detects chmod -R', () => {
+      expect(isDestructiveCommand('chmod -R 755 /var/www')).toBe(true);
+      expect(isDestructiveCommand('chmod -R u+x scripts/')).toBe(true);
+    });
+
+    // npm publish (package publication)
+    it('detects npm publish', () => {
+      expect(isDestructiveCommand('npm publish')).toBe(true);
+      expect(isDestructiveCommand('npm publish --access public')).toBe(true);
+    });
+
+    // docker kill
+    it('detects docker kill', () => {
+      expect(isDestructiveCommand('docker kill my-container')).toBe(true);
+    });
+
     // Safe commands
     it('returns false for safe commands', () => {
       expect(isDestructiveCommand('ls -la')).toBe(false);
@@ -510,8 +539,10 @@ describe('agentguard/core/aab', () => {
       expect(isDestructiveCommand('gcloud compute instances list')).toBe(false);
       expect(isDestructiveCommand('az vm list')).toBe(false);
       expect(isDestructiveCommand('kubectl get nodes')).toBe(false);
-      expect(isDestructiveCommand('npm publish')).toBe(false);
+      expect(isDestructiveCommand('npm pack')).toBe(false);
       expect(isDestructiveCommand('git log --all')).toBe(false);
+      expect(isDestructiveCommand('chmod 644 file.txt')).toBe(false);
+      expect(isDestructiveCommand('systemctl status nginx')).toBe(false);
     });
 
     it('returns false for empty/null input', () => {
@@ -581,6 +612,12 @@ describe('agentguard/core/aab', () => {
       expect(getDestructiveDetails('pg_dropcluster 14 main')!.category).toBe('database');
       expect(getDestructiveDetails('DROP KEYSPACE ks')!.category).toBe('database');
       expect(getDestructiveDetails('git filter-branch')!.category).toBe('filesystem');
+      // Issue #285 expanded patterns
+      expect(getDestructiveDetails('kill 1234')!.category).toBe('process');
+      expect(getDestructiveDetails('systemctl restart nginx')!.category).toBe('service');
+      expect(getDestructiveDetails('chmod -R 755 /var')!.category).toBe('system');
+      expect(getDestructiveDetails('npm publish')!.category).toBe('package');
+      expect(getDestructiveDetails('docker kill ctr')!.category).toBe('container');
     });
 
     it('returns critical risk level for high-severity commands', () => {
@@ -639,6 +676,12 @@ describe('agentguard/core/aab', () => {
       expect(getDestructiveDetails('reboot')!.riskLevel).toBe('high');
       expect(getDestructiveDetails('kubectl drain node')!.riskLevel).toBe('high');
       expect(getDestructiveDetails('docker swarm leave')!.riskLevel).toBe('high');
+      // Issue #285 expanded patterns
+      expect(getDestructiveDetails('kill 1234')!.riskLevel).toBe('high');
+      expect(getDestructiveDetails('systemctl restart nginx')!.riskLevel).toBe('high');
+      expect(getDestructiveDetails('chmod -R 755 /var')!.riskLevel).toBe('high');
+      expect(getDestructiveDetails('npm publish')!.riskLevel).toBe('high');
+      expect(getDestructiveDetails('docker kill ctr')!.riskLevel).toBe('high');
     });
 
     it('matches rm -rf even within sudo rm -rf', () => {


### PR DESCRIPTION
## Summary

Closes #285

Expands the Action Authorization Boundary (AAB) destructive command patterns from 87 to 92, completing the remaining gaps from the Phase 6 roadmap item (Reference Monitor Hardening).

**New patterns added:**
- `kill <pid>` — bare process termination (high risk, process category)
- `systemctl restart` — service restart causing potential downtime (high risk, service category)
- `chmod -R` — recursive permission changes (high risk, system category)
- `npm publish` — irreversible package publication (high risk, package category)
- `docker kill` — force kill Docker container (high risk, container category)

**Test updates:**
- Pattern count threshold updated from 87 → 92
- Added detection tests for all 5 new patterns
- Added category and risk level assertions
- Moved `npm publish` from safe commands to destructive commands
- Added `npm pack`, `chmod 644`, `systemctl status` as safe command verifications

## Test plan

- [x] `npm run build:ts` — TypeScript compilation passes
- [x] `npm run ts:check` — Type-check passes (0 errors)
- [x] `npm run lint` — ESLint passes (0 errors, only pre-existing warnings)
- [x] `npm run format` — Prettier formatting passes
- [x] `npm test` — All 210 JS tests pass
- [x] `npm run ts:test` — All 1574 TypeScript tests pass (including 126 AAB tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)