### PR TITLE
feat(storage): SQLite migration v2 — action_type and severity columns

### DIFF
--- a/src/storage/migrations.ts
+++ b/src/storage/migrations.ts
@@ -63,6 +63,57 @@ const MIGRATIONS: readonly Migration[] = [
       db.exec('CREATE INDEX IF NOT EXISTS idx_events_kind_timestamp ON events (kind, timestamp)');
     },
   },
+
+  {
+    version: 3,
+    description: 'Add action_type to events, severity to decisions; backfill from JSON data',
+    up(db) {
+      // Add new columns (nullable — old rows start as NULL until backfilled)
+      db.exec('ALTER TABLE events ADD COLUMN action_type TEXT');
+      db.exec('ALTER TABLE decisions ADD COLUMN severity INTEGER');
+
+      // Backfill events.action_type from JSON data payload
+      const eventRows = db
+        .prepare('SELECT id, data FROM events WHERE action_type IS NULL')
+        .all() as { id: string; data: string }[];
+
+      const updateEvent = db.prepare('UPDATE events SET action_type = ? WHERE id = ?');
+      for (const row of eventRows) {
+        try {
+          const parsed = JSON.parse(row.data) as Record<string, unknown>;
+          const actionType = (parsed.actionType as string) ?? null;
+          if (actionType) {
+            updateEvent.run(actionType, row.id);
+          }
+        } catch {
+          // Skip malformed JSON rows — don't crash the migration
+        }
+      }
+
+      // Backfill decisions.severity from JSON data payload
+      const decisionRows = db
+        .prepare('SELECT record_id, data FROM decisions WHERE severity IS NULL')
+        .all() as { record_id: string; data: string }[];
+
+      const updateDecision = db.prepare('UPDATE decisions SET severity = ? WHERE record_id = ?');
+      for (const row of decisionRows) {
+        try {
+          const parsed = JSON.parse(row.data) as Record<string, unknown>;
+          const policy = parsed.policy as Record<string, unknown> | undefined;
+          const severity = (policy?.severity as number) ?? null;
+          if (severity !== null) {
+            updateDecision.run(severity, row.record_id);
+          }
+        } catch {
+          // Skip malformed JSON rows
+        }
+      }
+
+      // Add indexes on the new columns for fast filtered queries
+      db.exec('CREATE INDEX IF NOT EXISTS idx_events_action_type ON events (action_type)');
+      db.exec('CREATE INDEX IF NOT EXISTS idx_decisions_severity ON decisions (severity)');
+    },
+  },
 ];
 
 /**

--- a/src/storage/sqlite-sink.ts
+++ b/src/storage/sqlite-sink.ts
@@ -13,20 +13,22 @@ export function createSqliteEventSink(
   onError?: (error: Error) => void
 ): EventSink {
   const stmt = db.prepare(`
-    INSERT OR IGNORE INTO events (id, run_id, kind, timestamp, fingerprint, data)
-    VALUES (?, ?, ?, ?, ?, ?)
+    INSERT OR IGNORE INTO events (id, run_id, kind, timestamp, fingerprint, data, action_type)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
   `);
 
   return {
     write(event: DomainEvent): void {
       try {
+        const actionType = extractActionType(event);
         stmt.run(
           event.id,
           runId,
           event.kind,
           event.timestamp,
           event.fingerprint,
-          JSON.stringify(event)
+          JSON.stringify(event),
+          actionType
         );
       } catch (err) {
         // Never crash the kernel — report via callback if available
@@ -47,13 +49,14 @@ export function createSqliteDecisionSink(
   onError?: (error: Error) => void
 ): DecisionSink {
   const stmt = db.prepare(`
-    INSERT OR IGNORE INTO decisions (record_id, run_id, timestamp, outcome, action_type, target, reason, data)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    INSERT OR IGNORE INTO decisions (record_id, run_id, timestamp, outcome, action_type, target, reason, data, severity)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
   `);
 
   return {
     write(record: GovernanceDecisionRecord): void {
       try {
+        const severity = record.policy?.severity ?? null;
         stmt.run(
           record.recordId,
           runId,
@@ -62,7 +65,8 @@ export function createSqliteDecisionSink(
           record.action.type,
           record.action.target,
           record.reason,
-          JSON.stringify(record)
+          JSON.stringify(record),
+          severity
         );
       } catch (err) {
         // Never crash the kernel — report via callback if available
@@ -74,4 +78,11 @@ export function createSqliteDecisionSink(
       // No buffering needed
     },
   };
+}
+
+/** Extract actionType from event payload if present (reference monitor events) */
+function extractActionType(event: DomainEvent): string | null {
+  const rec = event as unknown as Record<string, unknown>;
+  if (typeof rec.actionType === 'string') return rec.actionType;
+  return null;
 }

--- a/src/storage/sqlite-store.ts
+++ b/src/storage/sqlite-store.ts
@@ -12,8 +12,8 @@ import type { GovernanceDecisionRecord } from '../kernel/decisions/types.js';
  */
 export function createSqliteEventStore(db: Database.Database, runId?: string): EventStore {
   const insertStmt = db.prepare(`
-    INSERT OR IGNORE INTO events (id, run_id, kind, timestamp, fingerprint, data)
-    VALUES (?, ?, ?, ?, ?, ?)
+    INSERT OR IGNORE INTO events (id, run_id, kind, timestamp, fingerprint, data, action_type)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
   `);
 
   const allStmt = db.prepare('SELECT data FROM events ORDER BY timestamp');
@@ -44,13 +44,15 @@ export function createSqliteEventStore(db: Database.Database, runId?: string): E
   return {
     append(event: DomainEvent): void {
       const rid = runId ?? extractRunId(event) ?? 'unknown';
+      const actionType = extractActionType(event);
       insertStmt.run(
         event.id,
         rid,
         event.kind,
         event.timestamp,
         event.fingerprint,
-        JSON.stringify(event)
+        JSON.stringify(event),
+        actionType
       );
     },
 
@@ -115,7 +117,16 @@ export function createSqliteEventStore(db: Database.Database, runId?: string): E
         for (const line of lines) {
           const event = JSON.parse(line) as DomainEvent;
           const rid = runId ?? extractRunId(event) ?? 'unknown';
-          insertStmt.run(event.id, rid, event.kind, event.timestamp, event.fingerprint, line);
+          const actionType = extractActionType(event);
+          insertStmt.run(
+            event.id,
+            rid,
+            event.kind,
+            event.timestamp,
+            event.fingerprint,
+            line,
+            actionType
+          );
           loaded++;
         }
         return loaded;
@@ -165,4 +176,11 @@ function extractRunId(event: DomainEvent): string | undefined {
   if (meta && typeof meta.runId === 'string') return meta.runId;
   if (typeof event.runId === 'string') return event.runId;
   return undefined;
+}
+
+/** Extract actionType from event payload if present (reference monitor events) */
+function extractActionType(event: DomainEvent): string | null {
+  const rec = event as unknown as Record<string, unknown>;
+  if (typeof rec.actionType === 'string') return rec.actionType;
+  return null;
 }

--- a/tests/ts/sqlite-migrations.test.ts
+++ b/tests/ts/sqlite-migrations.test.ts
@@ -14,7 +14,7 @@ describe('SQLite migrations', () => {
 
   it('creates all tables on first run', () => {
     const applied = runMigrations(db);
-    expect(applied).toBe(2);
+    expect(applied).toBe(3);
 
     const tables = db
       .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
@@ -35,6 +35,7 @@ describe('SQLite migrations', () => {
       .all() as { name: string }[];
     const names = indexes.map((i) => i.name);
 
+    // v1 indexes
     expect(names).toContain('idx_events_run_ts');
     expect(names).toContain('idx_events_run_kind');
     expect(names).toContain('idx_events_kind');
@@ -43,20 +44,24 @@ describe('SQLite migrations', () => {
     expect(names).toContain('idx_decisions_run_ts');
     expect(names).toContain('idx_decisions_outcome');
     expect(names).toContain('idx_events_kind_timestamp');
+
+    // v2 indexes
+    expect(names).toContain('idx_events_action_type');
+    expect(names).toContain('idx_decisions_severity');
   });
 
   it('is idempotent — running twice applies nothing the second time', () => {
     const first = runMigrations(db);
     const second = runMigrations(db);
 
-    expect(first).toBe(2);
+    expect(first).toBe(3);
     expect(second).toBe(0);
   });
 
   it('tracks schema version', () => {
     expect(getSchemaVersion(db)).toBe(0);
     runMigrations(db);
-    expect(getSchemaVersion(db)).toBe(2);
+    expect(getSchemaVersion(db)).toBe(3);
   });
 
   it('enables WAL mode (on file-based databases)', () => {
@@ -94,7 +99,16 @@ describe('SQLite migrations', () => {
       CREATE TABLE events (
         id TEXT PRIMARY KEY, run_id TEXT NOT NULL, kind TEXT NOT NULL,
         timestamp INTEGER NOT NULL, fingerprint TEXT NOT NULL, data TEXT NOT NULL
-      )
+      );
+      CREATE TABLE decisions (
+        record_id TEXT PRIMARY KEY, run_id TEXT NOT NULL, timestamp INTEGER NOT NULL,
+        outcome TEXT NOT NULL, action_type TEXT NOT NULL, target TEXT NOT NULL,
+        reason TEXT NOT NULL, data TEXT NOT NULL
+      );
+      CREATE TABLE sessions (
+        id TEXT PRIMARY KEY, started_at TEXT NOT NULL, ended_at TEXT,
+        command TEXT, repo TEXT, data TEXT NOT NULL
+      );
     `);
     db.exec('CREATE INDEX idx_events_kind ON events (kind)');
     db.exec('CREATE INDEX idx_events_timestamp ON events (timestamp)');
@@ -102,8 +116,8 @@ describe('SQLite migrations', () => {
     expect(getSchemaVersion(db)).toBe(1);
 
     const applied = runMigrations(db);
-    expect(applied).toBe(1);
-    expect(getSchemaVersion(db)).toBe(2);
+    expect(applied).toBe(2);
+    expect(getSchemaVersion(db)).toBe(3);
 
     const indexes = db
       .prepare(
@@ -111,5 +125,174 @@ describe('SQLite migrations', () => {
       )
       .all() as { name: string }[];
     expect(indexes).toHaveLength(1);
+  });
+});
+
+describe('SQLite migration v2 — action_type and severity columns', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+  });
+
+  /** Helper to simulate a v1-only database */
+  function applyV1Only() {
+    db.exec(
+      'CREATE TABLE IF NOT EXISTS migrations (version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL)'
+    );
+    db.prepare('INSERT INTO migrations (version, applied_at) VALUES (?, ?)').run(
+      1,
+      '2026-01-01T00:00:00Z'
+    );
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS events (
+        id TEXT PRIMARY KEY, run_id TEXT NOT NULL, kind TEXT NOT NULL,
+        timestamp INTEGER NOT NULL, fingerprint TEXT NOT NULL, data TEXT NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS decisions (
+        record_id TEXT PRIMARY KEY, run_id TEXT NOT NULL, timestamp INTEGER NOT NULL,
+        outcome TEXT NOT NULL, action_type TEXT NOT NULL, target TEXT NOT NULL,
+        reason TEXT NOT NULL, data TEXT NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS sessions (
+        id TEXT PRIMARY KEY, started_at TEXT NOT NULL, ended_at TEXT,
+        command TEXT, repo TEXT, data TEXT NOT NULL
+      );
+    `);
+  }
+
+  it('adds action_type column to events table', () => {
+    runMigrations(db);
+    const cols = db.prepare("PRAGMA table_info('events')").all() as { name: string }[];
+    expect(cols.map((c) => c.name)).toContain('action_type');
+  });
+
+  it('adds severity column to decisions table', () => {
+    runMigrations(db);
+    const cols = db.prepare("PRAGMA table_info('decisions')").all() as { name: string }[];
+    expect(cols.map((c) => c.name)).toContain('severity');
+  });
+
+  it('creates v3 indexes', () => {
+    runMigrations(db);
+    const indexes = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='index' AND name LIKE 'idx_%'")
+      .all() as { name: string }[];
+    const names = indexes.map((i) => i.name);
+    expect(names).toContain('idx_events_action_type');
+    expect(names).toContain('idx_decisions_severity');
+  });
+
+  it('backfills action_type from existing event JSON data', () => {
+    applyV1Only();
+
+    // Insert an event with actionType in the JSON payload
+    db.prepare('INSERT INTO events VALUES (?, ?, ?, ?, ?, ?)').run(
+      'evt_1',
+      'run_1',
+      'ActionRequested',
+      1000,
+      'fp1',
+      JSON.stringify({
+        id: 'evt_1',
+        kind: 'ActionRequested',
+        actionType: 'git.push',
+        timestamp: 1000,
+        fingerprint: 'fp1',
+      })
+    );
+
+    // Insert an event without actionType
+    db.prepare('INSERT INTO events VALUES (?, ?, ?, ?, ?, ?)').run(
+      'evt_2',
+      'run_1',
+      'RunStarted',
+      1001,
+      'fp2',
+      JSON.stringify({ id: 'evt_2', kind: 'RunStarted', timestamp: 1001, fingerprint: 'fp2' })
+    );
+
+    // Run v2+v3 migrations
+    const applied = runMigrations(db);
+    expect(applied).toBe(2);
+
+    const row1 = db.prepare('SELECT action_type FROM events WHERE id = ?').get('evt_1') as {
+      action_type: string | null;
+    };
+    expect(row1.action_type).toBe('git.push');
+
+    const row2 = db.prepare('SELECT action_type FROM events WHERE id = ?').get('evt_2') as {
+      action_type: string | null;
+    };
+    expect(row2.action_type).toBeNull();
+  });
+
+  it('backfills severity from existing decision JSON data', () => {
+    applyV1Only();
+
+    db.prepare('INSERT INTO decisions VALUES (?, ?, ?, ?, ?, ?, ?, ?)').run(
+      'dec_1',
+      'run_1',
+      1000,
+      'deny',
+      'git.push',
+      'origin/main',
+      'Protected branch',
+      JSON.stringify({
+        recordId: 'dec_1',
+        policy: { severity: 4, matchedPolicyId: 'p1', matchedPolicyName: 'default' },
+      })
+    );
+
+    runMigrations(db);
+
+    const row = db.prepare('SELECT severity FROM decisions WHERE record_id = ?').get('dec_1') as {
+      severity: number | null;
+    };
+    expect(row.severity).toBe(4);
+  });
+
+  it('preserves existing data during upgrade', () => {
+    applyV1Only();
+
+    db.prepare('INSERT INTO events VALUES (?, ?, ?, ?, ?, ?)').run(
+      'evt_x',
+      'run_1',
+      'RunStarted',
+      500,
+      'fpx',
+      '{"id":"evt_x","kind":"RunStarted"}'
+    );
+
+    runMigrations(db);
+
+    const count = (db.prepare('SELECT COUNT(*) as c FROM events').get() as { c: number }).c;
+    expect(count).toBe(1);
+
+    const row = db.prepare('SELECT action_type FROM events WHERE id = ?').get('evt_x') as {
+      action_type: string | null;
+    };
+    expect(row.action_type).toBeNull();
+  });
+
+  it('handles malformed JSON gracefully during backfill', () => {
+    applyV1Only();
+
+    db.prepare('INSERT INTO events VALUES (?, ?, ?, ?, ?, ?)').run(
+      'evt_bad',
+      'run_1',
+      'ActionRequested',
+      1000,
+      'fp1',
+      'NOT_VALID_JSON'
+    );
+
+    // Should not throw
+    expect(() => runMigrations(db)).not.toThrow();
+
+    const row = db.prepare('SELECT action_type FROM events WHERE id = ?').get('evt_bad') as {
+      action_type: string | null;
+    };
+    expect(row.action_type).toBeNull();
   });
 });

--- a/tests/ts/sqlite-sink.test.ts
+++ b/tests/ts/sqlite-sink.test.ts
@@ -68,6 +68,36 @@ describe('SQLite EventSink', () => {
     expect(count).toBe(1);
   });
 
+  it('populates action_type column from event payload', () => {
+    const sink = createSqliteEventSink(db, 'run_1');
+    const event = {
+      ...makeEvent('e_at'),
+      actionType: 'file.write',
+    } as DomainEvent;
+    sink.write(event);
+
+    const row = db.prepare('SELECT action_type FROM events WHERE id = ?').get('e_at') as {
+      action_type: string | null;
+    };
+    expect(row.action_type).toBe('file.write');
+  });
+
+  it('sets action_type to null when not present in event', () => {
+    const sink = createSqliteEventSink(db, 'run_1');
+    const event = {
+      id: 'e_no_at',
+      kind: 'RunStarted',
+      timestamp: Date.now(),
+      fingerprint: 'fp',
+    } as DomainEvent;
+    sink.write(event);
+
+    const row = db.prepare('SELECT action_type FROM events WHERE id = ?').get('e_no_at') as {
+      action_type: string | null;
+    };
+    expect(row.action_type).toBeNull();
+  });
+
   it('does not throw on write errors', () => {
     const sink = createSqliteEventSink(db, 'run_1');
     db.close(); // Force errors
@@ -113,7 +143,9 @@ describe('SQLite DecisionSink', () => {
     const sink = createSqliteDecisionSink(db, 'run_1');
     sink.write(makeDecision('dec_1'));
 
-    const row = db.prepare('SELECT outcome, action_type, target FROM decisions WHERE record_id = ?').get('dec_1') as {
+    const row = db
+      .prepare('SELECT outcome, action_type, target FROM decisions WHERE record_id = ?')
+      .get('dec_1') as {
       outcome: string;
       action_type: string;
       target: string;
@@ -121,6 +153,20 @@ describe('SQLite DecisionSink', () => {
     expect(row.outcome).toBe('allow');
     expect(row.action_type).toBe('shell.exec');
     expect(row.target).toBe('/bin/ls');
+  });
+
+  it('populates severity column from policy', () => {
+    const sink = createSqliteDecisionSink(db, 'run_1');
+    const record = {
+      ...makeDecision('dec_sev'),
+      policy: { matchedPolicyId: 'p1', matchedPolicyName: 'default', severity: 3 },
+    } as unknown as GovernanceDecisionRecord;
+    sink.write(record);
+
+    const row = db.prepare('SELECT severity FROM decisions WHERE record_id = ?').get('dec_sev') as {
+      severity: number | null;
+    };
+    expect(row.severity).toBe(3);
   });
 
   it('does not throw on write errors', () => {

--- a/tests/ts/sqlite-store.test.ts
+++ b/tests/ts/sqlite-store.test.ts
@@ -173,6 +173,48 @@ describe('SQLite EventStore', () => {
     });
   });
 
+  describe('action_type column', () => {
+    it('populates action_type on append for events with actionType', () => {
+      const store = createSqliteEventStore(db, 'run_1');
+      const event = makeEvent({ id: 'e_at', actionType: 'git.push' } as Partial<DomainEvent>);
+      store.append(event);
+
+      const row = db.prepare('SELECT action_type FROM events WHERE id = ?').get('e_at') as {
+        action_type: string | null;
+      };
+      expect(row.action_type).toBe('git.push');
+    });
+
+    it('sets action_type to null for events without actionType', () => {
+      const store = createSqliteEventStore(db, 'run_1');
+      store.append(makeEvent({ id: 'e_no_at' }));
+
+      const row = db.prepare('SELECT action_type FROM events WHERE id = ?').get('e_no_at') as {
+        action_type: string | null;
+      };
+      expect(row.action_type).toBeNull();
+    });
+
+    it('populates action_type during fromNDJSON import', () => {
+      const event = {
+        id: 'e_ndjson',
+        kind: 'ActionRequested',
+        actionType: 'file.write',
+        timestamp: 100,
+        fingerprint: 'fp',
+      };
+      const ndjson = JSON.stringify(event);
+
+      const store = createSqliteEventStore(db, 'run_1');
+      store.fromNDJSON(ndjson);
+
+      const row = db.prepare('SELECT action_type FROM events WHERE id = ?').get('e_ndjson') as {
+        action_type: string | null;
+      };
+      expect(row.action_type).toBe('file.write');
+    });
+  });
+
   describe('run-scoped helpers', () => {
     it('listRunIds returns runs ordered by most recent', () => {
       const store = createSqliteEventStore(db);


### PR DESCRIPTION
## Summary

- Adds **v2 schema migration** to the SQLite storage backend introducing two denormalized columns for faster filtered queries without JSON parsing
- **`events.action_type`** — extracted from event payload (`actionType` field in reference monitor events like `ActionRequested`, `ActionAllowed`, etc.)
- **`decisions.severity`** — extracted from `policy.severity` in governance decision records
- Migration **backfills existing rows** by parsing JSON `data` column, with graceful handling of malformed JSON
- Adds `idx_events_action_type` and `idx_decisions_severity` indexes
- Updates `SqliteEventSink`, `SqliteDecisionSink`, and `SqliteEventStore` to populate new columns on insert

## Test plan

- [x] Migration v2 adds `action_type` column to events table
- [x] Migration v2 adds `severity` column to decisions table  
- [x] v2 indexes created (`idx_events_action_type`, `idx_decisions_severity`)
- [x] Backfills `action_type` from existing event JSON data
- [x] Backfills `severity` from existing decision JSON data
- [x] Preserves existing data during upgrade from v1 to v2
- [x] Handles malformed JSON gracefully during backfill
- [x] EventSink populates `action_type` on insert
- [x] DecisionSink populates `severity` on insert
- [x] EventStore populates `action_type` on append and fromNDJSON
- [x] All 1695 TypeScript tests pass, 210 JS tests pass
- [x] Build, lint, type-check pass

Closes #304

🤖 Generated with [Claude Code](https://claude.com/claude-code)