### PR TITLE
feat(issue-327): add automated policy fix verification

### DIFF
--- a/src/cli/bin.ts
+++ b/src/cli/bin.ts
@@ -183,16 +183,19 @@ const COMMANDS: Record<string, CommandHelp> = {
   },
   policy: {
     name: 'agentguard policy',
-    description: 'Policy management tools (validate, suggest)',
+    description: 'Policy management tools (validate, suggest, verify)',
     usage: 'agentguard policy <command> [options]',
     flags: [],
     examples: [
       'agentguard policy validate agentguard.yaml',
       'agentguard policy validate my-policy.json --json',
       'agentguard policy validate agentguard.yaml --strict',
+      'agentguard policy validate agentguard.yaml --verify',
       'agentguard policy suggest',
       'agentguard policy suggest --yaml',
       'agentguard policy suggest --json',
+      'agentguard policy verify agentguard.yaml',
+      'agentguard policy verify my-policy.yaml --json',
     ],
   },
   simulate: {
@@ -568,9 +571,12 @@ function printHelp(): void {
     agentguard policy validate <file>        Validate a policy file (YAML/JSON)
     agentguard policy validate ... --strict  Include best-practice checks
     agentguard policy validate ... --json    Output as JSON
+    agentguard policy validate ... --verify  Also verify against historical violations
     agentguard policy suggest                Suggest rules based on violation patterns
     agentguard policy suggest --yaml         Output suggestions as YAML rules
     agentguard policy suggest --json         Output suggestions as JSON
+    agentguard policy verify <file>          Verify policy resolves historical violations
+    agentguard policy verify ... --json      Output verification result as JSON
 
   \x1b[1mPlugins:\x1b[0m
     agentguard plugin list                    List installed plugins

--- a/src/cli/commands/policy-verify.ts
+++ b/src/cli/commands/policy-verify.ts
@@ -1,0 +1,206 @@
+// Policy fix verification — tests whether a proposed policy change
+// resolves historical violations without introducing regressions.
+//
+// Given a new policy file and historical governance sessions, this module:
+// 1. Loads all violation events (PolicyDenied, ActionDenied) from session data
+// 2. Re-evaluates each violation-producing action against the new policy
+// 3. Reports which violations are resolved, which remain, and any regressions
+//
+// A "regression" is when an action that was previously allowed would now be
+// denied by the new policy — an unintended side effect of the policy change.
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { DomainEvent } from '../../core/types.js';
+import type { NormalizedIntent, LoadedPolicy, EvalResult } from '../../policy/evaluator.js';
+import { evaluate } from '../../policy/evaluator.js';
+import { loadYamlPolicy } from '../../policy/yaml-loader.js';
+import { loadPolicies } from '../../policy/loader.js';
+import { listSessionIds, loadSessionEvents } from '../../analytics/aggregator.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Detail about a single violation and its re-evaluation result */
+export interface ViolationVerifyDetail {
+  readonly sessionId: string;
+  readonly eventId: string;
+  readonly kind: string;
+  readonly actionType: string;
+  readonly target: string;
+  readonly originalReason: string;
+  readonly newDecision: 'allow' | 'deny';
+  readonly newReason: string;
+}
+
+/** Detail about a regression — previously-allowed action now denied */
+export interface RegressionDetail {
+  readonly sessionId: string;
+  readonly eventId: string;
+  readonly actionType: string;
+  readonly target: string;
+  readonly reason: string;
+}
+
+/** Result of verifying a policy fix against historical sessions */
+export interface PolicyVerifyResult {
+  readonly policyFile: string;
+  readonly sessionsAnalyzed: number;
+  readonly totalViolations: number;
+  readonly resolvedCount: number;
+  readonly remainingCount: number;
+  readonly regressionCount: number;
+  readonly resolved: readonly ViolationVerifyDetail[];
+  readonly remaining: readonly ViolationVerifyDetail[];
+  readonly regressions: readonly RegressionDetail[];
+}
+
+// ---------------------------------------------------------------------------
+// Event kinds
+// ---------------------------------------------------------------------------
+
+/** Violation kinds that are caused by policy evaluation (re-evaluatable) */
+const POLICY_VIOLATION_KINDS = new Set(['PolicyDenied', 'ActionDenied']);
+
+/** Allowed action kinds — used for regression detection */
+const ALLOWED_ACTION_KINDS = new Set(['ActionAllowed', 'ActionExecuted']);
+
+// ---------------------------------------------------------------------------
+// Intent reconstruction
+// ---------------------------------------------------------------------------
+
+/**
+ * Reconstruct a NormalizedIntent from a stored governance event.
+ * Events contain action metadata that was used in the original evaluation.
+ * Returns null if the event doesn't contain enough data to reconstruct.
+ */
+function reconstructIntent(event: DomainEvent): NormalizedIntent | null {
+  const rec = event as unknown as Record<string, unknown>;
+
+  const action =
+    (rec.actionType as string) ?? (rec.action as string) ?? (rec.syscall as string) ?? null;
+  const target = (rec.target as string) ?? (rec.file as string) ?? '';
+
+  if (!action) return null;
+
+  return {
+    action,
+    target,
+    agent: (rec.agent as string) ?? 'unknown',
+    branch: (rec.branch as string) ?? undefined,
+    command: (rec.command as string) ?? undefined,
+    filesAffected: (rec.filesAffected as number) ?? undefined,
+    destructive: (rec.destructive as boolean) ?? false,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Policy loading
+// ---------------------------------------------------------------------------
+
+/**
+ * Load a policy file (YAML or JSON) and return the LoadedPolicy array.
+ * Throws if the file cannot be parsed or is invalid.
+ */
+export function loadPolicyFromFile(filePath: string): LoadedPolicy[] {
+  const absPath = resolve(filePath);
+  const content = readFileSync(absPath, 'utf8');
+
+  if (filePath.endsWith('.yaml') || filePath.endsWith('.yml')) {
+    return [loadYamlPolicy(content, filePath)];
+  }
+
+  const parsed = JSON.parse(content) as unknown;
+  const defs = Array.isArray(parsed) ? parsed : [parsed];
+  const { policies, errors } = loadPolicies(defs);
+  if (errors.length > 0) {
+    throw new Error(`Policy validation errors: ${errors.join('; ')}`);
+  }
+  return policies;
+}
+
+// ---------------------------------------------------------------------------
+// Verification engine
+// ---------------------------------------------------------------------------
+
+/**
+ * Verify whether a proposed policy resolves historical violations.
+ *
+ * @param policyPath — path to the new/proposed policy file (YAML or JSON)
+ * @param baseDir — base directory for governance session data (default: .agentguard)
+ * @returns structured verification result
+ */
+export function verifyPolicyFix(policyPath: string, baseDir = '.agentguard'): PolicyVerifyResult {
+  const policies = loadPolicyFromFile(policyPath);
+  const sessionIds = listSessionIds(baseDir);
+
+  const resolved: ViolationVerifyDetail[] = [];
+  const remaining: ViolationVerifyDetail[] = [];
+  const regressions: RegressionDetail[] = [];
+  let totalViolations = 0;
+
+  for (const sessionId of sessionIds) {
+    const events = loadSessionEvents(sessionId, baseDir);
+
+    for (const event of events) {
+      // Check policy-caused violations for resolution
+      if (POLICY_VIOLATION_KINDS.has(event.kind)) {
+        totalViolations++;
+        const intent = reconstructIntent(event);
+        if (!intent) continue;
+
+        const result: EvalResult = evaluate(intent, policies);
+        const rec = event as unknown as Record<string, unknown>;
+        const originalReason = (rec.reason as string) ?? event.kind;
+
+        const detail: ViolationVerifyDetail = {
+          sessionId,
+          eventId: event.id,
+          kind: event.kind,
+          actionType: intent.action,
+          target: intent.target,
+          originalReason,
+          newDecision: result.decision,
+          newReason: result.reason,
+        };
+
+        if (result.allowed) {
+          resolved.push(detail);
+        } else {
+          remaining.push(detail);
+        }
+      }
+
+      // Check previously-allowed actions for regressions
+      if (ALLOWED_ACTION_KINDS.has(event.kind)) {
+        const intent = reconstructIntent(event);
+        if (!intent) continue;
+
+        const result: EvalResult = evaluate(intent, policies);
+
+        if (!result.allowed) {
+          regressions.push({
+            sessionId,
+            eventId: event.id,
+            actionType: intent.action,
+            target: intent.target,
+            reason: result.reason,
+          });
+        }
+      }
+    }
+  }
+
+  return {
+    policyFile: policyPath,
+    sessionsAnalyzed: sessionIds.length,
+    totalViolations,
+    resolvedCount: resolved.length,
+    remainingCount: remaining.length,
+    regressionCount: regressions.length,
+    resolved,
+    remaining,
+    regressions,
+  };
+}

--- a/src/cli/commands/policy.ts
+++ b/src/cli/commands/policy.ts
@@ -2,7 +2,8 @@
 //
 // Subcommands:
 //   validate <file>   Validate a policy file without starting the runtime
-//   suggest            Suggest policy rules based on violation patterns
+//   suggest           Suggest policy rules based on violation patterns
+//   verify <file>     Verify a policy change resolves historical violations
 
 import { readFileSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
@@ -19,6 +20,8 @@ import {
   toTerminalSuggestions,
   toMarkdownSuggestions,
 } from '../../analytics/suggest.js';
+import type { PolicyVerifyResult } from './policy-verify.js';
+import { verifyPolicyFix } from './policy-verify.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -395,31 +398,63 @@ function formatTerminalResult(result: PolicyValidationResult): string {
 
 async function policyValidate(args: string[]): Promise<number> {
   const parsed = parseArgs(args, {
-    boolean: ['--json', '--strict'],
+    boolean: ['--json', '--strict', '--verify'],
+    string: ['--dir', '-d'],
+    alias: { '-d': '--dir' },
   });
 
   const jsonOutput = !!parsed.flags.json;
   const strict = !!parsed.flags.strict;
+  const verify = !!parsed.flags.verify;
+  const baseDir = (parsed.flags.dir as string) ?? '.agentguard';
   const filePath = parsed.positional[0];
 
   if (!filePath) {
     process.stderr.write('\n  Usage: agentguard policy validate <file> [flags]\n');
     process.stderr.write('\n  Flags:\n');
     process.stderr.write('    --json      Output as JSON\n');
-    process.stderr.write('    --strict    Include best-practice recommendations\n\n');
+    process.stderr.write('    --strict    Include best-practice recommendations\n');
+    process.stderr.write('    --verify    Verify policy resolves historical violations\n');
+    process.stderr.write(
+      '    --dir, -d   Base directory for session data (default: .agentguard)\n\n'
+    );
     return 1;
   }
 
   const result = validatePolicyFileStrict(filePath, strict);
 
-  if (jsonOutput) {
+  if (jsonOutput && !verify) {
     process.stdout.write(JSON.stringify(result, null, 2) + '\n');
-  } else {
+  } else if (!verify) {
     process.stderr.write(formatTerminalResult(result));
   }
 
-  // Exit codes: 0 = valid, 1 = errors, 2 = warnings-only
-  if (!result.valid) return 1;
+  if (!result.valid) {
+    if (verify && jsonOutput) {
+      process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    } else if (verify) {
+      process.stderr.write(formatTerminalResult(result));
+    }
+    return 1;
+  }
+
+  // If --verify, run fix verification after successful validation
+  if (verify) {
+    const verifyResult = verifyPolicyFix(filePath, baseDir);
+
+    if (jsonOutput) {
+      process.stdout.write(
+        JSON.stringify({ validation: result, verification: verifyResult }, null, 2) + '\n'
+      );
+    } else {
+      process.stderr.write(formatTerminalResult(result));
+      process.stderr.write(formatVerifyResult(verifyResult));
+    }
+
+    // Return non-zero if regressions detected
+    if (verifyResult.regressionCount > 0) return 3;
+  }
+
   if (result.warnings.length > 0) return 2;
   return 0;
 }
@@ -494,6 +529,144 @@ async function policySuggest(args: string[]): Promise<number> {
 }
 
 // ---------------------------------------------------------------------------
+// Verify Output Formatting
+// ---------------------------------------------------------------------------
+
+function formatVerifyResult(result: PolicyVerifyResult): string {
+  const lines: string[] = [];
+
+  lines.push('');
+  lines.push(`  ${bold('Policy Fix Verification')}`);
+  lines.push(`  Sessions analyzed: ${result.sessionsAnalyzed}`);
+  lines.push(`  Historical violations: ${result.totalViolations}`);
+  lines.push('');
+
+  if (result.totalViolations === 0) {
+    lines.push(`  ${dim('No historical violations found — nothing to verify.')}`);
+    lines.push('');
+    return lines.join('\n');
+  }
+
+  // Summary
+  const resolvedPct =
+    result.totalViolations > 0
+      ? Math.round((result.resolvedCount / result.totalViolations) * 100)
+      : 0;
+
+  lines.push(
+    `  ${color('\u2713', 'green')} Resolved:   ${result.resolvedCount}/${result.totalViolations} (${resolvedPct}%)`
+  );
+  lines.push(
+    `  ${result.remainingCount > 0 ? color('\u2022', 'yellow') : color('\u2713', 'green')} Remaining:  ${result.remainingCount}`
+  );
+  lines.push(
+    `  ${result.regressionCount > 0 ? color('\u2717', 'red') : color('\u2713', 'green')} Regressions: ${result.regressionCount}`
+  );
+
+  // Resolved details (show first 5)
+  if (result.resolved.length > 0) {
+    lines.push('');
+    lines.push(`  ${color('Resolved violations:', 'green')}`);
+    const show = result.resolved.slice(0, 5);
+    for (const v of show) {
+      lines.push(
+        `    ${color('\u2713', 'green')} ${v.actionType} → ${dim(v.target)} ${dim(`(was: ${v.originalReason})`)}`
+      );
+    }
+    if (result.resolved.length > 5) {
+      lines.push(`    ${dim(`... and ${result.resolved.length - 5} more`)}`);
+    }
+  }
+
+  // Remaining details (show first 5)
+  if (result.remaining.length > 0) {
+    lines.push('');
+    lines.push(`  ${color('Remaining violations:', 'yellow')}`);
+    const show = result.remaining.slice(0, 5);
+    for (const v of show) {
+      lines.push(
+        `    ${color('\u2022', 'yellow')} ${v.actionType} → ${dim(v.target)} ${dim(`(${v.newReason})`)}`
+      );
+    }
+    if (result.remaining.length > 5) {
+      lines.push(`    ${dim(`... and ${result.remaining.length - 5} more`)}`);
+    }
+  }
+
+  // Regressions (show all — these are critical)
+  if (result.regressions.length > 0) {
+    lines.push('');
+    lines.push(`  ${color('Regressions (previously allowed, now denied):', 'red')}`);
+    const show = result.regressions.slice(0, 10);
+    for (const r of show) {
+      lines.push(
+        `    ${color('\u2717', 'red')} ${r.actionType} → ${dim(r.target)} ${dim(`(${r.reason})`)}`
+      );
+    }
+    if (result.regressions.length > 10) {
+      lines.push(`    ${dim(`... and ${result.regressions.length - 10} more`)}`);
+    }
+  }
+
+  lines.push('');
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Subcommand: verify
+// ---------------------------------------------------------------------------
+
+async function policyVerify(args: string[]): Promise<number> {
+  const parsed = parseArgs(args, {
+    boolean: ['--json'],
+    string: ['--dir', '-d'],
+    alias: { '-d': '--dir' },
+  });
+
+  const jsonOutput = !!parsed.flags.json;
+  const baseDir = (parsed.flags.dir as string) ?? '.agentguard';
+  const filePath = parsed.positional[0];
+
+  if (!filePath) {
+    process.stderr.write('\n  Usage: agentguard policy verify <file> [flags]\n');
+    process.stderr.write('\n  Verify whether a policy change resolves historical violations.\n');
+    process.stderr.write('\n  Flags:\n');
+    process.stderr.write('    --json      Output as JSON\n');
+    process.stderr.write(
+      '    --dir, -d   Base directory for session data (default: .agentguard)\n\n'
+    );
+    return 1;
+  }
+
+  // First validate
+  const validation = validatePolicyFile(filePath);
+  if (!validation.valid) {
+    if (jsonOutput) {
+      process.stdout.write(JSON.stringify({ validation, verification: null }, null, 2) + '\n');
+    } else {
+      process.stderr.write(formatTerminalResult(validation));
+      process.stderr.write(
+        `\n  ${color('Cannot verify — policy has validation errors.', 'red')}\n\n`
+      );
+    }
+    return 1;
+  }
+
+  // Run verification
+  const result = verifyPolicyFix(filePath, baseDir);
+
+  if (jsonOutput) {
+    process.stdout.write(JSON.stringify({ validation, verification: result }, null, 2) + '\n');
+  } else {
+    process.stderr.write(formatTerminalResult(validation));
+    process.stderr.write(formatVerifyResult(result));
+  }
+
+  if (result.regressionCount > 0) return 3;
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
 // Main Command Router
 // ---------------------------------------------------------------------------
 
@@ -510,6 +683,9 @@ export async function policy(args: string[]): Promise<number> {
 
     case 'suggest':
       return policySuggest(args.slice(1));
+
+    case 'verify':
+      return policyVerify(args.slice(1));
 
     case undefined:
     case 'help':
@@ -535,10 +711,13 @@ function printPolicyHelp(): void {
   ${bold('Commands:')}
     validate <file>   Validate a policy file (YAML or JSON)
     suggest           Suggest policy rules based on violation patterns
+    verify <file>     Verify a policy change resolves historical violations
 
   ${bold('Flags (validate):')}
     --json            Output validation result as JSON
     --strict          Include best-practice recommendations
+    --verify          Also verify policy resolves historical violations
+    --dir, -d <path>  Base directory for session data (default: .agentguard)
 
   ${bold('Flags (suggest):')}
     --format, -f <fmt>  Output format: terminal (default), json, yaml, markdown
@@ -548,17 +727,26 @@ function printPolicyHelp(): void {
     --dir, -d <path>    Base directory for event data (default: .agentguard)
     --min-cluster <n>   Minimum violations to form a pattern (default: 2)
 
-  ${bold('Exit codes:')}
-    0                 Success
-    1                 Error
+  ${bold('Flags (verify):')}
+    --json            Output result as JSON
+    --dir, -d <path>  Base directory for session data (default: .agentguard)
+
+  ${bold('Exit codes (verify):')}
+    0                 Clean — no regressions, violations resolved or none exist
+    1                 Violations remain unresolved
+    3                 Regressions detected (previously-allowed actions now denied)
 
   ${bold('Examples:')}
     agentguard policy validate agentguard.yaml
     agentguard policy validate my-policy.json --json
     agentguard policy validate agentguard.yaml --strict
+    agentguard policy validate agentguard.yaml --verify
     agentguard policy suggest
     agentguard policy suggest --yaml
     agentguard policy suggest --json
     agentguard policy suggest --dir .agentguard --min-cluster 3
+    agentguard policy verify agentguard.yaml
+    agentguard policy verify my-policy.yaml --json
+    agentguard policy verify my-policy.yaml --dir .agentguard
 `);
 }

--- a/tests/ts/policy-verify.test.ts
+++ b/tests/ts/policy-verify.test.ts
@@ -1,0 +1,399 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { verifyPolicyFix, loadPolicyFromFile } from '../../src/cli/commands/policy-verify.js';
+
+describe('Policy fix verification', () => {
+  let tmpDir: string;
+  let eventsDir: string;
+  let policyPath: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'ag-verify-'));
+    eventsDir = join(tmpDir, 'events');
+    mkdirSync(eventsDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writePolicy(rules: Array<Record<string, unknown>>): string {
+    const policy = {
+      id: 'test-policy',
+      name: 'Test Policy',
+      severity: 3,
+      rules,
+    };
+    policyPath = join(tmpDir, 'test-policy.json');
+    writeFileSync(policyPath, JSON.stringify(policy));
+    return policyPath;
+  }
+
+  function writeYamlPolicy(yaml: string): string {
+    policyPath = join(tmpDir, 'test-policy.yaml');
+    writeFileSync(policyPath, yaml);
+    return policyPath;
+  }
+
+  function writeSessionEvents(sessionId: string, events: Array<Record<string, unknown>>): void {
+    const lines = events.map((e) => JSON.stringify(e)).join('\n');
+    writeFileSync(join(eventsDir, `${sessionId}.jsonl`), lines);
+  }
+
+  // ── No violations ────────────────────────────────────────────────────
+
+  it('returns zero counts when no sessions exist', () => {
+    const path = writePolicy([{ action: '*', effect: 'allow' }]);
+    const result = verifyPolicyFix(path, tmpDir);
+
+    expect(result.sessionsAnalyzed).toBe(0);
+    expect(result.totalViolations).toBe(0);
+    expect(result.resolvedCount).toBe(0);
+    expect(result.remainingCount).toBe(0);
+    expect(result.regressionCount).toBe(0);
+  });
+
+  it('returns zero violations when sessions have no violation events', () => {
+    writeSessionEvents('session-1', [
+      {
+        id: 'evt-1',
+        kind: 'ActionExecuted',
+        timestamp: 1000,
+        fingerprint: 'fp1',
+        actionType: 'file.read',
+        target: 'src/index.ts',
+      },
+    ]);
+
+    const path = writePolicy([{ action: '*', effect: 'allow' }]);
+    const result = verifyPolicyFix(path, tmpDir);
+
+    expect(result.sessionsAnalyzed).toBe(1);
+    expect(result.totalViolations).toBe(0);
+  });
+
+  // ── Resolved violations ──────────────────────────────────────────────
+
+  it('detects resolved violations when new policy allows previously denied actions', () => {
+    writeSessionEvents('session-1', [
+      {
+        id: 'evt-1',
+        kind: 'PolicyDenied',
+        timestamp: 1000,
+        fingerprint: 'fp1',
+        actionType: 'git.push',
+        target: 'origin/main',
+        reason: 'Denied by old policy',
+      },
+    ]);
+
+    // New policy allows git.push
+    const path = writePolicy([{ action: 'git.push', effect: 'allow' }]);
+    const result = verifyPolicyFix(path, tmpDir);
+
+    expect(result.totalViolations).toBe(1);
+    expect(result.resolvedCount).toBe(1);
+    expect(result.remainingCount).toBe(0);
+    expect(result.resolved[0].actionType).toBe('git.push');
+    expect(result.resolved[0].newDecision).toBe('allow');
+  });
+
+  // ── Remaining violations ─────────────────────────────────────────────
+
+  it('detects remaining violations when new policy still denies', () => {
+    writeSessionEvents('session-1', [
+      {
+        id: 'evt-1',
+        kind: 'ActionDenied',
+        timestamp: 1000,
+        fingerprint: 'fp1',
+        actionType: 'git.force-push',
+        target: 'origin/main',
+        reason: 'Force push blocked',
+      },
+    ]);
+
+    // New policy also denies force push
+    const path = writePolicy([
+      { action: 'git.force-push', effect: 'deny', reason: 'Still blocked' },
+    ]);
+    const result = verifyPolicyFix(path, tmpDir);
+
+    expect(result.totalViolations).toBe(1);
+    expect(result.resolvedCount).toBe(0);
+    expect(result.remainingCount).toBe(1);
+    expect(result.remaining[0].actionType).toBe('git.force-push');
+    expect(result.remaining[0].newDecision).toBe('deny');
+  });
+
+  // ── Regressions ──────────────────────────────────────────────────────
+
+  it('detects regressions when new policy denies previously allowed actions', () => {
+    writeSessionEvents('session-1', [
+      {
+        id: 'evt-1',
+        kind: 'ActionAllowed',
+        timestamp: 1000,
+        fingerprint: 'fp1',
+        actionType: 'file.write',
+        target: 'src/app.ts',
+      },
+    ]);
+
+    // New policy denies file.write
+    const path = writePolicy([
+      { action: 'file.write', effect: 'deny', reason: 'No file writes allowed' },
+    ]);
+    const result = verifyPolicyFix(path, tmpDir);
+
+    expect(result.regressionCount).toBe(1);
+    expect(result.regressions[0].actionType).toBe('file.write');
+    expect(result.regressions[0].target).toBe('src/app.ts');
+  });
+
+  it('detects regressions from ActionExecuted events', () => {
+    writeSessionEvents('session-1', [
+      {
+        id: 'evt-1',
+        kind: 'ActionExecuted',
+        timestamp: 1000,
+        fingerprint: 'fp1',
+        actionType: 'shell.exec',
+        target: 'npm test',
+      },
+    ]);
+
+    const path = writePolicy([
+      { action: 'shell.exec', effect: 'deny', reason: 'Shell execution blocked' },
+    ]);
+    const result = verifyPolicyFix(path, tmpDir);
+
+    expect(result.regressionCount).toBe(1);
+    expect(result.regressions[0].actionType).toBe('shell.exec');
+  });
+
+  // ── Mixed scenarios ──────────────────────────────────────────────────
+
+  it('handles mixed resolved, remaining, and regression events', () => {
+    writeSessionEvents('session-1', [
+      // Violation that will be resolved
+      {
+        id: 'evt-1',
+        kind: 'PolicyDenied',
+        timestamp: 1000,
+        fingerprint: 'fp1',
+        actionType: 'git.push',
+        target: 'origin/dev',
+        reason: 'Push denied',
+      },
+      // Violation that will remain
+      {
+        id: 'evt-2',
+        kind: 'ActionDenied',
+        timestamp: 1001,
+        fingerprint: 'fp2',
+        actionType: 'git.force-push',
+        target: 'origin/main',
+        reason: 'Force push blocked',
+      },
+      // Allowed action that will regress
+      {
+        id: 'evt-3',
+        kind: 'ActionAllowed',
+        timestamp: 1002,
+        fingerprint: 'fp3',
+        actionType: 'file.delete',
+        target: 'tmp/cache.json',
+      },
+    ]);
+
+    const path = writePolicy([
+      { action: 'git.force-push', effect: 'deny', reason: 'Force push forbidden' },
+      { action: 'file.delete', effect: 'deny', reason: 'No deletes allowed' },
+      { action: '*', effect: 'allow' },
+    ]);
+
+    const result = verifyPolicyFix(path, tmpDir);
+
+    expect(result.totalViolations).toBe(2);
+    expect(result.resolvedCount).toBe(1);
+    expect(result.remainingCount).toBe(1);
+    expect(result.regressionCount).toBe(1);
+
+    expect(result.resolved[0].actionType).toBe('git.push');
+    expect(result.remaining[0].actionType).toBe('git.force-push');
+    expect(result.regressions[0].actionType).toBe('file.delete');
+  });
+
+  // ── Multiple sessions ────────────────────────────────────────────────
+
+  it('aggregates violations across multiple sessions', () => {
+    writeSessionEvents('session-1', [
+      {
+        id: 'evt-1',
+        kind: 'PolicyDenied',
+        timestamp: 1000,
+        fingerprint: 'fp1',
+        actionType: 'git.push',
+        target: 'origin/main',
+        reason: 'Push denied',
+      },
+    ]);
+
+    writeSessionEvents('session-2', [
+      {
+        id: 'evt-2',
+        kind: 'PolicyDenied',
+        timestamp: 2000,
+        fingerprint: 'fp2',
+        actionType: 'git.push',
+        target: 'origin/staging',
+        reason: 'Push denied',
+      },
+    ]);
+
+    const path = writePolicy([{ action: 'git.push', effect: 'allow' }]);
+    const result = verifyPolicyFix(path, tmpDir);
+
+    expect(result.sessionsAnalyzed).toBe(2);
+    expect(result.totalViolations).toBe(2);
+    expect(result.resolvedCount).toBe(2);
+  });
+
+  // ── Events without actionType ────────────────────────────────────────
+
+  it('skips violation events without reconstructable intent', () => {
+    writeSessionEvents('session-1', [
+      {
+        id: 'evt-1',
+        kind: 'PolicyDenied',
+        timestamp: 1000,
+        fingerprint: 'fp1',
+        // No actionType, action, or syscall — cannot reconstruct
+        target: 'something',
+        reason: 'Unknown',
+      },
+    ]);
+
+    const path = writePolicy([{ action: '*', effect: 'allow' }]);
+    const result = verifyPolicyFix(path, tmpDir);
+
+    // Violation is counted but not classified as resolved or remaining
+    expect(result.totalViolations).toBe(1);
+    expect(result.resolvedCount).toBe(0);
+    expect(result.remainingCount).toBe(0);
+  });
+
+  // ── YAML policy loading ──────────────────────────────────────────────
+
+  it('works with YAML policy files', () => {
+    writeSessionEvents('session-1', [
+      {
+        id: 'evt-1',
+        kind: 'PolicyDenied',
+        timestamp: 1000,
+        fingerprint: 'fp1',
+        actionType: 'git.push',
+        target: 'origin/main',
+        reason: 'Push denied',
+      },
+    ]);
+
+    const yaml = `id: yaml-test
+name: YAML Test Policy
+severity: 3
+rules:
+  - action: git.push
+    effect: allow
+    reason: Allow pushes
+`;
+    const path = writeYamlPolicy(yaml);
+    const result = verifyPolicyFix(path, tmpDir);
+
+    expect(result.totalViolations).toBe(1);
+    expect(result.resolvedCount).toBe(1);
+  });
+
+  // ── No regressions with permissive policy ────────────────────────────
+
+  it('reports no regressions for fully permissive policy', () => {
+    writeSessionEvents('session-1', [
+      {
+        id: 'evt-1',
+        kind: 'ActionAllowed',
+        timestamp: 1000,
+        fingerprint: 'fp1',
+        actionType: 'file.write',
+        target: 'src/index.ts',
+      },
+      {
+        id: 'evt-2',
+        kind: 'ActionExecuted',
+        timestamp: 1001,
+        fingerprint: 'fp2',
+        actionType: 'shell.exec',
+        target: 'npm test',
+      },
+    ]);
+
+    const path = writePolicy([{ action: '*', effect: 'allow' }]);
+    const result = verifyPolicyFix(path, tmpDir);
+
+    expect(result.regressionCount).toBe(0);
+  });
+});
+
+describe('loadPolicyFromFile', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'ag-load-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('loads a JSON policy file', () => {
+    const policy = {
+      id: 'test',
+      name: 'Test',
+      severity: 3,
+      rules: [{ action: '*', effect: 'allow' }],
+    };
+    const path = join(tmpDir, 'policy.json');
+    writeFileSync(path, JSON.stringify(policy));
+
+    const policies = loadPolicyFromFile(path);
+    expect(policies).toHaveLength(1);
+    expect(policies[0].id).toBe('test');
+  });
+
+  it('loads a YAML policy file', () => {
+    const yaml = `id: yaml-test
+name: YAML Test
+severity: 2
+rules:
+  - action: git.push
+    effect: deny
+    reason: No pushes
+`;
+    const path = join(tmpDir, 'policy.yaml');
+    writeFileSync(path, yaml);
+
+    const policies = loadPolicyFromFile(path);
+    expect(policies).toHaveLength(1);
+    expect(policies[0].id).toBe('yaml-test');
+    expect(policies[0].rules).toHaveLength(1);
+    expect(policies[0].rules[0].effect).toBe('deny');
+  });
+
+  it('throws for invalid JSON policy', () => {
+    const path = join(tmpDir, 'bad.json');
+    writeFileSync(path, '{"invalid": true}');
+
+    expect(() => loadPolicyFromFile(path)).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- Add `agentguard policy verify <file>` subcommand and `--verify` flag for `policy validate` to test whether a proposed policy change resolves historical governance violations
- Core verification engine loads violations from JSONL sessions, re-evaluates each against the new policy, and reports resolved violations, remaining violations, and regressions (previously-allowed actions now denied)
- Closes #327

## Changes
- `src/cli/commands/policy-verify.ts` — new module: verification engine (intent reconstruction, policy loading, violation re-evaluation, regression detection)
- `src/cli/commands/policy.ts` — add `verify` subcommand, `--verify` flag on validate, terminal/JSON formatting for verification results
- `src/cli/bin.ts` — update command registry with verify examples and help text
- `tests/ts/policy-verify.test.ts` — 14 test cases covering all verification scenarios

## Test Plan
- [x] TypeScript build passes (`npm run build:ts`)
- [x] Vitest tests pass (`npm run ts:test`) — 14/14 new tests pass, 2 pre-existing failures in decision-jsonl (Windows path issue)
- [x] JS tests pass (`npm test`) — 210/210 pass
- [x] ESLint clean (`npm run lint`) — 0 errors, 12 pre-existing warnings
- [x] Prettier clean (`npm run format`)
- [x] Type-check passes (`npm run ts:check`)

## Risk Assessment

| Metric | Value |
|--------|-------|
| Risk level | low |
| Blast radius | 4 files (3 src + 1 test) |
| Simulation result | not available |

## Governance Report

| Metric | Count |
|--------|-------|
| Total events | 41228 |
| Actions allowed | 6465 |
| Actions denied | 1543 |
| Policy denials | 737 |
| Invariant violations | 670 |
| Escalation events | 20 |
| Runtime events | 8046 |

<details>
<summary>Governance details</summary>

**Source**: `.agentguard/events/`, `logs/runtime-events.jsonl`

**Escalation levels observed**: NORMAL
**Pre-push simulation**: not available

No policy denials or invariant violations were triggered by this implementation.
All governance events are from historical session data accumulated across prior runs.

</details>