### PR TITLE
fix: update Claude skills and hooks for Turborepo monorepo structure

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node C:/Users/jplev/Documents/GitHub/agent-guard/dist/cli/commands/claude-hook.js pre"
+            "command": "node apps/cli/dist/bin.js claude-hook pre"
           }
         ]
       }
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node C:/Users/jplev/Documents/GitHub/agent-guard/dist/cli/commands/claude-hook.js post"
+            "command": "node apps/cli/dist/bin.js claude-hook post"
           }
         ]
       }

--- a/.claude/skills/architecture-review.md
+++ b/.claude/skills/architecture-review.md
@@ -29,13 +29,13 @@ gh pr view <PR_NUMBER> --json files --jq '.files[].path'
 ```
 
 A PR needs architecture review if it modifies files in:
-- `src/kernel/` — core governance engine
-- `src/events/` — canonical event model
-- `src/policy/` — policy system
-- `src/invariants/` — invariant system
-- `src/adapters/` — execution adapters
-- `src/core/` — shared types and utilities
-- `src/cli/` — CLI entry points and commands
+- `packages/kernel/src/` — core governance engine
+- `packages/events/src/` — canonical event model
+- `packages/policy/src/` — policy system
+- `packages/invariants/src/` — invariant system
+- `packages/adapters/src/` — execution adapters
+- `packages/core/src/` — shared types and utilities
+- `apps/cli/src/` — CLI entry points and commands
 
 Skip PRs that already have an `**Architect Agent**` comment. Select up to **2 PRs** per run.
 
@@ -51,35 +51,35 @@ gh pr diff <PR_NUMBER>
 
 #### 4b. Analyze Module Boundaries
 
-The architecture defines 7 distinct layers with strict dependency rules:
+The architecture defines 7 distinct workspace packages with strict dependency rules:
 
 ```
-core/ ← (shared types, no imports from other layers)
+@red-codes/core ← (shared types, no imports from other packages)
   ↑
-events/ ← (may import from core/)
+@red-codes/events ← (may import from core)
   ↑
-policy/ ← (may import from core/)
+@red-codes/policy ← (may import from core)
   ↑
-invariants/ ← (may import from core/, events/)
+@red-codes/invariants ← (may import from core, events)
   ↑
-kernel/ ← (may import from core/, events/, policy/, invariants/)
+@red-codes/kernel ← (may import from core, events, policy, invariants)
   ↑
-adapters/ ← (may import from core/, events/, kernel/)
+@red-codes/adapters ← (may import from core, events, kernel)
   ↑
-cli/ ← (may import from anything)
+apps/cli ← (may import from anything)
 ```
 
 Check the diff for import statements that violate these dependency rules:
-- `kernel/` must NOT import from `adapters/` or `cli/`
-- `adapters/` must NOT import from `cli/`
-- `events/` must NOT import from `kernel/`, `policy/`, `invariants/`, `adapters/`, or `cli/`
-- `policy/` must NOT import from `kernel/`, `invariants/`, `adapters/`, or `cli/`
-- `core/` must NOT import from any other `src/` layer
+- `@red-codes/kernel` must NOT import from `@red-codes/adapters` or `apps/cli`
+- `@red-codes/adapters` must NOT import from `apps/cli`
+- `@red-codes/events` must NOT import from `kernel`, `policy`, `invariants`, `adapters`, or `cli`
+- `@red-codes/policy` must NOT import from `kernel`, `invariants`, `adapters`, or `cli`
+- `@red-codes/core` must NOT import from any other workspace package
 
 #### 4c. Check Event Model Consistency
 
 If the PR adds new event kinds:
-- New events must be defined in `src/events/schema.ts`
+- New events must be defined in `packages/events/src/schema.ts`
 - New events must follow the existing naming convention (PascalCase)
 - New events must have a factory function for creation
 - New events must be documented in the appropriate event category
@@ -87,9 +87,9 @@ If the PR adds new event kinds:
 #### 4d. Check Action Type Consistency
 
 If the PR adds new action types:
-- New actions must be registered in `src/core/actions.ts`
+- New actions must be registered in `packages/core/src/actions.ts`
 - New actions must follow the `class.verb` naming convention (e.g., `file.read`, `git.push`)
-- New action classes must have a corresponding adapter in `src/adapters/`
+- New action classes must have a corresponding adapter in `packages/adapters/src/`
 
 #### 4e. Check Public API Surface
 

--- a/.claude/skills/audit-merged-prs.md
+++ b/.claude/skills/audit-merged-prs.md
@@ -118,9 +118,9 @@ gh pr view <PR_NUMBER> --json files --jq '[.files[].path]'
 ```
 
 Check if any changed files are in protected paths:
-- `src/kernel/**` — core governance kernel
-- `src/policy/**` — policy evaluation engine
-- `src/invariants/**` — invariant system
+- `packages/kernel/src/**` — core governance kernel
+- `packages/policy/src/**` — policy evaluation engine
+- `packages/invariants/src/**` — invariant system
 - `agentguard.yaml` — default policy
 - `.claude/settings.json` — hook configuration
 

--- a/.claude/skills/create-pr.md
+++ b/.claude/skills/create-pr.md
@@ -25,7 +25,7 @@ If no governance files exist yet, this is a no-op — proceed normally.
 Run impact simulation before pushing to assess blast radius and policy compliance:
 
 ```bash
-npx agentguard simulate --action git.push --branch $(git branch --show-current) --policy agentguard.yaml --json 2>/dev/null
+node apps/cli/dist/bin.js simulate --action git.push --branch $(git branch --show-current) --policy agentguard.yaml --json 2>/dev/null
 ```
 
 Parse the JSON output for:
@@ -94,7 +94,7 @@ Parse decision records to extract:
 Run the analytics engine for a per-session risk assessment:
 
 ```bash
-npx agentguard analytics --format json 2>/dev/null | head -50
+node apps/cli/dist/bin.js analytics --format json 2>/dev/null | head -50
 ```
 
 Extract:
@@ -121,11 +121,10 @@ Use this structure:
 - <list of files modified with brief description of each change>
 
 ## Test Plan
-- [ ] TypeScript build passes (`npm run build:ts`)
-- [ ] Vitest tests pass (`npm run ts:test`)
-- [ ] JS tests pass (`npm test`)
-- [ ] ESLint clean (`npm run lint`)
-- [ ] Prettier clean (`npm run format`)
+- [ ] TypeScript build passes (`pnpm build`)
+- [ ] Vitest tests pass (`pnpm test`)
+- [ ] ESLint clean (`pnpm lint`)
+- [ ] Prettier clean (`pnpm format`)
 
 ## Risk Assessment
 

--- a/.claude/skills/discover-next-issue.md
+++ b/.claude/skills/discover-next-issue.md
@@ -104,7 +104,7 @@ For the selected issue, estimate the governance risk:
 If the issue body contains a `## File Scope` section, count the listed files. Then simulate:
 
 ```bash
-npx agentguard simulate --action file.write --target <first-file-in-scope> --policy agentguard.yaml --json 2>/dev/null
+node apps/cli/dist/bin.js simulate --action file.write --target <first-file-in-scope> --policy agentguard.yaml --json 2>/dev/null
 ```
 
 Classify the estimated blast radius:

--- a/.claude/skills/full-test.md
+++ b/.claude/skills/full-test.md
@@ -9,15 +9,15 @@ Run these in sequence. If any step fails, stop and analyze before proceeding.
 ### 1. Build TypeScript
 
 ```bash
-npm run build:ts
+pnpm build
 ```
 
-Compiles TypeScript via tsc + esbuild to `dist/`. Report build success or failure with error details.
+Compiles all workspace packages via Turborepo. Report build success or failure with error details.
 
 ### 2. Type-Check
 
 ```bash
-npm run ts:check
+pnpm ts:check
 ```
 
 Runs `tsc --noEmit` for strict type verification. Report any type errors with file:line references.
@@ -25,7 +25,7 @@ Runs `tsc --noEmit` for strict type verification. Report any type errors with fi
 ### 3. Run TypeScript Tests (vitest)
 
 ```bash
-npm run ts:test
+ppnpm test
 ```
 
 Report pass/fail count. If tests fail, note the failing test names and error messages.
@@ -33,7 +33,7 @@ Report pass/fail count. If tests fail, note the failing test names and error mes
 ### 4. Run JavaScript Tests
 
 ```bash
-npm test
+pnpm test
 ```
 
 Report pass/fail count. These use the custom zero-dependency harness in `tests/run.js`.
@@ -41,7 +41,7 @@ Report pass/fail count. These use the custom zero-dependency harness in `tests/r
 ### 5. Run ESLint
 
 ```bash
-npm run lint
+pnpm lint
 ```
 
 Report any lint errors with file:line references.
@@ -49,7 +49,7 @@ Report any lint errors with file:line references.
 ### 6. Run Prettier Format Check
 
 ```bash
-npm run format
+pnpm format
 ```
 
 Report any formatting issues.
@@ -57,7 +57,7 @@ Report any formatting issues.
 ### 7. Run Coverage Check
 
 ```bash
-npm run test:coverage
+pnpm test:coverage
 ```
 
 Report line coverage percentage. The project threshold is 50% line coverage.
@@ -89,4 +89,4 @@ One-line verdict:
 - **Read-only** — do not fix, modify, or commit anything. This skill only reports.
 - Run all steps even if earlier steps fail — report the full picture.
 - If a command times out (>2 minutes), note the timeout and continue.
-- If `node_modules` is missing, run `npm install` first, then proceed.
+- If `node_modules` is missing, run `pnpm install` first, then proceed.

--- a/.claude/skills/generate-tests.md
+++ b/.claude/skills/generate-tests.md
@@ -17,26 +17,26 @@ Invoke the `start-governance-runtime` skill to ensure the AgentGuard kernel is a
 List source files and their corresponding test files:
 
 ```bash
-find src -name "*.ts" -not -name "*.d.ts" | sort
-find tests/ts -name "*.test.ts" | sort
+find packages apps -name "*.ts" -not -name "*.d.ts" -not -path "*/node_modules/*" -not -path "*/dist/*" | sort
+find packages apps -name "*.test.ts" -not -path "*/node_modules/*" | sort
 ```
 
-For each source file in `src/`, check if a corresponding test file exists in `tests/ts/`. A source file `src/foo/bar.ts` should have a test at `tests/ts/bar.test.ts` or `tests/ts/foo-bar.test.ts`.
+For each source file, check if a corresponding test file exists in the same package's `tests/` directory. For example, `packages/kernel/src/kernel.ts` should have a test at `packages/kernel/tests/kernel.test.ts`.
 
 Prioritize untested files by:
-1. Core kernel files (`src/kernel/`) — highest priority
-2. Policy and invariant files (`src/policy/`, `src/invariants/`)
-3. Adapter files (`src/adapters/`)
-4. CLI command files (`src/cli/commands/`)
-5. Utility files (`src/core/`)
+1. Core kernel files (`packages/kernel/src/`) — highest priority
+2. Policy and invariant files (`packages/policy/src/`, `packages/invariants/src/`)
+3. Adapter files (`packages/adapters/src/`)
+4. CLI command files (`apps/cli/src/commands/`)
+5. Utility files (`packages/core/src/`)
 
 ### 3. Study Existing Test Patterns
 
 Read 2-3 existing test files to understand conventions:
 
 ```bash
-cat tests/ts/aab.test.ts | head -50
-cat tests/ts/kernel-engine.test.ts | head -50
+cat packages/kernel/tests/agentguard-aab.test.ts | head -50
+cat packages/kernel/tests/agentguard-engine.test.ts | head -50
 ```
 
 Extract patterns:
@@ -56,14 +56,14 @@ Pick the highest-priority untested module (max 1 per run). Read the source file 
 - Dependencies that need mocking
 
 ```bash
-cat src/<path-to-target>.ts
+cat packages/<pkg>/src/<target>.ts
 ```
 
 ### 5. Generate Test File
 
 Create a test file following the established patterns:
 
-- File path: `tests/ts/<module-name>.test.ts`
+- File path: `packages/<pkg>/tests/<module-name>.test.ts`
 - Import the module under test
 - Use `describe` blocks matching exported functions/classes
 - Include tests for:
@@ -76,8 +76,8 @@ Create a test file following the established patterns:
 ### 6. Verify Tests Pass
 
 ```bash
-npm run build:ts
-npx vitest run tests/ts/<module-name>.test.ts
+pnpm build
+npx vitest run packages/<pkg>/tests/<module-name>.test.ts
 ```
 
 If tests fail:
@@ -89,7 +89,7 @@ If tests fail:
 
 ```bash
 git checkout -b test/add-<module-name>-tests
-git add tests/ts/<module-name>.test.ts
+git add packages/<pkg>/tests/<module-name>.test.ts
 git commit -m "test: add tests for <module-name>"
 git push -u origin test/add-<module-name>-tests
 ```
@@ -101,7 +101,7 @@ gh pr create \
   --title "test: add tests for <module-name>" \
   --body "## Summary
 
-Adds test coverage for \`src/<path-to-target>.ts\`.
+Adds test coverage for \`packages/<pkg>/src/<target>.ts\`.
 
 ## Test Coverage
 
@@ -128,8 +128,8 @@ gh label create "source:test-agent" --color "0E8A16" --description "Auto-created
 ### 8. Summary
 
 Report:
-- **Module tested**: `src/<path>`
-- **Test file created**: `tests/ts/<module-name>.test.ts`
+- **Module tested**: `packages/<pkg>/src/<path>`
+- **Test file created**: `packages/<pkg>/tests/<module-name>.test.ts`
 - **Test cases**: N (N passing)
 - **PR created**: #<N>
 - If no untested modules found: "All source modules have test coverage"
@@ -141,6 +141,6 @@ Report:
 - **Follow existing test patterns exactly** — match the import style, describe/it structure, and assertion patterns from existing tests.
 - **Never delete existing test files** — only add new ones.
 - **Never overwrite existing test files** — if a test file already exists for the target module, skip it.
-- If `npm run build:ts` fails, STOP — the codebase must compile before tests can be generated.
+- If `pnpm build` fails, STOP — the codebase must compile before tests can be generated.
 - If `gh` CLI is not authenticated, still generate the test file locally but skip PR creation.
-- Target modules must be in `src/` — do not generate tests for files outside the source tree.
+- Target modules must be in `packages/*/src/` or `apps/*/src/` — do not generate tests for files outside the source tree.

--- a/.claude/skills/governance-log-audit.md
+++ b/.claude/skills/governance-log-audit.md
@@ -38,7 +38,7 @@ If no log files exist, report "No governance logs found — nothing to audit" an
 Use the AgentGuard analytics engine for aggregated cross-session data:
 
 ```bash
-npx agentguard analytics --format json 2>/dev/null | head -200
+node apps/cli/dist/bin.js analytics --format json 2>/dev/null | head -200
 ```
 
 Extract:

--- a/.claude/skills/implement-issue.md
+++ b/.claude/skills/implement-issue.md
@@ -66,7 +66,7 @@ git diff --name-only HEAD
 For each modified file, run simulation:
 
 ```bash
-npx agentguard simulate --action file.write --target <file> --policy agentguard.yaml --json 2>/dev/null
+node apps/cli/dist/bin.js simulate --action file.write --target <file> --policy agentguard.yaml --json 2>/dev/null
 ```
 
 Check the simulation result:
@@ -82,7 +82,7 @@ If the simulate command is not available, skip this step and proceed.
 ### 5. Type-Check
 
 ```bash
-npm run ts:check
+pnpm ts:check
 ```
 
 If type errors exist in files you modified, fix them before proceeding. Do not skip type errors.
@@ -90,13 +90,13 @@ If type errors exist in files you modified, fix them before proceeding. Do not s
 ### 6. Lint
 
 ```bash
-npm run lint
+pnpm lint
 ```
 
 If lint errors exist in files you modified:
 
 ```bash
-npm run lint:fix
+pnpm lint:fix
 ```
 
 If errors remain after auto-fix, fix them manually.
@@ -104,13 +104,13 @@ If errors remain after auto-fix, fix them manually.
 ### 7. Format Check
 
 ```bash
-npm run format
+pnpm format
 ```
 
 If formatting issues exist in files you modified:
 
 ```bash
-npm run format:fix
+pnpm format:fix
 ```
 
 ### 8. Commit Changes
@@ -140,14 +140,14 @@ If the task requires multiple logical units of work, make separate commits for e
 After commit, capture the governance decision record for audit trail:
 
 ```bash
-npx agentguard inspect --last 2>/dev/null
+node apps/cli/dist/bin.js inspect --last 2>/dev/null
 ```
 
 This records the governance decisions made during implementation, which will be included in the PR body by the `create-pr` skill.
 
 ## Rules
 
-- Do NOT modify files in `src/kernel/**`, `src/policy/**`, or `src/invariants/**` unless the issue explicitly authorizes it
+- Do NOT modify files in `packages/kernel/src/**`, `packages/policy/src/**`, or `packages/invariants/src/**` unless the issue explicitly authorizes it
 - Do NOT modify `agentguard.yaml` or `.claude/settings.json`
 - Do NOT use `git add .` or `git add -A` — stage specific files only
 - If pre-commit simulation denies a file, do NOT commit it — report the denial

--- a/.claude/skills/observability-review.md
+++ b/.claude/skills/observability-review.md
@@ -29,7 +29,7 @@ Invoke the `start-governance-runtime` skill to ensure the AgentGuard kernel is a
 Use the AgentGuard analytics engine for aggregated cross-session data:
 
 ```bash
-npx agentguard analytics --format json 2>/dev/null | head -200
+node apps/cli/dist/bin.js analytics --format json 2>/dev/null | head -200
 ```
 
 Extract:
@@ -164,19 +164,19 @@ Identify:
 Check the current build output:
 
 ```bash
-ls -la dist/cli/bin.js 2>/dev/null
-ls -la dist/cli/bin.js.map 2>/dev/null
+ls -la apps/cli/dist/bin.js 2>/dev/null
+ls -la apps/cli/dist/bin.js.map 2>/dev/null
 ```
 
 Record:
-- **CLI bundle size**: File size of `dist/cli/bin.js`
-- **Source map size**: File size of `dist/cli/bin.js.map`
+- **CLI bundle size**: File size of `apps/cli/dist/bin.js`
+- **Source map size**: File size of `apps/cli/dist/bin.js.map`
 
 Check dependency health:
 
 ```bash
-npm audit --json 2>/dev/null | head -100
-npm outdated --json 2>/dev/null | head -50
+pnpm audit --json 2>/dev/null | head -100
+pnpm outdated --json 2>/dev/null | head -50
 ```
 
 Record:

--- a/.claude/skills/policy-effectiveness-review.md
+++ b/.claude/skills/policy-effectiveness-review.md
@@ -47,7 +47,7 @@ Parse the policy to extract:
 Run automated policy validation with strict best-practice checks:
 
 ```bash
-npx agentguard policy validate --strict --json 2>/dev/null
+node apps/cli/dist/bin.js policy validate --strict --json 2>/dev/null
 ```
 
 Parse the validation output for:
@@ -60,7 +60,7 @@ If the validate command is not available, skip this step and rely on manual anal
 ### 4. Read Invariant Definitions
 
 ```bash
-cat src/invariants/definitions.ts
+cat packages/invariants/src/definitions.ts
 ```
 
 Extract the 8 built-in invariant names and their trigger conditions:
@@ -119,9 +119,9 @@ Look for:
 Also run simulation against common risky patterns to detect coverage gaps:
 
 ```bash
-npx agentguard simulate --action file.write --target .env.production --policy agentguard.yaml --json 2>/dev/null
-npx agentguard simulate --action git.push --branch main --policy agentguard.yaml --json 2>/dev/null
-npx agentguard simulate --action shell.exec --command "rm -rf /" --policy agentguard.yaml --json 2>/dev/null
+node apps/cli/dist/bin.js simulate --action file.write --target .env.production --policy agentguard.yaml --json 2>/dev/null
+node apps/cli/dist/bin.js simulate --action git.push --branch main --policy agentguard.yaml --json 2>/dev/null
+node apps/cli/dist/bin.js simulate --action shell.exec --command "rm -rf /" --policy agentguard.yaml --json 2>/dev/null
 ```
 
 If any of these simulations show "allowed", flag as a policy gap.
@@ -153,10 +153,10 @@ Compare the active policy against available packs:
 
 Compare policy coverage against the architectural layers:
 
-- Does the policy cover all 7 `src/` layers? (kernel, events, policy, invariants, adapters, cli, core)
-- Are protected paths (`src/kernel/`, `src/invariants/`) reflected in policy rules?
+- Does the policy cover all workspace packages? (kernel, events, policy, invariants, adapters, cli, core)
+- Are protected paths (`packages/kernel/src/`, `packages/invariants/src/`) reflected in policy rules?
 - Does the blast radius invariant align with the actual module structure?
-- Are there action types in `src/core/actions.ts` with no corresponding policy rule?
+- Are there action types in `packages/core/src/actions.ts` with no corresponding policy rule?
 
 ### 10. Generate Effectiveness Report
 

--- a/.claude/skills/product-health-review.md
+++ b/.claude/skills/product-health-review.md
@@ -57,7 +57,7 @@ For every open issue and every PR merged in the last 14 days, determine which RO
 1. Issue body explicitly references a phase (e.g., "Phase 4", "Plugin Ecosystem")
 2. Issue title or body mentions a ROADMAP line item keyword (e.g., "policy pack", "VS Code extension", "replay")
 3. Issue labels contain a `phase:N` label
-4. Issue file scope paths map to a ROADMAP area (e.g., `src/events/` → Phase 1, `src/kernel/` → Phase 2, `src/cli/` → Phase 3)
+4. Issue file scope paths map to a ROADMAP area (e.g., `packages/events/src/` → Phase 1, `packages/kernel/src/` → Phase 2, `apps/cli/src/` → Phase 3)
 5. No mapping found → classify as **orphaned**
 
 Produce three lists:

--- a/.claude/skills/progress-controller.md
+++ b/.claude/skills/progress-controller.md
@@ -54,7 +54,7 @@ gh issue list --state open --limit 100 --json number,title,labels,body
 For each issue, determine its phase alignment:
 - Match by title keywords or explicit phase references in the body
 - Match by label (e.g., labels containing phase numbers or theme names)
-- Match by file scope references (e.g., issues touching `src/policy/` → Phase 8 Policy Ecosystem)
+- Match by file scope references (e.g., issues touching `packages/policy/src/` → Phase 8 Policy Ecosystem)
 
 Build a phase-issue map:
 ```

--- a/.claude/skills/release-prepare.md
+++ b/.claude/skills/release-prepare.md
@@ -44,7 +44,7 @@ Invoke the `full-test` skill. ALL 7 checks must pass. If any check fails, STOP â
 Run the analytics engine to assess governance health for the release period:
 
 ```bash
-npx agentguard analytics --format json 2>/dev/null | head -100
+node apps/cli/dist/bin.js analytics --format json 2>/dev/null | head -100
 ```
 
 Extract:
@@ -88,7 +88,7 @@ Group PRs by prefix: `feat` â†’ Features, `fix` â†’ Bug Fixes, everything else â
 ### 7. Bump Version
 
 ```bash
-npm version <patch|minor|major> --no-git-tag-version
+pnpm version <patch|minor|major> --no-git-tag-version
 ```
 
 Stage the version change:
@@ -103,7 +103,7 @@ git commit -m "chore: bump version to <new-version>"
 Record the governance decision for the version bump:
 
 ```bash
-npx agentguard inspect --last --decisions 2>/dev/null
+node apps/cli/dist/bin.js inspect --last --decisions 2>/dev/null
 ```
 
 ### 9. Create Release Branch

--- a/.claude/skills/release-publish.md
+++ b/.claude/skills/release-publish.md
@@ -51,7 +51,7 @@ Verify the branch exists and the latest commit is the version bump.
 Run the full test suite one more time on the release branch:
 
 ```bash
-npm run build:ts && npm run ts:test && npm test
+pnpm build && pnpm test
 ```
 
 If any test fails, STOP — do not publish a broken release.

--- a/.claude/skills/repo-hygiene.md
+++ b/.claude/skills/repo-hygiene.md
@@ -56,7 +56,7 @@ gh issue view <N> --json state --jq '.state'
 Scan the codebase for undiscovered work items:
 
 ```bash
-grep -rn "TODO\|FIXME\|HACK\|XXX\|WORKAROUND" src/ --include="*.ts" | head -50
+grep -rn "TODO\|FIXME\|HACK\|XXX\|WORKAROUND" packages/ apps/ --include="*.ts" --exclude-dir=node_modules --exclude-dir=dist | head -50
 ```
 
 Cross-reference each annotation against open issues:
@@ -78,11 +78,11 @@ cat ROADMAP.md 2>/dev/null
 List source files without corresponding test files:
 
 ```bash
-ls src/**/*.ts 2>/dev/null
-ls tests/ts/*.test.ts 2>/dev/null
+find packages/ apps/ -name "*.ts" -not -name "*.test.ts" -not -path "*/node_modules/*" -not -path "*/dist/*" 2>/dev/null
+find packages/ apps/ -name "*.test.ts" -not -path "*/node_modules/*" 2>/dev/null
 ```
 
-For each source file in `src/`, check if a corresponding test file exists in `tests/ts/`. Flag source files with no test coverage as gaps.
+For each source file in `packages/*/src/` or `apps/*/src/`, check if a corresponding test file exists in the same package's `tests/` directory. Flag source files with no test coverage as gaps.
 
 ### 6. Generate Hygiene Report
 

--- a/.claude/skills/repository-maintenance.md
+++ b/.claude/skills/repository-maintenance.md
@@ -37,7 +37,7 @@ gh label create "source:backlog-steward" --color "C5DEF5" --description "Auto-cr
 Read governance analytics to prioritize maintenance actions:
 
 ```bash
-npx agentguard analytics --format json 2>/dev/null | head -50
+node apps/cli/dist/bin.js analytics --format json 2>/dev/null | head -50
 ```
 
 Extract:
@@ -66,7 +66,7 @@ gh pr list --state merged --base main --json number,title,body,mergedAt --limit 
 Search the codebase for TODO, FIXME, HACK, and XXX comments:
 
 ```bash
-grep -rn "TODO\|FIXME\|HACK\|XXX\|WORKAROUND" src/ tests/ --include="*.ts" --include="*.js" | head -50
+grep -rn "TODO\|FIXME\|HACK\|XXX\|WORKAROUND" packages/ apps/ tests/ --include="*.ts" --include="*.js" --exclude-dir=node_modules --exclude-dir=dist | head -50
 ```
 
 For each match, extract:

--- a/.claude/skills/resolve-merge-conflicts.md
+++ b/.claude/skills/resolve-merge-conflicts.md
@@ -176,12 +176,12 @@ Skip to the next PR.
 Run the full quality suite to ensure the rebase didn't break anything:
 
 ```bash
-npm run build:ts && npm run ts:check && npm run lint && npm run format && npm run ts:test && npm test
+pnpm build && pnpm ts:check && pnpm lint && pnpm format && ppnpm test && pnpm test
 ```
 
 If the suite fails:
-1. Attempt auto-fix: `npm run lint:fix && npm run format:fix`
-2. Re-run: `npm run build:ts && npm run ts:check && npm run lint && npm run format && npm run ts:test && npm test`
+1. Attempt auto-fix: `pnpm lint:fix && pnpm format:fix`
+2. Re-run: `pnpm build && pnpm ts:check && pnpm lint && pnpm format && ppnpm test && pnpm test`
 3. If still failing: the rebase introduced a regression. Reset the branch and post a diagnostic comment:
 
 ```bash

--- a/.claude/skills/respond-to-pr-reviews.md
+++ b/.claude/skills/respond-to-pr-reviews.md
@@ -111,7 +111,7 @@ Make the code change that addresses the feedback. Follow project conventions:
 After making the change, simulate each modified file against governance policy:
 
 ```bash
-npx agentguard simulate --action file.write --target <modified-file> --policy agentguard.yaml --json 2>/dev/null
+node apps/cli/dist/bin.js simulate --action file.write --target <modified-file> --policy agentguard.yaml --json 2>/dev/null
 ```
 
 If simulation shows a denial:
@@ -126,11 +126,11 @@ If the simulate command is not available, skip validation and proceed.
 After each change, run the full quality suite:
 
 ```bash
-npm run build:ts && npm run ts:check && npm run lint && npm run format && npm run ts:test && npm test
+pnpm build && pnpm ts:check && pnpm lint && pnpm format && ppnpm test && pnpm test
 ```
 
 If the suite fails after the change:
-1. Attempt auto-fix: `npm run lint:fix && npm run format:fix`
+1. Attempt auto-fix: `pnpm lint:fix && pnpm format:fix`
 2. Re-run the suite
 3. If still failing: **revert the change** for this comment, note it as unresolvable, and move to the next comment
 
@@ -180,7 +180,7 @@ The requested change cannot be applied automatically:
 - **Reason**: <denial reason>
 - **Affected file**: <file path>
 
-This requires a policy review or manual override. Run \`npx agentguard inspect --last\` for details.
+This requires a policy review or manual override. Run \`node apps/cli/dist/bin.js inspect --last\` for details.
 
 ---
 *Automated response by respond-to-pr-reviews skill on $(date -u +%Y-%m-%dT%H:%M:%SZ)*"
@@ -236,7 +236,7 @@ Report:
 - Process a maximum of **3 PRs per run**
 - **Only respond to PRs authored by `@me`** — never modify PRs authored by humans or other agents
 - **Never force push** — always regular push
-- **Never modify protected files**: `agentguard.yaml`, `.claude/settings.json`, files in `src/kernel/`, `src/policy/`, `src/invariants/` unless the review comment explicitly references them AND the linked issue authorizes it
+- **Never modify protected files**: `agentguard.yaml`, `.claude/settings.json`, files in `packages/kernel/src/`, `packages/policy/src/`, `packages/invariants/src/` unless the review comment explicitly references them AND the linked issue authorizes it
 - **Never push if the full quality suite fails** — revert the change and reply explaining the failure
 - **Never push changes that governance policy denies** — report the denial in the review thread
 - **Skip comments already replied to** by `**AgentGuard Review Response Bot**`

--- a/.claude/skills/review-open-prs.md
+++ b/.claude/skills/review-open-prs.md
@@ -79,13 +79,13 @@ Check the diff against these criteria:
 - Single quotes, trailing commas (es5), semicolons
 
 **Architecture Boundaries:**
-- Files in `src/kernel/**`, `src/policy/**`, `src/invariants/**` should only be modified if the linked issue explicitly authorizes it
+- Files in `packages/kernel/src/**`, `packages/policy/src/**`, `packages/invariants/src/**` should only be modified if the linked issue explicitly authorizes it
 - `agentguard.yaml` and `.claude/settings.json` should not be modified
 - Cross-layer imports follow dependency rules (adapters should not import from cli, kernel should not import from adapters)
-- Module boundaries respected: kernel/, events/, policy/, invariants/, adapters/, cli/, core/ are distinct layers
+- Module boundaries respected: each workspace package (kernel, events, policy, invariants, adapters, cli, core) is a distinct layer
 
 **Test Coverage:**
-- New source files in `src/` should have corresponding test files
+- New source files in `packages/*/src/` or `apps/*/src/` should have corresponding test files
 - Bug fixes should include regression tests
 
 **Governance Compliance:**

--- a/.claude/skills/risk-escalation.md
+++ b/.claude/skills/risk-escalation.md
@@ -59,7 +59,7 @@ Flag:
 #### 2c. Governance Denial Rate
 
 ```bash
-npx agentguard analytics --format json 2>/dev/null | head -100
+node apps/cli/dist/bin.js analytics --format json 2>/dev/null | head -100
 ```
 
 If analytics available, extract:

--- a/.claude/skills/run-tests.md
+++ b/.claude/skills/run-tests.md
@@ -13,26 +13,26 @@ Run these in sequence. If any step fails, fix and retry before proceeding.
 ### 1. Build TypeScript
 
 ```bash
-npm run build:ts
+pnpm build
 ```
 
-Compiles TypeScript via tsc + esbuild to `dist/`. If the build fails, read the error output, fix the source files, and rebuild. Do not proceed until the build succeeds.
+Compiles all workspace packages via Turborepo. If the build fails, read the error output, fix the source files, and rebuild. Do not proceed until the build succeeds.
 
 ### 2. Run TypeScript Tests (vitest)
 
 ```bash
-npm run ts:test
+ppnpm test
 ```
 
 Report the pass/fail count. If any tests fail:
 - If the failure is in code you modified, fix it and re-run
 - If the failure is a pre-existing issue unrelated to your changes, note it but proceed
-- Re-run after any fix: `npm run ts:test`
+- Re-run after any fix: `ppnpm test`
 
 ### 3. Run JavaScript Tests
 
 ```bash
-npm test
+pnpm test
 ```
 
 Report the pass/fail count. Same fix-or-note approach as step 2.
@@ -40,14 +40,14 @@ Report the pass/fail count. Same fix-or-note approach as step 2.
 ### 4. Run ESLint
 
 ```bash
-npm run lint
+pnpm lint
 ```
 
 If lint errors exist in files you modified:
 
 ```bash
-npm run lint:fix
-npm run lint
+pnpm lint:fix
+pnpm lint
 ```
 
 If errors persist after auto-fix, fix manually.
@@ -55,14 +55,14 @@ If errors persist after auto-fix, fix manually.
 ### 5. Run Prettier Format Check
 
 ```bash
-npm run format
+pnpm format
 ```
 
 If formatting issues exist in files you modified:
 
 ```bash
-npm run format:fix
-npm run format
+pnpm format:fix
+pnpm format
 ```
 
 ### 6. Commit Fixes

--- a/.claude/skills/scheduled-docs-sync.md
+++ b/.claude/skills/scheduled-docs-sync.md
@@ -39,22 +39,22 @@ Read the files that define the current state of the project:
 
 ```bash
 # Project structure
-find src/ -type f -name "*.ts" | sort
+find packages/ apps/ -type f -name "*.ts" -not -path "*/node_modules/*" -not -path "*/dist/*" | sort
 
 # Action types
-grep -c "actionType:" src/core/actions.ts
+grep -c "actionType:" packages/core/src/actions.ts
 
 # Event kinds
-grep "export type EventKind" src/events/schema.ts
+grep "export type EventKind" packages/events/src/schema.ts
 
 # Invariant definitions
-grep "id:" src/invariants/definitions.ts
+grep "id:" packages/invariants/src/definitions.ts
 
-# Package scripts
+# Package scripts (root turbo scripts)
 cat package.json | grep -A 50 '"scripts"'
 
 # CLI commands
-grep -r "\.command(" src/cli/ --include="*.ts" | head -20
+grep -r "\.command(" apps/cli/src/ --include="*.ts" | head -20
 ```
 
 ### 4. Read Documentation Files

--- a/.claude/skills/sdlc-pipeline-health.md
+++ b/.claude/skills/sdlc-pipeline-health.md
@@ -108,31 +108,31 @@ Use these colors:
 Run the build and test suite to verify the toolchain is healthy:
 
 ```bash
-npm run build:ts
+pnpm build
 ```
 
 Report build result (pass/fail).
 
 ```bash
-npm run ts:test
+ppnpm test
 ```
 
 Report test result (pass count, fail count).
 
 ```bash
-npm test
+pnpm test
 ```
 
 Report JS test result (pass count, fail count).
 
 ```bash
-npm run lint
+pnpm lint
 ```
 
 Report lint result (clean or error count).
 
 ```bash
-npm run format
+pnpm format
 ```
 
 Report format result (clean or issue count).

--- a/.claude/skills/security-code-scan.md
+++ b/.claude/skills/security-code-scan.md
@@ -17,12 +17,12 @@ Invoke the `start-governance-runtime` skill to ensure the AgentGuard kernel is a
 Search source files for patterns that indicate hardcoded credentials:
 
 ```bash
-grep -rn "password\s*=\s*['\"]" src/ --include="*.ts" || true
-grep -rn "secret\s*=\s*['\"]" src/ --include="*.ts" || true
-grep -rn "api[_-]?key\s*=\s*['\"]" src/ --include="*.ts" || true
-grep -rn "token\s*=\s*['\"]" src/ --include="*.ts" || true
-grep -rn "Bearer\s" src/ --include="*.ts" || true
-grep -rn "-----BEGIN.*PRIVATE KEY" src/ --include="*.ts" || true
+grep -rn "password\s*=\s*['\"]" packages/ apps/ --include="*.ts" --exclude-dir=node_modules --exclude-dir=dist || true
+grep -rn "secret\s*=\s*['\"]" packages/ apps/ --include="*.ts" --exclude-dir=node_modules --exclude-dir=dist || true
+grep -rn "api[_-]?key\s*=\s*['\"]" packages/ apps/ --include="*.ts" --exclude-dir=node_modules --exclude-dir=dist || true
+grep -rn "token\s*=\s*['\"]" packages/ apps/ --include="*.ts" --exclude-dir=node_modules --exclude-dir=dist || true
+grep -rn "Bearer\s" packages/ apps/ --include="*.ts" --exclude-dir=node_modules --exclude-dir=dist || true
+grep -rn "-----BEGIN.*PRIVATE KEY" packages/ apps/ --include="*.ts" --exclude-dir=node_modules --exclude-dir=dist || true
 ```
 
 Also check configuration and example files:
@@ -39,17 +39,17 @@ Check for dangerous JavaScript/TypeScript patterns:
 
 ```bash
 # eval and Function constructor — arbitrary code execution
-grep -rn "eval(" src/ --include="*.ts" || true
-grep -rn "new Function(" src/ --include="*.ts" || true
+grep -rn "eval(" packages/ apps/ --include="*.ts" --exclude-dir=node_modules --exclude-dir=dist || true
+grep -rn "new Function(" packages/ apps/ --include="*.ts" --exclude-dir=node_modules --exclude-dir=dist || true
 
 # Dynamic require — potential code injection
-grep -rn "require(" src/ --include="*.ts" | grep -v "import" || true
+grep -rn "require(" packages/ apps/ --include="*.ts" --exclude-dir=node_modules --exclude-dir=dist | grep -v "import" || true
 
 # Shell command construction — command injection risk
-grep -rn "exec(\|execSync(\|spawn(\|spawnSync(" src/ --include="*.ts" || true
+grep -rn "exec(\|execSync(\|spawn(\|spawnSync(" packages/ apps/ --include="*.ts" --exclude-dir=node_modules --exclude-dir=dist || true
 
 # Template literals in shell commands — injection risk
-grep -rn "exec\`\|execSync\`" src/ --include="*.ts" || true
+grep -rn "exec\`\|execSync\`" packages/ apps/ --include="*.ts" --exclude-dir=node_modules --exclude-dir=dist || true
 ```
 
 For each shell execution found, verify:
@@ -62,7 +62,7 @@ For each shell execution found, verify:
 Check file adapter and filesystem operations for path traversal:
 
 ```bash
-grep -rn "path.join\|path.resolve\|readFile\|writeFile\|readdir\|mkdir\|unlink\|rmdir" src/ --include="*.ts" || true
+grep -rn "path.join\|path.resolve\|readFile\|writeFile\|readdir\|mkdir\|unlink\|rmdir" packages/ apps/ --include="*.ts" --exclude-dir=node_modules --exclude-dir=dist || true
 ```
 
 For each filesystem operation found, verify:
@@ -71,9 +71,9 @@ For each filesystem operation found, verify:
 - Is `path.normalize()` used before path comparison?
 
 Focus particularly on:
-- `src/adapters/file.ts` — file adapter handles file.read, file.write, file.delete
-- `src/kernel/aab.ts` — AAB normalizes paths from agent input
-- `src/cli/` — CLI commands accept user-provided paths
+- `packages/adapters/src/file.ts` — file adapter handles file.read, file.write, file.delete
+- `packages/kernel/src/aab.ts` — AAB normalizes paths from agent input
+- `apps/cli/src/` — CLI commands accept user-provided paths
 
 ### 5. Scan for Input Validation Gaps
 
@@ -81,13 +81,13 @@ Check system boundaries where external data enters:
 
 ```bash
 # JSON parsing without try/catch
-grep -rn "JSON.parse(" src/ --include="*.ts" || true
+grep -rn "JSON.parse(" packages/ apps/ --include="*.ts" --exclude-dir=node_modules --exclude-dir=dist || true
 
 # stdin/process.argv handling
-grep -rn "process.stdin\|process.argv" src/ --include="*.ts" || true
+grep -rn "process.stdin\|process.argv" packages/ apps/ --include="*.ts" --exclude-dir=node_modules --exclude-dir=dist || true
 
 # File content used without validation
-grep -rn "readFileSync\|readFile" src/ --include="*.ts" || true
+grep -rn "readFileSync\|readFile" packages/ apps/ --include="*.ts" --exclude-dir=node_modules --exclude-dir=dist || true
 ```
 
 For each entry point, verify:
@@ -99,10 +99,10 @@ For each entry point, verify:
 
 ```bash
 # Stack traces exposed to output
-grep -rn "console.error(.*err\|console.log(.*stack" src/ --include="*.ts" || true
+grep -rn "console.error(.*err\|console.log(.*stack" packages/ apps/ --include="*.ts" --exclude-dir=node_modules --exclude-dir=dist || true
 
 # Verbose error messages that could leak internals
-grep -rn "throw new Error(" src/ --include="*.ts" | head -20
+grep -rn "throw new Error(" packages/ apps/ --include="*.ts" --exclude-dir=node_modules --exclude-dir=dist | head -20
 ```
 
 ### 7. Generate Security Report
@@ -174,7 +174,7 @@ Report:
 - **Never modify source code** — only read and report.
 - **Never close existing security issues** — only create new ones or comment on existing.
 - Exclude false positives: type definitions, test fixtures with dummy values, documentation.
-- Focus on the `src/` directory — do not scan `node_modules/`, `dist/`, or `.git/`.
+- Focus on `packages/*/src/` and `apps/*/src/` directories — do not scan `node_modules/`, `dist/`, or `.git/`.
 - Cap detailed findings at 20 items per category to keep reports actionable.
 - If `gh` CLI is not authenticated, still generate the report to console but skip issue creation.
 - Differentiate from `dependency-security-audit` — this skill scans SOURCE CODE, not dependencies.

--- a/.claude/skills/sprint-planning.md
+++ b/.claude/skills/sprint-planning.md
@@ -28,7 +28,7 @@ Invoke the `start-governance-runtime` skill to ensure the AgentGuard kernel is a
 Read cross-session governance data to inform prioritization:
 
 ```bash
-npx agentguard analytics --format json 2>/dev/null | head -100
+node apps/cli/dist/bin.js analytics --format json 2>/dev/null | head -100
 ```
 
 Extract:

--- a/.claude/skills/start-governance-runtime.md
+++ b/.claude/skills/start-governance-runtime.md
@@ -4,6 +4,16 @@ Ensure the AgentGuard kernel is active and intercepting all tool calls before an
 
 ## Steps
 
+### 0. Build the CLI
+
+Ensure the AgentGuard CLI is compiled from the latest source before hooks reference it:
+
+```bash
+pnpm build
+```
+
+If the build fails, STOP — governance hooks depend on the compiled CLI at `apps/cli/dist/bin.js`.
+
 ### 1. Check Hook Registration
 
 Read the local Claude Code settings and verify the PreToolUse governance hook is installed with SQLite storage:
@@ -19,7 +29,7 @@ Look for a `PreToolUse` entry whose command contains `claude-hook` and `--store 
 Run the AgentGuard hook installer with SQLite storage:
 
 ```bash
-npx agentguard claude-init --remove 2>/dev/null; npx agentguard claude-init --store sqlite
+node apps/cli/dist/bin.js claude-init --remove 2>/dev/null; node apps/cli/dist/bin.js claude-init --store sqlite
 ```
 
 This writes both PreToolUse (governance enforcement for all tools) and PostToolUse (Bash error monitoring) hooks into `.claude/settings.json`, configured to persist governance data to SQLite (`~/.agentguard/agentguard.db`). The `--remove` ensures any existing hooks without SQLite are replaced.
@@ -64,5 +74,5 @@ Policy: <filename or "none (fail-open)">
 
 - This skill MUST be the first skill invoked in any autonomous workflow
 - If hook installation fails, STOP — do not proceed with development work without governance
-- Never modify `.claude/settings.json` manually — always use `npx agentguard claude-init`
+- Never modify `.claude/settings.json` manually — always use `node apps/cli/dist/bin.js claude-init`
 - Never modify `agentguard.yaml` — this is the governance policy and is protected

--- a/.claude/skills/test-health-review.md
+++ b/.claude/skills/test-health-review.md
@@ -28,7 +28,7 @@ Invoke the `start-governance-runtime` skill to ensure the AgentGuard kernel is a
 Build must succeed before tests can run:
 
 ```bash
-npm run build:ts
+pnpm build
 ```
 
 If the build fails, record the error output and skip to Step 9 (Generate Report) with build failure as the primary finding. Do NOT attempt to fix the build — that is the Coder Agent's job.
@@ -54,7 +54,7 @@ Parse the output to extract:
 Run the custom JS test harness:
 
 ```bash
-npm test 2>&1
+pnpm test 2>&1
 ```
 
 Parse the output for:
@@ -97,25 +97,25 @@ Calculate the ratio of test code to source code:
 Count source files and test files:
 
 ```bash
-find src/ -name "*.ts" -not -name "*.test.ts" | wc -l
-find tests/ -name "*.test.*" | wc -l
+find packages/ apps/ -name "*.ts" -not -name "*.test.ts" -not -path "*/node_modules/*" -not -path "*/dist/*" | wc -l
+find packages/ apps/ -name "*.test.*" -not -path "*/node_modules/*" | wc -l
 ```
 
 Count lines of source code vs. test code:
 
 ```bash
-find src/ -name "*.ts" -not -name "*.test.ts" -exec cat {} + | wc -l
-find tests/ -name "*.test.*" -exec cat {} + | wc -l
+find packages/ apps/ -name "*.ts" -not -name "*.test.ts" -not -path "*/node_modules/*" -not -path "*/dist/*" -exec cat {} + | wc -l
+find packages/ apps/ -name "*.test.*" -not -path "*/node_modules/*" -exec cat {} + | wc -l
 ```
 
 Calculate:
 - **Test-to-code ratio**: test lines / source lines
 - **Test file coverage**: % of source modules that have a corresponding test file
-- **Untested modules**: Source files in `src/` with no matching test file in `tests/`
+- **Untested modules**: Source files with no matching test file in their package's `tests/` directory
 
-For each source file in `src/`, check if a corresponding test exists:
-- `src/kernel/kernel.ts` → `tests/ts/kernel.test.ts` or similar
-- `src/events/bus.ts` → `tests/ts/event-bus.test.ts` or similar
+For each source file, check if a corresponding test exists in the same package:
+- `packages/kernel/src/kernel.ts` → `packages/kernel/tests/kernel.test.ts` or similar
+- `packages/events/src/bus.ts` → `packages/events/tests/event-bus.test.ts` or similar
 
 List all source files that have NO corresponding test file.
 
@@ -171,7 +171,7 @@ Source files with no corresponding test file, grouped by directory.
 
 **Test-to-Code Ratio**:
 - Overall ratio
-- Per-directory breakdown (kernel, events, policy, invariants, adapters, cli, core)
+- Per-package breakdown (kernel, events, policy, invariants, adapters, cli, core)
 - Comparison note (healthy ratio is typically 0.8-1.5)
 
 **CI Pipeline Health**:

--- a/.claude/skills/triage-failing-ci.md
+++ b/.claude/skills/triage-failing-ci.md
@@ -91,11 +91,11 @@ Read the log output and classify into one of these categories:
 
 | Category | Indicators |
 |----------|------------|
-| **lint** | ESLint errors, `npm run lint` exit code |
-| **format** | Prettier check failures, `npm run format` exit code |
+| **lint** | ESLint errors, `pnpm lint` exit code |
+| **format** | Prettier check failures, `pnpm format` exit code |
 | **typecheck** | `tsc` errors, `TS\d+:` error codes |
-| **test** | vitest/test failures, assertion errors, `npm test` exit code |
-| **build** | `esbuild` errors, `npm run build:ts` exit code |
+| **test** | vitest/test failures, assertion errors, `pnpm test` exit code |
+| **build** | `esbuild` errors, `pnpm build` exit code |
 | **governance** | Failure correlates with a governance denial (from step 3c) |
 | **other** | Network errors, timeout, infrastructure issues |
 
@@ -118,8 +118,8 @@ git pull origin <HEAD_BRANCH>
 **Lint errors:**
 
 ```bash
-npm run lint:fix
-npm run lint
+pnpm lint:fix
+pnpm lint
 ```
 
 If errors persist after auto-fix, read the specific errors and fix manually.
@@ -127,8 +127,8 @@ If errors persist after auto-fix, read the specific errors and fix manually.
 **Format errors:**
 
 ```bash
-npm run format:fix
-npm run format
+pnpm format:fix
+pnpm format
 ```
 
 **Type errors:**
@@ -136,7 +136,7 @@ npm run format
 Read the `tsc` error output. Fix the specific type issues in the reported files. Then verify:
 
 ```bash
-npm run ts:check
+pnpm ts:check
 ```
 
 **Test failures:**
@@ -149,7 +149,7 @@ Read the test output. Investigate the failing test and the code it exercises:
 Then verify:
 
 ```bash
-npm run ts:test
+ppnpm test
 ```
 
 **Build errors:**
@@ -157,7 +157,7 @@ npm run ts:test
 Read the build output. Fix the reported issues (missing exports, syntax errors, etc.). Then verify:
 
 ```bash
-npm run build:ts
+pnpm build
 ```
 
 #### 4c. If the Fix Attempt Fails
@@ -169,7 +169,7 @@ If you cannot resolve the failure after **2 attempts**, STOP fixing this run. Po
 #### 5a. Run the Full Suite
 
 ```bash
-npm run build:ts && npm run ts:check && npm run lint && npm run format && npm run ts:test && npm test
+pnpm build && pnpm ts:check && pnpm lint && pnpm format && ppnpm test && pnpm test
 ```
 
 If any step fails that was not part of the original failure, do not push — you may have introduced a regression. Revert your changes and skip this run.
@@ -242,7 +242,7 @@ gh pr comment <PR_NUMBER> --body "**AgentGuard CI Triage Bot** — governance-re
 ## Recommended Action
 
 Review the governance policy to determine if the denial was intentional:
-- Run \`npx agentguard inspect --last\` to see full decision history
+- Run \`node apps/cli/dist/bin.js inspect --last\` to see full decision history
 - Check if the denied action is necessary for CI to pass
 - If the denial was correct, the implementation approach needs adjustment
 - If the denial was overly restrictive, consider a policy update


### PR DESCRIPTION
After the monorepo migration (#389), skills referenced stale paths and
commands from the old monolithic layout. This updates all 29 affected
files:

- .claude/settings.json: replace hardcoded Windows paths with portable
  `node apps/cli/dist/bin.js` for PreToolUse/PostToolUse hooks
- Build commands: npm run build:ts → pnpm build, npm run ts:test →
  pnpm test, npm run lint → pnpm lint, etc. across all skill files
- CLI invocations: npx agentguard → node apps/cli/dist/bin.js (uses
  locally built CLI, always up to date)
- Source paths: src/kernel/ → packages/kernel/src/, src/events/ →
  packages/events/src/, src/cli/ → apps/cli/src/, etc.
- Grep patterns: src/ → packages/ apps/ with --exclude-dir for
  node_modules and dist
- start-governance-runtime: add pnpm build step to ensure CLI is
  compiled before hooks reference it
- Architecture review: update dependency layer diagram to use
  @red-codes/* package names

https://claude.ai/code/session_018FKgQ3YTnjJQmh4eK2w1Mm