### PR TITLE
docs: sync documentation with codebase state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,7 @@ src/
 │   ├── index.ts            # Module re-exports
 │   ├── migrations.ts       # Schema migrations (version-based)
 │   ├── sqlite-analytics.ts # SQLite-backed analytics queries
+│   ├── sqlite-session.ts   # SQLite session lifecycle (insert on start, update on end)
 │   ├── sqlite-sink.ts      # SQLite event/decision sink
 │   ├── sqlite-store.ts     # SQLite event store implementation
 │   ├── firestore-analytics.ts # Firestore-backed analytics queries
@@ -150,7 +151,7 @@ vscode-extension/              # VS Code extension
 
 tests/
 ├── *.test.js               # 14 JS test files (custom zero-dependency harness)
-└── ts/*.test.ts            # 76 TS test files (vitest)
+└── ts/*.test.ts            # 77 TS test files (vitest)
 policy/                     # Policy configuration (JSON: action_rules, capabilities)
 policies/                   # Policy packs (YAML: ci-safe, enterprise, open-source, strict)
 docs/                       # System documentation (architecture, event model, specs)
@@ -300,8 +301,8 @@ npm run test:coverage      # Run with coverage (c8, 50% line threshold)
 
 **Test structure:**
 - **JS tests** (`tests/*.test.js`): 14 files using a custom zero-dependency harness (`tests/run.js` with `node:assert`)
-- **TypeScript tests** (`tests/ts/*.test.ts`): 76 files using vitest
-- **Coverage areas**: adapters, analytics (including risk scorer), kernel (AAB, engine, monitor, blast radius, heartbeat, integration, e2e pipeline), CLI commands (args, guard, inspect, init, simulate, ci-check, claude-hook, claude-init, export/import, policy-validate, diff, evidence-pr, traces), decision records, domain models, events, evidence packs, evidence summary, execution log, export-import roundtrip, impact forecast, invariants, JSONL persistence, notification formatter, plugins (discovery, registry, validation), policy evaluation (including composer, pack loader, policy packs, evaluation trace), renderers, replay (engine, comparator, processor), simulation, SQLite storage (analytics, commands, migrations, sink, store, factory), Firestore storage, telemetry (including tracepoint), TUI renderer, violation mapper, VS Code event reader, YAML loading
+- **TypeScript tests** (`tests/ts/*.test.ts`): 77 files using vitest
+- **Coverage areas**: adapters, analytics (including risk scorer), kernel (AAB, engine, monitor, blast radius, heartbeat, integration, e2e pipeline), CLI commands (args, guard, inspect, init, simulate, ci-check, claude-hook, claude-init, export/import, policy-validate, diff, evidence-pr, traces), decision records, domain models, events, evidence packs, evidence summary, execution log, export-import roundtrip, impact forecast, invariants, JSONL persistence, notification formatter, plugins (discovery, registry, validation), policy evaluation (including composer, pack loader, policy packs, evaluation trace), renderers, replay (engine, comparator, processor), simulation, SQLite storage (analytics, commands, migrations, session, sink, store, factory), Firestore storage, telemetry (including tracepoint), TUI renderer, violation mapper, VS Code event reader, YAML loading
 
 ## CI/CD & Automation
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ AI coding agents execute file writes, shell commands, and git operations autonom
 AgentGuard adds a **deterministic decision point** between proposal and execution:
 
 - **Safety policies** — declare what agents can and cannot do in YAML
-- **Invariant enforcement** — 10 built-in checks (secrets, protected branches, blast radius, skill/task protection, package script injection, CI/CD config) run on every action
+- **Invariant enforcement** — 10 built-in checks (secrets, protected branches, blast radius, skill/task protection, package script injection, lockfile integrity) run on every action
 - **Audit trail** — every decision is recorded as structured JSONL, inspectable after the fact
 - **Session debugging** — replay any agent session to see exactly what happened and why
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -252,7 +252,7 @@ This is the architectural hinge. These changes transform the AAB from advisory i
 
 ### Phase 6.5 — Invariant Expansion `NEXT`
 
-> **Theme:** Close invariant coverage gaps. The current 9 invariants leave large classes of agent behavior ungoverned.
+> **Theme:** Close invariant coverage gaps. The current 10 invariants leave large classes of agent behavior ungoverned.
 
 The `SystemState` interface in `src/invariants/definitions.ts` is the bottleneck for invariant expansion — it needs to become a richer context object with action-specific fields.
 
@@ -318,7 +318,7 @@ The JSONL persistence layer was the right starting point — append-only, human-
 - [x] Retain JSONL as optional fallback/streaming sink for real-time tailing
 - [x] Firestore NoSQL storage backend for cross-session governance data sharing (`src/storage/firestore-store.ts`, `firestore-sink.ts`, `firestore-analytics.ts`)
 - [x] `agentguard init firestore` scaffold command for secure Firestore backend setup
-- [ ] Wire up `sessions` table — insert on `RunStarted`, update on `RunEnded` (dead schema today)
+- [x] Wire up `sessions` table — insert on `RunStarted`, update on `RunEnded` (`src/storage/sqlite-session.ts`)
 - [ ] Migration v2: add `action_type` column to `events` table, `severity` column to `decisions` table
 - [ ] Add composite index `(kind, timestamp)` on events for covering index scans
 - [ ] Add standalone index on `decisions.action_type` for filtered queries


### PR DESCRIPTION
## Summary

- Automated documentation sync detected drift between codebase and docs
- Added missing sqlite-session.ts to CLAUDE.md storage listing
- Updated TS test file count 76 to 77 in CLAUDE.md
- Added sqlite-session to test coverage areas in CLAUDE.md
- Fixed README.md invariant description (replaced stale CI/CD config with lockfile integrity)
- Fixed ROADMAP.md Phase 6.5 invariant count (9 to 10)
- Marked sessions table wiring as complete in ROADMAP.md Phase 10

## Changes

- **CLAUDE.md**: Added sqlite-session.ts to storage directory tree, updated test count to 77, added sqlite-session to test coverage areas
- **README.md**: Fixed invariant enforcement description to list actual invariants
- **ROADMAP.md**: Fixed Phase 6.5 invariant count, checked off sessions table item in Phase 10

## Source

Auto-generated by the **Scheduled Docs Sync** skill.

---
*Run: 2026-03-13*