### PR TITLE
docs: sync documentation with codebase state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ The system has one architectural spine: the **canonical event model**. All syste
 
 **Key characteristics:**
 - Governed action kernel: propose → normalize → evaluate → execute → emit
-- 9 built-in invariants (secret exposure, protected branches, blast radius, test-before-push, no force push, no skill modification, no scheduled task modification, CI/CD config protection, lockfile integrity)
+- 9 built-in invariants (secret exposure, protected branches, blast radius, test-before-push, no force push, no skill modification, no scheduled task modification, credential file creation, lockfile integrity)
 - YAML/JSON policy format with pattern matching, scopes, and branch conditions
 - Escalation tracking: NORMAL → ELEVATED → HIGH → LOCKDOWN
 - JSONL event persistence for audit trail and replay

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Drop an `agentguard.yaml` in your repo root — the CLI picks it up automaticall
 | Invariant | Severity | Description |
 |-----------|----------|-------------|
 | **no-secret-exposure** | 5 (critical) | Blocks access to .env, credentials, .pem, .key files |
-| **no-cicd-config-modification** | 5 (critical) | Blocks modification of CI/CD pipeline configs (.github/workflows/, Jenkinsfile, etc.) |
+| **no-credential-file-creation** | 5 (critical) | Blocks creation or modification of well-known credential files (SSH keys, cloud configs, auth tokens) |
 | **protected-branch** | 4 (high) | Prevents direct push to main/master |
 | **no-force-push** | 4 (high) | Forbids force push |
 | **no-skill-modification** | 4 (high) | Prevents modification of .claude/skills/ files |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -256,9 +256,9 @@ This is the architectural hinge. These changes transform the AAB from advisory i
 
 The `SystemState` interface in `src/invariants/definitions.ts` is the bottleneck for invariant expansion — it needs to become a richer context object with action-specific fields.
 
-- [x] CI/CD config modification invariant (severity 5) — block writes to `.github/workflows/`, `.gitlab-ci.yml`, `Jenkinsfile`, `.circleci/config.yml`
+- [ ] CI/CD config modification invariant (severity 5) — block writes to `.github/workflows/`, `.gitlab-ci.yml`, `Jenkinsfile`, `.circleci/config.yml`
 - [ ] Network egress governance invariant (severity 4) — deny HTTP requests to non-allowlisted domains (extend `SystemState` with `isNetworkRequest`, `requestUrl`, `requestDomain`)
-- [ ] Credential file creation invariant (severity 5) — inspect `currentTarget` for SSH keys, `.netrc`, `~/.aws/credentials`, Docker config (closes gap where `no-secret-exposure` misses new file creation)
+- [x] Credential file creation invariant (severity 5) — inspect `currentTarget` for SSH keys, `.netrc`, `~/.aws/credentials`, Docker config (closes gap where `no-secret-exposure` misses new file creation)
 - [ ] Package.json script injection invariant (severity 4) — flag `package.json` modifications that alter `scripts` entries
 - [ ] Large single-file write invariant (severity 3) — enforce per-file size limit (extend `SystemState` with `writeSizeBytes`)
 - [ ] Docker/container config modification invariant (severity 3) — protect `Dockerfile`, `docker-compose.yml`, `.dockerignore`
@@ -444,7 +444,7 @@ The pre-execution simulation system is the most mature advanced feature and a ke
 
 AgentGuard is built for contributors. Here are the best places to start:
 
-- **Write an invariant pack** — Define domain-specific invariants in `src/invariants/community/`. See `src/invariants/definitions.ts` for the 8 built-in invariants as a reference.
+- **Write an invariant pack** — Define domain-specific invariants in `src/invariants/community/`. See `src/invariants/definitions.ts` for the 9 built-in invariants as a reference.
 - **Create a policy pack** — Ship a reusable policy YAML in `policies/`. See `agentguard.yaml` for the format and `src/policy/pack-loader.ts` for the pack loading contract.
 - **Build an adapter** — Add support for a new agent framework in `src/adapters/`. Follow the pattern in `src/adapters/claude-code.ts`.
 - **Add a renderer** — Create a custom governance output renderer implementing the `GovernanceRenderer` interface in `src/renderers/types.ts`.


### PR DESCRIPTION
## Summary

- **Invariant reference fix**: Docs listed `no-cicd-config-modification` invariant which does not exist in code. Replaced with `no-credential-file-creation` which IS implemented in `src/invariants/definitions.ts`
- **ROADMAP phase status**: Marked credential file creation invariant as `[x]` (implemented), unmarked CI/CD config modification invariant as `[ ]` (not yet in code)
- **Invariant count fix**: Updated community contributions reference from "8 built-in invariants" to "9 built-in invariants"

## Changes

- `CLAUDE.md` — Fixed invariant list description (CI/CD config protection → credential file creation)
- `README.md` — Fixed invariant table row (no-cicd-config-modification → no-credential-file-creation)
- `ROADMAP.md` — Fixed phase 6.5 checkbox status and community contributions invariant count

## Source

Auto-generated by the **Scheduled Docs Sync** skill.

---
*Run: 2026-03-13*