### PR TITLE
docs: update invariant count (8→9) across documentation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -47,7 +47,7 @@ src/
 ├── kernel/        Governed action kernel (orchestrate, normalize, decide, escalate)
 ├── events/        Canonical event model (schema, bus, store, JSONL persistence)
 ├── policy/        Policy system (composer, evaluator, loaders, pack loader)
-├── invariants/    Invariant system (8 built-in definitions, checker)
+├── invariants/    Invariant system (9 built-in definitions, checker)
 ├── adapters/      Execution adapters (file, shell, git, claude-code)
 ├── plugins/       Plugin ecosystem (discovery, registry, validation, sandboxing)
 ├── renderers/     Renderer plugin system (registry, TUI renderer)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ The system has one architectural spine: the **canonical event model**. All syste
 
 **Key characteristics:**
 - Governed action kernel: propose → normalize → evaluate → execute → emit
-- 8 built-in invariants (secret exposure, protected branches, blast radius, test-before-push, no force push, no skill modification, no scheduled task modification, lockfile integrity)
+- 9 built-in invariants (secret exposure, protected branches, blast radius, test-before-push, no force push, no skill modification, no scheduled task modification, CI/CD config protection, lockfile integrity)
 - YAML/JSON policy format with pattern matching, scopes, and branch conditions
 - Escalation tracking: NORMAL → ELEVATED → HIGH → LOCKDOWN
 - JSONL event persistence for audit trail and replay
@@ -71,7 +71,7 @@ src/
 │   ├── pack-loader.ts      # Policy pack loader (community policy sets)
 │   └── yaml-loader.ts      # YAML policy parser
 ├── invariants/             # Invariant system
-│   ├── definitions.ts      # 8 built-in invariant definitions
+│   ├── definitions.ts      # 9 built-in invariant definitions
 │   └── checker.ts          # Invariant evaluation engine
 ├── analytics/              # Cross-session violation analytics
 │   ├── aggregator.ts       # Violation aggregation across sessions
@@ -187,7 +187,7 @@ The kernel loop is the core of AgentGuard. Every agent action passes through it:
 1. Agent proposes action (Claude Code tool call → `RawAgentAction`)
 2. AAB normalizes intent (tool → action type, detect git/destructive commands)
 3. Policy evaluator matches rules (deny/allow with scopes, branches, limits)
-4. Invariant checker verifies system state (8 defaults)
+4. Invariant checker verifies system state (9 defaults)
 5. If allowed: execute via adapter (file/shell/git handlers)
 6. Emit lifecycle events: `ACTION_REQUESTED` → `ACTION_ALLOWED/DENIED` → `ACTION_EXECUTED/FAILED`
 7. Sink all events to JSONL for audit trail

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ AI coding agents execute file writes, shell commands, and git operations autonom
 AgentGuard adds a **deterministic decision point** between proposal and execution:
 
 - **Safety policies** — declare what agents can and cannot do in YAML
-- **Invariant enforcement** — 8 built-in checks (secrets, protected branches, blast radius, skill/task protection) run on every action
+- **Invariant enforcement** — 9 built-in checks (secrets, protected branches, blast radius, skill/task protection, CI/CD config) run on every action
 - **Audit trail** — every decision is recorded as structured JSONL, inspectable after the fact
 - **Session debugging** — replay any agent session to see exactly what happened and why
 
@@ -58,7 +58,7 @@ AgentGuard evaluates every agent action through a **governed action kernel**:
 
 1. **Normalize** — Claude Code tool calls (Bash, Write, Edit, Read) are mapped to canonical action types (shell.exec, file.write, file.read)
 2. **Evaluate** — policies match against the action (deny git.push to main, deny destructive commands, enforce scope limits)
-3. **Check invariants** — 8 built-in safety checks run on every action
+3. **Check invariants** — 9 built-in safety checks run on every action
 4. **Execute** — if allowed, the action runs via adapters (file, shell, git handlers)
 5. **Emit events** — full lifecycle events sunk to JSONL for audit trail
 
@@ -66,7 +66,7 @@ AgentGuard evaluates every agent action through a **governed action kernel**:
 
 ```
   AgentGuard Runtime Active
-  policy: agentguard.yaml | invariants: 8 active
+  policy: agentguard.yaml | invariants: 9 active
 
   ✓ file.write src/auth/service.ts
   ✓ shell.exec npm test
@@ -106,11 +106,12 @@ Drop an `agentguard.yaml` in your repo root — the CLI picks it up automaticall
 
 ## Built-in Invariants
 
-8 safety invariants run on every action evaluation:
+9 safety invariants run on every action evaluation:
 
 | Invariant | Severity | Description |
 |-----------|----------|-------------|
 | **no-secret-exposure** | 5 (critical) | Blocks access to .env, credentials, .pem, .key files |
+| **no-cicd-config-modification** | 5 (critical) | Blocks modification of CI/CD pipeline configs (.github/workflows/, Jenkinsfile, etc.) |
 | **protected-branch** | 4 (high) | Prevents direct push to main/master |
 | **no-force-push** | 4 (high) | Forbids force push |
 | **no-skill-modification** | 4 (high) | Prevents modification of .claude/skills/ files |
@@ -262,7 +263,7 @@ src/
 │   ├── pack-loader.ts      # Policy pack loader (community policy sets)
 │   └── yaml-loader.ts      # YAML policy parser
 ├── invariants/             # Invariant system
-│   ├── definitions.ts      # 8 built-in invariants
+│   ├── definitions.ts      # 9 built-in invariants
 │   └── checker.ts          # Invariant evaluation engine
 ├── analytics/              # Cross-session violation analytics
 │   ├── aggregator.ts       # Violation aggregation across sessions

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -59,7 +59,7 @@ A comprehensive codebase audit assessed the current system against the strategic
 | Canonical Action Representation (23 types, 8 classes) | Implemented | `src/core/actions.ts` |
 | Action Authorization Boundary (AAB) | Implemented (2 bypass vectors) | `src/kernel/aab.ts` |
 | Policy Evaluator (two-phase deny/allow) | Implemented | `src/policy/evaluator.ts` |
-| 8 Built-in Invariants | Fully Implemented | `src/invariants/definitions.ts`, `src/invariants/checker.ts` |
+| 9 Built-in Invariants | Fully Implemented | `src/invariants/definitions.ts`, `src/invariants/checker.ts` |
 | Event Model (49 event kinds) | Comprehensive | `src/events/schema.ts` |
 | JSONL Persistence | Implemented | `src/events/jsonl.ts` |
 | Simulation Engine (3 simulators + impact forecast) | Fully Implemented | `src/kernel/simulation/` |
@@ -104,7 +104,7 @@ A comprehensive codebase audit assessed the current system against the strategic
 | Canonical Action Representation | Implemented | Production |
 | AAB Reference Monitor | Implemented | 1 bypass vector to close (missing-adapter fixed) |
 | Policy Evaluator | Implemented | Production |
-| 8 Built-in Invariants | Fully Implemented | Production |
+| 9 Built-in Invariants | Fully Implemented | Production |
 | Event Model (49 kinds) | Comprehensive | Production |
 | Simulation & Forecasting | Fully Implemented | Production |
 | Escalation State Machine | Implemented | Functional (events persisted as StateChanged) |
@@ -252,11 +252,11 @@ This is the architectural hinge. These changes transform the AAB from advisory i
 
 ### Phase 6.5 — Invariant Expansion `NEXT`
 
-> **Theme:** Close invariant coverage gaps. The current 8 invariants leave large classes of agent behavior ungoverned.
+> **Theme:** Close invariant coverage gaps. The current 9 invariants leave large classes of agent behavior ungoverned.
 
 The `SystemState` interface in `src/invariants/definitions.ts` is the bottleneck for invariant expansion — it needs to become a richer context object with action-specific fields.
 
-- [ ] CI/CD config modification invariant (severity 5) — block writes to `.github/workflows/`, `.gitlab-ci.yml`, `Jenkinsfile`, `.circleci/config.yml`
+- [x] CI/CD config modification invariant (severity 5) — block writes to `.github/workflows/`, `.gitlab-ci.yml`, `Jenkinsfile`, `.circleci/config.yml`
 - [ ] Network egress governance invariant (severity 4) — deny HTTP requests to non-allowlisted domains (extend `SystemState` with `isNetworkRequest`, `requestUrl`, `requestDomain`)
 - [ ] Credential file creation invariant (severity 5) — inspect `currentTarget` for SSH keys, `.netrc`, `~/.aws/credentials`, Docker config (closes gap where `no-secret-exposure` misses new file creation)
 - [ ] Package.json script injection invariant (severity 4) — flag `package.json` modifications that alter `scripts` entries


### PR DESCRIPTION
## Summary

- Automated documentation sync detected invariant count drift between codebase and docs
- The `no-cicd-config-modification` invariant (severity 5) was added to the codebase but documentation still referenced 8 built-in invariants instead of 9
- This PR updates all documentation files to reflect the current invariant count

## Changes

- **CLAUDE.md**: Updated invariant count (8→9) in key characteristics, project structure tree comment, and kernel step description
- **README.md**: Updated invariant count in feature list, "How It Works" section, example output, invariant table (added `no-cicd-config-modification`), and directory tree comment
- **ARCHITECTURE.md**: Updated invariant count in directory layout description
- **ROADMAP.md**: Updated invariant counts in Core Governance Kernel and Maturity Matrix tables, marked CI/CD config invariant as `[x]` in Phase 6.5, updated Phase 6.5 theme description

## Source

Auto-generated by the **Scheduled Docs Sync** skill.

---
*Run: 2026-03-12T05:14:00Z*