### PR TITLE
Add credential file creation invariant (severity 5)

### DIFF
--- a/src/invariants/checker.ts
+++ b/src/invariants/checker.ts
@@ -73,5 +73,6 @@ export function buildSystemState(context: Record<string, unknown> = {}): SystemS
     protectedBranches: (context.protectedBranches as string[]) || ['main', 'master'],
     currentTarget: (context.currentTarget as string) || '',
     currentCommand: (context.currentCommand as string) || '',
+    currentActionType: (context.currentActionType as string) || '',
   };
 }

--- a/src/invariants/definitions.ts
+++ b/src/invariants/definitions.ts
@@ -33,6 +33,8 @@ export interface SystemState {
   currentTarget?: string;
   /** Shell command of the current action (for shell.exec detection) */
   currentCommand?: string;
+  /** Canonical action type of the current action (e.g. 'file.write', 'git.push') */
+  currentActionType?: string;
 }
 
 /** Patterns matched as substrings (case-insensitive) against file paths. */
@@ -59,6 +61,58 @@ export const SENSITIVE_FILE_PATTERNS = [
   'secrets.yml',
   'vault.json',
 ];
+
+/** Well-known credential file paths and directory prefixes.
+ * Checked as case-insensitive substring matches against currentTarget. */
+export const CREDENTIAL_PATH_PATTERNS = [
+  // SSH
+  '/.ssh/',
+  '\\.ssh\\',
+  // AWS
+  '/.aws/credentials',
+  '/.aws/config',
+  '\\.aws\\credentials',
+  '\\.aws\\config',
+  // Google Cloud
+  '/.config/gcloud/',
+  '\\.config\\gcloud\\',
+  // Azure
+  '/.azure/',
+  '\\.azure\\',
+  // Docker
+  '/.docker/config.json',
+  '\\.docker\\config.json',
+];
+
+/** Exact basenames (case-insensitive) that are credential files at any depth. */
+export const CREDENTIAL_BASENAME_PATTERNS = ['.npmrc', '.pypirc', '.netrc', '.curlrc'];
+
+/** Matches .env files: .env, .env.local, .env.production, etc. */
+const ENV_FILE_REGEX = /(?:^|[\\/])\.env(?:\.\w+)?$/i;
+
+/** Returns true if the given path targets a well-known credential file location. */
+export function isCredentialPath(filePath: string): boolean {
+  const lower = filePath.toLowerCase();
+
+  // Check directory-based patterns (substring match)
+  if (CREDENTIAL_PATH_PATTERNS.some((p) => lower.includes(p.toLowerCase()))) {
+    return true;
+  }
+
+  // Check basename patterns
+  const basename = filePath.split(/[\\/]/).pop() || '';
+  const lowerBase = basename.toLowerCase();
+  if (CREDENTIAL_BASENAME_PATTERNS.some((p) => lowerBase === p)) {
+    return true;
+  }
+
+  // Check .env file pattern
+  if (ENV_FILE_REGEX.test(filePath)) {
+    return true;
+  }
+
+  return false;
+}
 
 export const DEFAULT_INVARIANTS: AgentGuardInvariant[] = [
   {
@@ -215,6 +269,40 @@ export const DEFAULT_INVARIANTS: AgentGuardInvariant[] = [
         actual: holds
           ? 'No scheduled task files affected'
           : `Scheduled task modification detected (${violations.join('; ')})`,
+      };
+    },
+  },
+
+  {
+    id: 'no-credential-file-creation',
+    name: 'No Credential File Creation',
+    description:
+      'Agents must not create or overwrite well-known credential files (SSH keys, cloud configs, auth tokens)',
+    severity: 5,
+    check(state) {
+      const actionType = state.currentActionType || '';
+      const writingActions = ['file.write', 'file.move'];
+
+      // Only applies to write/move actions — reading credential files is allowed
+      if (actionType !== '' && !writingActions.includes(actionType)) {
+        return {
+          holds: true,
+          expected: 'N/A',
+          actual: `Action type ${actionType} is not a write operation`,
+        };
+      }
+
+      const target = state.currentTarget || '';
+      if (target === '') {
+        return { holds: true, expected: 'N/A', actual: 'No target specified' };
+      }
+
+      const violation = isCredentialPath(target);
+
+      return {
+        holds: !violation,
+        expected: 'No creation or modification of credential files',
+        actual: violation ? `Credential file targeted: ${target}` : 'No credential files affected',
       };
     },
   },

--- a/src/kernel/decision.ts
+++ b/src/kernel/decision.ts
@@ -124,6 +124,7 @@ export function createEngine(config: EngineConfig = {}): Engine {
         ...systemContext,
         currentTarget: intent.target,
         currentCommand: intent.command,
+        currentActionType: intent.action,
         filesAffected: intent.filesAffected || systemContext.filesAffected,
         targetBranch: intent.branch || systemContext.targetBranch,
         forcePush: intent.action === 'git.force-push',

--- a/src/kernel/kernel.ts
+++ b/src/kernel/kernel.ts
@@ -249,6 +249,7 @@ export function createKernel(config: KernelConfig = {}): Kernel {
                 filesAffected: simulationResult.blastRadius,
                 simulatedBlastRadius: simulationResult.blastRadius,
                 simulatedRiskLevel: simulationResult.riskLevel,
+                currentActionType: decision.intent.action,
                 targetBranch: decision.intent.branch || (systemContext.targetBranch as string),
                 forcePush: decision.intent.action === 'git.force-push',
                 directPush: decision.intent.action === 'git.push',

--- a/tests/ts/agentguard-engine.test.ts
+++ b/tests/ts/agentguard-engine.test.ts
@@ -15,7 +15,7 @@ describe('agentguard/core/engine', () => {
     it('creates an engine with defaults', () => {
       const engine = createEngine();
       expect(engine.getPolicyCount()).toBe(0);
-      expect(engine.getInvariantCount()).toBe(8); // DEFAULT_INVARIANTS
+      expect(engine.getInvariantCount()).toBe(9); // DEFAULT_INVARIANTS
       expect(engine.getPolicyErrors()).toEqual([]);
     });
 

--- a/tests/ts/invariant-definitions.test.ts
+++ b/tests/ts/invariant-definitions.test.ts
@@ -1,6 +1,12 @@
 // Tests for invariant definitions and checker — TypeScript version
 import { describe, it, expect, beforeEach } from 'vitest';
-import { DEFAULT_INVARIANTS, SENSITIVE_FILE_PATTERNS } from '../../src/invariants/definitions.js';
+import {
+  DEFAULT_INVARIANTS,
+  SENSITIVE_FILE_PATTERNS,
+  CREDENTIAL_PATH_PATTERNS,
+  CREDENTIAL_BASENAME_PATTERNS,
+  isCredentialPath,
+} from '../../src/invariants/definitions.js';
 import type { SystemState } from '../../src/invariants/definitions.js';
 import { checkAllInvariants, buildSystemState } from '../../src/invariants/checker.js';
 import { resetEventCounter } from '../../src/events/schema.js';
@@ -349,6 +355,207 @@ describe('no-scheduled-task-modification', () => {
   });
 });
 
+describe('isCredentialPath', () => {
+  it('detects SSH key paths', () => {
+    expect(isCredentialPath('/home/user/.ssh/id_rsa')).toBe(true);
+    expect(isCredentialPath('/home/user/.ssh/id_ed25519')).toBe(true);
+    expect(isCredentialPath('/home/user/.ssh/authorized_keys')).toBe(true);
+    expect(isCredentialPath('/home/user/.ssh/config')).toBe(true);
+  });
+
+  it('detects AWS credential paths', () => {
+    expect(isCredentialPath('/home/user/.aws/credentials')).toBe(true);
+    expect(isCredentialPath('/home/user/.aws/config')).toBe(true);
+  });
+
+  it('detects Google Cloud paths', () => {
+    expect(isCredentialPath('/home/user/.config/gcloud/credentials.json')).toBe(true);
+  });
+
+  it('detects Azure paths', () => {
+    expect(isCredentialPath('/home/user/.azure/credentials')).toBe(true);
+  });
+
+  it('detects Docker config', () => {
+    expect(isCredentialPath('/home/user/.docker/config.json')).toBe(true);
+  });
+
+  it('detects .npmrc at any depth', () => {
+    expect(isCredentialPath('.npmrc')).toBe(true);
+    expect(isCredentialPath('/home/user/.npmrc')).toBe(true);
+  });
+
+  it('detects .pypirc', () => {
+    expect(isCredentialPath('/home/user/.pypirc')).toBe(true);
+  });
+
+  it('detects .netrc and .curlrc', () => {
+    expect(isCredentialPath('/home/user/.netrc')).toBe(true);
+    expect(isCredentialPath('/home/user/.curlrc')).toBe(true);
+  });
+
+  it('detects .env files at any depth', () => {
+    expect(isCredentialPath('.env')).toBe(true);
+    expect(isCredentialPath('.env.local')).toBe(true);
+    expect(isCredentialPath('.env.production')).toBe(true);
+    expect(isCredentialPath('config/.env')).toBe(true);
+    expect(isCredentialPath('apps/web/.env.staging')).toBe(true);
+  });
+
+  it('handles Windows backslash paths', () => {
+    expect(isCredentialPath('C:\\Users\\user\\.ssh\\id_rsa')).toBe(true);
+    expect(isCredentialPath('C:\\Users\\user\\.aws\\credentials')).toBe(true);
+    expect(isCredentialPath('C:\\Users\\user\\.docker\\config.json')).toBe(true);
+  });
+
+  it('returns false for safe paths', () => {
+    expect(isCredentialPath('src/index.ts')).toBe(false);
+    expect(isCredentialPath('README.md')).toBe(false);
+    expect(isCredentialPath('package.json')).toBe(false);
+    expect(isCredentialPath('.eslintrc.json')).toBe(false);
+  });
+
+  it('returns false for paths that partially match but are not credential files', () => {
+    expect(isCredentialPath('docs/ssh-guide.md')).toBe(false);
+    expect(isCredentialPath('src/aws-client.ts')).toBe(false);
+    // .env-like but not .env pattern
+    expect(isCredentialPath('environment.ts')).toBe(false);
+  });
+});
+
+describe('CREDENTIAL_PATH_PATTERNS export', () => {
+  it('is a non-empty array', () => {
+    expect(Array.isArray(CREDENTIAL_PATH_PATTERNS)).toBe(true);
+    expect(CREDENTIAL_PATH_PATTERNS.length).toBeGreaterThan(0);
+  });
+});
+
+describe('CREDENTIAL_BASENAME_PATTERNS export', () => {
+  it('includes key credential basenames', () => {
+    expect(CREDENTIAL_BASENAME_PATTERNS).toContain('.npmrc');
+    expect(CREDENTIAL_BASENAME_PATTERNS).toContain('.pypirc');
+    expect(CREDENTIAL_BASENAME_PATTERNS).toContain('.netrc');
+    expect(CREDENTIAL_BASENAME_PATTERNS).toContain('.curlrc');
+  });
+});
+
+describe('no-credential-file-creation', () => {
+  const inv = findInvariant('no-credential-file-creation');
+
+  it('has severity 5', () => {
+    expect(inv.severity).toBe(5);
+  });
+
+  it('fails when file.write targets SSH key', () => {
+    const result = inv.check({
+      currentTarget: '/home/user/.ssh/id_rsa',
+      currentActionType: 'file.write',
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('.ssh/id_rsa');
+  });
+
+  it('fails when file.write targets .env file', () => {
+    const result = inv.check({
+      currentTarget: '.env',
+      currentActionType: 'file.write',
+    });
+    expect(result.holds).toBe(false);
+  });
+
+  it('fails when file.write targets .env.local', () => {
+    const result = inv.check({
+      currentTarget: '.env.local',
+      currentActionType: 'file.write',
+    });
+    expect(result.holds).toBe(false);
+  });
+
+  it('fails when file.move targets AWS credentials', () => {
+    const result = inv.check({
+      currentTarget: '/home/user/.aws/credentials',
+      currentActionType: 'file.move',
+    });
+    expect(result.holds).toBe(false);
+  });
+
+  it('fails when file.write targets .npmrc', () => {
+    const result = inv.check({
+      currentTarget: '/home/user/.npmrc',
+      currentActionType: 'file.write',
+    });
+    expect(result.holds).toBe(false);
+  });
+
+  it('fails when file.write targets Docker config', () => {
+    const result = inv.check({
+      currentTarget: '/home/user/.docker/config.json',
+      currentActionType: 'file.write',
+    });
+    expect(result.holds).toBe(false);
+  });
+
+  it('fails when file.write targets Google Cloud credentials', () => {
+    const result = inv.check({
+      currentTarget: '/home/user/.config/gcloud/application_default_credentials.json',
+      currentActionType: 'file.write',
+    });
+    expect(result.holds).toBe(false);
+  });
+
+  it('fails when file.write targets Azure credentials', () => {
+    const result = inv.check({
+      currentTarget: '/home/user/.azure/accessTokens.json',
+      currentActionType: 'file.write',
+    });
+    expect(result.holds).toBe(false);
+  });
+
+  it('holds when file.read targets credential file (reads are allowed)', () => {
+    const result = inv.check({
+      currentTarget: '/home/user/.ssh/id_rsa',
+      currentActionType: 'file.read',
+    });
+    expect(result.holds).toBe(true);
+  });
+
+  it('holds when file.delete targets credential file (deletion not blocked)', () => {
+    const result = inv.check({
+      currentTarget: '/home/user/.ssh/id_rsa',
+      currentActionType: 'file.delete',
+    });
+    expect(result.holds).toBe(true);
+  });
+
+  it('holds when file.write targets a safe path', () => {
+    const result = inv.check({
+      currentTarget: 'src/index.ts',
+      currentActionType: 'file.write',
+    });
+    expect(result.holds).toBe(true);
+  });
+
+  it('holds with empty state', () => {
+    const result = inv.check({});
+    expect(result.holds).toBe(true);
+  });
+
+  it('still checks credential path when actionType is not set (conservative)', () => {
+    const result = inv.check({
+      currentTarget: '/home/user/.ssh/id_rsa',
+    });
+    expect(result.holds).toBe(false);
+  });
+
+  it('handles Windows backslash paths', () => {
+    const result = inv.check({
+      currentTarget: 'C:\\Users\\user\\.ssh\\id_rsa',
+      currentActionType: 'file.write',
+    });
+    expect(result.holds).toBe(false);
+  });
+});
+
 describe('lockfile-integrity', () => {
   const inv = findInvariant('lockfile-integrity');
 
@@ -450,6 +657,7 @@ describe('buildSystemState', () => {
     expect(state.protectedBranches).toEqual(['main', 'master']);
     expect(state.currentTarget).toBe('');
     expect(state.currentCommand).toBe('');
+    expect(state.currentActionType).toBe('');
   });
 
   it('populates from context values', () => {
@@ -465,6 +673,7 @@ describe('buildSystemState', () => {
       protectedBranches: ['production'],
       currentTarget: 'src/index.ts',
       currentCommand: 'npm test',
+      currentActionType: 'file.write',
     });
     expect(state.modifiedFiles).toEqual(['a.ts', 'b.ts']);
     expect(state.targetBranch).toBe('main');
@@ -472,6 +681,7 @@ describe('buildSystemState', () => {
     expect(state.filesAffected).toBe(5);
     expect(state.currentTarget).toBe('src/index.ts');
     expect(state.currentCommand).toBe('npm test');
+    expect(state.currentActionType).toBe('file.write');
   });
 
   it('computes filesAffected from modifiedFiles when not specified', () => {


### PR DESCRIPTION
## Summary

- Adds `no-credential-file-creation` invariant (severity 5) that blocks agents from creating or overwriting well-known credential files: SSH keys, AWS/GCloud/Azure configs, Docker registry, `.npmrc`, `.pypirc`, `.netrc`, `.curlrc`, and `.env` files at any depth
- Adds `currentActionType` to `SystemState` for action-type-aware invariant checks — only `file.write` and `file.move` are blocked; reading credential files remains allowed
- Exposes `isCredentialPath()` helper function and `CREDENTIAL_PATH_PATTERNS`/`CREDENTIAL_BASENAME_PATTERNS` constants for reuse

Closes #290

## Changed Files

| File | Change |
|------|--------|
| `src/invariants/definitions.ts` | New invariant definition, credential path detection logic |
| `src/invariants/checker.ts` | Add `currentActionType` to `buildSystemState` |
| `src/kernel/decision.ts` | Pass `intent.action` as `currentActionType` |
| `src/kernel/kernel.ts` | Pass `currentActionType` in simulation re-check state |
| `tests/ts/invariant-definitions.test.ts` | 19 new tests for credential invariant + `isCredentialPath` |
| `tests/ts/agentguard-engine.test.ts` | Update invariant count 8 → 9 |

## Test plan

- [x] All 1632 TypeScript tests pass (76 files)
- [x] All 210 JS tests pass
- [x] ESLint: 0 errors
- [x] TypeScript type-check: clean
- [x] Prettier formatting: clean
- [x] New invariant tested for: SSH, AWS, GCloud, Azure, Docker, .npmrc, .pypirc, .netrc, .curlrc, .env variants, Windows paths, safe paths, read-allowed, empty state

🤖 Generated with [Claude Code](https://claude.com/claude-code)