### PR TITLE
feat: add webhook storage backend for cloud logging via HTTP

### DIFF
--- a/src/cli/commands/claude-hook.ts
+++ b/src/cli/commands/claude-hook.ts
@@ -84,6 +84,23 @@ async function handlePreToolUse(payload: ClaudeCodeHookPayload, cliArgs: string[
     // Sink creation failure is non-fatal
   }
 
+  // Build tracer with webhook trace backend when using webhook storage
+  let tracer: import('../../telemetry/tracer.js').Tracer | undefined;
+  if (storageConfig.backend === 'webhook') {
+    const { createTracer } = await import('../../telemetry/tracer.js');
+    const { createWebhookTraceBackend } = await import('../../storage/webhook-sink.js');
+    tracer = createTracer({
+      backends: [
+        createWebhookTraceBackend({
+          url: storageConfig.webhookUrl ?? process.env.AGENTGUARD_WEBHOOK_URL ?? '',
+          headers: storageConfig.webhookHeaders,
+          batchSize: storageConfig.webhookBatchSize,
+          flushIntervalMs: storageConfig.webhookFlushIntervalMs,
+        }),
+      ],
+    });
+  }
+
   // Build kernel — dryRun: true = evaluate policies/invariants only (no adapter execution).
   // Claude Code handles actual tool execution; the hook only governs (allow/deny).
   // Events and decision records are still emitted and persisted to the configured storage backend.
@@ -95,6 +112,7 @@ async function handlePreToolUse(payload: ClaudeCodeHookPayload, cliArgs: string[
     decisionSinks: [decisionSink, telemetrySink].filter(
       Boolean
     ) as import('../../kernel/decisions/types.js').DecisionSink[],
+    tracer,
   });
 
   // Record session in the sessions table (SQLite only).

--- a/src/cli/commands/guard.ts
+++ b/src/cli/commands/guard.ts
@@ -24,6 +24,8 @@ import { createStorageBundle } from '../../storage/factory.js';
 import type { StorageBundle } from '../../storage/factory.js';
 import type { StorageConfig } from '../../storage/types.js';
 import type { PolicyTracePayload } from '../../renderers/types.js';
+import { createTracer } from '../../telemetry/tracer.js';
+import { createWebhookTraceBackend } from '../../storage/webhook-sink.js';
 
 export interface GuardOptions {
   /** Single policy path (backwards compatible) */
@@ -80,6 +82,21 @@ export async function guard(_args: string[], options: GuardOptions = {}): Promis
   const decisionSink = storage.createDecisionSink(runId);
   const telemetrySink = createTelemetryDecisionSink();
 
+  // Build tracer with webhook trace backend when using webhook storage
+  const tracer =
+    storeConfig.backend === 'webhook'
+      ? createTracer({
+          backends: [
+            createWebhookTraceBackend({
+              url: storeConfig.webhookUrl ?? process.env.AGENTGUARD_WEBHOOK_URL ?? '',
+              headers: storeConfig.webhookHeaders,
+              batchSize: storeConfig.webhookBatchSize,
+              flushIntervalMs: storeConfig.webhookFlushIntervalMs,
+            }),
+          ],
+        })
+      : undefined;
+
   // Build kernel config
   const kernelConfig: KernelConfig = {
     runId,
@@ -90,6 +107,7 @@ export async function guard(_args: string[], options: GuardOptions = {}): Promis
     sinks: [eventSink],
     decisionSinks: [decisionSink, telemetrySink],
     simulators: simulators.all().length > 0 ? simulators : undefined,
+    tracer,
   };
 
   const kernel = createKernel(kernelConfig);

--- a/src/kernel/kernel.ts
+++ b/src/kernel/kernel.ts
@@ -29,6 +29,7 @@ import type { SimulatorRegistry, ImpactForecast } from './simulation/types.js';
 import { buildImpactForecast } from './simulation/forecast.js';
 import type { SeededRng } from '../core/rng.js';
 import { generateSeed, createSeededRng } from '../core/rng.js';
+import type { Tracer } from '../telemetry/tracer.js';
 
 export interface KernelResult {
   allowed: boolean;
@@ -67,6 +68,8 @@ export interface KernelConfig extends MonitorConfig {
   rng?: SeededRng;
   /** Maximum time (ms) for the full propose pipeline. Default: 30000 */
   proposalTimeoutMs?: number;
+  /** Optional tracer for kernel-level tracing. Spans are sent to registered backends. */
+  tracer?: Tracer;
 }
 
 export interface Kernel {
@@ -96,6 +99,7 @@ export function createKernel(config: KernelConfig = {}): Kernel {
   const simulators = config.simulators || null;
   const blastRadiusThreshold = config.simulationBlastRadiusThreshold ?? 50;
   const proposalTimeoutMs = config.proposalTimeoutMs ?? 30_000;
+  const tracer = config.tracer ?? null;
   const actionLog: KernelResult[] = [];
   let eventCount = 0;
 
@@ -128,6 +132,7 @@ export function createKernel(config: KernelConfig = {}): Kernel {
 
   return {
     propose: async (rawAction, systemContext = {}) => {
+      const span = tracer?.startSpan('kernel.propose', `propose:${rawAction.tool || 'unknown'}`) ?? null;
       const proposalBody = async (): Promise<KernelResult> => {
         const allEvents: DomainEvent[] = [];
 
@@ -548,20 +553,30 @@ export function createKernel(config: KernelConfig = {}): Kernel {
         return result;
       };
 
-      if (proposalTimeoutMs <= 0 || proposalTimeoutMs === Infinity) {
-        return proposalBody();
-      }
-      let timer: ReturnType<typeof setTimeout>;
-      const timeoutPromise = new Promise<never>((_, reject) => {
-        timer = setTimeout(
-          () => reject(new Error(`Proposal timed out after ${proposalTimeoutMs}ms`)),
-          proposalTimeoutMs
-        );
-      });
       try {
-        return await Promise.race([proposalBody(), timeoutPromise]);
-      } finally {
-        clearTimeout(timer!);
+        let result: KernelResult;
+        if (proposalTimeoutMs <= 0 || proposalTimeoutMs === Infinity) {
+          result = await proposalBody();
+        } else {
+          let timer: ReturnType<typeof setTimeout>;
+          const timeoutPromise = new Promise<never>((_, reject) => {
+            timer = setTimeout(
+              () => reject(new Error(`Proposal timed out after ${proposalTimeoutMs}ms`)),
+              proposalTimeoutMs
+            );
+          });
+          try {
+            result = await Promise.race([proposalBody(), timeoutPromise]);
+          } finally {
+            clearTimeout(timer!);
+          }
+        }
+        span?.setAttribute('outcome', result.allowed ? 'allow' : 'deny');
+        span?.end();
+        return result;
+      } catch (err) {
+        span?.endWithError(err instanceof Error ? err.message : String(err));
+        throw err;
       }
     },
 
@@ -588,6 +603,7 @@ export function createKernel(config: KernelConfig = {}): Kernel {
       for (const sink of decisionSinks) {
         if (sink.flush) sink.flush();
       }
+      tracer?.shutdown();
     },
   };
 }

--- a/src/storage/factory.ts
+++ b/src/storage/factory.ts
@@ -5,6 +5,8 @@ import { join, dirname } from 'node:path';
 import { existsSync, mkdirSync } from 'node:fs';
 import { createJsonlSink } from '../events/jsonl.js';
 import { createDecisionJsonlSink } from '../events/decision-jsonl.js';
+import { createWebhookEventSink, createWebhookDecisionSink } from './webhook-sink.js';
+import type { WebhookConfig } from './webhook-sink.js';
 import type { EventSink } from '../kernel/kernel.js';
 import type { DecisionSink } from '../kernel/decisions/types.js';
 import type { StorageConfig } from './types.js';
@@ -29,6 +31,9 @@ export async function createStorageBundle(config: StorageConfig): Promise<Storag
   }
   if (config.backend === 'firestore') {
     return createFirestoreBundle(config);
+  }
+  if (config.backend === 'webhook') {
+    return createWebhookBundle(config);
   }
   return createJsonlBundle(config);
 }
@@ -134,6 +139,50 @@ async function createFirestoreBundle(config: StorageConfig): Promise<StorageBund
   };
 }
 
+function createWebhookBundle(config: StorageConfig): StorageBundle {
+  const url = config.webhookUrl ?? process.env.AGENTGUARD_WEBHOOK_URL;
+  if (!url) {
+    throw new Error(
+      'Webhook backend requires a URL. Set --webhook-url <url> or AGENTGUARD_WEBHOOK_URL env var.'
+    );
+  }
+
+  const headers: Record<string, string> = { ...config.webhookHeaders };
+  const envAuth = process.env.AGENTGUARD_WEBHOOK_AUTH;
+  if (envAuth && !headers['Authorization']) {
+    headers['Authorization'] = envAuth;
+  }
+
+  const webhookConfig: WebhookConfig = {
+    url,
+    headers,
+    batchSize: config.webhookBatchSize,
+    flushIntervalMs: config.webhookFlushIntervalMs,
+  };
+
+  // Track sinks so close() can flush them all
+  const sinks: Array<{ close?: () => void; flush?: () => void }> = [];
+
+  return {
+    createEventSink(runId: string): EventSink {
+      const sink = createWebhookEventSink(webhookConfig, runId);
+      sinks.push(sink);
+      return sink;
+    },
+    createDecisionSink(runId: string): DecisionSink {
+      const sink = createWebhookDecisionSink(webhookConfig, runId);
+      sinks.push(sink);
+      return sink;
+    },
+    close(): void {
+      for (const sink of sinks) {
+        sink.close?.();
+        sink.flush?.();
+      }
+    },
+  };
+}
+
 /**
  * Resolve the SQLite database path from config, with home-dir default.
  *
@@ -168,7 +217,14 @@ export function resolveStorageConfig(args: string[]): StorageConfig {
   const envStore = process.env.AGENTGUARD_STORE;
 
   const raw = storeArg !== undefined ? storeArg : envStore;
-  const backend = raw === 'sqlite' ? 'sqlite' : raw === 'firestore' ? 'firestore' : 'jsonl';
+  const backend =
+    raw === 'sqlite'
+      ? 'sqlite'
+      : raw === 'firestore'
+        ? 'firestore'
+        : raw === 'webhook'
+          ? 'webhook'
+          : 'jsonl';
 
   const dirIdx = args.findIndex((a) => a === '--dir' || a === '-d');
   const baseDir = dirIdx !== -1 ? args[dirIdx + 1] : undefined;
@@ -178,5 +234,9 @@ export function resolveStorageConfig(args: string[]): StorageConfig {
   const dbPathArg = dbPathIdx !== -1 ? args[dbPathIdx + 1] : undefined;
   const dbPath = dbPathArg ?? process.env.AGENTGUARD_DB_PATH ?? undefined;
 
-  return { backend, baseDir, dbPath };
+  // --webhook-url flag or AGENTGUARD_WEBHOOK_URL env var for webhook endpoint
+  const webhookUrlIdx = args.findIndex((a) => a === '--webhook-url');
+  const webhookUrl = webhookUrlIdx !== -1 ? args[webhookUrlIdx + 1] : undefined;
+
+  return { backend, baseDir, dbPath, webhookUrl };
 }

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -58,5 +58,11 @@ export {
   loadRunEventsFirestore,
 } from './firestore-store.js';
 export { aggregateViolationsFirestore, loadAllEventsFirestore } from './firestore-analytics.js';
+export {
+  createWebhookEventSink,
+  createWebhookDecisionSink,
+  createWebhookTraceBackend,
+} from './webhook-sink.js';
+export type { WebhookConfig } from './webhook-sink.js';
 export type { StorageBundle } from './factory.js';
 export { createStorageBundle, resolveStorageConfig, resolveSqlitePath } from './factory.js';

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -4,7 +4,7 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 
 /** Supported storage backends */
-export type StorageBackend = 'jsonl' | 'sqlite' | 'firestore';
+export type StorageBackend = 'jsonl' | 'sqlite' | 'firestore' | 'webhook';
 
 /** Configuration for the storage layer */
 export interface StorageConfig {
@@ -18,6 +18,14 @@ export interface StorageConfig {
   readonly firestoreProjectId?: string;
   /** For firestore: collection name prefix (e.g. 'myrepo_'). Default: '' */
   readonly firestorePrefix?: string;
+  /** For webhook: HTTP endpoint URL. Falls back to AGENTGUARD_WEBHOOK_URL env var. */
+  readonly webhookUrl?: string;
+  /** For webhook: custom HTTP headers (e.g. Authorization). */
+  readonly webhookHeaders?: Record<string, string>;
+  /** For webhook: max items per batch before auto-flush. Default: 50. */
+  readonly webhookBatchSize?: number;
+  /** For webhook: flush interval in milliseconds. Default: 5000. */
+  readonly webhookFlushIntervalMs?: number;
 }
 
 /** Default paths */

--- a/src/storage/webhook-sink.ts
+++ b/src/storage/webhook-sink.ts
@@ -1,0 +1,169 @@
+// Webhook event, decision, and trace sinks — batched HTTP POST to a configurable endpoint.
+// Follows the fire-and-forget pattern: never crashes the kernel, errors reported via callback.
+// Uses Node.js built-in fetch (Node 18+).
+
+import type { DomainEvent } from '../core/types.js';
+import type { EventSink } from '../kernel/kernel.js';
+import type { GovernanceDecisionRecord, DecisionSink } from '../kernel/decisions/types.js';
+import type { TraceBackend, TraceSpan } from '../telemetry/tracepoint.js';
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+export interface WebhookConfig {
+  /** HTTP endpoint URL (required). */
+  readonly url: string;
+  /** Custom headers (e.g., Authorization). */
+  readonly headers?: Record<string, string>;
+  /** Max items per batch before auto-flush. Default: 50. */
+  readonly batchSize?: number;
+  /** Flush interval in milliseconds. Default: 5000. */
+  readonly flushIntervalMs?: number;
+  /** Error callback — report but never crash. */
+  readonly onError?: (error: Error) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Batched sender — shared buffering + flush logic
+// ---------------------------------------------------------------------------
+
+interface BatchedSender<T> {
+  enqueue(item: T): void;
+  flush(): void;
+  close(): void;
+}
+
+function createBatchedSender<T>(
+  config: WebhookConfig,
+  payloadType: string,
+  runId?: string
+): BatchedSender<T> {
+  const batchSize = config.batchSize ?? 50;
+  const flushIntervalMs = config.flushIntervalMs ?? 5000;
+  let buffer: T[] = [];
+  let timer: ReturnType<typeof setInterval> | undefined;
+
+  if (flushIntervalMs > 0) {
+    timer = setInterval(() => flush(), flushIntervalMs);
+    // Allow the process to exit even if the timer is still running
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    if (timer && typeof (timer as any).unref === 'function') {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (timer as any).unref();
+    }
+  }
+
+  function flush(): void {
+    if (buffer.length === 0) return;
+    const batch = buffer;
+    buffer = [];
+
+    const body = JSON.stringify({
+      type: payloadType,
+      ...(runId ? { run_id: runId } : {}),
+      timestamp: new Date().toISOString(),
+      batch,
+    });
+
+    fetch(config.url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...config.headers,
+      },
+      body,
+    }).catch((err: unknown) => {
+      config.onError?.(err instanceof Error ? err : new Error(String(err)));
+    });
+  }
+
+  function enqueue(item: T): void {
+    buffer.push(item);
+    if (buffer.length >= batchSize) {
+      flush();
+    }
+  }
+
+  function close(): void {
+    if (timer !== undefined) {
+      clearInterval(timer);
+      timer = undefined;
+    }
+    flush();
+  }
+
+  return { enqueue, flush, close };
+}
+
+// ---------------------------------------------------------------------------
+// Event Sink
+// ---------------------------------------------------------------------------
+
+/** Extended EventSink with close() for cleanup. */
+export interface WebhookEventSink extends EventSink {
+  close(): void;
+}
+
+/** Create an EventSink that batches and POSTs domain events to a webhook endpoint. */
+export function createWebhookEventSink(config: WebhookConfig, runId: string): WebhookEventSink {
+  const sender = createBatchedSender<DomainEvent>(config, 'events', runId);
+
+  return {
+    write(event: DomainEvent): void {
+      sender.enqueue(event);
+    },
+    flush(): void {
+      sender.flush();
+    },
+    close(): void {
+      sender.close();
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Decision Sink
+// ---------------------------------------------------------------------------
+
+/** Create a DecisionSink that batches and POSTs governance decisions to a webhook endpoint. */
+export function createWebhookDecisionSink(
+  config: WebhookConfig,
+  runId: string
+): DecisionSink {
+  const sender = createBatchedSender<GovernanceDecisionRecord>(config, 'decisions', runId);
+
+  return {
+    write(record: GovernanceDecisionRecord): void {
+      sender.enqueue(record);
+    },
+    flush(): void {
+      sender.flush();
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Trace Backend
+// ---------------------------------------------------------------------------
+
+/** Create a TraceBackend that batches and POSTs completed trace spans to a webhook endpoint. */
+export function createWebhookTraceBackend(config: WebhookConfig): TraceBackend {
+  const sender = createBatchedSender<TraceSpan>(config, 'traces');
+
+  return {
+    name: 'webhook',
+
+    onSpanStart(): void {
+      // No-op: only send completed spans
+    },
+
+    onSpanEnd(span: TraceSpan): void {
+      sender.enqueue(span);
+    },
+
+    shutdown(): void {
+      sender.close();
+    },
+  };
+}

--- a/tests/ts/webhook-sink.test.ts
+++ b/tests/ts/webhook-sink.test.ts
@@ -1,0 +1,259 @@
+// Tests for webhook storage backend — batched HTTP POST sinks.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  createWebhookEventSink,
+  createWebhookDecisionSink,
+  createWebhookTraceBackend,
+} from '../../src/storage/webhook-sink.js';
+import type { WebhookConfig } from '../../src/storage/webhook-sink.js';
+import type { DomainEvent } from '../../src/core/types.js';
+import type { GovernanceDecisionRecord } from '../../src/kernel/decisions/types.js';
+import type { TraceSpan } from '../../src/telemetry/tracepoint.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeDomainEvent(id: string, kind = 'ActionRequested'): DomainEvent {
+  return {
+    id,
+    kind,
+    timestamp: new Date().toISOString(),
+    fingerprint: `fp_${id}`,
+    data: {},
+  } as unknown as DomainEvent;
+}
+
+function makeDecisionRecord(id: string): GovernanceDecisionRecord {
+  return {
+    recordId: id,
+    runId: 'run_test',
+    timestamp: new Date().toISOString(),
+    outcome: 'allow' as const,
+    action: { type: 'file.read', target: '/tmp/test', agent: 'test', destructive: false },
+    reason: 'allowed by policy',
+    intervention: null,
+    matchedPolicyId: 'test-policy',
+    severity: 'info',
+    violations: [],
+    simulation: null,
+    evidencePackId: null,
+    escalationState: 'NORMAL',
+    execution: null,
+    executionDurationMs: null,
+  } as unknown as GovernanceDecisionRecord;
+}
+
+function makeTraceSpan(id: string): TraceSpan {
+  return {
+    spanId: id,
+    parentSpanId: undefined,
+    kind: 'kernel.propose' as const,
+    name: `propose:file.read`,
+    startTime: Date.now() - 100,
+    endTime: Date.now(),
+    durationMs: 100,
+    status: 'ok' as const,
+    error: undefined,
+    attributes: {},
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('webhook-sink', () => {
+  let fetchCalls: Array<{ url: string; init: RequestInit }>;
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    fetchCalls = [];
+    globalThis.fetch = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      fetchCalls.push({ url: url as string, init: init! });
+      return new Response('ok', { status: 200 });
+    }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const baseConfig: WebhookConfig = {
+    url: 'https://logs.example.com/ingest',
+    batchSize: 3,
+    flushIntervalMs: 0, // Disable timer for deterministic tests
+  };
+
+  describe('createWebhookEventSink', () => {
+    it('batches events and flushes at batchSize', () => {
+      const sink = createWebhookEventSink(baseConfig, 'run_1');
+
+      sink.write(makeDomainEvent('e1'));
+      sink.write(makeDomainEvent('e2'));
+      expect(fetchCalls).toHaveLength(0);
+
+      sink.write(makeDomainEvent('e3'));
+      expect(fetchCalls).toHaveLength(1);
+
+      const body = JSON.parse(fetchCalls[0].init.body as string);
+      expect(body.type).toBe('events');
+      expect(body.run_id).toBe('run_1');
+      expect(body.batch).toHaveLength(3);
+      expect(body.batch[0].id).toBe('e1');
+    });
+
+    it('flushes remaining items on explicit flush()', () => {
+      const sink = createWebhookEventSink(baseConfig, 'run_1');
+      sink.write(makeDomainEvent('e1'));
+      expect(fetchCalls).toHaveLength(0);
+
+      sink.flush!();
+      expect(fetchCalls).toHaveLength(1);
+
+      const body = JSON.parse(fetchCalls[0].init.body as string);
+      expect(body.batch).toHaveLength(1);
+    });
+
+    it('does not flush when buffer is empty', () => {
+      const sink = createWebhookEventSink(baseConfig, 'run_1');
+      sink.flush!();
+      expect(fetchCalls).toHaveLength(0);
+    });
+
+    it('sends custom headers', () => {
+      const config: WebhookConfig = {
+        ...baseConfig,
+        headers: { Authorization: 'Bearer token123' },
+        batchSize: 1,
+      };
+      const sink = createWebhookEventSink(config, 'run_1');
+      sink.write(makeDomainEvent('e1'));
+
+      expect(fetchCalls).toHaveLength(1);
+      const headers = fetchCalls[0].init.headers as Record<string, string>;
+      expect(headers['Authorization']).toBe('Bearer token123');
+      expect(headers['Content-Type']).toBe('application/json');
+    });
+
+    it('calls onError when fetch fails', async () => {
+      const errors: Error[] = [];
+      const config: WebhookConfig = {
+        ...baseConfig,
+        batchSize: 1,
+        onError: (err) => errors.push(err),
+      };
+
+      globalThis.fetch = vi.fn(async () => {
+        throw new Error('network error');
+      }) as unknown as typeof fetch;
+
+      const sink = createWebhookEventSink(config, 'run_1');
+      sink.write(makeDomainEvent('e1'));
+
+      // Wait for the async catch to fire
+      await new Promise((r) => setTimeout(r, 10));
+      expect(errors).toHaveLength(1);
+      expect(errors[0].message).toBe('network error');
+    });
+
+    it('flushes on close()', () => {
+      const sink = createWebhookEventSink(baseConfig, 'run_1');
+      sink.write(makeDomainEvent('e1'));
+      sink.write(makeDomainEvent('e2'));
+      expect(fetchCalls).toHaveLength(0);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (sink as any).close();
+      expect(fetchCalls).toHaveLength(1);
+      const body = JSON.parse(fetchCalls[0].init.body as string);
+      expect(body.batch).toHaveLength(2);
+    });
+  });
+
+  describe('createWebhookDecisionSink', () => {
+    it('batches decisions and flushes at batchSize', () => {
+      const sink = createWebhookDecisionSink(baseConfig, 'run_2');
+
+      sink.write(makeDecisionRecord('d1'));
+      sink.write(makeDecisionRecord('d2'));
+      expect(fetchCalls).toHaveLength(0);
+
+      sink.write(makeDecisionRecord('d3'));
+      expect(fetchCalls).toHaveLength(1);
+
+      const body = JSON.parse(fetchCalls[0].init.body as string);
+      expect(body.type).toBe('decisions');
+      expect(body.run_id).toBe('run_2');
+      expect(body.batch).toHaveLength(3);
+    });
+
+    it('flushes remaining items on flush()', () => {
+      const sink = createWebhookDecisionSink(baseConfig, 'run_2');
+      sink.write(makeDecisionRecord('d1'));
+      sink.flush!();
+
+      expect(fetchCalls).toHaveLength(1);
+      const body = JSON.parse(fetchCalls[0].init.body as string);
+      expect(body.batch).toHaveLength(1);
+    });
+  });
+
+  describe('createWebhookTraceBackend', () => {
+    it('buffers spans on onSpanEnd and flushes at batchSize', () => {
+      const backend = createWebhookTraceBackend({ ...baseConfig, batchSize: 2 });
+
+      backend.onSpanEnd(makeTraceSpan('s1'));
+      expect(fetchCalls).toHaveLength(0);
+
+      backend.onSpanEnd(makeTraceSpan('s2'));
+      expect(fetchCalls).toHaveLength(1);
+
+      const body = JSON.parse(fetchCalls[0].init.body as string);
+      expect(body.type).toBe('traces');
+      expect(body.batch).toHaveLength(2);
+    });
+
+    it('onSpanStart is a no-op', () => {
+      const backend = createWebhookTraceBackend(baseConfig);
+      backend.onSpanStart(makeTraceSpan('s1'));
+      expect(fetchCalls).toHaveLength(0);
+    });
+
+    it('flushes remaining spans on shutdown', () => {
+      const backend = createWebhookTraceBackend(baseConfig);
+      backend.onSpanEnd(makeTraceSpan('s1'));
+      expect(fetchCalls).toHaveLength(0);
+
+      backend.shutdown!();
+      expect(fetchCalls).toHaveLength(1);
+    });
+
+    it('has name "webhook"', () => {
+      const backend = createWebhookTraceBackend(baseConfig);
+      expect(backend.name).toBe('webhook');
+    });
+  });
+
+  describe('timer-based flush', () => {
+    it('flushes on interval when flushIntervalMs > 0', async () => {
+      const config: WebhookConfig = {
+        url: 'https://logs.example.com/ingest',
+        batchSize: 100, // High threshold so only timer triggers flush
+        flushIntervalMs: 50,
+      };
+
+      const sink = createWebhookEventSink(config, 'run_timer');
+      sink.write(makeDomainEvent('e1'));
+      expect(fetchCalls).toHaveLength(0);
+
+      // Wait for timer to fire
+      await new Promise((r) => setTimeout(r, 80));
+      expect(fetchCalls).toHaveLength(1);
+
+      // Clean up: close sink to clear interval
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (sink as any).close();
+    });
+  });
+});


### PR DESCRIPTION
Add a new `webhook` storage backend that batches and POSTs domain events,
governance decisions, and trace spans to a configurable HTTP endpoint.
Enables streaming AgentGuard telemetry to any cloud log aggregator.

- New `src/storage/webhook-sink.ts` with batched sender, event/decision
  sinks, and TraceBackend implementation
- Extend StorageBackend type with 'webhook' option and config fields
- Wire webhook trace backend into kernel via new optional `tracer` field
  on KernelConfig, with top-level propose span instrumentation
- Integrate in guard.ts and claude-hook.ts CLI commands
- Config via --store webhook --webhook-url <url>, AGENTGUARD_WEBHOOK_URL,
  and AGENTGUARD_WEBHOOK_AUTH env vars
- 13 new tests covering batching, flush, timer, error handling, and all
  three sink types

https://claude.ai/code/session_01KDDtrhp2Lp5bbaGF86tf9c