### PR TITLE
docs: sync documentation with codebase state

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -52,7 +52,7 @@ src/
 ├── plugins/       Plugin ecosystem (discovery, registry, validation, sandboxing)
 ├── renderers/     Renderer plugin system (registry, TUI renderer)
 ├── cli/           CLI entry point and commands
-├── storage/       SQLite storage backend (opt-in alternative to JSONL)
+├── storage/       Storage backends: SQLite and Firestore (opt-in alternatives to JSONL)
 ├── telemetry/     Runtime telemetry and logging
 └── core/          Shared utilities (types, actions, hash, execution-log)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,13 +110,16 @@ src/
 │   ├── tui-renderer.ts     # TUI renderer implementation
 │   ├── types.ts            # Renderer type definitions
 │   └── index.ts            # Module re-exports
-├── storage/                # SQLite storage backend (opt-in)
+├── storage/                # Storage backends (SQLite + Firestore, opt-in)
 │   ├── factory.ts          # Storage bundle factory
 │   ├── index.ts            # Module re-exports
 │   ├── migrations.ts       # Schema migrations (version-based)
 │   ├── sqlite-analytics.ts # SQLite-backed analytics queries
 │   ├── sqlite-sink.ts      # SQLite event/decision sink
 │   ├── sqlite-store.ts     # SQLite event store implementation
+│   ├── firestore-analytics.ts # Firestore-backed analytics queries
+│   ├── firestore-sink.ts     # Firestore event/decision sink
+│   ├── firestore-store.ts    # Firestore event store implementation
 │   └── types.ts            # Storage type definitions
 ├── telemetry/              # Runtime telemetry
 │   ├── index.ts            # Module re-exports
@@ -147,7 +150,7 @@ vscode-extension/              # VS Code extension
 
 tests/
 ├── *.test.js               # 14 JS test files (custom zero-dependency harness)
-└── ts/*.test.ts            # 74 TS test files (vitest)
+└── ts/*.test.ts            # 76 TS test files (vitest)
 policy/                     # Policy configuration (JSON: action_rules, capabilities)
 policies/                   # Policy packs (YAML: ci-safe, enterprise, open-source, strict)
 docs/                       # System documentation (architecture, event model, specs)
@@ -207,7 +210,7 @@ Each top-level directory maps to a single architectural concept:
 - **src/renderers/** — Renderer plugin system (registry, TUI renderer)
 - **src/cli/** — CLI entry point and commands
 - **src/core/** — Shared utilities (types, actions, hash, execution-log)
-- **src/storage/** — SQLite storage backend (opt-in alternative to JSONL, indexed queries)
+- **src/storage/** — Storage backends: SQLite and Firestore (opt-in alternatives to JSONL, indexed queries)
 - **src/telemetry/** — Runtime telemetry and logging
 
 ### CLI Commands
@@ -229,7 +232,7 @@ Each top-level directory maps to a single architectural concept:
 - `agentguard diff <run1> <run2>` — Compare two governance sessions side-by-side
 - `agentguard evidence-pr` — Attach governance evidence summary to a pull request
 - `agentguard traces [runId]` — Display policy evaluation traces for a run
-- `agentguard init <type>` — Scaffold governance extensions (invariant, policy-pack, adapter, renderer, replay-processor)
+- `agentguard init <type>` — Scaffold governance extensions (invariant, policy-pack, adapter, renderer, replay-processor, firestore)
 
 ### Event Model
 The canonical event model is the architectural spine. Event kinds defined in `src/events/schema.ts`:
@@ -297,8 +300,8 @@ npm run test:coverage      # Run with coverage (c8, 50% line threshold)
 
 **Test structure:**
 - **JS tests** (`tests/*.test.js`): 14 files using a custom zero-dependency harness (`tests/run.js` with `node:assert`)
-- **TypeScript tests** (`tests/ts/*.test.ts`): 74 files using vitest
-- **Coverage areas**: adapters, analytics (including risk scorer), kernel (AAB, engine, monitor, blast radius, heartbeat, integration, e2e pipeline), CLI commands (args, guard, inspect, init, simulate, ci-check, claude-hook, claude-init, export/import, policy-validate, diff, evidence-pr, traces), decision records, domain models, events, evidence packs, evidence summary, execution log, export-import roundtrip, impact forecast, invariants, JSONL persistence, notification formatter, plugins (discovery, registry, validation), policy evaluation (including composer, pack loader, policy packs, evaluation trace), renderers, replay (engine, comparator, processor), simulation, SQLite storage (analytics, commands, migrations, sink, store, factory), telemetry (including tracepoint), TUI renderer, violation mapper, VS Code event reader, YAML loading
+- **TypeScript tests** (`tests/ts/*.test.ts`): 76 files using vitest
+- **Coverage areas**: adapters, analytics (including risk scorer), kernel (AAB, engine, monitor, blast radius, heartbeat, integration, e2e pipeline), CLI commands (args, guard, inspect, init, simulate, ci-check, claude-hook, claude-init, export/import, policy-validate, diff, evidence-pr, traces), decision records, domain models, events, evidence packs, evidence summary, execution log, export-import roundtrip, impact forecast, invariants, JSONL persistence, notification formatter, plugins (discovery, registry, validation), policy evaluation (including composer, pack loader, policy packs, evaluation trace), renderers, replay (engine, comparator, processor), simulation, SQLite storage (analytics, commands, migrations, sink, store, factory), Firestore storage, telemetry (including tracepoint), TUI renderer, violation mapper, VS Code event reader, YAML loading
 
 ## CI/CD & Automation
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ agentguard traces --last --json          # JSON output
 
 # === Integration ===
 agentguard claude-init                    # Set up Claude Code hook integration
-agentguard init <type>                    # Scaffold governance extensions
+agentguard init <type>                    # Scaffold governance extensions or storage backends
 agentguard help                           # Show all commands
 ```
 
@@ -293,7 +293,7 @@ src/
 │   ├── bin.ts              # Main entry
 │   ├── evidence-summary.ts # Evidence summary generator for PR reports
 │   └── commands/           # analytics, guard, inspect, replay, export, import, simulate, ci-check, plugin, policy, claude-hook, claude-init, init, diff, evidence-pr, traces
-├── storage/                # SQLite storage backend (opt-in alternative to JSONL)
+├── storage/                # Storage backends: SQLite and Firestore (opt-in alternatives to JSONL)
 ├── telemetry/              # Runtime telemetry and logging
 └── core/                   # Shared utilities (types, actions, hash, rng, execution-log)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -306,6 +306,8 @@ The `SystemState` interface in `src/invariants/definitions.ts` is the bottleneck
 The JSONL persistence layer was the right starting point — append-only, human-readable, zero dependencies. But it doesn't scale: every query requires filesystem enumeration + full file parsing, and hundreds of `.jsonl` files accumulate in `.agentguard/`.
 
 - [x] SQLite storage adapter implementing existing `EventStore` interface
+- [x] Firestore storage adapter (analytics, sink, store) for cloud-native deployments (`src/storage/firestore-*.ts`)
+- [x] `agentguard init firestore` scaffolding (security rules + credentials guide)
 - [x] Schema design: `events`, `decisions`, `sessions` tables with JSON payload columns
 - [x] Indexed columns: `kind`, `timestamp`, `runId`, `actionType`, `fingerprint`
 - [ ] Migration utility: bulk-import existing `.jsonl` files into SQLite (`agentguard migrate`)


### PR DESCRIPTION
## Summary

- Automated documentation sync detected drift between codebase and docs
- Firestore storage backend (3 new source files, 1 test file) was added in PR #295 but not reflected in documentation
- TS test count was stale (74 → 76)

## Changes

- **CLAUDE.md**: Updated TS test count (74 → 76), added Firestore storage files to project structure tree, updated storage directory description, added `firestore` to init command types, added Firestore to test coverage areas
- **ARCHITECTURE.md**: Updated storage directory description to mention Firestore
- **README.md**: Updated storage directory description and init command description
- **ROADMAP.md**: Added Firestore storage items to Phase 10 (Structured Storage Backend)

## Source

Auto-generated by the **Scheduled Docs Sync** skill.

---
*Run: 2026-03-12T18:00:00Z*