### PR TITLE
docs: update all documentation for monorepo structure

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -37,44 +37,48 @@ All system activity — agent tool calls, governance decisions, invariant violat
 └──────────────────────────────────────────────┘
 ```
 
-## Directory Layout
+## Package Layout
 
-Each top-level directory under `src/` maps to a single architectural concept:
+This is a **pnpm monorepo** orchestrated by **Turbo**. Each workspace package maps to a single architectural concept:
 
 ```
-src/
-├── analytics/     Cross-session violation analytics (aggregation, clustering, trends, risk scoring)
-├── kernel/        Governed action kernel (orchestrate, normalize, decide, escalate)
-├── events/        Canonical event model (schema, bus, store, JSONL persistence)
-├── policy/        Policy system (composer, evaluator, loaders, pack loader)
-├── invariants/    Invariant system (10 built-in definitions, checker)
-├── adapters/      Execution adapters (file, shell, git, claude-code)
-├── plugins/       Plugin ecosystem (discovery, registry, validation, sandboxing)
-├── renderers/     Renderer plugin system (registry, TUI renderer)
-├── cli/           CLI entry point and commands
-├── storage/       Storage backends: SQLite and Firestore (opt-in alternatives to JSONL)
-├── telemetry/     Runtime telemetry and logging
-└── core/          Shared utilities (types, actions, hash, execution-log)
+packages/
+├── core/          @red-codes/core — Shared utilities (types, actions, hash, execution-log)
+├── events/        @red-codes/events — Canonical event model (schema, bus, store, JSONL persistence)
+├── policy/        @red-codes/policy — Policy system (composer, evaluator, loaders, pack loader)
+├── invariants/    @red-codes/invariants — Invariant system (10 built-in definitions, checker)
+├── kernel/        @red-codes/kernel — Governed action kernel (orchestrate, normalize, decide, escalate)
+├── adapters/      @red-codes/adapters — Execution adapters (file, shell, git, claude-code)
+├── analytics/     @red-codes/analytics — Cross-session violation analytics
+├── storage/       @red-codes/storage — SQLite and Firestore backends (opt-in)
+├── telemetry/     @red-codes/telemetry — Runtime telemetry and logging
+├── plugins/       @red-codes/plugins — Plugin ecosystem (discovery, registry, validation, sandboxing)
+└── renderers/     @red-codes/renderers — Renderer plugin system (registry, TUI renderer)
 
-vscode-extension/  VS Code extension (sidebar panels, notifications, event reader, inline diagnostics)
+apps/
+├── cli/           @red-codes/agentguard — CLI entry point and commands (published npm package)
+├── vscode-extension/  agentguard-vscode — VS Code extension (sidebar panels, notifications, diagnostics)
+└── telemetry-server/  Telemetry server (placeholder)
 
 policies/          Policy packs (YAML: ci-safe, enterprise, open-source, strict)
 ```
 
 ## Layer Rules
 
-- **kernel/** may import from events/, policy/, invariants/, adapters/, core/
-- **events/** may import from core/ only
-- **policy/** may import from core/ only
-- **invariants/** may import from core/, events/ only
-- **adapters/** may import from core/, kernel/ only
-- **plugins/** may import from core/, events/, kernel/ only
-- **renderers/** may import from core/, events/ only
-- **analytics/** may import from events/, core/ only
-- **storage/** may import from events/, core/ only
-- **cli/** may import from analytics/, kernel/, events/, policy/, plugins/, renderers/, storage/, core/
-- **telemetry/** may import from core/ only
-- **core/** has no project imports (leaf layer)
+Package boundaries enforce these dependency rules via `package.json` workspace dependencies:
+
+- **@red-codes/kernel** may import from events, policy, invariants, telemetry, core
+- **@red-codes/events** may import from core only
+- **@red-codes/policy** may import from core only
+- **@red-codes/invariants** may import from core, events only
+- **@red-codes/adapters** may import from core, kernel only
+- **@red-codes/plugins** may import from core only
+- **@red-codes/renderers** may import from core, kernel, plugins only
+- **@red-codes/analytics** may import from core only
+- **@red-codes/storage** may import from core, events, kernel, analytics, telemetry only
+- **@red-codes/agentguard** (cli) may import from all workspace packages
+- **@red-codes/telemetry** may import from core only
+- **@red-codes/core** has no project imports (leaf layer)
 
 ## Key Design Decisions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,14 +13,17 @@ The system has one architectural spine: the **canonical event model**. All syste
 - Escalation tracking: NORMAL → ELEVATED → HIGH → LOCKDOWN
 - JSONL event persistence for audit trail and replay
 - Claude Code adapter for PreToolUse/PostToolUse hooks
-- TypeScript source (`src/`), compiled to `dist/` via tsc + esbuild
+- **pnpm monorepo** with Turbo orchestration: 15 packages under `packages/`, 3 apps under `apps/`
+- Each package compiles independently via `tsc`; CLI bundle via `esbuild` in `apps/cli`
+- Scoped npm packages: `@red-codes/*` for workspace modules, `@red-codes/agentguard` for published CLI
 - CLI has runtime dependencies (`chokidar`, `commander`, `pino`); optional `better-sqlite3` for SQLite storage backend; optional Firestore for cloud-based governance data sharing
-- Build tooling: tsc + esbuild + vitest (dev dependencies only)
+- Build tooling: Turbo + tsc + esbuild + vitest (dev dependencies only)
 
 ## Quick Start
 
 ```bash
-npm run build:ts     # Compile TypeScript → dist/
+pnpm install         # Install dependencies
+pnpm build           # Build all packages (turbo build)
 
 # Governance runtime
 echo '{"tool":"Bash","command":"git push origin main"}' | npx agentguard guard --dry-run
@@ -31,123 +34,126 @@ npx agentguard events --last                    # Show raw event stream
 
 ## Project Structure
 
-TypeScript in `src/` is the **single source of truth**. It compiles to `dist/` via `tsc` (individual modules) + `esbuild` (CLI bundle).
+This is a **pnpm monorepo** orchestrated by **Turbo**. Workspace packages live in `packages/`, applications in `apps/`. Each package has its own `src/`, `dist/`, `package.json`, and `tsconfig.json`.
 
 **Top-level documentation**: `README.md`, `CLAUDE.md`, `ARCHITECTURE.md`, `ROADMAP.md`, `agentguard.yaml` (default policy)
 
 ```
-src/
-├── kernel/                 # Governed action kernel
-│   ├── kernel.ts           # Orchestrator (propose → evaluate → execute → emit)
-│   ├── aab.ts              # Action Authorization Boundary (normalization)
-│   ├── blast-radius.ts     # Weighted blast radius computation engine
-│   ├── decision.ts         # Runtime assurance engine
-│   ├── monitor.ts          # Escalation state machine
-│   ├── evidence.ts         # Evidence pack generation
-│   ├── replay-comparator.ts # Replay outcome comparison
-│   ├── replay-engine.ts    # Deterministic replay engine
-│   ├── replay-processor.ts # Replay event processor
-│   ├── heartbeat.ts        # Agent heartbeat monitor
-│   ├── decisions/          # Typed decision records
-│   │   ├── factory.ts      # Decision record factory
-│   │   └── types.ts        # Decision record type definitions
-│   └── simulation/         # Pre-execution impact simulation
+packages/
+├── core/src/                   # @red-codes/core — Shared utilities
+│   ├── types.ts                # Shared TypeScript type definitions
+│   ├── actions.ts              # 23 canonical action types across 8 classes
+│   ├── hash.ts                 # Content hashing utilities
+│   ├── adapters.ts             # Adapter registry interface
+│   ├── rng.ts                  # Seeded random number generator
+│   └── execution-log/          # Execution audit log
+│       ├── bridge.ts           # Bridge between event systems
+│       ├── event-log.ts        # Event logging
+│       ├── event-projections.ts # Event projections
+│       ├── event-schema.ts     # Event schema definitions
+│       └── index.ts            # Module re-exports
+├── events/src/                 # @red-codes/events — Canonical event model
+│   ├── schema.ts               # Event kinds, factory, validation
+│   ├── bus.ts                  # Generic typed EventBus
+│   ├── store.ts                # In-memory event store
+│   ├── jsonl.ts                # JSONL event persistence (audit trail)
+│   └── decision-jsonl.ts       # Decision record persistence
+├── policy/src/                 # @red-codes/policy — Policy system
+│   ├── composer.ts             # Policy composition (multi-file merging)
+│   ├── evaluator.ts            # Rule matching engine
+│   ├── loader.ts               # Policy validation + loading
+│   ├── pack-loader.ts          # Policy pack loader (community policy sets)
+│   └── yaml-loader.ts          # YAML policy parser
+├── invariants/src/             # @red-codes/invariants — Invariant system
+│   ├── definitions.ts          # 10 built-in invariant definitions
+│   └── checker.ts              # Invariant evaluation engine
+├── kernel/src/                 # @red-codes/kernel — Governed action kernel
+│   ├── kernel.ts               # Orchestrator (propose → evaluate → execute → emit)
+│   ├── aab.ts                  # Action Authorization Boundary (normalization)
+│   ├── blast-radius.ts         # Weighted blast radius computation engine
+│   ├── decision.ts             # Runtime assurance engine
+│   ├── monitor.ts              # Escalation state machine
+│   ├── evidence.ts             # Evidence pack generation
+│   ├── replay-comparator.ts    # Replay outcome comparison
+│   ├── replay-engine.ts        # Deterministic replay engine
+│   ├── replay-processor.ts     # Replay event processor
+│   ├── heartbeat.ts            # Agent heartbeat monitor
+│   ├── decisions/              # Typed decision records
+│   │   ├── factory.ts          # Decision record factory
+│   │   └── types.ts            # Decision record type definitions
+│   └── simulation/             # Pre-execution impact simulation
 │       ├── filesystem-simulator.ts  # File system impact simulation
 │       ├── git-simulator.ts         # Git operation simulation
 │       ├── package-simulator.ts     # Package change simulation
 │       ├── forecast.ts              # Impact forecast builder
 │       ├── registry.ts              # Simulator registry
 │       └── types.ts                 # Simulation type definitions
-├── events/                 # Canonical event model
-│   ├── schema.ts           # Event kinds, factory, validation
-│   ├── bus.ts              # Generic typed EventBus
-│   ├── store.ts            # In-memory event store
-│   ├── jsonl.ts            # JSONL event persistence (audit trail)
-│   └── decision-jsonl.ts   # Decision record persistence
-├── policy/                 # Policy system
-│   ├── composer.ts         # Policy composition (multi-file merging)
-│   ├── evaluator.ts        # Rule matching engine
-│   ├── loader.ts           # Policy validation + loading
-│   ├── pack-loader.ts      # Policy pack loader (community policy sets)
-│   └── yaml-loader.ts      # YAML policy parser
-├── invariants/             # Invariant system
-│   ├── definitions.ts      # 10 built-in invariant definitions
-│   └── checker.ts          # Invariant evaluation engine
-├── analytics/              # Cross-session violation analytics
-│   ├── aggregator.ts       # Violation aggregation across sessions
-│   ├── cluster.ts          # Violation clustering by dimension
-│   ├── engine.ts           # Analytics engine orchestrator
-│   ├── index.ts            # Module re-exports
-│   ├── reporter.ts         # Output formatters (terminal, JSON, markdown)
-│   ├── risk-scorer.ts      # Per-run risk scoring engine
-│   ├── trends.ts           # Violation trend computation
-│   └── types.ts            # Analytics type definitions
-├── adapters/               # Execution adapters
-│   ├── registry.ts         # Adapter registry (action class → handler)
+├── adapters/src/               # @red-codes/adapters — Execution adapters
+│   ├── registry.ts             # Adapter registry (action class → handler)
 │   ├── file.ts, shell.ts, git.ts  # Action handlers
-│   └── claude-code.ts      # Claude Code hook adapter
-├── cli/                    # CLI entry point + commands
-│   ├── bin.ts              # CLI entry point
-│   ├── args.ts             # Argument parsing utilities
-│   ├── colors.ts           # Terminal color helpers
-│   ├── tui.ts              # TUI renderer (terminal action stream)
-│   ├── policy-resolver.ts  # Policy file discovery and resolution
-│   ├── recorder.ts         # Event recording
-│   ├── replay.ts           # Session replay logic
-│   ├── session-store.ts    # Session management
-│   ├── file-event-store.ts # File-based event persistence
-│   ├── evidence-summary.ts # Evidence summary generator for PR reports
-│   └── commands/           # analytics, guard, inspect, replay, export, import, simulate, ci-check, plugin, policy, claude-hook, claude-init, init, diff, evidence-pr, traces
-├── plugins/                # Plugin ecosystem
-│   ├── discovery.ts        # Plugin discovery mechanism
-│   ├── registry.ts         # Plugin registry
-│   ├── sandbox.ts          # Plugin sandboxing
-│   ├── validator.ts        # Plugin validation
-│   ├── types.ts            # Plugin type definitions
-│   └── index.ts            # Module re-exports
-├── renderers/              # Renderer plugin system
-│   ├── registry.ts         # Renderer registry
-│   ├── tui-renderer.ts     # TUI renderer implementation
-│   ├── types.ts            # Renderer type definitions
-│   └── index.ts            # Module re-exports
-├── storage/                # Storage backends (SQLite + Firestore, opt-in)
-│   ├── factory.ts          # Storage bundle factory
-│   ├── index.ts            # Module re-exports
-│   ├── migrations.ts       # Schema migrations (version-based)
-│   ├── sqlite-analytics.ts # SQLite-backed analytics queries
-│   ├── sqlite-session.ts   # SQLite session lifecycle (insert on start, update on end)
-│   ├── sqlite-sink.ts      # SQLite event/decision sink
-│   ├── sqlite-store.ts     # SQLite event store implementation
-│   ├── firestore-analytics.ts # Firestore-backed analytics queries
-│   ├── firestore-sink.ts     # Firestore event/decision sink
-│   ├── firestore-store.ts    # Firestore event store implementation
-│   └── types.ts            # Storage type definitions
-├── telemetry/              # Runtime telemetry
-│   ├── index.ts            # Module re-exports
-│   ├── runtimeLogger.ts    # Runtime logging implementation
-│   ├── tracepoint.ts       # Kernel-level tracepoint interface
-│   ├── tracer.ts           # Tracepoint execution engine
-│   └── types.ts            # Telemetry type definitions
-└── core/                   # Shared utilities
-    ├── types.ts            # Shared TypeScript type definitions
-    ├── actions.ts          # 23 canonical action types across 8 classes
-    ├── hash.ts             # Content hashing utilities
-    ├── adapters.ts         # Adapter registry interface
-    ├── rng.ts              # Seeded random number generator
-    └── execution-log/      # Execution audit log
-        ├── bridge.ts       # Bridge between event systems
-        ├── event-log.ts    # Event logging
-        ├── event-projections.ts # Event projections
-        ├── event-schema.ts # Event schema definitions
-        └── index.ts        # Module re-exports
+│   └── claude-code.ts          # Claude Code hook adapter
+├── analytics/src/              # @red-codes/analytics — Cross-session violation analytics
+│   ├── aggregator.ts           # Violation aggregation across sessions
+│   ├── cluster.ts              # Violation clustering by dimension
+│   ├── engine.ts               # Analytics engine orchestrator
+│   ├── index.ts                # Module re-exports
+│   ├── reporter.ts             # Output formatters (terminal, JSON, markdown)
+│   ├── risk-scorer.ts          # Per-run risk scoring engine
+│   ├── trends.ts               # Violation trend computation
+│   └── types.ts                # Analytics type definitions
+├── plugins/src/                # @red-codes/plugins — Plugin ecosystem
+│   ├── discovery.ts            # Plugin discovery mechanism
+│   ├── registry.ts             # Plugin registry
+│   ├── sandbox.ts              # Plugin sandboxing
+│   ├── validator.ts            # Plugin validation
+│   ├── types.ts                # Plugin type definitions
+│   └── index.ts                # Module re-exports
+├── renderers/src/              # @red-codes/renderers — Renderer plugin system
+│   ├── registry.ts             # Renderer registry
+│   ├── tui-renderer.ts         # TUI renderer implementation
+│   ├── types.ts                # Renderer type definitions
+│   └── index.ts                # Module re-exports
+├── storage/src/                # @red-codes/storage — Storage backends (SQLite + Firestore, opt-in)
+│   ├── factory.ts              # Storage bundle factory
+│   ├── index.ts                # Module re-exports
+│   ├── migrations.ts           # Schema migrations (version-based)
+│   ├── sqlite-analytics.ts     # SQLite-backed analytics queries
+│   ├── sqlite-session.ts       # SQLite session lifecycle (insert on start, update on end)
+│   ├── sqlite-sink.ts          # SQLite event/decision sink
+│   ├── sqlite-store.ts         # SQLite event store implementation
+│   ├── firestore-analytics.ts  # Firestore-backed analytics queries
+│   ├── firestore-sink.ts       # Firestore event/decision sink
+│   ├── firestore-store.ts      # Firestore event store implementation
+│   └── types.ts                # Storage type definitions
+├── telemetry/src/              # @red-codes/telemetry — Runtime telemetry
+│   ├── index.ts                # Module re-exports
+│   ├── runtimeLogger.ts        # Runtime logging implementation
+│   ├── tracepoint.ts           # Kernel-level tracepoint interface
+│   ├── tracer.ts               # Tracepoint execution engine
+│   └── types.ts                # Telemetry type definitions
+├── runtime/src/                # @red-codes/runtime — Agent runtime (placeholder)
+├── sentinel01/src/             # @red-codes/sentinel01 — Robotics/edge module (placeholder)
+├── adapter-openclaw/src/       # @red-codes/adapter-openclaw — OpenClaw adapter (placeholder)
+└── telemetry-client/src/       # @red-codes/telemetry-client — Telemetry client (placeholder)
 
-vscode-extension/              # VS Code extension
-├── src/
-│   ├── extension.ts           # Extension entry point (sidebar panels, file watcher)
-│   ├── providers/             # Tree data providers (run status, run history, recent events)
-│   └── services/              # Event reader, notification formatter, notification service, diagnostics service, violation mapper
-├── package.json               # Extension manifest (activation, views, configuration)
-└── tsconfig.json              # Extension TypeScript config
+apps/
+├── cli/src/                    # @red-codes/agentguard — CLI (published npm package)
+│   ├── bin.ts                  # CLI entry point
+│   ├── args.ts                 # Argument parsing utilities
+│   ├── colors.ts               # Terminal color helpers
+│   ├── tui.ts                  # TUI renderer (terminal action stream)
+│   ├── policy-resolver.ts      # Policy file discovery and resolution
+│   ├── recorder.ts             # Event recording
+│   ├── replay.ts               # Session replay logic
+│   ├── session-store.ts        # Session management
+│   ├── file-event-store.ts     # File-based event persistence
+│   ├── evidence-summary.ts     # Evidence summary generator for PR reports
+│   └── commands/               # analytics, guard, inspect, replay, export, import, simulate, ci-check, plugin, policy, claude-hook, claude-init, init, diff, evidence-pr, traces
+├── vscode-extension/src/       # agentguard-vscode — VS Code extension
+│   ├── extension.ts            # Extension entry point (sidebar panels, file watcher)
+│   ├── providers/              # Tree data providers (run status, run history, recent events)
+│   └── services/               # Event reader, notification formatter, notification service, diagnostics service, violation mapper
+└── telemetry-server/src/       # @red-codes/telemetry-server — Telemetry server (placeholder)
 
 tests/
 ├── *.test.js               # 14 JS test files (custom zero-dependency harness)
@@ -168,24 +174,24 @@ templates/                  # Policy templates (ci-only, development, permissive
 ## Development Commands
 
 ```bash
-# TypeScript build (required before running tests or CLI)
-npm run build:ts           # Build TypeScript (tsc + esbuild → dist/)
-npm run ts:check           # Type-check TypeScript (tsc --noEmit)
+# Build all packages (Turbo orchestrates per-package tsc + esbuild for CLI)
+pnpm build                 # Build all packages (turbo build)
+pnpm ts:check              # Type-check all packages (turbo ts:check)
 
 # Run tests
-npm test                   # Run JS tests
-npm run ts:test            # Run TypeScript tests (vitest)
-npm run ts:test:watch      # Run TypeScript tests in watch mode
-npm run test:coverage      # Run with coverage (c8, 50% line threshold)
+pnpm test                  # Run all tests across workspace (turbo test)
 
 # Code quality
-npm run lint               # Run ESLint
-npm run lint:fix           # Run ESLint with auto-fix
-npm run format             # Check formatting (Prettier)
-npm run format:fix         # Fix formatting (Prettier)
+pnpm lint                  # Run ESLint across all packages (turbo lint)
+pnpm format                # Check formatting (Prettier)
+pnpm format:fix            # Fix formatting (Prettier)
+
+# Per-package filtering
+pnpm build --filter=@red-codes/kernel     # Build a single package
+pnpm test --filter=@red-codes/kernel      # Test a single package
 
 # Run AgentGuard CLI
-npm run dev
+pnpm dev
 ```
 
 ## Architecture & Key Patterns
@@ -200,23 +206,23 @@ The kernel loop is the core of AgentGuard. Every agent action passes through it:
 6. Emit lifecycle events: `ACTION_REQUESTED` → `ACTION_ALLOWED/DENIED` → `ACTION_EXECUTED/FAILED`
 7. Sink all events to JSONL for audit trail
 
-Key files: `kernel/kernel.ts`, `kernel/aab.ts`, `kernel/decision.ts`, `kernel/monitor.ts`
+Key files: `packages/kernel/src/kernel.ts`, `packages/kernel/src/aab.ts`, `packages/kernel/src/decision.ts`, `packages/kernel/src/monitor.ts`
 See `docs/unified-architecture.md` for the full model.
 
-### Directory Layout
-Each top-level directory maps to a single architectural concept:
-- **src/analytics/** — Cross-session violation analytics (aggregation, clustering, trends, risk scoring, reporting)
-- **src/kernel/** — Governed action kernel, escalation, evidence, decisions, simulation
-- **src/events/** — Canonical event model (schema, bus, store, persistence)
-- **src/policy/** — Policy evaluator + loaders (YAML/JSON, pack loader)
-- **src/invariants/** — Invariant definitions + checker
-- **src/adapters/** — Execution adapters (file, shell, git, claude-code)
-- **src/plugins/** — Plugin ecosystem (discovery, registry, validation, sandboxing)
-- **src/renderers/** — Renderer plugin system (registry, TUI renderer)
-- **src/cli/** — CLI entry point and commands
-- **src/core/** — Shared utilities (types, actions, hash, execution-log)
-- **src/storage/** — Storage backends: SQLite and Firestore (opt-in alternatives to JSONL, indexed queries)
-- **src/telemetry/** — Runtime telemetry and logging
+### Package Layout
+Each workspace package maps to a single architectural concept:
+- **packages/analytics/** — Cross-session violation analytics (aggregation, clustering, trends, risk scoring, reporting)
+- **packages/kernel/** — Governed action kernel, escalation, evidence, decisions, simulation
+- **packages/events/** — Canonical event model (schema, bus, store, persistence)
+- **packages/policy/** — Policy evaluator + loaders (YAML/JSON, pack loader)
+- **packages/invariants/** — Invariant definitions + checker
+- **packages/adapters/** — Execution adapters (file, shell, git, claude-code)
+- **packages/plugins/** — Plugin ecosystem (discovery, registry, validation, sandboxing)
+- **packages/renderers/** — Renderer plugin system (registry, TUI renderer)
+- **apps/cli/** — CLI entry point and commands (published as `@red-codes/agentguard`)
+- **packages/core/** — Shared utilities (types, actions, hash, execution-log)
+- **packages/storage/** — Storage backends: SQLite and Firestore (opt-in alternatives to JSONL, indexed queries)
+- **packages/telemetry/** — Runtime telemetry and logging
 
 ### CLI Commands
 - `agentguard analytics` — Analyze violation patterns across governance sessions
@@ -240,7 +246,7 @@ Each top-level directory maps to a single architectural concept:
 - `agentguard init <type>` — Scaffold governance extensions (invariant, policy-pack, adapter, renderer, replay-processor, firestore)
 
 ### Event Model
-The canonical event model is the architectural spine. Event kinds defined in `src/events/schema.ts`:
+The canonical event model is the architectural spine. Event kinds defined in `packages/events/src/schema.ts`:
 - **Governance**: `PolicyDenied`, `UnauthorizedAction`, `InvariantViolation`
 - **Lifecycle**: `RunStarted`, `RunEnded`, `CheckpointReached`, `StateChanged`
 - **Safety**: `BlastRadiusExceeded`, `MergeGuardFailure`, `EvidencePackGenerated`
@@ -255,7 +261,7 @@ The canonical event model is the architectural spine. Event kinds defined in `sr
 - **Ingestion**: `ErrorObserved`, `BugClassified`, `ActivityRecorded`, `EvolutionTriggered`
 
 ### Action Classes & Types
-23 canonical action types across 8 classes, defined in `src/core/actions.ts`:
+23 canonical action types across 8 classes, defined in `packages/core/src/actions.ts`:
 - **file**: `file.read`, `file.write`, `file.delete`, `file.move`
 - **test**: `test.run`, `test.run.unit`, `test.run.integration`
 - **git**: `git.diff`, `git.commit`, `git.push`, `git.branch.create`, `git.branch.delete`, `git.checkout`, `git.reset`, `git.merge`
@@ -266,7 +272,7 @@ The canonical event model is the architectural spine. Event kinds defined in `sr
 - **infra**: `infra.apply`, `infra.destroy`
 
 ### Build & Module System
-TypeScript source compiles via `tsc` (individual modules for tests/imports) + `esbuild` (CLI bundle).
+Turbo orchestrates per-package `tsc` builds (incremental via TypeScript project references). The CLI app (`apps/cli`) is additionally bundled via `esbuild`. Workspace imports use `@red-codes/*` scoped package names.
 
 ## Coding Conventions
 
@@ -276,16 +282,18 @@ TypeScript source compiles via `tsc` (individual modules for tests/imports) + `e
 - Arrow functions preferred
 - **ESLint** enforced via `eslint.config.js` (flat config): `no-var`, `prefer-const`, `eqeqeq`, `no-undef`
 - **Prettier** enforced via `.prettierrc` for consistent formatting
-- Run `npm run lint` and `npm run format` before committing
+- Run `pnpm lint` and `pnpm format` before committing
 - Node.js ≥18 required
 
 ### Configuration
 
-**TypeScript** (`tsconfig.json`):
+**TypeScript** (`tsconfig.base.json` + per-package `tsconfig.json`):
+- Root `tsconfig.base.json` defines shared compiler options; each package extends it
+- Root `tsconfig.json` declares project references for all packages and apps
 - Target: ES2022, Module: ESNext, ModuleResolution: bundler
 - Strict mode enabled, plus `noUnusedLocals`, `noUnusedParameters`, `noFallthroughCasesInSwitch`
 - `verbatimModuleSyntax: true` — use `import type` for type-only imports
-- Source: `src/`, Output: `dist/`, with declarations and source maps
+- Each package has its own `src/` → `dist/` with declarations and source maps
 
 **Prettier** (`.prettierrc`):
 - Single quotes, trailing commas (es5), printWidth 100, tabWidth 2, semicolons
@@ -297,13 +305,12 @@ TypeScript source compiles via `tsc` (individual modules for tests/imports) + `e
 ## Testing
 
 ```bash
-npm test                   # Run JS tests
-npm run ts:test            # Run TypeScript tests (vitest)
-npm run ts:test:watch      # Run TypeScript tests in watch mode
-npm run test:coverage      # Run with coverage (c8, 50% line threshold)
+pnpm test                  # Run all tests across workspace (turbo test)
+pnpm test --filter=@red-codes/kernel  # Test a single package
 ```
 
 **Test structure:**
+- **Vitest workspace** (`vitest.workspace.ts`): orchestrates tests across all packages
 - **JS tests** (`tests/*.test.js`): 14 files using a custom zero-dependency harness (`tests/run.js` with `node:assert`)
 - **TypeScript tests** (`tests/ts/*.test.ts`): 77 files using vitest
 - **Coverage areas**: adapters, analytics (including risk scorer), kernel (AAB, engine, monitor, blast radius, heartbeat, integration, e2e pipeline), CLI commands (args, guard, inspect, init, simulate, ci-check, claude-hook, claude-init, export/import, policy-validate, diff, evidence-pr, traces), decision records, domain models, events, evidence packs, evidence summary, execution log, export-import roundtrip, impact forecast, invariants, JSONL persistence, notification formatter, plugins (discovery, registry, validation), policy evaluation (including composer, pack loader, policy packs, evaluation trace), renderers, replay (engine, comparator, processor), simulation, SQLite storage (analytics, commands, migrations, session, sink, store, factory), Firestore storage, telemetry (including tracepoint), TUI renderer, violation mapper, VS Code event reader, YAML loading

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,28 +5,30 @@ Thanks for your interest in contributing to AgentGuard -- a governed action runt
 ## Getting Started
 
 ```bash
-git clone https://github.com/jpleva91/agent-guard.git
+git clone https://github.com/AgentGuardHQ/agent-guard.git
 cd agent-guard
-npm install
-npm run build:ts
+pnpm install
+pnpm build
 ```
 
-The TypeScript source in `src/` is the single source of truth. It compiles to `dist/` via `tsc` (individual modules) and `esbuild` (CLI bundle). All tests import from `dist/`, so you must build before running them.
+This is a **pnpm monorepo** orchestrated by **Turbo**. Workspace packages live in `packages/`, applications in `apps/`. Each package has its own `src/`, `dist/`, `package.json`, and `tsconfig.json`. All tests import from `dist/`, so you must build before running them.
 
 ## Development
 
 ```bash
-npm run build:ts       # Compile TypeScript to dist/
-npm test               # Run JS test suite
-npm run ts:test        # Run TypeScript tests (vitest)
-npm run lint           # Check code with ESLint
-npm run lint:fix       # Auto-fix lint issues
-npm run format         # Check formatting with Prettier
-npm run format:fix     # Auto-fix formatting
-npm run ts:check       # Type-check without emitting (tsc --noEmit)
+pnpm build             # Build all packages (turbo build)
+pnpm test              # Run all tests (turbo test)
+pnpm lint              # Check code with ESLint (turbo lint)
+pnpm format            # Check formatting with Prettier
+pnpm format:fix        # Auto-fix formatting
+pnpm ts:check          # Type-check all packages (turbo ts:check)
+
+# Per-package filtering
+pnpm build --filter=@red-codes/kernel   # Build a single package
+pnpm test --filter=@red-codes/kernel    # Test a single package
 ```
 
-Run `npm run build:ts` after making changes, then run both test suites before submitting a PR.
+Run `pnpm build` after making changes, then run tests before submitting a PR.
 
 ## How to Contribute
 
@@ -57,9 +59,9 @@ Invariants are runtime checks that verify system state before an action executes
 
 To add a new invariant:
 
-1. Open `src/invariants/` (or `src/agentguard/invariants/definitions.ts` on main)
+1. Open `packages/invariants/src/definitions.ts`
 2. Add a check function that returns a violation result with a severity level
-3. Register the invariant in the checker
+3. Register the invariant in the checker (`packages/invariants/src/checker.ts`)
 4. Add tests covering the new check
 
 ### Bug Fixes and Improvements
@@ -71,30 +73,36 @@ To add a new invariant:
 ## Project Structure
 
 ```
-src/
-├── kernel/          # Governed action kernel (orchestrator)
-├── events/          # Canonical event model and lifecycle events
-├── policy/          # Policy evaluator, YAML/JSON loaders
-├── invariants/      # Invariant checker and built-in definitions
-├── adapters/        # Execution adapters (file, shell, git, claude-code)
-├── core/            # Shared logic (EventBus, types, hashing)
-├── cli/             # CLI entry point and commands (guard, inspect, replay)
-│   └── commands/    # Individual CLI subcommands
-├── domain/          # Pure domain logic (actions, events, reference monitor)
-└── agentguard/      # Legacy kernel location (being consolidated)
+packages/
+├── core/            # @red-codes/core — Shared types, actions, hash, utilities
+├── events/          # @red-codes/events — Canonical event model (schema, bus, store, JSONL)
+├── policy/          # @red-codes/policy — Policy evaluator, YAML/JSON loaders, composition
+├── invariants/      # @red-codes/invariants — Invariant checker and built-in definitions
+├── kernel/          # @red-codes/kernel — Governed action kernel (orchestrator, AAB, decisions)
+├── adapters/        # @red-codes/adapters — Execution adapters (file, shell, git, claude-code)
+├── analytics/       # @red-codes/analytics — Cross-session violation analytics
+├── storage/         # @red-codes/storage — SQLite + Firestore backends (opt-in)
+├── telemetry/       # @red-codes/telemetry — Runtime telemetry and logging
+├── plugins/         # @red-codes/plugins — Plugin ecosystem (discovery, registry, sandboxing)
+└── renderers/       # @red-codes/renderers — Renderer plugin system (TUI renderer)
+
+apps/
+├── cli/             # @red-codes/agentguard — CLI (published npm package)
+│   └── src/commands/  # Individual CLI subcommands
+└── vscode-extension/  # agentguard-vscode — VS Code extension
 
 policy/              # Policy configuration files (JSON)
-tests/               # Test suite (JS + TypeScript)
-dist/                # Compiled output (generated, do not edit)
+policies/            # Policy packs (YAML: ci-safe, enterprise, open-source, strict)
+tests/               # Root-level test suite (JS + TypeScript)
 ```
 
 ## Pull Request Process
 
 1. Fork the repository and create a branch from `main`
-2. Make your changes in `src/` (never edit `dist/` directly)
-3. Run `npm run build:ts` to compile
-4. Run `npm test` and `npm run ts:test` to verify all tests pass
-5. Run `npm run lint` and `npm run format` to check code style
+2. Make your changes in the relevant `packages/*/src/` or `apps/*/src/` directory (never edit `dist/` directly)
+3. Run `pnpm build` to compile
+4. Run `pnpm test` to verify all tests pass
+5. Run `pnpm lint` and `pnpm format` to check code style
 6. Open a PR against `main` with a clear description of what changed and why
 
 ## Code Style

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ agent proposes action  →  policy evaluated  →  invariants checked  →  allo
 ```bash
 git clone https://github.com/AgentGuardHQ/agent-guard.git
 cd agent-guard
-npm install && npm run build:ts
+pnpm install && pnpm build
 
 # Evaluate a sample action against the default policy
 echo '{"tool":"Bash","command":"git push origin main"}' | npx agentguard guard --dry-run
@@ -238,77 +238,38 @@ Full kernel loop detail: [docs/unified-architecture.md](docs/unified-architectur
 
 ### Repository Structure
 
+This is a **pnpm monorepo** orchestrated by **Turbo**. Workspace packages live in `packages/`, applications in `apps/`.
+
 ```
-src/
-├── kernel/                 # Governed action kernel
-│   ├── kernel.ts           # Orchestrator (propose → evaluate → execute → emit)
-│   ├── aab.ts              # Action Authorization Boundary (normalization)
-│   ├── blast-radius.ts     # Weighted blast radius computation engine
-│   ├── decision.ts         # Runtime assurance engine
-│   ├── monitor.ts          # Escalation state machine
-│   ├── evidence.ts         # Evidence pack generation
-│   ├── replay-comparator.ts # Replay outcome comparison
-│   ├── replay-engine.ts    # Deterministic replay engine
-│   ├── replay-processor.ts # Replay event processor
-│   ├── heartbeat.ts        # Agent heartbeat monitor
-│   ├── decisions/          # Typed decision records
-│   └── simulation/         # Pre-execution impact simulation
-├── events/                 # Canonical event model
-│   ├── schema.ts           # Event kinds, factory, validation
-│   ├── bus.ts              # Generic typed EventBus
-│   ├── store.ts            # In-memory event store
-│   ├── jsonl.ts            # JSONL event persistence (audit trail)
-│   └── decision-jsonl.ts   # Decision record persistence
-├── policy/                 # Policy system
-│   ├── composer.ts         # Policy composition (multi-file merging)
-│   ├── evaluator.ts        # Rule matching engine
-│   ├── loader.ts           # Policy validation + loading
-│   ├── pack-loader.ts      # Policy pack loader (community policy sets)
-│   └── yaml-loader.ts      # YAML policy parser
-├── invariants/             # Invariant system
-│   ├── definitions.ts      # 10 built-in invariants
-│   └── checker.ts          # Invariant evaluation engine
-├── analytics/              # Cross-session violation analytics
-│   ├── aggregator.ts       # Violation aggregation across sessions
-│   ├── cluster.ts          # Violation clustering by dimension
-│   ├── engine.ts           # Analytics engine orchestrator
-│   ├── index.ts            # Module re-exports
-│   ├── reporter.ts         # Output formatters (terminal, JSON, markdown)
-│   ├── risk-scorer.ts      # Per-run risk scoring engine
-│   ├── trends.ts           # Violation trend computation
-│   └── types.ts            # Analytics type definitions
-├── adapters/               # Execution adapters
-│   ├── file.ts, shell.ts, git.ts  # Action handlers
-│   ├── claude-code.ts      # Claude Code hook adapter
-│   └── registry.ts         # Adapter registry
-├── plugins/                # Plugin ecosystem
-│   ├── discovery.ts        # Plugin discovery mechanism
-│   ├── registry.ts         # Plugin registry
-│   ├── sandbox.ts          # Plugin sandboxing
-│   ├── validator.ts        # Plugin validation
-│   ├── types.ts            # Plugin type definitions
-│   └── index.ts            # Module re-exports
-├── renderers/              # Renderer plugin system
-│   ├── registry.ts         # Renderer registry
-│   ├── tui-renderer.ts     # TUI renderer implementation
-│   ├── types.ts            # Renderer type definitions
-│   └── index.ts            # Module re-exports
-├── cli/                    # CLI entry point + commands
-│   ├── bin.ts              # Main entry
+packages/
+├── core/src/               # @red-codes/core — Shared types, actions, hash, rng, execution-log
+├── events/src/             # @red-codes/events — Canonical event model (schema, bus, store, JSONL)
+├── policy/src/             # @red-codes/policy — Policy evaluation, YAML/JSON loaders, composition
+├── invariants/src/         # @red-codes/invariants — 10 built-in invariant definitions + checker
+├── kernel/src/             # @red-codes/kernel — Governed action kernel (orchestrator, AAB, decisions, simulation)
+├── adapters/src/           # @red-codes/adapters — Execution adapters (file, shell, git, claude-code)
+├── analytics/src/          # @red-codes/analytics — Cross-session violation analytics
+├── storage/src/            # @red-codes/storage — SQLite + Firestore backends (opt-in)
+├── telemetry/src/          # @red-codes/telemetry — Runtime telemetry and logging
+├── plugins/src/            # @red-codes/plugins — Plugin ecosystem (discovery, registry, sandboxing)
+├── renderers/src/          # @red-codes/renderers — Renderer plugin system (TUI renderer)
+├── runtime/src/            # @red-codes/runtime — Agent runtime (placeholder)
+├── sentinel01/src/         # @red-codes/sentinel01 — Robotics/edge module (placeholder)
+├── adapter-openclaw/src/   # @red-codes/adapter-openclaw — OpenClaw adapter (placeholder)
+└── telemetry-client/src/   # @red-codes/telemetry-client — Telemetry client (placeholder)
+
+apps/
+├── cli/src/                # @red-codes/agentguard — CLI (published npm package)
+│   ├── bin.ts              # CLI entry point
 │   ├── evidence-summary.ts # Evidence summary generator for PR reports
-│   └── commands/           # analytics, guard, inspect, replay, export, import, simulate, ci-check, plugin, policy, claude-hook, claude-init, init, diff, evidence-pr, traces
-├── storage/                # Storage backends: SQLite and Firestore (opt-in alternatives to JSONL)
-├── telemetry/              # Runtime telemetry and logging
-└── core/                   # Shared utilities (types, actions, hash, rng, execution-log)
+│   └── commands/           # analytics, guard, inspect, replay, export, import, simulate, ci-check, etc.
+├── vscode-extension/src/   # agentguard-vscode — VS Code extension
+│   ├── extension.ts        # Sidebar panels, file watcher, notifications
+│   ├── providers/          # Tree data providers (run status, run history, recent events)
+│   └── services/           # Event reader, notification formatter, diagnostics, violation mapper
+└── telemetry-server/src/   # Telemetry server (placeholder)
 
-vscode-extension/              # VS Code extension
-├── src/
-│   ├── extension.ts           # Sidebar panels, file watcher, notifications
-│   ├── providers/             # Tree data providers (run status, run history, recent events)
-│   └── services/              # Event reader, notification formatter + service, diagnostics, violation mapper
-└── package.json               # Extension manifest
-
-policies/                      # Policy packs (YAML: ci-safe, enterprise, open-source, strict)
+policies/                   # Policy packs (YAML: ci-safe, enterprise, open-source, strict)
 ```
 
 ## Run Locally
@@ -316,10 +277,9 @@ policies/                      # Policy packs (YAML: ci-safe, enterprise, open-s
 ```bash
 git clone https://github.com/AgentGuardHQ/agent-guard.git
 cd agent-guard
-npm install
-npm run build:ts        # Compile TypeScript → dist/
-npm run ts:test         # Run TypeScript tests (vitest)
-npm test                # Run JavaScript tests
+pnpm install            # Install dependencies
+pnpm build              # Build all packages (turbo build)
+pnpm test               # Run all tests (turbo test)
 ```
 
 ## Documentation

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -56,31 +56,31 @@ A comprehensive codebase audit assessed the current system against the strategic
 
 | Component | Status | Key Files |
 |-----------|--------|-----------|
-| Canonical Action Representation (23 types, 8 classes) | Implemented | `src/core/actions.ts` |
-| Action Authorization Boundary (AAB) | Implemented (2 bypass vectors) | `src/kernel/aab.ts` |
-| Policy Evaluator (two-phase deny/allow) | Implemented | `src/policy/evaluator.ts` |
-| 10 Built-in Invariants | Fully Implemented | `src/invariants/definitions.ts`, `src/invariants/checker.ts` |
-| Event Model (49 event kinds) | Comprehensive | `src/events/schema.ts` |
-| JSONL Persistence | Implemented | `src/events/jsonl.ts` |
-| Simulation Engine (3 simulators + impact forecast) | Fully Implemented | `src/kernel/simulation/` |
-| Blast Radius Computation | Implemented | `src/kernel/blast-radius.ts` |
-| Escalation State Machine (NORMAL → LOCKDOWN) | Implemented | `src/kernel/monitor.ts` |
-| Replay Engine + Comparator | Implemented | `src/kernel/replay-engine.ts`, `src/kernel/replay-comparator.ts` |
-| Evidence Pack Generation | Implemented | `src/kernel/evidence.ts` |
-| Decision Record Factory | Implemented | `src/kernel/decisions/factory.ts` |
+| Canonical Action Representation (23 types, 8 classes) | Implemented | `packages/core/src/actions.ts` |
+| Action Authorization Boundary (AAB) | Implemented (2 bypass vectors) | `packages/kernel/src/aab.ts` |
+| Policy Evaluator (two-phase deny/allow) | Implemented | `packages/policy/src/evaluator.ts` |
+| 10 Built-in Invariants | Fully Implemented | `packages/invariants/src/definitions.ts`, `packages/invariants/src/checker.ts` |
+| Event Model (49 event kinds) | Comprehensive | `packages/events/src/schema.ts` |
+| JSONL Persistence | Implemented | `packages/events/src/jsonl.ts` |
+| Simulation Engine (3 simulators + impact forecast) | Fully Implemented | `packages/kernel/src/simulation/` |
+| Blast Radius Computation | Implemented | `packages/kernel/src/blast-radius.ts` |
+| Escalation State Machine (NORMAL → LOCKDOWN) | Implemented | `packages/kernel/src/monitor.ts` |
+| Replay Engine + Comparator | Implemented | `packages/kernel/src/replay-engine.ts`, `packages/kernel/src/replay-comparator.ts` |
+| Evidence Pack Generation | Implemented | `packages/kernel/src/evidence.ts` |
+| Decision Record Factory | Implemented | `packages/kernel/src/decisions/factory.ts` |
 
 ### Supporting Systems — Functional
 
 | Component | Status | Key Files |
 |-----------|--------|-----------|
-| Cross-session Analytics (aggregation, clustering, trends) | Implemented | `src/analytics/` |
-| Plugin Ecosystem (discovery, registry, validation) | Implemented | `src/plugins/` |
-| Renderer Plugin System | Implemented | `src/renderers/` |
-| CLI (guard, inspect, events, replay, export, import, simulate, ci-check, analytics, plugin, policy, claude-hook, claude-init, init, diff, evidence-pr, traces) | Implemented | `src/cli/` |
-| Claude Code Hook Integration | Implemented | `src/adapters/claude-code.ts` |
-| VS Code Extension (sidebar panels, event reader, inline diagnostics) | Implemented | `vscode-extension/` |
-| Policy Pack Loader | Implemented | `src/policy/pack-loader.ts` |
-| YAML Policy Parser | Implemented | `src/policy/yaml-loader.ts` |
+| Cross-session Analytics (aggregation, clustering, trends) | Implemented | `packages/analytics/src/` |
+| Plugin Ecosystem (discovery, registry, validation) | Implemented | `packages/plugins/src/` |
+| Renderer Plugin System | Implemented | `packages/renderers/src/` |
+| CLI (guard, inspect, events, replay, export, import, simulate, ci-check, analytics, plugin, policy, claude-hook, claude-init, init, diff, evidence-pr, traces) | Implemented | `apps/cli/src/` |
+| Claude Code Hook Integration | Implemented | `packages/adapters/src/claude-code.ts` |
+| VS Code Extension (sidebar panels, event reader, inline diagnostics) | Implemented | `apps/vscode-extension/` |
+| Policy Pack Loader | Implemented | `packages/policy/src/pack-loader.ts` |
+| YAML Policy Parser | Implemented | `packages/policy/src/yaml-loader.ts` |
 
 ### Advanced Roadmap Items — Status
 
@@ -115,7 +115,7 @@ A comprehensive codebase audit assessed the current system against the strategic
 | P-1b Transactional Protocol | Not Started | Aspirational |
 | Confidence-Based HITL | Partial | Labels only |
 | Multi-Agent Identity | Aspirational | Types exist, no enforcement |
-| Shared State & Heartbeat | Partial | Heartbeat implemented (`src/kernel/heartbeat.ts`) |
+| Shared State & Heartbeat | Partial | Heartbeat implemented (`packages/kernel/src/heartbeat.ts`) |
 | Formal Verification (Z3) | Not Started | Aspirational |
 | Automated Invariant Learning | Not Started | Aspirational |
 
@@ -128,24 +128,24 @@ A comprehensive codebase audit assessed the current system against the strategic
 One bypass path remains in the AAB (one previously identified vector has been resolved):
 
 **1. Unknown actions default-allow.**
-`src/policy/evaluator.ts` returns `allowed: true` when no policy rule matches an action. Unrecognized tool calls pass through governance unchecked. This violates the core principle of reference monitors: default deny.
+`packages/policy/src/evaluator.ts` returns `allowed: true` when no policy rule matches an action. Unrecognized tool calls pass through governance unchecked. This violates the core principle of reference monitors: default deny.
 
 **~~2. Missing adapters silently skip execution.~~ — Resolved.**
-`src/kernel/kernel.ts` now emits `ActionDenied` when no registered adapter exists, closing this bypass vector.
+`packages/kernel/src/kernel.ts` now emits `ActionDenied` when no registered adapter exists, closing this bypass vector.
 
 ### Claims Requiring Correction
 
 - **"Complete Mediation"** — Not achieved due to the remaining default-allow bypass vector above.
 - **"Tamper-proof"** — Event sink errors are silently swallowed. Escalation state can be reset without audit lock.
-- **Intervention types (PAUSE, ROLLBACK, TEST_ONLY)** — Defined in `src/kernel/decision.ts` but only DENY is enforced. Others are metadata labels.
+- **Intervention types (PAUSE, ROLLBACK, TEST_ONLY)** — Defined in `packages/kernel/src/decision.ts` but only DENY is enforced. Others are metadata labels.
 
 ### Destructive Pattern Coverage Gap — Resolved
 
-The AAB now detects 87 destructive shell patterns (`src/kernel/aab.ts`), expanded from the original 10. Coverage includes `sudo`, `pkill`, `killall`, `truncate`, `shred`, `chown`, `docker rm/rmi/system prune`, `systemctl stop/disable`, database-specific DROP commands, `npm uninstall -g`, and many more.
+The AAB now detects 87 destructive shell patterns (`packages/kernel/src/aab.ts`), expanded from the original 10. Coverage includes `sudo`, `pkill`, `killall`, `truncate`, `shred`, `chown`, `docker rm/rmi/system prune`, `systemctl stop/disable`, database-specific DROP commands, `npm uninstall -g`, and many more.
 
 ### Escalation Audit Gap — Resolved
 
-Monitor escalation state transitions are now persisted as `StateChanged` DomainEvents in the event store (`src/kernel/monitor.ts`). State changes include trigger action, denial/violation counts, and threshold values.
+Monitor escalation state transitions are now persisted as `StateChanged` DomainEvents in the event store (`packages/kernel/src/monitor.ts`). State changes include trigger action, denial/violation counts, and threshold values.
 
 ---
 
@@ -179,21 +179,21 @@ Monitor escalation state transitions are now persisted as `StateChanged` DomainE
 
 > **Theme:** Deterministic agent governance
 
-- [x] Action Authorization Boundary (AAB) implementation (`src/kernel/aab.ts`)
+- [x] Action Authorization Boundary (AAB) implementation (`packages/kernel/src/aab.ts`)
 - [x] Policy definition format (JSON + YAML) (`policy/action_rules.json`)
-- [x] Policy loader and parser (`src/policy/loader.ts`)
-- [x] Deterministic policy evaluator (`src/policy/evaluator.ts`)
-- [x] Invariant monitoring engine (`src/invariants/checker.ts`)
-- [x] Built-in invariants (`src/invariants/definitions.ts`)
-- [x] Blast radius computation (`src/kernel/blast-radius.ts`)
-- [x] Evidence pack generation and persistence (`src/kernel/evidence.ts`)
+- [x] Policy loader and parser (`packages/policy/src/loader.ts`)
+- [x] Deterministic policy evaluator (`packages/policy/src/evaluator.ts`)
+- [x] Invariant monitoring engine (`packages/invariants/src/checker.ts`)
+- [x] Built-in invariants (`packages/invariants/src/definitions.ts`)
+- [x] Blast radius computation (`packages/kernel/src/blast-radius.ts`)
+- [x] Evidence pack generation and persistence (`packages/kernel/src/evidence.ts`)
 - [x] CLI governance commands (`agentguard guard`, `agentguard inspect`)
 - [x] Governance event emission into canonical event model
-- [x] Integration with Claude Code hook (`src/adapters/claude-code.ts`, `src/cli/commands/claude-hook.ts`)
-- [x] Pre-execution simulation engine (`src/kernel/simulation/`)
-- [x] Filesystem simulator — risk assessment by path pattern (`src/kernel/simulation/filesystem-simulator.ts`)
-- [x] Git simulator — push/merge/branch impact analysis (`src/kernel/simulation/git-simulator.ts`)
-- [x] Package simulator — dependency change detection via dry-run (`src/kernel/simulation/package-simulator.ts`)
+- [x] Integration with Claude Code hook (`packages/adapters/src/claude-code.ts`, `apps/cli/src/commands/claude-hook.ts`)
+- [x] Pre-execution simulation engine (`packages/kernel/src/simulation/`)
+- [x] Filesystem simulator — risk assessment by path pattern (`packages/kernel/src/simulation/filesystem-simulator.ts`)
+- [x] Git simulator — push/merge/branch impact analysis (`packages/kernel/src/simulation/git-simulator.ts`)
+- [x] Package simulator — dependency change detection via dry-run (`packages/kernel/src/simulation/package-simulator.ts`)
 - [x] Simulation-triggered invariant re-evaluation (high-risk simulation flips ALLOW → DENY)
 - [x] `SIMULATION_COMPLETED` event kind with blast radius and risk level
 
@@ -201,33 +201,33 @@ Monitor escalation state transitions are now persisted as `StateChanged` DomainE
 
 > **Theme:** Every session is replayable
 
-- [x] File-based event store (`src/cli/file-event-store.ts`)
+- [x] File-based event store (`apps/cli/src/file-event-store.ts`)
 - [x] Event stream serialization (NDJSON/JSONL)
 - [x] Session metadata (run ID, timestamps)
-- [x] Execution event log (`src/core/execution-log/`)
+- [x] Execution event log (`packages/core/src/execution-log/`)
 - [x] CLI replay command (`agentguard replay`)
-- [x] Deterministic replay with seeded RNG (`src/core/rng.ts`, `src/kernel/replay-engine.ts`)
-- [x] Replay comparator (verify original vs replayed outcomes) (`src/kernel/replay-comparator.ts`)
-- [x] Event export/import for sharing sessions (`src/cli/commands/export.ts`, `src/cli/commands/import.ts`)
-- [x] SQLite storage backend (opt-in alternative to JSONL with indexed queries) (`src/storage/`)
+- [x] Deterministic replay with seeded RNG (`packages/core/src/rng.ts`, `packages/kernel/src/replay-engine.ts`)
+- [x] Replay comparator (verify original vs replayed outcomes) (`packages/kernel/src/replay-comparator.ts`)
+- [x] Event export/import for sharing sessions (`apps/cli/src/commands/export.ts`, `apps/cli/src/commands/import.ts`)
+- [x] SQLite storage backend (opt-in alternative to JSONL with indexed queries) (`packages/storage/src/`)
 
 ### Phase 4 — Plugin Ecosystem `STABLE`
 
 > **Theme:** Extensible by design
 
-- [x] Policy pack loading system (community policy sets) (`src/policy/pack-loader.ts`)
-- [x] Renderer plugin interface (`src/renderers/`)
-- [x] Replay processor interface (`src/kernel/replay-processor.ts`)
-- [x] Plugin validation and sandboxing (`src/plugins/validator.ts`, `src/plugins/sandbox.ts`)
-- [x] Plugin registry / discovery mechanism (`src/plugins/registry.ts`, `src/plugins/discovery.ts`)
+- [x] Policy pack loading system (community policy sets) (`packages/policy/src/pack-loader.ts`)
+- [x] Renderer plugin interface (`packages/renderers/src/`)
+- [x] Replay processor interface (`packages/kernel/src/replay-processor.ts`)
+- [x] Plugin validation and sandboxing (`packages/plugins/src/validator.ts`, `packages/plugins/src/sandbox.ts`)
+- [x] Plugin registry / discovery mechanism (`packages/plugins/src/registry.ts`, `packages/plugins/src/discovery.ts`)
 
 ### Phase 5 — Editor Integrations `IN PROGRESS`
 
 > **Theme:** Governance moves into the editor
 
-- [x] VS Code extension: sidebar panel with run status (`vscode-extension/src/providers/run-status-provider.ts`)
-- [x] VS Code: governance notifications for policy violations (`vscode-extension/src/services/notification-service.ts`)
-- [x] VS Code: inline invariant violation indicators (`vscode-extension/src/services/diagnostics-service.ts`, `vscode-extension/src/services/violation-mapper.ts`)
+- [x] VS Code extension: sidebar panel with run status (`apps/vscode-extension/src/providers/run-status-provider.ts`)
+- [x] VS Code: governance notifications for policy violations (`apps/vscode-extension/src/services/notification-service.ts`)
+- [x] VS Code: inline invariant violation indicators (`apps/vscode-extension/src/services/diagnostics-service.ts`, `apps/vscode-extension/src/services/violation-mapper.ts`)
 - [ ] JetBrains plugin (IntelliJ/WebStorm)
 - [ ] Claude Code deep integration (full governance kernel in hook pipeline)
 
@@ -243,10 +243,10 @@ Phases are ordered to prioritize **effect-path closure and mandatory mediation**
 
 This is the architectural hinge. These changes transform the AAB from advisory interception to mandatory execution control.
 
-- [ ] Default-deny unknown actions in `src/policy/evaluator.ts` (change fallback from `allowed: true` to `allowed: false`)
-- [x] Deny actions with no registered adapter in `src/kernel/kernel.ts` (emit `ActionDenied` instead of silently skipping)
-- [x] Persist escalation state changes as `StateChanged` DomainEvents in `src/kernel/monitor.ts`
-- [x] Expand destructive command patterns in `src/kernel/aab.ts` (expanded from 10 to 87 patterns covering sudo, pkill, docker, systemctl, database commands, and more)
+- [ ] Default-deny unknown actions in `packages/policy/src/evaluator.ts` (change fallback from `allowed: true` to `allowed: false`)
+- [x] Deny actions with no registered adapter in `packages/kernel/src/kernel.ts` (emit `ActionDenied` instead of silently skipping)
+- [x] Persist escalation state changes as `StateChanged` DomainEvents in `packages/kernel/src/monitor.ts`
+- [x] Expand destructive command patterns in `packages/kernel/src/aab.ts` (expanded from 10 to 87 patterns covering sudo, pkill, docker, systemctl, database commands, and more)
 - [ ] Enforce intervention types beyond DENY (implement PAUSE and ROLLBACK behaviors in kernel execution)
 - [ ] Governance self-modification invariant — agents must not modify `agentguard.yaml`, `.agentguard/`, or `policies/` (prerequisite for tamper-resistance claim)
 - [ ] Performance benchmark suite — formal latency measurement (p50/p95/p99) per action type for policy evaluation, invariant checking, and simulation overhead. Publish results as a marketing asset and regression gate in CI
@@ -255,12 +255,12 @@ This is the architectural hinge. These changes transform the AAB from advisory i
 
 > **Theme:** Close invariant coverage gaps. The current 10 invariants leave large classes of agent behavior ungoverned.
 
-The `SystemState` interface in `src/invariants/definitions.ts` is the bottleneck for invariant expansion — it needs to become a richer context object with action-specific fields.
+The `SystemState` interface in `packages/invariants/src/definitions.ts` is the bottleneck for invariant expansion — it needs to become a richer context object with action-specific fields.
 
 - [ ] CI/CD config modification invariant (severity 5) — block writes to `.github/workflows/`, `.gitlab-ci.yml`, `Jenkinsfile`, `.circleci/config.yml`
 - [ ] Network egress governance invariant (severity 4) — deny HTTP requests to non-allowlisted domains (extend `SystemState` with `isNetworkRequest`, `requestUrl`, `requestDomain`)
 - [x] Credential file creation invariant (severity 5) — inspect `currentTarget` for SSH keys, `.netrc`, `~/.aws/credentials`, Docker config (closes gap where `no-secret-exposure` misses new file creation)
-- [x] Package.json script injection invariant (severity 4) — flag `package.json` modifications that alter lifecycle script entries (`src/invariants/definitions.ts`)
+- [x] Package.json script injection invariant (severity 4) — flag `package.json` modifications that alter lifecycle script entries (`packages/invariants/src/definitions.ts`)
 - [ ] Large single-file write invariant (severity 3) — enforce per-file size limit (extend `SystemState` with `writeSizeBytes`)
 - [ ] Docker/container config modification invariant (severity 3) — protect `Dockerfile`, `docker-compose.yml`, `.dockerignore`
 - [ ] Database migration safety invariant (severity 3) — flag writes to migration directories containing destructive DDL
@@ -277,11 +277,11 @@ The `RunManifest` defines the session's authority boundary. The `IntentSpec` (a 
 
 Prior art: Kubernetes Capability Primitives (KCP), OS capability-based security models.
 
-- [ ] `RunManifest` type with role and capability grants (extend existing `Capability` type in `src/core/types.ts`)
+- [ ] `RunManifest` type with role and capability grants (extend existing `Capability` type in `packages/core/src/types.ts`)
 - [ ] `IntentSpec` format — machine-readable contract of expected agent behavior (planned action types, target files/branches, expected scope). Declared independently of the agent, loaded at session start
 - [ ] Intent-vs-execution comparison in audit trail — flag actions that fall outside declared intent even if policy allows them (advisory initially, enforceable later)
-- [ ] Validate every adapter call against session capabilities in `src/kernel/kernel.ts`
-- [ ] Shell adapter privilege profiles (allowlist/denylist patterns per profile) in `src/adapters/shell.ts`
+- [ ] Validate every adapter call against session capabilities in `packages/kernel/src/kernel.ts`
+- [ ] Shell adapter privilege profiles (allowlist/denylist patterns per profile) in `packages/adapters/src/shell.ts`
 - [ ] Wire existing `AgentRole` and `RoleDefinition` types to enforcement layer
 - [ ] Emit capability usage in audit trail (which grant authorized each action)
 - [ ] `RunManifest` YAML format for declarative session configuration
@@ -291,7 +291,7 @@ Prior art: Kubernetes Capability Primitives (KCP), OS capability-based security 
 > **Theme:** Shareable, composable, discoverable policies
 
 - [x] Policy templates for common scenarios (`policies/strict`, `policies/ci-safe`, `policies/enterprise`, `policies/open-source`)
-- [x] Policy composition (multiple policy files merged with precedence) (`src/policy/composer.ts`, `guard --policy a --policy b`)
+- [x] Policy composition (multiple policy files merged with precedence) (`packages/policy/src/composer.ts`, `guard --policy a --policy b`)
 - [x] Policy validation CLI (`agentguard policy validate <file>`)
 - [ ] Community policy packs (SOC2, HIPAA, internal engineering standards)
 - [ ] Policy pack versioning and compatibility
@@ -314,7 +314,7 @@ Prior art: Kubernetes Capability Primitives (KCP), OS capability-based security 
 The JSONL persistence layer was the right starting point — append-only, human-readable, zero dependencies. But it doesn't scale: every query requires filesystem enumeration + full file parsing, and hundreds of `.jsonl` files accumulate in `.agentguard/`.
 
 - [x] SQLite storage adapter implementing existing `EventStore` interface
-- [x] Firestore storage adapter (analytics, sink, store) for cloud-native deployments (`src/storage/firestore-*.ts`)
+- [x] Firestore storage adapter (analytics, sink, store) for cloud-native deployments (`packages/storage/src/firestore-*.ts`)
 - [x] `agentguard init firestore` scaffolding (security rules + credentials guide)
 - [x] Schema design: `events`, `decisions`, `sessions` tables with JSON payload columns
 - [x] Indexed columns: `kind`, `timestamp`, `runId`, `actionType`, `fingerprint`
@@ -324,15 +324,15 @@ The JSONL persistence layer was the right starting point — append-only, human-
 - [x] JSONL export compatibility — `agentguard export` still produces portable JSONL
 - [x] Storage location: `~/.agentguard/agentguard.db` (home directory, out of repo tree)
 - [x] Retain JSONL as optional fallback/streaming sink for real-time tailing
-- [x] Firestore NoSQL storage backend for cross-session governance data sharing (`src/storage/firestore-store.ts`, `firestore-sink.ts`, `firestore-analytics.ts`)
+- [x] Firestore NoSQL storage backend for cross-session governance data sharing (`packages/storage/src/firestore-store.ts`, `firestore-sink.ts`, `firestore-analytics.ts`)
 - [x] `agentguard init firestore` scaffold command for secure Firestore backend setup
-- [x] Wire up `sessions` table — insert on `RunStarted`, update on `RunEnded` (`src/storage/sqlite-session.ts`)
+- [x] Wire up `sessions` table — insert on `RunStarted`, update on `RunEnded` (`packages/storage/src/sqlite-session.ts`)
 - [ ] Migration v2: add `action_type` column to `events` table, `severity` column to `decisions` table
 - [ ] Add composite index `(kind, timestamp)` on events for covering index scans
 - [ ] Add standalone index on `decisions.action_type` for filtered queries
 - [ ] Built-in SQL analytics queries: top denied actions, violation rate over time, session duration/action count
 - [ ] Replace `loadAllEventsSqlite` full table scan with SQL-native aggregation (`GROUP BY`, pagination)
-- [x] Prepared statement caching for `EventStore.query()` hot paths (`src/storage/sqlite-store.ts`)
+- [x] Prepared statement caching for `EventStore.query()` hot paths (`packages/storage/src/sqlite-store.ts`)
 
 ### Phase 11 — Runtime Tracing & Observability `PLANNED`
 
@@ -340,9 +340,9 @@ The JSONL persistence layer was the right starting point — append-only, human-
 
 - [ ] Adaptive governance depth — tiered evaluation pipeline where known-safe patterns get cached fast-path allow (sub-ms), normal actions get full policy evaluation (~1ms), and high-risk actions get simulation + deep invariant checks (~10-50ms). Reduces throughput impact for typical workflows while maintaining deep analysis where it matters
 - [ ] Enhanced telemetry beyond current flat event logging
-- [x] Run comparison and diff (`agentguard diff <run1> <run2>`) (`src/cli/commands/diff.ts`)
+- [x] Run comparison and diff (`agentguard diff <run1> <run2>`) (`apps/cli/src/commands/diff.ts`)
 - [x] Risk scoring per agent run
-- [x] Failure clustering and trend detection (`src/analytics/cluster.ts`, `src/analytics/trends.ts`)
+- [x] Failure clustering and trend detection (`packages/analytics/src/cluster.ts`, `packages/analytics/src/trends.ts`)
 - [ ] Timeline viewer for governance sessions (`agentguard replay --ui`)
 - [x] Policy evaluation traces CLI (`agentguard traces`)
 - [ ] Metrics export (Prometheus / OpenTelemetry)
@@ -356,7 +356,7 @@ The JSONL persistence layer was the right starting point — append-only, human-
 - [x] GitHub Actions integration (reusable workflow)
 - [ ] Pre-merge policy validation (block PRs that violate policy)
 - [ ] CI replay verification (replay governance session in CI)
-- [x] Evidence packs attached to pull requests (`src/cli/commands/evidence-pr.ts`, `src/cli/evidence-summary.ts`)
+- [x] Evidence packs attached to pull requests (`apps/cli/src/commands/evidence-pr.ts`, `apps/cli/src/evidence-summary.ts`)
 - [ ] Policy violation gating (fail CI on unresolved violations)
 
 ### Phase 13 — Environmental Enforcement `PLANNED`
@@ -378,7 +378,7 @@ The JSONL persistence layer was the right starting point — append-only, human-
 - [ ] PID-bound capability tokens for privilege separation
 - [ ] Cross-agent policy definitions
 - [ ] Shared state contracts with provenance tracking
-- [x] Heartbeat mechanism for agent liveness (`src/kernel/heartbeat.ts`)
+- [x] Heartbeat mechanism for agent liveness (`packages/kernel/src/heartbeat.ts`)
 - [ ] Multi-agent pipeline orchestration (implement `docs/multi-agent-pipeline.md`)
 - [ ] Multi-agent escalation coordination
 
@@ -470,10 +470,10 @@ The agent governance space is emerging. Several projects address overlapping pro
 
 AgentGuard is built for contributors. Here are the best places to start:
 
-- **Write an invariant pack** — Define domain-specific invariants in `src/invariants/community/`. See `src/invariants/definitions.ts` for the 10 built-in invariants as a reference.
-- **Create a policy pack** — Ship a reusable policy YAML in `policies/`. See `agentguard.yaml` for the format and `src/policy/pack-loader.ts` for the pack loading contract.
-- **Build an adapter** — Add support for a new agent framework in `src/adapters/`. Follow the pattern in `src/adapters/claude-code.ts`.
-- **Add a renderer** — Create a custom governance output renderer implementing the `GovernanceRenderer` interface in `src/renderers/types.ts`.
-- **Write a replay processor** — Build session analysis tools using the `ReplayProcessor` interface in `src/kernel/replay-processor.ts`.
+- **Write an invariant pack** — Define domain-specific invariants in `packages/invariants/src/community/`. See `packages/invariants/src/definitions.ts` for the 10 built-in invariants as a reference.
+- **Create a policy pack** — Ship a reusable policy YAML in `policies/`. See `agentguard.yaml` for the format and `packages/policy/src/pack-loader.ts` for the pack loading contract.
+- **Build an adapter** — Add support for a new agent framework in `packages/adapters/src/`. Follow the pattern in `packages/adapters/src/claude-code.ts`.
+- **Add a renderer** — Create a custom governance output renderer implementing the `GovernanceRenderer` interface in `packages/renderers/src/types.ts`.
+- **Write a replay processor** — Build session analysis tools using the `ReplayProcessor` interface in `packages/kernel/src/replay-processor.ts`.
 
 See the [Plugin API specification](docs/plugin-api.md) for detailed contracts.

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -10,16 +10,14 @@ Event sources feed raw signals into the normalization pipeline. Any system that 
 
 **Contract:** An event source must implement `{ name, start(onRawSignal), stop() }`. The `onRawSignal(rawText)` callback feeds raw text into the ingestion pipeline.
 
-**Implementation:** `domain/source-registry.js` — the `SourceRegistry` class manages source lifecycle.
+**Implementation:** `packages/plugins/src/registry.ts` — the plugin registry manages source lifecycle.
 
 **Quick Start:**
 
-```javascript
-import { SourceRegistry } from '../domain/source-registry.js';
-import { EventBus } from '../domain/event-bus.js';
-import { ingest } from '../domain/ingestion/pipeline.js';
+```typescript
+import { EventBus } from '@red-codes/events';
 
-const registry = new SourceRegistry({ eventBus: new EventBus(), ingest });
+const bus = new EventBus();
 
 registry.register({
   name: 'my-custom-source',
@@ -35,9 +33,9 @@ registry.start();
 **Built-in sources:**
 | Source | Adapter | Path |
 |--------|---------|------|
-| stderr (watch mode) | Watch source | `core/sources/watch-source.js` |
-| Claude Code errors | Claude hook source | `core/sources/claude-hook-source.js` |
-| Project scan | Scan source | `core/sources/scan-source.js` |
+| stderr (watch mode) | Watch source | `packages/adapters/src/` |
+| Claude Code errors | Claude hook source | `packages/adapters/src/claude-code.ts` |
+| Project scan | Scan source | `packages/plugins/src/discovery.ts` |
 
 **SourceRegistry API:**
 
@@ -92,13 +90,13 @@ Renderers subscribe to governance events and present them to the developer in re
 
 **Contract:** A renderer subscribes to EventBus events and presents the appropriate output for each event type.
 
-**Integration point:** Subscribe to events via `domain/event-bus.js`.
+**Integration point:** Subscribe to events via `@red-codes/events` (`EventBus`).
 
 **Built-in renderers:**
 | Renderer | Platform | Path |
 |----------|----------|------|
-| TUI renderer | CLI / terminal | `agentguard/renderers/tui.ts` |
-| JSONL sink | Persistence | `agentguard/sinks/jsonl.ts` |
+| TUI renderer | CLI / terminal | `packages/renderers/src/tui-renderer.ts` |
+| JSONL sink | Persistence | `packages/events/src/jsonl.ts` |
 
 **Planned renderers:**
 | Renderer | Platform |
@@ -109,22 +107,22 @@ Renderers subscribe to governance events and present them to the developer in re
 
 **Implementing a custom renderer:**
 
-```javascript
-import { EventBus } from '../domain/event-bus.js';
-import { Events } from '../domain/events.js';
+```typescript
+import { EventBus } from '@red-codes/events';
+import { EventKind } from '@red-codes/events';
 
 const bus = new EventBus();
 
 // Subscribe to governance events
-bus.on(Events.ACTION_REQUESTED, (event) => {
+bus.on(EventKind.ACTION_REQUESTED, (event) => {
   // Display action proposal
 });
 
-bus.on(Events.ACTION_DENIED, (event) => {
+bus.on(EventKind.ACTION_DENIED, (event) => {
   // Display denial with reason
 });
 
-bus.on(Events.ACTION_EXECUTED, (event) => {
+bus.on(EventKind.ACTION_EXECUTED, (event) => {
   // Display execution result
 });
 ```

--- a/docs/unified-architecture.md
+++ b/docs/unified-architecture.md
@@ -26,7 +26,7 @@ The system has one architectural spine: the **canonical event model**. All syste
          │              Claude Code Adapter                     │
          │                                                     │
          │  Normalize tool calls → RawAgentAction              │
-         │  Implementation: agentguard/adapters/claude-code.ts │
+         │  Implementation: packages/adapters/src/claude-code.ts │
          └──────────────────────┬──────────────────────────────┘
                                 │
                                 ▼
@@ -42,7 +42,7 @@ The system has one architectural spine: the **canonical event model**. All syste
          │  7. ACTION_ALLOWED/DENIED + ACTION_EXECUTED/FAILED  │
          │  8. Escalation tracking (monitor)                   │
          │                                                     │
-         │  Implementation: agentguard/kernel.ts               │
+         │  Implementation: packages/kernel/src/kernel.ts               │
          └──────────────────────┬──────────────────────────────┘
                                 │
                ┌────────────────┼────────────────┐
@@ -107,21 +107,21 @@ The kernel is the **governance producer and action executor**. It is the core of
 
 | Component | File | Responsibility |
 |-----------|------|----------------|
-| Kernel loop | `agentguard/kernel.ts` | Orchestrate propose → evaluate → execute → emit |
-| AAB | `agentguard/core/aab.ts` | Normalize tool calls, detect destructive commands |
-| Engine | `agentguard/core/engine.ts` | Policy + invariant evaluation, intervention selection |
-| Monitor | `agentguard/monitor.ts` | Escalation tracking, lockdown enforcement |
-| Policy evaluator | `agentguard/policies/evaluator.ts` | Rule matching with wildcards and scopes |
-| Policy loader | `agentguard/policies/loader.ts` | JSON policy validation |
-| YAML loader | `agentguard/policies/yaml-loader.ts` | YAML policy parsing |
-| Invariant checker | `agentguard/invariants/checker.ts` | System state invariant verification |
-| Evidence packs | `agentguard/evidence/pack.ts` | Audit trail generation |
-| File adapter | `agentguard/adapters/file.ts` | Read/write/delete/move files |
-| Shell adapter | `agentguard/adapters/shell.ts` | Execute shell commands with timeout |
-| Git adapter | `agentguard/adapters/git.ts` | Git operations with validation |
-| Claude Code adapter | `agentguard/adapters/claude-code.ts` | Hook payload normalization |
-| TUI renderer | `agentguard/renderers/tui.ts` | Terminal action stream display |
-| JSONL sink | `agentguard/sinks/jsonl.ts` | Event persistence |
+| Kernel loop | `packages/kernel/src/kernel.ts` | Orchestrate propose → evaluate → execute → emit |
+| AAB | `packages/kernel/src/aab.ts` | Normalize tool calls, detect destructive commands |
+| Engine | `packages/kernel/src/decision.ts` | Policy + invariant evaluation, intervention selection |
+| Monitor | `packages/kernel/src/monitor.ts` | Escalation tracking, lockdown enforcement |
+| Policy evaluator | `packages/policy/src/evaluator.ts` | Rule matching with wildcards and scopes |
+| Policy loader | `packages/policy/src/loader.ts` | JSON policy validation |
+| YAML loader | `packages/policy/src/yaml-loader.ts` | YAML policy parsing |
+| Invariant checker | `packages/invariants/src/checker.ts` | System state invariant verification |
+| Evidence packs | `packages/kernel/src/evidence.ts` | Audit trail generation |
+| File adapter | `packages/adapters/src/file.ts` | Read/write/delete/move files |
+| Shell adapter | `packages/adapters/src/shell.ts` | Execute shell commands with timeout |
+| Git adapter | `packages/adapters/src/git.ts` | Git operations with validation |
+| Claude Code adapter | `packages/adapters/src/claude-code.ts` | Hook payload normalization |
+| TUI renderer | `packages/renderers/src/tui-renderer.ts` | Terminal action stream display |
+| JSONL sink | `packages/events/src/jsonl.ts` | Event persistence |
 
 ### Domain Layer (Shared)
 
@@ -129,19 +129,19 @@ Pure domain logic with no environment dependencies.
 
 | Component | File | Responsibility |
 |-----------|------|----------------|
-| Canonical actions | `domain/actions.ts` | 23 action types, 8 classes |
-| Canonical events | `domain/events.ts` | 50+ event kinds, factory, validation |
-| Reference monitor | `domain/reference-monitor.ts` | Action authorization with decision trail |
-| Adapter registry | `domain/execution/adapters.ts` | Action class → handler mapping |
-| Event store | `domain/event-store.ts` | In-memory event persistence |
+| Canonical actions | `packages/core/src/actions.ts` | 23 action types, 8 classes |
+| Canonical events | `packages/events/src/schema.ts` | 50+ event kinds, factory, validation |
+| Reference monitor | `packages/kernel/src/decision.ts` | Action authorization with decision trail |
+| Adapter registry | `packages/adapters/src/registry.ts` | Action class → handler mapping |
+| Event store | `packages/events/src/store.ts` | In-memory event persistence |
 
 ### CLI Layer
 
 | Component | File | Responsibility |
 |-----------|------|----------------|
-| `agentguard guard` | `cli/commands/guard.ts` | Start governed action runtime |
-| `agentguard inspect` | `cli/commands/inspect.ts` | Show action graph for a run |
-| `agentguard events` | `cli/commands/inspect.ts` | Show raw event stream for a run |
+| `agentguard guard` | `apps/cli/src/commands/guard.ts` | Start governed action runtime |
+| `agentguard inspect` | `apps/cli/src/commands/inspect.ts` | Show action graph for a run |
+| `agentguard events` | `apps/cli/src/commands/inspect.ts` | Show raw event stream for a run |
 
 ## Integration Guarantees
 

--- a/paper/agentguard-whitepaper.md
+++ b/paper/agentguard-whitepaper.md
@@ -41,7 +41,7 @@ The surface area of agent execution is substantial. A typical development agent 
 | `deploy` | trigger | Critical |
 | `infra` | apply, destroy | Critical |
 
-> *Source: `src/core/actions.ts` --- 23 action types across 8 classes defined in the reference implementation.*
+> *Source: `packages/core/src/actions.ts` --- 23 action types across 8 classes defined in the reference implementation.*
 
 The core thesis of this paper is:
 
@@ -135,7 +135,7 @@ Runtime Telemetry
 ```
 
 > *See diagram: `paper/diagrams/system-architecture.md`*
-> *Implementation: `src/kernel/decision.ts` --- the `evaluate()` method is the central entry point where all layers converge.*
+> *Implementation: `packages/kernel/src/decision.ts` --- the `evaluate()` method is the central entry point where all layers converge.*
 
 ### 3.2 Design Principles
 
@@ -160,7 +160,7 @@ When an agent requests an action, the engine executes the following pipeline:
 6. **Evidence pack generation** --- If the action was denied or any events were produced, generate an `EvidencePack` containing the full decision context: intent, evaluation result, violation details, event IDs, summary, and severity.
 7. **Event emission** --- Emit all canonical events (policy denials, invariant violations, evidence packs) to the event bus and event store.
 
-> *Implementation: `src/kernel/decision.ts` (evaluate method), `src/kernel/aab.ts` (authorize function)*
+> *Implementation: `packages/kernel/src/decision.ts` (evaluate method), `packages/kernel/src/aab.ts` (authorize function)*
 > *See diagram: `paper/diagrams/aab-decision-flow.md`*
 
 ---
@@ -204,7 +204,7 @@ ACTION_CLASS: { FILE, TEST, GIT, SHELL, NPM, HTTP, DEPLOY, INFRA }
 'infra.destroy'  // Destroy infrastructure
 ```
 
-> *Full definition: `src/core/actions.ts` --- `ACTION_TYPES` object with 23 entries.*
+> *Full definition: `packages/core/src/actions.ts` --- `ACTION_TYPES` object with 23 entries.*
 
 ### 4.3 Intent Normalization
 
@@ -229,7 +229,7 @@ The normalization pipeline:
 3. **Destructive detection**: `isDestructiveCommand()` matches against 11 destructive patterns (rm -rf, DROP DATABASE, dd if=, chmod 777, etc.).
 4. **Branch extraction**: `extractBranch()` parses the target branch from git push commands.
 
-> *Implementation: `src/kernel/aab.ts` --- `normalizeIntent()` function.*
+> *Implementation: `packages/kernel/src/aab.ts` --- `normalizeIntent()` function.*
 > *See diagram: `paper/diagrams/canonical-action-pipeline.md`*
 
 ### 4.4 Key Insight: Actions as Data
@@ -238,7 +238,7 @@ The fundamental insight of CAR is that **actions are data, not commands**. Once 
 
 - **Evaluated** against policies without execution
 - **Validated** for required fields and known types
-- **Fingerprinted** for deduplication (`fingerprintAction()` in `src/core/actions.ts`)
+- **Fingerprinted** for deduplication (`fingerprintAction()` in `packages/core/src/actions.ts`)
 - **Recorded** as canonical events for audit and replay
 - **Compared** across agents, sessions, and time
 
@@ -256,9 +256,9 @@ The AAB implements the classical reference monitor concept (Anderson, 1972) with
 
 **Tamper-proof.** The AAB operates as a deterministic runtime *outside* the AI reasoning layer. The agent cannot modify its own constraints because the policy evaluation logic is not part of the LLM's context or tool set. The agent can only submit raw actions; it cannot access or alter the governance engine.
 
-**Verifiable.** The policy evaluation logic (`src/policy/evaluator.ts`) is pure functions operating on data. There is no inference, no heuristics, no neural network in the evaluation path. The entire authorization codebase is under 500 lines of TypeScript and can be fully analyzed and tested.
+**Verifiable.** The policy evaluation logic (`packages/policy/src/evaluator.ts`) is pure functions operating on data. There is no inference, no heuristics, no neural network in the evaluation path. The entire authorization codebase is under 500 lines of TypeScript and can be fully analyzed and tested.
 
-> *Implementation: `src/kernel/aab.ts`, `src/policy/evaluator.ts`*
+> *Implementation: `packages/kernel/src/aab.ts`, `packages/policy/src/evaluator.ts`*
 
 ### 5.2 Policy Model
 
@@ -288,7 +288,7 @@ Pattern matching supports wildcards: `*` matches all actions, `file.*` matches a
 
 Scope matching supports glob-like patterns: `src/**` matches all files under `src/`, `*.ts` matches all TypeScript files.
 
-> *Implementation: `src/policy/evaluator.ts` --- `evaluate()` function.*
+> *Implementation: `packages/policy/src/evaluator.ts` --- `evaluate()` function.*
 
 ### 5.3 Capability-Based Permissions
 
@@ -348,7 +348,7 @@ The reference implementation ships with six default invariants:
 | `no-force-push` | No Force Push | 4 (high) | Force push is forbidden |
 | `lockfile-integrity` | Lockfile Integrity | 2 (low) | Lockfile must update when manifest changes |
 
-> *Implementation: `src/invariants/definitions.ts` --- `DEFAULT_INVARIANTS` array (10 invariants).*
+> *Implementation: `packages/invariants/src/definitions.ts` --- `DEFAULT_INVARIANTS` array (10 invariants).*
 
 ### 6.3 Severity-Based Intervention
 
@@ -361,7 +361,7 @@ Each invariant has a severity level (1-5). When invariants are violated, the max
 | >= 3 | `ROLLBACK` | Action is blocked; system suggests reversal |
 | < 3 | `TEST_ONLY` | Action is allowed but flagged for testing |
 
-> *Implementation: `src/kernel/decision.ts` --- `selectIntervention()` function.*
+> *Implementation: `packages/kernel/src/decision.ts` --- `selectIntervention()` function.*
 
 ### 6.4 Invariant Checking Pipeline
 
@@ -371,7 +371,7 @@ The `checkAllInvariants()` function iterates through all registered invariants a
 2. Emits an `INVARIANT_VIOLATION` canonical event with full metadata (invariant name, severity, description)
 3. Adds the violation to the evidence pack
 
-> *Implementation: `src/invariants/checker.ts` --- `checkAllInvariants()` function.*
+> *Implementation: `packages/invariants/src/checker.ts` --- `checkAllInvariants()` function.*
 > *See diagram: `paper/diagrams/invariant-enforcement.md`*
 
 ---
@@ -407,7 +407,7 @@ Evidence packs serve three purposes:
 2. **Debugging**: Developers can inspect the evidence pack to understand what policy or invariant was triggered.
 3. **Compliance**: Evidence packs provide the structured documentation needed for governance auditing.
 
-> *Implementation: `src/kernel/evidence.ts` --- `createEvidencePack()` function.*
+> *Implementation: `packages/kernel/src/evidence.ts` --- `createEvidencePack()` function.*
 
 ### 7.2 Escalation Monitor
 
@@ -424,7 +424,7 @@ The escalation model prevents persistent agents from gradually overwhelming the 
 
 The monitor tracks statistics per-agent and per-invariant, enabling targeted analysis of which agents are most frequently denied and which invariants are most frequently violated.
 
-> *Implementation: `src/kernel/monitor.ts` --- `createMonitor()` function with 4-level escalation.*
+> *Implementation: `packages/kernel/src/monitor.ts` --- `createMonitor()` function with 4-level escalation.*
 > *See diagram: `paper/diagrams/escalation-model.md`*
 
 ### 7.3 Canonical Event Model
@@ -440,7 +440,7 @@ All system activity is captured as immutable canonical events. The event model d
 
 Events are immutable, fingerprinted for deduplication, and stored in an append-only event store that supports query, replay, and filtering.
 
-> *Implementation: `src/events/schema.ts` --- event kind definitions and `createEvent()` factory.*
+> *Implementation: `packages/events/src/schema.ts` --- event kind definitions and `createEvent()` factory.*
 
 ---
 
@@ -454,27 +454,27 @@ AgentGuard is a TypeScript implementation of the execution governance architectu
 
 | Paper Concept | Source File | Key Export |
 |---|---|---|
-| Canonical Action Representation | `src/core/actions.ts` | `ACTION_TYPES` (23 types), `createAction()`, `validateAction()` |
-| Intent Normalization | `src/kernel/aab.ts` | `normalizeIntent()`, `detectGitAction()`, `isDestructiveCommand()` |
-| Action Authorization Boundary | `src/kernel/aab.ts` | `authorize()`, `DESTRUCTIVE_PATTERNS` |
-| RTA Decision Engine | `src/kernel/decision.ts` | `createEngine()`, `evaluate()`, `INTERVENTION` |
-| Policy Evaluation | `src/policy/evaluator.ts` | `evaluate()`, `matchAction()`, `matchScope()` |
-| Policy Loading & Validation | `src/policy/loader.ts` | `loadPolicies()`, `validatePolicy()` |
-| System Invariants | `src/invariants/definitions.ts` | `DEFAULT_INVARIANTS` (10 invariants) |
-| Invariant Checking | `src/invariants/checker.ts` | `checkAllInvariants()`, `buildSystemState()` |
-| Evidence Packs | `src/kernel/evidence.ts` | `createEvidencePack()`, `ExplainableEvidencePack` |
-| Escalation Monitor | `src/kernel/monitor.ts` | `createMonitor()`, `ESCALATION` (4 levels) |
-| Canonical Events | `src/events/schema.ts` | 49 event kinds, `createEvent()`, `validateEvent()` |
-| Blast Radius Engine | `src/kernel/blast-radius.ts` | Weighted blast radius computation |
-| Governed Action Kernel | `src/kernel/kernel.ts` | `propose()`, lifecycle orchestration |
-| Impact Simulation | `src/kernel/simulation/` | Pre-execution impact simulation (filesystem, git, package) |
-| Storage Backend | `src/storage/` | SQLite + Firestore event/decision persistence |
+| Canonical Action Representation | `packages/core/src/actions.ts` | `ACTION_TYPES` (23 types), `createAction()`, `validateAction()` |
+| Intent Normalization | `packages/kernel/src/aab.ts` | `normalizeIntent()`, `detectGitAction()`, `isDestructiveCommand()` |
+| Action Authorization Boundary | `packages/kernel/src/aab.ts` | `authorize()`, `DESTRUCTIVE_PATTERNS` |
+| RTA Decision Engine | `packages/kernel/src/decision.ts` | `createEngine()`, `evaluate()`, `INTERVENTION` |
+| Policy Evaluation | `packages/policy/src/evaluator.ts` | `evaluate()`, `matchAction()`, `matchScope()` |
+| Policy Loading & Validation | `packages/policy/src/loader.ts` | `loadPolicies()`, `validatePolicy()` |
+| System Invariants | `packages/invariants/src/definitions.ts` | `DEFAULT_INVARIANTS` (10 invariants) |
+| Invariant Checking | `packages/invariants/src/checker.ts` | `checkAllInvariants()`, `buildSystemState()` |
+| Evidence Packs | `packages/kernel/src/evidence.ts` | `createEvidencePack()`, `ExplainableEvidencePack` |
+| Escalation Monitor | `packages/kernel/src/monitor.ts` | `createMonitor()`, `ESCALATION` (4 levels) |
+| Canonical Events | `packages/events/src/schema.ts` | 49 event kinds, `createEvent()`, `validateEvent()` |
+| Blast Radius Engine | `packages/kernel/src/blast-radius.ts` | Weighted blast radius computation |
+| Governed Action Kernel | `packages/kernel/src/kernel.ts` | `propose()`, lifecycle orchestration |
+| Impact Simulation | `packages/kernel/src/simulation/` | Pre-execution impact simulation (filesystem, git, package) |
+| Storage Backend | `packages/storage/src/` | SQLite + Firestore event/decision persistence |
 
 ### 8.3 Code Characteristics
 
 - **Pure domain logic**: Core governance components (kernel, policy evaluator, invariant checker) have zero DOM dependencies and minimal Node.js-specific API usage.
 - **Deterministic**: All evaluation functions are pure --- same input always produces same output.
-- **Modular architecture**: The governance runtime spans kernel, policy, invariants, events, and adapters across `src/`, with optional storage backends (SQLite, Firestore).
+- **Modular architecture**: The governance runtime spans kernel, policy, invariants, events, and adapters across `packages/` and `apps/`, with optional storage backends (SQLite, Firestore).
 - **Fully tested**: 77 TypeScript test files (vitest) and 14 JavaScript test files cover policy evaluation, invariant checking, evidence generation, escalation logic, storage backends, and CLI commands.
 
 ### 8.4 Multi-Agent Pipeline
@@ -485,15 +485,15 @@ The governance kernel enforces authorization at each stage:
 
 | Governance Layer | Enforcement Mechanism | Key Component |
 |-------|----------------|-----------------|
-| Action Authorization | AAB normalization + policy rules | `src/kernel/aab.ts` |
-| File Scope | `FileScopeViolation` events + invariant checks | `src/invariants/checker.ts` |
-| Blast Radius | Weighted impact computation | `src/kernel/blast-radius.ts` |
-| Escalation | State machine (NORMAL → LOCKDOWN) | `src/kernel/monitor.ts` |
-| Impact Simulation | Pre-execution prediction | `src/kernel/simulation/` |
+| Action Authorization | AAB normalization + policy rules | `packages/kernel/src/aab.ts` |
+| File Scope | `FileScopeViolation` events + invariant checks | `packages/invariants/src/checker.ts` |
+| Blast Radius | Weighted impact computation | `packages/kernel/src/blast-radius.ts` |
+| Escalation | State machine (NORMAL → LOCKDOWN) | `packages/kernel/src/monitor.ts` |
+| Impact Simulation | Pre-execution prediction | `packages/kernel/src/simulation/` |
 
 The file scope enforcement prevents agents from modifying files outside their declared scope --- a common vector for unintended changes in multi-agent systems.
 
-> *Implementation: `src/kernel/kernel.ts` --- `propose()` with policy evaluation, invariant checks, and simulation.*
+> *Implementation: `packages/kernel/src/kernel.ts` --- `propose()` with policy evaluation, invariant checks, and simulation.*
 
 ---
 
@@ -586,36 +586,41 @@ Key references:
 
 ```
 agent-guard/
-  src/
-    kernel/               # Governed action kernel
-      kernel.ts           # Orchestrator (propose → evaluate → execute → emit)
-      aab.ts              # Action Authorization Boundary (normalization)
-      decision.ts         # Runtime assurance engine (RTA)
-      monitor.ts          # Escalation state machine
-      evidence.ts         # Evidence pack generation
-      blast-radius.ts     # Weighted blast radius computation
-      simulation/         # Pre-execution impact simulation
-    events/               # Canonical event model
-      schema.ts           # Event kinds, factory, validation
-      bus.ts              # Typed EventBus
-      store.ts            # In-memory event store
-      jsonl.ts            # JSONL event persistence
-    policy/               # Policy system
-      evaluator.ts        # Rule matching engine
-      loader.ts           # Policy validation + loading
-      composer.ts         # Policy composition (multi-file merging)
-    invariants/           # Invariant system
-      definitions.ts      # 10 built-in invariant definitions
-      checker.ts          # Invariant evaluation engine
-    core/                 # Shared utilities
-      actions.ts          # 23 canonical action types across 8 classes
-      types.ts            # Shared TypeScript type definitions
-    adapters/             # Execution adapters (file, shell, git)
-    storage/              # SQLite + Firestore backends (opt-in)
-    analytics/            # Cross-session violation analytics
-    cli/                  # CLI entry point + commands
-  policy/                 # Policy configuration (JSON)
-  policies/               # Policy packs (YAML)
-  paper/                  # This research artifact
-  examples/               # Example governance scenarios
+  packages/
+    core/src/               # @red-codes/core — Shared utilities
+      actions.ts            # 23 canonical action types across 8 classes
+      types.ts              # Shared TypeScript type definitions
+    events/src/             # @red-codes/events — Canonical event model
+      schema.ts             # Event kinds, factory, validation
+      bus.ts                # Typed EventBus
+      store.ts              # In-memory event store
+      jsonl.ts              # JSONL event persistence
+    policy/src/             # @red-codes/policy — Policy system
+      evaluator.ts          # Rule matching engine
+      loader.ts             # Policy validation + loading
+      composer.ts           # Policy composition (multi-file merging)
+    invariants/src/         # @red-codes/invariants — Invariant system
+      definitions.ts        # 10 built-in invariant definitions
+      checker.ts            # Invariant evaluation engine
+    kernel/src/             # @red-codes/kernel — Governed action kernel
+      kernel.ts             # Orchestrator (propose → evaluate → execute → emit)
+      aab.ts                # Action Authorization Boundary (normalization)
+      decision.ts           # Runtime assurance engine (RTA)
+      monitor.ts            # Escalation state machine
+      evidence.ts           # Evidence pack generation
+      blast-radius.ts       # Weighted blast radius computation
+      simulation/           # Pre-execution impact simulation
+    adapters/src/           # @red-codes/adapters — Execution adapters (file, shell, git)
+    analytics/src/          # @red-codes/analytics — Cross-session violation analytics
+    storage/src/            # @red-codes/storage — SQLite + Firestore backends (opt-in)
+    telemetry/src/          # @red-codes/telemetry — Runtime telemetry
+    plugins/src/            # @red-codes/plugins — Plugin ecosystem
+    renderers/src/          # @red-codes/renderers — Renderer plugin system
+  apps/
+    cli/src/                # @red-codes/agentguard — CLI (published npm package)
+    vscode-extension/src/   # agentguard-vscode — VS Code extension
+  policy/                   # Policy configuration (JSON)
+  policies/                 # Policy packs (YAML)
+  paper/                    # This research artifact
+  examples/                 # Example governance scenarios
 ```


### PR DESCRIPTION
Update path references, project structure trees, and build commands
across 8 documentation files to reflect the pnpm + Turbo monorepo
migration (packages/ and apps/ layout, @red-codes/* scoped packages).

Files updated: CLAUDE.md, README.md, ARCHITECTURE.md, CONTRIBUTING.md,
ROADMAP.md, docs/unified-architecture.md, docs/plugin-api.md,
paper/agentguard-whitepaper.md

https://claude.ai/code/session_01NbQTm6VG52xJ3ACzhSVehq