### PR TITLE
fix: use fixed height for terminal animation container to prevent content shift

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -333,7 +333,7 @@
               <span class="font-mono text-xs text-muted ml-2">agentguard guard --policy agentguard.yaml</span>
             </div>
             <!-- Terminal body -->
-            <div class="p-5 font-mono text-sm leading-relaxed min-h-[280px]">
+            <div class="p-5 font-mono text-sm leading-relaxed h-[380px] overflow-hidden">
               <div id="terminal-output" aria-live="polite"></div>
               <span class="cursor" aria-hidden="true"></span>
             </div>


### PR DESCRIPTION
The terminal body used min-h-[280px] which allowed it to grow as lines were
added and shrink when cleared, causing page content below to bounce up and down.
Changed to fixed h-[380px] with overflow-hidden so the container stays constant.

https://claude.ai/code/session_01AtBtP3GkeyBekN3b8vAFi7