### PR TITLE
test: improve test coverage with new test files, coverage tooling, and edge cases

### DIFF
--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -35,3 +35,5 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm turbo build
       - run: pnpm turbo test
+      - name: Coverage check
+        run: pnpm test:coverage

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -27,6 +27,7 @@
     "build": "tsc -b && tsx esbuild.config.ts",
     "dev": "node dist/bin.js",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "lint": "eslint src/",
     "ts:check": "tsc --noEmit",
     "clean": "rm -rf dist"

--- a/apps/cli/tests/cli-analytics.test.ts
+++ b/apps/cli/tests/cli-analytics.test.ts
@@ -1,0 +1,167 @@
+// Tests for CLI analytics command — cross-session violation pattern analysis
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock @red-codes/analytics before importing the command
+vi.mock('@red-codes/analytics', () => ({
+  analyze: vi.fn(),
+  toMarkdown: vi.fn(() => '# Markdown Report'),
+  toJson: vi.fn(() => '{"json":true}'),
+  toTerminal: vi.fn(() => '\n  Terminal Report\n'),
+  computeAllRunRiskScores: vi.fn(() => []),
+}));
+
+import { analyze, toMarkdown, toJson, toTerminal } from '@red-codes/analytics';
+
+// Mock process.stderr and process.stdout to capture output
+const stderrChunks: string[] = [];
+const stdoutChunks: string[] = [];
+vi.spyOn(process.stderr, 'write').mockImplementation((chunk: string | Uint8Array) => {
+  stderrChunks.push(chunk.toString());
+  return true;
+});
+vi.spyOn(process.stdout, 'write').mockImplementation((chunk: string | Uint8Array) => {
+  stdoutChunks.push(chunk.toString());
+  return true;
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  stderrChunks.length = 0;
+  stdoutChunks.length = 0;
+});
+
+const mockAnalyze = vi.mocked(analyze);
+const mockToTerminal = vi.mocked(toTerminal);
+const mockToJson = vi.mocked(toJson);
+const mockToMarkdown = vi.mocked(toMarkdown);
+
+const emptyReport = {
+  generatedAt: Date.now(),
+  sessionsAnalyzed: 0,
+  totalViolations: 0,
+  violationsByKind: {},
+  clusters: [],
+  trends: [],
+  topInferredCauses: [],
+  runRiskScores: [],
+};
+
+const violationReport = {
+  generatedAt: Date.now(),
+  sessionsAnalyzed: 3,
+  totalViolations: 5,
+  violationsByKind: { PolicyDenied: 3, InvariantViolation: 2 },
+  clusters: [],
+  trends: [],
+  topInferredCauses: [],
+  runRiskScores: [],
+};
+
+describe('analytics() with JSONL backend (no storageConfig)', () => {
+  it('returns 0 and writes "No violations found" when analyze returns totalViolations: 0', async () => {
+    mockAnalyze.mockReturnValue(emptyReport);
+
+    const { analytics } = await import('../src/commands/analytics.js');
+    const code = await analytics([]);
+
+    expect(code).toBe(0);
+    const output = stderrChunks.join('');
+    expect(output).toContain('No violations found');
+  });
+
+  it('returns 0 and calls toTerminal when violations exist (default format)', async () => {
+    mockAnalyze.mockReturnValue(violationReport);
+
+    const { analytics } = await import('../src/commands/analytics.js');
+    const code = await analytics([]);
+
+    expect(code).toBe(0);
+    expect(mockToTerminal).toHaveBeenCalledWith(violationReport);
+  });
+
+  it('calls toJson when --json flag is present', async () => {
+    mockAnalyze.mockReturnValue(violationReport);
+
+    const { analytics } = await import('../src/commands/analytics.js');
+    const code = await analytics(['--json']);
+
+    expect(code).toBe(0);
+    expect(mockToJson).toHaveBeenCalledWith(violationReport);
+    expect(stdoutChunks.join('')).toContain('{"json":true}');
+  });
+
+  it('calls toJson when --format json is present', async () => {
+    mockAnalyze.mockReturnValue(violationReport);
+
+    const { analytics } = await import('../src/commands/analytics.js');
+    const code = await analytics(['--format', 'json']);
+
+    expect(code).toBe(0);
+    expect(mockToJson).toHaveBeenCalledWith(violationReport);
+  });
+
+  it('calls toMarkdown when --markdown flag is present', async () => {
+    mockAnalyze.mockReturnValue(violationReport);
+
+    const { analytics } = await import('../src/commands/analytics.js');
+    const code = await analytics(['--markdown']);
+
+    expect(code).toBe(0);
+    expect(mockToMarkdown).toHaveBeenCalledWith(violationReport);
+    expect(stdoutChunks.join('')).toContain('# Markdown Report');
+  });
+
+  it('calls toMarkdown when --md flag is present', async () => {
+    mockAnalyze.mockReturnValue(violationReport);
+
+    const { analytics } = await import('../src/commands/analytics.js');
+    const code = await analytics(['--md']);
+
+    expect(code).toBe(0);
+    expect(mockToMarkdown).toHaveBeenCalledWith(violationReport);
+  });
+
+  it('passes --dir to analyze', async () => {
+    mockAnalyze.mockReturnValue(emptyReport);
+
+    const { analytics } = await import('../src/commands/analytics.js');
+    await analytics(['--dir', '/tmp/sessions']);
+
+    expect(mockAnalyze).toHaveBeenCalledWith(
+      expect.objectContaining({ baseDir: '/tmp/sessions' })
+    );
+  });
+
+  it('passes --min-cluster to analyze', async () => {
+    mockAnalyze.mockReturnValue(emptyReport);
+
+    const { analytics } = await import('../src/commands/analytics.js');
+    await analytics(['--min-cluster', '5']);
+
+    expect(mockAnalyze).toHaveBeenCalledWith(
+      expect.objectContaining({ minClusterSize: 5 })
+    );
+  });
+});
+
+describe('analytics() with --query (requires sqlite)', () => {
+  it('returns 1 with error when storageConfig is not sqlite', async () => {
+    const { analytics } = await import('../src/commands/analytics.js');
+    const code = await analytics(['--query', 'top-denied'], {
+      backend: 'jsonl',
+    } as unknown as import('@red-codes/storage').StorageConfig);
+
+    expect(code).toBe(1);
+    const output = stderrChunks.join('');
+    expect(output).toContain('--query requires SQLite storage backend');
+  });
+
+  it('returns 1 with error when storageConfig is undefined', async () => {
+    const { analytics } = await import('../src/commands/analytics.js');
+    const code = await analytics(['--query', 'top-denied']);
+
+    expect(code).toBe(1);
+    const output = stderrChunks.join('');
+    expect(output).toContain('--query requires SQLite storage backend');
+  });
+});

--- a/apps/cli/tests/cli-evidence-pr.test.ts
+++ b/apps/cli/tests/cli-evidence-pr.test.ts
@@ -1,0 +1,304 @@
+// Tests for the agentguard evidence-pr CLI command
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('node:fs', () => ({
+  readFileSync: vi.fn(),
+  existsSync: vi.fn(),
+  readdirSync: vi.fn(),
+}));
+
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn(),
+}));
+
+vi.mock('../src/args.js', () => ({
+  parseArgs: vi.fn(),
+}));
+
+vi.mock('../src/evidence-summary.js', () => ({
+  aggregateEvents: vi.fn(),
+  formatEvidenceMarkdown: vi.fn(),
+}));
+
+import { evidencePr } from '../src/commands/evidence-pr.js';
+import { readFileSync, existsSync, readdirSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { parseArgs } from '../src/args.js';
+import { aggregateEvents, formatEvidenceMarkdown } from '../src/evidence-summary.js';
+
+const mockSummary = {
+  totalEvents: 5,
+  actionsAllowed: 3,
+  actionsDenied: 1,
+  policyDenials: 0,
+  invariantViolations: 1,
+  escalations: 0,
+  blastRadiusExceeded: 0,
+  evidencePacksGenerated: 0,
+  maxEscalationLevel: 'NORMAL',
+  actionTypeBreakdown: {},
+  denialReasons: [],
+  violationDetails: [],
+  runIds: [],
+};
+
+let stderrOutput: string[];
+let stdoutOutput: string[];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  stderrOutput = [];
+  stdoutOutput = [];
+  vi.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
+    stderrOutput.push(String(chunk));
+    return true;
+  });
+  vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+    stdoutOutput.push(String(chunk));
+    return true;
+  });
+});
+
+/** Helper: set up parseArgs to return the given flags and positional args. */
+function mockParsed(flags: Record<string, unknown>, positional: string[] = []) {
+  vi.mocked(parseArgs).mockReturnValue({ flags, positional, rest: [] });
+}
+
+/** Helper: set up a run directory with the given JSONL file names. */
+function mockRunDir(files: string[]) {
+  vi.mocked(existsSync).mockReturnValue(true);
+  vi.mocked(readdirSync).mockReturnValue(files as never);
+}
+
+/** Helper: make existsSync respond true for the events dir and a specific run file. */
+function mockRunFile(content: string) {
+  vi.mocked(existsSync).mockReturnValue(true);
+  vi.mocked(readFileSync).mockReturnValue(content);
+}
+
+/** Helper: set up aggregate + format mocks with defaults. */
+function mockEvidencePipeline(markdown = '## Governance Evidence Report') {
+  vi.mocked(aggregateEvents).mockReturnValue(mockSummary as never);
+  vi.mocked(formatEvidenceMarkdown).mockReturnValue(markdown);
+}
+
+function makeEventLine(kind: string) {
+  return JSON.stringify({ id: 'evt_1', kind, timestamp: 1700000000000 });
+}
+
+describe('evidencePr CLI', () => {
+  describe('--dry-run mode', () => {
+    it('returns 0 and writes markdown to stdout', async () => {
+      mockParsed({ 'dry-run': true, run: 'run_abc' });
+      const eventLine = makeEventLine('ActionAllowed');
+      mockRunFile(eventLine + '\n');
+      mockEvidencePipeline('# Evidence MD');
+
+      const code = await evidencePr([]);
+
+      expect(code).toBe(0);
+      expect(stdoutOutput.join('')).toContain('# Evidence MD');
+    });
+
+    it('aggregates events from specified run (--run flag)', async () => {
+      mockParsed({ 'dry-run': true, run: 'run_xyz' });
+      const eventLine = makeEventLine('ActionDenied');
+      mockRunFile(eventLine + '\n');
+      mockEvidencePipeline();
+
+      await evidencePr([]);
+
+      expect(aggregateEvents).toHaveBeenCalledWith(
+        expect.arrayContaining([expect.objectContaining({ kind: 'ActionDenied' })])
+      );
+    });
+  });
+
+  describe('--run flag', () => {
+    it('returns 1 with error when run has no events', async () => {
+      mockParsed({ run: 'run_empty' });
+      // existsSync returns false for the run file so loadRunEvents returns []
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      const code = await evidencePr([]);
+
+      expect(code).toBe(1);
+      expect(stderrOutput.join('')).toContain('run_empty');
+      expect(stderrOutput.join('')).toContain('no events');
+    });
+
+    it('loads events for the specified run ID', async () => {
+      mockParsed({ run: 'run_specific', 'dry-run': true });
+      const eventLine = makeEventLine('ActionRequested');
+      mockRunFile(eventLine + '\n');
+      mockEvidencePipeline();
+
+      const code = await evidencePr([]);
+
+      expect(code).toBe(0);
+      expect(readFileSync).toHaveBeenCalled();
+      expect(aggregateEvents).toHaveBeenCalled();
+    });
+  });
+
+  describe('--last flag', () => {
+    it('returns 1 when no runs exist (readdirSync returns [])', async () => {
+      mockParsed({ last: true });
+      // existsSync for EVENTS_DIR returns false
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      const code = await evidencePr([]);
+
+      expect(code).toBe(1);
+      expect(stderrOutput.join('')).toContain('No governance runs');
+    });
+
+    it('returns 1 when most recent run has no events', async () => {
+      mockParsed({ last: true });
+      // First call: existsSync for EVENTS_DIR → true (for listRuns)
+      // Second call: existsSync for run file → false (no events)
+      vi.mocked(existsSync).mockReturnValueOnce(true).mockReturnValueOnce(false);
+      vi.mocked(readdirSync).mockReturnValue(['run_latest.jsonl'] as never);
+
+      const code = await evidencePr([]);
+
+      expect(code).toBe(1);
+      expect(stderrOutput.join('')).toContain('Most recent run');
+      expect(stderrOutput.join('')).toContain('no events');
+    });
+
+    it('loads most recent run events', async () => {
+      mockParsed({ last: true, 'dry-run': true });
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readdirSync).mockReturnValue(['run_a.jsonl', 'run_b.jsonl'] as never);
+      const eventLine = makeEventLine('ActionAllowed');
+      vi.mocked(readFileSync).mockReturnValue(eventLine + '\n');
+      mockEvidencePipeline();
+
+      const code = await evidencePr([]);
+
+      expect(code).toBe(0);
+      expect(aggregateEvents).toHaveBeenCalled();
+    });
+  });
+
+  describe('default mode (all runs)', () => {
+    it('returns 1 when no events found anywhere', async () => {
+      mockParsed({});
+      // existsSync for EVENTS_DIR returns false → listRuns returns []
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      const code = await evidencePr([]);
+
+      expect(code).toBe(1);
+      expect(stderrOutput.join('')).toContain('No governance events found');
+    });
+  });
+
+  describe('PR number resolution', () => {
+    it('uses --pr flag when provided', async () => {
+      mockParsed({ pr: '42', run: 'run_pr' });
+      const eventLine = makeEventLine('ActionAllowed');
+      mockRunFile(eventLine + '\n');
+      mockEvidencePipeline();
+      vi.mocked(execSync).mockReturnValue('' as never);
+
+      const code = await evidencePr([]);
+
+      expect(code).toBe(0);
+      expect(stderrOutput.join('')).toContain('PR #42');
+    });
+
+    it('uses positional arg for PR number', async () => {
+      mockParsed({}, ['99']);
+      // Load all runs with events
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readdirSync).mockReturnValue(['run_1.jsonl'] as never);
+      const eventLine = makeEventLine('ActionAllowed');
+      vi.mocked(readFileSync).mockReturnValue(eventLine + '\n');
+      mockEvidencePipeline();
+      vi.mocked(execSync).mockReturnValue('' as never);
+
+      const code = await evidencePr([]);
+
+      expect(code).toBe(0);
+      expect(stderrOutput.join('')).toContain('PR #99');
+    });
+
+    it('auto-detects via execSync gh pr view', async () => {
+      mockParsed({ run: 'run_auto' });
+      const eventLine = makeEventLine('ActionAllowed');
+      mockRunFile(eventLine + '\n');
+      mockEvidencePipeline();
+      // First execSync call: detectPrNumber → returns '77'
+      // Subsequent calls: postPrComment
+      vi.mocked(execSync).mockReturnValue('77' as never);
+
+      const code = await evidencePr([]);
+
+      expect(code).toBe(0);
+      expect(stderrOutput.join('')).toContain('PR #77');
+    });
+
+    it('returns 1 when PR number cannot be determined', async () => {
+      mockParsed({ run: 'run_nopr' });
+      const eventLine = makeEventLine('ActionAllowed');
+      mockRunFile(eventLine + '\n');
+      mockEvidencePipeline();
+      // detectPrNumber throws → returns null
+      vi.mocked(execSync).mockImplementation(() => {
+        throw new Error('gh not found');
+      });
+
+      const code = await evidencePr([]);
+
+      expect(code).toBe(1);
+      expect(stderrOutput.join('')).toContain('Could not determine PR number');
+    });
+
+    it('returns 1 when PR number is non-numeric', async () => {
+      mockParsed({ pr: 'abc', run: 'run_badpr' });
+      const eventLine = makeEventLine('ActionAllowed');
+      mockRunFile(eventLine + '\n');
+      mockEvidencePipeline();
+
+      const code = await evidencePr([]);
+
+      expect(code).toBe(1);
+      expect(stderrOutput.join('')).toContain('PR number must be numeric');
+    });
+  });
+
+  describe('comment posting', () => {
+    it('returns 1 when postPrComment fails (execSync throws)', async () => {
+      mockParsed({ pr: '10', run: 'run_fail' });
+      const eventLine = makeEventLine('ActionAllowed');
+      mockRunFile(eventLine + '\n');
+      mockEvidencePipeline();
+      // All execSync calls throw (checking existing comments fails, posting fails)
+      vi.mocked(execSync).mockImplementation(() => {
+        throw new Error('gh error');
+      });
+
+      const code = await evidencePr([]);
+
+      expect(code).toBe(1);
+      expect(stderrOutput.join('')).toContain('Failed to post evidence comment');
+    });
+
+    it('returns 0 on success and writes confirmation to stderr', async () => {
+      mockParsed({ pr: '55', run: 'run_ok' });
+      const eventLine = makeEventLine('ActionAllowed');
+      mockRunFile(eventLine + '\n');
+      mockEvidencePipeline();
+      // execSync succeeds for comment posting
+      vi.mocked(execSync).mockReturnValue('' as never);
+
+      const code = await evidencePr([]);
+
+      expect(code).toBe(0);
+      expect(stderrOutput.join('')).toContain('Evidence report posted to PR #55');
+      expect(stderrOutput.join('')).toContain('Events analyzed');
+    });
+  });
+});

--- a/apps/cli/tests/cli-plugin.test.ts
+++ b/apps/cli/tests/cli-plugin.test.ts
@@ -1,0 +1,340 @@
+// Tests for CLI plugin command — manage installed plugins
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+
+// Mock @red-codes/plugins
+const mockRegistry = {
+  list: vi.fn(),
+  install: vi.fn(),
+  get: vi.fn(),
+  remove: vi.fn(),
+  enable: vi.fn(),
+  disable: vi.fn(),
+};
+
+vi.mock('@red-codes/plugins', () => ({
+  createPluginRegistry: vi.fn(() => mockRegistry),
+  searchNpmPlugins: vi.fn(async () => []),
+  searchLocalPlugins: vi.fn(() => []),
+}));
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+}));
+
+vi.mock('../src/colors.js', () => ({
+  bold: (text: string) => text,
+  color: (text: string) => text,
+  dim: (text: string) => text,
+}));
+
+import { plugin } from '../src/commands/plugin.js';
+import { createPluginRegistry, searchNpmPlugins, searchLocalPlugins } from '@red-codes/plugins';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('plugin command', () => {
+  describe('subcommand routing', () => {
+    it('routes to list for "list"', async () => {
+      mockRegistry.list.mockReturnValue([]);
+      const code = await plugin(['list']);
+      expect(code).toBe(0);
+      expect(mockRegistry.list).toHaveBeenCalled();
+    });
+
+    it('routes to list for "ls"', async () => {
+      mockRegistry.list.mockReturnValue([]);
+      const code = await plugin(['ls']);
+      expect(code).toBe(0);
+      expect(mockRegistry.list).toHaveBeenCalled();
+    });
+
+    it('routes to install for "install"', async () => {
+      const code = await plugin(['install']);
+      expect(code).toBe(1);
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('Please specify a plugin source')
+      );
+    });
+
+    it('routes to install for "add"', async () => {
+      const code = await plugin(['add']);
+      expect(code).toBe(1);
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('Please specify a plugin source')
+      );
+    });
+
+    it('routes to remove for "remove"', async () => {
+      const code = await plugin(['remove']);
+      expect(code).toBe(1);
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('Please specify a plugin ID to remove')
+      );
+    });
+
+    it('routes to remove for "rm"', async () => {
+      const code = await plugin(['rm']);
+      expect(code).toBe(1);
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('Please specify a plugin ID to remove')
+      );
+    });
+
+    it('returns 0 for "help"', async () => {
+      const code = await plugin(['help']);
+      expect(code).toBe(0);
+      expect(console.log).toHaveBeenCalled();
+    });
+
+    it('returns 0 for "--help"', async () => {
+      const code = await plugin(['--help']);
+      expect(code).toBe(0);
+      expect(console.log).toHaveBeenCalled();
+    });
+
+    it('returns 0 for "-h"', async () => {
+      const code = await plugin(['-h']);
+      expect(code).toBe(0);
+      expect(console.log).toHaveBeenCalled();
+    });
+
+    it('returns 0 when no args given (undefined subcommand)', async () => {
+      const code = await plugin([]);
+      expect(code).toBe(0);
+      expect(console.log).toHaveBeenCalled();
+    });
+
+    it('returns 1 for unknown subcommand', async () => {
+      const code = await plugin(['bogus']);
+      expect(code).toBe(1);
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('Unknown plugin subcommand: bogus')
+      );
+    });
+  });
+
+  describe('pluginList', () => {
+    it('returns 0 with "No plugins installed" when registry is empty', async () => {
+      mockRegistry.list.mockReturnValue([]);
+      const code = await plugin(['list']);
+      expect(code).toBe(0);
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('No plugins installed'));
+    });
+
+    it('returns 0 and prints plugin info when plugins exist', async () => {
+      mockRegistry.list.mockReturnValue([
+        {
+          manifest: {
+            id: 'test-plugin',
+            name: 'Test Plugin',
+            version: '1.0.0',
+            type: 'renderer',
+            description: 'A test plugin',
+            capabilities: ['render'],
+          },
+          enabled: true,
+          source: '/path/to/plugin',
+        },
+      ]);
+      const code = await plugin(['list']);
+      expect(code).toBe(0);
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Installed Plugins'));
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Test Plugin'));
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('test-plugin'));
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('renderer'));
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('enabled'));
+    });
+  });
+
+  describe('pluginInstall', () => {
+    it('returns 1 when no source arg is given', async () => {
+      const code = await plugin(['install']);
+      expect(code).toBe(1);
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('Please specify a plugin source')
+      );
+    });
+
+    it('returns 1 when manifest file does not exist', async () => {
+      vi.mocked(existsSync).mockReturnValue(false);
+      const code = await plugin(['install', './my-plugin']);
+      expect(code).toBe(1);
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('Could not find a valid plugin manifest')
+      );
+    });
+
+    it('returns 0 on successful install', async () => {
+      const manifest = {
+        id: 'my-plugin',
+        name: 'My Plugin',
+        version: '1.0.0',
+        type: 'renderer',
+      };
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFileSync).mockReturnValue(
+        JSON.stringify({ agentguard: manifest })
+      );
+      mockRegistry.install.mockReturnValue({ valid: true, errors: [] });
+
+      const code = await plugin(['install', './my-plugin']);
+      expect(code).toBe(0);
+      expect(mockRegistry.install).toHaveBeenCalledWith(manifest, expect.any(String));
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Installed'));
+    });
+
+    it('returns 1 when validation fails', async () => {
+      const manifest = {
+        id: 'bad-plugin',
+        name: 'Bad Plugin',
+        version: '0.0.1',
+        type: 'renderer',
+      };
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFileSync).mockReturnValue(
+        JSON.stringify({ agentguard: manifest })
+      );
+      mockRegistry.install.mockReturnValue({
+        valid: false,
+        errors: [{ field: 'type', message: 'Invalid plugin type' }],
+      });
+
+      const code = await plugin(['install', './bad-plugin']);
+      expect(code).toBe(1);
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('Installation failed')
+      );
+    });
+  });
+
+  describe('pluginRemove', () => {
+    it('returns 1 when no ID arg given', async () => {
+      const code = await plugin(['remove']);
+      expect(code).toBe(1);
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('Please specify a plugin ID to remove')
+      );
+    });
+
+    it('returns 1 when plugin not found', async () => {
+      mockRegistry.get.mockReturnValue(null);
+      const code = await plugin(['remove', 'nonexistent']);
+      expect(code).toBe(1);
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('not installed')
+      );
+    });
+
+    it('returns 0 on successful removal', async () => {
+      mockRegistry.get.mockReturnValue({
+        manifest: { id: 'test-plugin', name: 'Test Plugin', version: '1.0.0' },
+        enabled: true,
+        source: '/path/to/plugin',
+      });
+      mockRegistry.remove.mockReturnValue(true);
+
+      const code = await plugin(['remove', 'test-plugin']);
+      expect(code).toBe(0);
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Removed'));
+    });
+
+    it('returns 1 when removal blocked by dependencies', async () => {
+      mockRegistry.get.mockReturnValue({
+        manifest: { id: 'dep-plugin', name: 'Dep Plugin', version: '1.0.0' },
+        enabled: true,
+        source: '/path/to/plugin',
+      });
+      mockRegistry.remove.mockReturnValue(false);
+
+      const code = await plugin(['remove', 'dep-plugin']);
+      expect(code).toBe(1);
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('other plugins depend on it')
+      );
+    });
+  });
+
+  describe('pluginEnable', () => {
+    it('returns 1 when no ID given', async () => {
+      const code = await plugin(['enable']);
+      expect(code).toBe(1);
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('Please specify a plugin ID to enable')
+      );
+    });
+
+    it('returns 1 when plugin not found', async () => {
+      mockRegistry.enable.mockReturnValue(false);
+      const code = await plugin(['enable', 'nonexistent']);
+      expect(code).toBe(1);
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('not installed')
+      );
+    });
+
+    it('returns 0 on success', async () => {
+      mockRegistry.enable.mockReturnValue(true);
+      const code = await plugin(['enable', 'my-plugin']);
+      expect(code).toBe(0);
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Enabled'));
+    });
+  });
+
+  describe('pluginDisable', () => {
+    it('returns 1 when no ID given', async () => {
+      const code = await plugin(['disable']);
+      expect(code).toBe(1);
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('Please specify a plugin ID to disable')
+      );
+    });
+
+    it('returns 1 when plugin not found', async () => {
+      mockRegistry.disable.mockReturnValue(false);
+      const code = await plugin(['disable', 'nonexistent']);
+      expect(code).toBe(1);
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('not installed')
+      );
+    });
+
+    it('returns 0 on success', async () => {
+      mockRegistry.disable.mockReturnValue(true);
+      const code = await plugin(['disable', 'my-plugin']);
+      expect(code).toBe(0);
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Disabled'));
+    });
+  });
+
+  describe('pluginSearch', () => {
+    it('returns 0 and shows "No plugins found" when both searches return empty', async () => {
+      vi.mocked(searchNpmPlugins).mockResolvedValue([]);
+      vi.mocked(searchLocalPlugins).mockReturnValue([]);
+      const code = await plugin(['search', 'renderer']);
+      expect(code).toBe(0);
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('No plugins found'));
+    });
+
+    it('returns 0 and shows npm results', async () => {
+      vi.mocked(searchNpmPlugins).mockResolvedValue([
+        { name: 'agentguard-renderer-json', version: '2.0.0', description: 'JSON renderer' },
+      ]);
+      const code = await plugin(['search', 'renderer']);
+      expect(code).toBe(0);
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('npm registry'));
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringContaining('agentguard-renderer-json')
+      );
+    });
+  });
+});

--- a/apps/cli/tests/policy-resolver.test.ts
+++ b/apps/cli/tests/policy-resolver.test.ts
@@ -1,0 +1,337 @@
+// Tests for the policy-resolver module — policy discovery, loading, and composition.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('node:fs', () => ({
+  readFileSync: vi.fn(),
+  existsSync: vi.fn(),
+}));
+
+vi.mock('node:os', () => ({
+  homedir: vi.fn(() => '/mock-home'),
+}));
+
+vi.mock('@red-codes/policy', () => ({
+  loadYamlPolicy: vi.fn(),
+  parseYamlPolicy: vi.fn(),
+  resolveExtends: vi.fn(),
+  mergePolicies: vi.fn(),
+  composePolicies: vi.fn(),
+  describeComposition: vi.fn(),
+}));
+
+// Mock process.exit to prevent test process from exiting
+const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+const mockStderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+import { readFileSync, existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { resolve, join } from 'node:path';
+import {
+  loadYamlPolicy,
+  parseYamlPolicy,
+  resolveExtends,
+  mergePolicies,
+  composePolicies,
+  describeComposition,
+} from '@red-codes/policy';
+
+import {
+  findDefaultPolicy,
+  findUserPolicy,
+  loadPolicyFile,
+  loadPolicyDefs,
+  loadComposedPolicies,
+} from '../src/policy-resolver.js';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// findDefaultPolicy
+// ---------------------------------------------------------------------------
+
+describe('findDefaultPolicy', () => {
+  it('returns first matching candidate when existsSync returns true', () => {
+    vi.mocked(existsSync).mockImplementation((p) => p === 'agentguard.yaml');
+    expect(findDefaultPolicy()).toBe('agentguard.yaml');
+  });
+
+  it('returns null when no candidates exist', () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+    expect(findDefaultPolicy()).toBeNull();
+  });
+
+  it('returns agentguard.yml if agentguard.yaml does not exist but .yml does', () => {
+    vi.mocked(existsSync).mockImplementation((p) => p === 'agentguard.yml');
+    expect(findDefaultPolicy()).toBe('agentguard.yml');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findUserPolicy
+// ---------------------------------------------------------------------------
+
+describe('findUserPolicy', () => {
+  it('returns full path when user policy exists', () => {
+    const expectedPath = join('/mock-home', '.agentguard', 'policy.yaml');
+    vi.mocked(existsSync).mockImplementation((p) => p === expectedPath);
+    expect(findUserPolicy()).toBe(expectedPath);
+  });
+
+  it('returns null when no user policy exists', () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+    expect(findUserPolicy()).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadPolicyFile
+// ---------------------------------------------------------------------------
+
+describe('loadPolicyFile', () => {
+  it('loads YAML policy file (.yaml extension)', () => {
+    const absPath = resolve('test-policy.yaml');
+    const yamlContent = 'id: test\nname: Test\nrules: []';
+    const mockPolicy = { id: 'test', name: 'Test', rules: [], severity: 3 };
+
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(yamlContent);
+    vi.mocked(loadYamlPolicy).mockReturnValue(mockPolicy as never);
+    vi.mocked(parseYamlPolicy).mockReturnValue({ extends: [] } as never);
+
+    const result = loadPolicyFile('test-policy.yaml');
+
+    expect(loadYamlPolicy).toHaveBeenCalledWith(yamlContent, 'test-policy.yaml');
+    expect(result).toEqual([{ id: 'test', name: 'Test', rules: [], severity: 3 }]);
+  });
+
+  it('loads YAML policy file with extends chain', () => {
+    const absPath = resolve('test-policy.yaml');
+    const yamlContent = 'id: test\nname: Test\nextends: [ci-safe]';
+    const localPolicy = { id: 'test', name: 'Test', rules: [{ action: 'file.read' }], severity: 3 };
+    const packPolicy = { id: 'ci-safe', name: 'CI Safe', rules: [{ action: 'git.push' }], severity: 2 };
+    const mergedPolicies = [localPolicy, packPolicy];
+
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(yamlContent);
+    vi.mocked(loadYamlPolicy).mockReturnValue(localPolicy as never);
+    vi.mocked(parseYamlPolicy).mockReturnValue({ extends: ['ci-safe'] } as never);
+    vi.mocked(resolveExtends).mockReturnValue({ policies: [packPolicy], errors: [] } as never);
+    vi.mocked(mergePolicies).mockReturnValue(mergedPolicies as never);
+
+    const result = loadPolicyFile('test-policy.yaml');
+
+    expect(resolveExtends).toHaveBeenCalled();
+    expect(mergePolicies).toHaveBeenCalledWith(localPolicy, [packPolicy]);
+    expect(result).toHaveLength(2);
+  });
+
+  it('loads JSON policy file (single object)', () => {
+    const absPath = resolve('policy.json');
+    const jsonContent = JSON.stringify({ id: 'json-policy', rules: [] });
+
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(jsonContent);
+
+    const result = loadPolicyFile('policy.json');
+
+    expect(result).toEqual([{ id: 'json-policy', rules: [] }]);
+  });
+
+  it('loads JSON policy file (array of policies)', () => {
+    const policies = [
+      { id: 'policy-a', rules: [] },
+      { id: 'policy-b', rules: [] },
+    ];
+    const jsonContent = JSON.stringify(policies);
+
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(jsonContent);
+
+    const result = loadPolicyFile('policies.json');
+
+    expect(result).toEqual(policies);
+    expect(result).toHaveLength(2);
+  });
+
+  it('exits with error for missing file', () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    loadPolicyFile('nonexistent.yaml');
+
+    expect(mockStderr).toHaveBeenCalledWith(expect.stringContaining('Policy file not found'));
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  it('exits with error for malformed JSON', () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue('{ invalid json');
+
+    loadPolicyFile('bad.json');
+
+    expect(mockStderr).toHaveBeenCalledWith(expect.stringContaining('Failed to parse policy file'));
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadPolicyDefs
+// ---------------------------------------------------------------------------
+
+describe('loadPolicyDefs', () => {
+  it('uses provided path', () => {
+    const jsonContent = JSON.stringify({ id: 'explicit', rules: [] });
+
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(jsonContent);
+
+    const result = loadPolicyDefs('explicit.json');
+
+    expect(result).toEqual([{ id: 'explicit', rules: [] }]);
+  });
+
+  it('falls back to findDefaultPolicy', () => {
+    // existsSync returns true for agentguard.yaml (first candidate)
+    vi.mocked(existsSync).mockImplementation(
+      (p) => p === 'agentguard.yaml' || p === resolve('agentguard.yaml')
+    );
+    const yamlContent = 'id: default\nname: Default\nrules: []';
+    const mockPolicy = { id: 'default', name: 'Default', rules: [], severity: 3 };
+
+    vi.mocked(readFileSync).mockReturnValue(yamlContent);
+    vi.mocked(loadYamlPolicy).mockReturnValue(mockPolicy as never);
+    vi.mocked(parseYamlPolicy).mockReturnValue({ extends: [] } as never);
+
+    const result = loadPolicyDefs();
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ id: 'default', name: 'Default', rules: [], severity: 3 });
+  });
+
+  it('returns empty array when no policy found', () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    const result = loadPolicyDefs();
+
+    expect(result).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadComposedPolicies
+// ---------------------------------------------------------------------------
+
+describe('loadComposedPolicies', () => {
+  const userPolicyPath = join('/mock-home', '.agentguard', 'policy.yaml');
+
+  it('includes user-level policy when it exists', () => {
+    const userPolicy = { id: 'user-policy', name: 'User', rules: [], severity: 1 };
+    const yamlContent = 'id: user-policy\nname: User\nrules: []';
+
+    vi.mocked(existsSync).mockImplementation((p) => p === userPolicyPath);
+    vi.mocked(readFileSync).mockReturnValue(yamlContent);
+    vi.mocked(loadYamlPolicy).mockReturnValue(userPolicy as never);
+    vi.mocked(parseYamlPolicy).mockReturnValue({ extends: [] } as never);
+    vi.mocked(composePolicies).mockReturnValue({ policies: [userPolicy], sources: [] } as never);
+
+    loadComposedPolicies();
+
+    expect(composePolicies).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ path: userPolicyPath, layer: 'user' }),
+      ])
+    );
+  });
+
+  it('includes project-level policy', () => {
+    const projectPolicy = { id: 'project-policy', name: 'Project', rules: [], severity: 2 };
+    const yamlContent = 'id: project-policy\nname: Project\nrules: []';
+
+    // No user policy, but project-level agentguard.yaml exists
+    vi.mocked(existsSync).mockImplementation(
+      (p) => p === 'agentguard.yaml' || p === resolve('agentguard.yaml')
+    );
+    vi.mocked(readFileSync).mockReturnValue(yamlContent);
+    vi.mocked(loadYamlPolicy).mockReturnValue(projectPolicy as never);
+    vi.mocked(parseYamlPolicy).mockReturnValue({ extends: [] } as never);
+    vi.mocked(composePolicies).mockReturnValue({ policies: [projectPolicy], sources: [] } as never);
+
+    loadComposedPolicies();
+
+    expect(composePolicies).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ layer: 'project' }),
+      ])
+    );
+  });
+
+  it('includes explicit policy paths', () => {
+    const explicitPolicy = { id: 'explicit', name: 'Explicit', rules: [], severity: 3 };
+    const jsonContent = JSON.stringify(explicitPolicy);
+
+    // No user or project policy, only explicit
+    vi.mocked(existsSync).mockImplementation((p) => p === resolve('custom.json'));
+    vi.mocked(readFileSync).mockReturnValue(jsonContent);
+    vi.mocked(composePolicies).mockReturnValue({ policies: [explicitPolicy], sources: [] } as never);
+
+    loadComposedPolicies(['custom.json']);
+
+    expect(composePolicies).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ layer: 'explicit' }),
+      ])
+    );
+  });
+
+  it('avoids loading default policy twice when explicitly listed', () => {
+    const policy = { id: 'default', name: 'Default', rules: [], severity: 2 };
+    const yamlContent = 'id: default\nname: Default\nrules: []';
+    const absDefault = resolve('agentguard.yaml');
+
+    // agentguard.yaml exists as both project default and is passed explicitly
+    vi.mocked(existsSync).mockImplementation(
+      (p) => p === 'agentguard.yaml' || p === absDefault
+    );
+    vi.mocked(readFileSync).mockReturnValue(yamlContent);
+    vi.mocked(loadYamlPolicy).mockReturnValue(policy as never);
+    vi.mocked(parseYamlPolicy).mockReturnValue({ extends: [] } as never);
+    vi.mocked(composePolicies).mockReturnValue({ policies: [policy], sources: [] } as never);
+
+    loadComposedPolicies(['agentguard.yaml']);
+
+    // composePolicies should be called with sources that do NOT include a 'project' layer
+    // since the default policy is explicitly listed (only 'explicit' layer)
+    const sources = vi.mocked(composePolicies).mock.calls[0][0] as Array<{ layer: string }>;
+    const projectSources = sources.filter((s) => s.layer === 'project');
+    expect(projectSources).toHaveLength(0);
+  });
+
+  it('handles load failures gracefully (warns but continues)', () => {
+    // User policy exists but fails to load
+    vi.mocked(existsSync).mockImplementation((p) => p === userPolicyPath);
+    vi.mocked(readFileSync).mockImplementation(() => {
+      throw new Error('read error');
+    });
+    vi.mocked(composePolicies).mockReturnValue({ policies: [], sources: [] } as never);
+
+    loadComposedPolicies();
+
+    expect(mockStderr).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to load user policy')
+    );
+    // composePolicies should still be called (with empty sources)
+    expect(composePolicies).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// describeComposition re-export
+// ---------------------------------------------------------------------------
+
+describe('describeComposition', () => {
+  it('is re-exported from @red-codes/policy', () => {
+    expect(describeComposition).toBeDefined();
+    expect(typeof describeComposition).toBe('function');
+  });
+});

--- a/apps/cli/vitest.config.ts
+++ b/apps/cli/vitest.config.ts
@@ -4,5 +4,14 @@ export default defineConfig({
   test: {
     include: ['tests/**/*.test.ts'],
     environment: 'node',
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.ts'],
+      reporter: ['text', 'json-summary', 'lcov'],
+      thresholds: {
+        lines: 50,
+        branches: 40,
+      },
+    },
   },
 });

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "turbo build",
     "dev": "turbo dev",
     "test": "turbo test",
+    "test:coverage": "turbo test:coverage",
     "lint": "turbo lint",
     "format": "prettier --check 'packages/*/src/**' 'apps/*/src/**'",
     "format:fix": "prettier --write 'packages/*/src/**' 'apps/*/src/**'",

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "build": "tsc -b",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "lint": "eslint src/",
     "ts:check": "tsc --noEmit",
     "clean": "rm -rf dist"

--- a/packages/adapters/vitest.config.ts
+++ b/packages/adapters/vitest.config.ts
@@ -4,5 +4,14 @@ export default defineConfig({
   test: {
     include: ['tests/**/*.test.ts'],
     environment: 'node',
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.ts'],
+      reporter: ['text', 'json-summary', 'lcov'],
+      thresholds: {
+        lines: 50,
+        branches: 40,
+      },
+    },
   },
 });

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "build": "tsc -b",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "lint": "eslint src/",
     "ts:check": "tsc --noEmit",
     "clean": "rm -rf dist"

--- a/packages/analytics/tests/reporter-direct.test.ts
+++ b/packages/analytics/tests/reporter-direct.test.ts
@@ -1,0 +1,189 @@
+// Direct tests for the analytics reporter — toTerminal, toMarkdown, toJson
+import { describe, it, expect } from 'vitest';
+import { toTerminal, toMarkdown, toJson } from '@red-codes/analytics';
+import type { AnalyticsReport } from '@red-codes/analytics';
+
+function makeReport(overrides: Partial<AnalyticsReport> = {}): AnalyticsReport {
+  return {
+    generatedAt: Date.now(),
+    sessionsAnalyzed: 5,
+    totalViolations: 10,
+    violationsByKind: { InvariantViolation: 6, PolicyDenied: 4 },
+    clusters: [
+      {
+        id: 'c1',
+        label: 'secret-exposure',
+        groupBy: 'invariant',
+        key: 'no-secret-exposure',
+        violations: [],
+        count: 6,
+        firstSeen: Date.now() - 86400000,
+        lastSeen: Date.now(),
+        sessionCount: 3,
+        inferredCause: 'Developers frequently modify .env files',
+      },
+    ],
+    trends: [
+      {
+        key: 'InvariantViolation',
+        dimension: 'kind',
+        direction: 'increasing',
+        recentCount: 8,
+        previousCount: 2,
+        changePercent: 300,
+      },
+    ],
+    topInferredCauses: [{ cause: 'Developers frequently modify .env files', count: 3 }],
+    runRiskScores: [
+      {
+        sessionId: 'session_abc123def456',
+        score: 75,
+        riskLevel: 'high',
+        factors: [],
+        totalActions: 20,
+        totalDenials: 5,
+        totalViolations: 3,
+        peakEscalation: 2,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function makeEmptyReport(): AnalyticsReport {
+  return {
+    generatedAt: Date.now(),
+    sessionsAnalyzed: 0,
+    totalViolations: 0,
+    violationsByKind: {},
+    clusters: [],
+    trends: [],
+    topInferredCauses: [],
+    runRiskScores: [],
+  };
+}
+
+describe('toTerminal', () => {
+  it('contains violation counts and session info', () => {
+    const output = toTerminal(makeReport());
+    expect(output).toContain('Violation Pattern Analysis');
+    expect(output).toContain('Sessions: 5');
+    expect(output).toContain('Violations: 10');
+  });
+
+  it('contains violations by kind', () => {
+    const output = toTerminal(makeReport());
+    expect(output).toContain('InvariantViolation: 6');
+    expect(output).toContain('PolicyDenied: 4');
+  });
+
+  it('contains cluster information', () => {
+    const output = toTerminal(makeReport());
+    expect(output).toContain('Clusters');
+    expect(output).toContain('secret-exposure');
+    expect(output).toContain('6 violations');
+  });
+
+  it('contains trend indicators', () => {
+    const output = toTerminal(makeReport());
+    expect(output).toContain('Trends');
+    expect(output).toContain('+300%');
+  });
+
+  it('contains inferred causes', () => {
+    const output = toTerminal(makeReport());
+    expect(output).toContain('Top Inferred Causes');
+    expect(output).toContain('Developers frequently modify .env files');
+  });
+
+  it('contains risk scores', () => {
+    const output = toTerminal(makeReport());
+    expect(output).toContain('Run Risk Scores');
+    expect(output).toContain('score: 75');
+    expect(output).toContain('HIGH');
+  });
+
+  it('handles empty report gracefully', () => {
+    const output = toTerminal(makeEmptyReport());
+    expect(output).toContain('Violation Pattern Analysis');
+    expect(output).toContain('Sessions: 0');
+    expect(output).toContain('Violations: 0');
+    // Should not contain section headers for empty data
+    expect(output).not.toContain('Clusters');
+    expect(output).not.toContain('Trends');
+    expect(output).not.toContain('Top Inferred Causes');
+  });
+});
+
+describe('toMarkdown', () => {
+  it('produces valid markdown structure', () => {
+    const output = toMarkdown(makeReport());
+    expect(output).toContain('# Violation Pattern Analysis');
+    expect(output).toContain('## Violations by Kind');
+    expect(output).toContain('| Kind | Count |');
+  });
+
+  it('includes violation kind table rows', () => {
+    const output = toMarkdown(makeReport());
+    expect(output).toContain('| InvariantViolation | 6 |');
+    expect(output).toContain('| PolicyDenied | 4 |');
+  });
+
+  it('includes cluster sections', () => {
+    const output = toMarkdown(makeReport());
+    expect(output).toContain('## Violation Clusters');
+    expect(output).toContain('### secret-exposure');
+    expect(output).toContain('**Count**: 6');
+  });
+
+  it('includes trend table', () => {
+    const output = toMarkdown(makeReport());
+    expect(output).toContain('## Trends');
+    expect(output).toContain('| Pattern | Direction |');
+    expect(output).toContain('+300%');
+  });
+
+  it('includes risk score table', () => {
+    const output = toMarkdown(makeReport());
+    expect(output).toContain('## Run Risk Scores');
+    expect(output).toContain('| Session | Score |');
+  });
+
+  it('handles empty report', () => {
+    const output = toMarkdown(makeEmptyReport());
+    expect(output).toContain('# Violation Pattern Analysis');
+    expect(output).toContain('Total violations: 0');
+  });
+});
+
+describe('toJson', () => {
+  it('returns valid JSON', () => {
+    const output = toJson(makeReport());
+    const parsed = JSON.parse(output);
+    expect(parsed.totalViolations).toBe(10);
+    expect(parsed.sessionsAnalyzed).toBe(5);
+  });
+
+  it('preserves all report fields', () => {
+    const report = makeReport();
+    const parsed = JSON.parse(toJson(report));
+    expect(parsed.violationsByKind).toEqual(report.violationsByKind);
+    expect(parsed.clusters).toHaveLength(1);
+    expect(parsed.trends).toHaveLength(1);
+    expect(parsed.runRiskScores).toHaveLength(1);
+  });
+
+  it('handles empty report', () => {
+    const output = toJson(makeEmptyReport());
+    const parsed = JSON.parse(output);
+    expect(parsed.totalViolations).toBe(0);
+    expect(parsed.clusters).toEqual([]);
+  });
+
+  it('is pretty-printed with 2-space indent', () => {
+    const output = toJson(makeReport());
+    // Pretty-printed JSON has newlines and indentation
+    expect(output).toContain('\n');
+    expect(output).toContain('  ');
+  });
+});

--- a/packages/analytics/vitest.config.ts
+++ b/packages/analytics/vitest.config.ts
@@ -4,5 +4,14 @@ export default defineConfig({
   test: {
     include: ['tests/**/*.test.ts'],
     environment: 'node',
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.ts'],
+      reporter: ['text', 'json-summary', 'lcov'],
+      thresholds: {
+        lines: 50,
+        branches: 40,
+      },
+    },
   },
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "build": "tsc -b",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "lint": "eslint src/",
     "ts:check": "tsc --noEmit",
     "clean": "rm -rf dist"

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -4,5 +4,14 @@ export default defineConfig({
   test: {
     include: ['tests/**/*.test.ts'],
     environment: 'node',
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.ts'],
+      reporter: ['text', 'json-summary', 'lcov'],
+      thresholds: {
+        lines: 50,
+        branches: 40,
+      },
+    },
   },
 });

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "build": "tsc -b",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "lint": "eslint src/",
     "ts:check": "tsc --noEmit",
     "clean": "rm -rf dist"

--- a/packages/events/vitest.config.ts
+++ b/packages/events/vitest.config.ts
@@ -4,5 +4,14 @@ export default defineConfig({
   test: {
     include: ['tests/**/*.test.ts'],
     environment: 'node',
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.ts'],
+      reporter: ['text', 'json-summary', 'lcov'],
+      thresholds: {
+        lines: 50,
+        branches: 40,
+      },
+    },
   },
 });

--- a/packages/invariants/package.json
+++ b/packages/invariants/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "build": "tsc -b",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "lint": "eslint src/",
     "ts:check": "tsc --noEmit",
     "clean": "rm -rf dist"

--- a/packages/invariants/tests/invariant-definitions.test.ts
+++ b/packages/invariants/tests/invariant-definitions.test.ts
@@ -1828,3 +1828,55 @@ describe('recursive-operation-guard', () => {
     expect(result.actual).toContain('find -exec sh -c (shred)');
   });
 });
+
+describe('checkAllInvariants interaction tests', () => {
+  it('reports multiple simultaneous violations', () => {
+    // State that triggers both no-secret-exposure and protected-branch
+    const state = {
+      modifiedFiles: ['.env'],
+      targetBranch: 'main',
+      directPush: true,
+      isPush: true,
+    };
+
+    const result = checkAllInvariants(DEFAULT_INVARIANTS, buildSystemState(state));
+    expect(result.allHold).toBe(false);
+    expect(result.violations.length).toBeGreaterThanOrEqual(2);
+
+    const violatedIds = result.violations.map((v) => v.invariant.id);
+    expect(violatedIds).toContain('no-secret-exposure');
+    expect(violatedIds).toContain('protected-branch');
+  });
+
+  it('emits one event per violation', () => {
+    const state = {
+      modifiedFiles: ['.env'],
+      targetBranch: 'main',
+      directPush: true,
+      isPush: true,
+    };
+
+    const result = checkAllInvariants(DEFAULT_INVARIANTS, buildSystemState(state));
+    expect(result.events.length).toBe(result.violations.length);
+
+    for (const event of result.events) {
+      expect(event.kind).toBe('InvariantViolation');
+    }
+  });
+
+  it('returns allHold: true and empty violations when no invariants fail', () => {
+    const state = { modifiedFiles: ['src/index.ts'] };
+    const result = checkAllInvariants(DEFAULT_INVARIANTS, buildSystemState(state));
+    expect(result.allHold).toBe(true);
+    expect(result.violations).toEqual([]);
+    expect(result.events).toEqual([]);
+  });
+
+  it('handles empty invariant list', () => {
+    const state = { modifiedFiles: ['.env'], directPush: true, targetBranch: 'main' };
+    const result = checkAllInvariants([], buildSystemState(state));
+    expect(result.allHold).toBe(true);
+    expect(result.violations).toEqual([]);
+    expect(result.events).toEqual([]);
+  });
+});

--- a/packages/invariants/vitest.config.ts
+++ b/packages/invariants/vitest.config.ts
@@ -4,5 +4,14 @@ export default defineConfig({
   test: {
     include: ['tests/**/*.test.ts'],
     environment: 'node',
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.ts'],
+      reporter: ['text', 'json-summary', 'lcov'],
+      thresholds: {
+        lines: 50,
+        branches: 40,
+      },
+    },
   },
 });

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "build": "tsc -b",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "lint": "eslint src/",
     "ts:check": "tsc --noEmit",
     "clean": "rm -rf dist"

--- a/packages/kernel/tests/kernel.test.ts
+++ b/packages/kernel/tests/kernel.test.ts
@@ -416,3 +416,54 @@ describe('Kernel proposal timeout', () => {
     expect(result.allowed).toBe(true);
   });
 });
+
+describe('Kernel edge cases', () => {
+  it('handles proposal with minimal fields', async () => {
+    const kernel = createKernel({ dryRun: true });
+    const result = await kernel.propose({
+      tool: 'Read',
+      agent: 'test',
+    });
+    // Should still produce a result (file.read with empty target)
+    expect(result).toBeDefined();
+    expect(typeof result.allowed).toBe('boolean');
+  });
+
+  it('handles proposal with very long command string', async () => {
+    const kernel = createKernel({ dryRun: true });
+    const longCommand = 'echo ' + 'x'.repeat(10000);
+    const result = await kernel.propose({
+      tool: 'Bash',
+      command: longCommand,
+      agent: 'test',
+    });
+    expect(result).toBeDefined();
+    expect(typeof result.allowed).toBe('boolean');
+  });
+
+  it('handles proposal with special characters in file path', async () => {
+    const kernel = createKernel({ dryRun: true });
+    const result = await kernel.propose({
+      tool: 'Write',
+      file: "src/file with spaces & 'quotes'.ts",
+      content: 'test',
+      agent: 'test',
+    });
+    expect(result).toBeDefined();
+    expect(typeof result.allowed).toBe('boolean');
+  });
+
+  it('handles rapid sequential proposals', async () => {
+    const kernel = createKernel({ dryRun: true });
+    const results = await Promise.all([
+      kernel.propose({ tool: 'Read', file: 'a.ts', agent: 'test' }),
+      kernel.propose({ tool: 'Read', file: 'b.ts', agent: 'test' }),
+      kernel.propose({ tool: 'Read', file: 'c.ts', agent: 'test' }),
+    ]);
+
+    expect(results).toHaveLength(3);
+    for (const result of results) {
+      expect(result.allowed).toBe(true);
+    }
+  });
+});

--- a/packages/kernel/tests/simulation-filesystem.test.ts
+++ b/packages/kernel/tests/simulation-filesystem.test.ts
@@ -117,3 +117,74 @@ describe('FilesystemSimulator', () => {
     expect(result.blastRadius).toBe(5);
   });
 });
+
+describe('FilesystemSimulator edge cases', () => {
+  const simulator = createFilesystemSimulator();
+
+  it('handles empty target string', async () => {
+    const result = await simulator.simulate(
+      { action: 'file.write', target: '', agent: 'test', destructive: false },
+      {}
+    );
+    expect(result.riskLevel).toBe('low');
+    expect(result.simulatorId).toBe('filesystem-simulator');
+  });
+
+  it('handles deeply nested paths', async () => {
+    const result = await simulator.simulate(
+      { action: 'file.write', target: 'a/b/c/d/e/f/g/h.ts', agent: 'test', destructive: false },
+      {}
+    );
+    expect(result.riskLevel).toBe('low');
+    expect(result.predictedChanges.some((c) => c.includes('Write'))).toBe(true);
+  });
+
+  it('handles paths with .. components', async () => {
+    const result = await simulator.simulate(
+      { action: 'file.write', target: '../../../etc/passwd', agent: 'test', destructive: false },
+      {}
+    );
+    expect(result.simulatorId).toBe('filesystem-simulator');
+  });
+
+  it('handles files with no extension', async () => {
+    const result = await simulator.simulate(
+      { action: 'file.write', target: 'Makefile', agent: 'test', destructive: false },
+      {}
+    );
+    expect(result.riskLevel).toBe('low');
+  });
+
+  it('handles very long file paths', async () => {
+    const longPath = 'src/' + 'a'.repeat(200) + '/file.ts';
+    const result = await simulator.simulate(
+      { action: 'file.write', target: longPath, agent: 'test', destructive: false },
+      {}
+    );
+    expect(result.riskLevel).toBe('low');
+  });
+
+  it('detects sensitive files in nested paths', async () => {
+    const result = await simulator.simulate(
+      { action: 'file.write', target: 'deploy/config/.env.production', agent: 'test', destructive: false },
+      {}
+    );
+    expect(result.riskLevel).toBe('high');
+  });
+
+  it('defaults blast radius to 1 when filesAffected is not set', async () => {
+    const result = await simulator.simulate(
+      { action: 'file.write', target: 'test.ts', agent: 'test', destructive: false },
+      {}
+    );
+    expect(result.blastRadius).toBe(1);
+  });
+
+  it('returns durationMs as a non-negative number', async () => {
+    const result = await simulator.simulate(
+      { action: 'file.write', target: 'test.ts', agent: 'test', destructive: false },
+      {}
+    );
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/packages/kernel/vitest.config.ts
+++ b/packages/kernel/vitest.config.ts
@@ -4,5 +4,14 @@ export default defineConfig({
   test: {
     include: ['tests/**/*.test.ts'],
     environment: 'node',
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.ts'],
+      reporter: ['text', 'json-summary', 'lcov'],
+      thresholds: {
+        lines: 50,
+        branches: 40,
+      },
+    },
   },
 });

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "build": "tsc -b",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "lint": "eslint src/",
     "ts:check": "tsc --noEmit",
     "clean": "rm -rf dist"

--- a/packages/plugins/vitest.config.ts
+++ b/packages/plugins/vitest.config.ts
@@ -4,5 +4,14 @@ export default defineConfig({
   test: {
     include: ['tests/**/*.test.ts'],
     environment: 'node',
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.ts'],
+      reporter: ['text', 'json-summary', 'lcov'],
+      thresholds: {
+        lines: 50,
+        branches: 40,
+      },
+    },
   },
 });

--- a/packages/policy/package.json
+++ b/packages/policy/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "build": "tsc -b",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "lint": "eslint src/",
     "ts:check": "tsc --noEmit",
     "clean": "rm -rf dist"

--- a/packages/policy/vitest.config.ts
+++ b/packages/policy/vitest.config.ts
@@ -4,5 +4,14 @@ export default defineConfig({
   test: {
     include: ['tests/**/*.test.ts'],
     environment: 'node',
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.ts'],
+      reporter: ['text', 'json-summary', 'lcov'],
+      thresholds: {
+        lines: 50,
+        branches: 40,
+      },
+    },
   },
 });

--- a/packages/renderers/package.json
+++ b/packages/renderers/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "build": "tsc -b",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "lint": "eslint src/",
     "ts:check": "tsc --noEmit",
     "clean": "rm -rf dist"

--- a/packages/renderers/vitest.config.ts
+++ b/packages/renderers/vitest.config.ts
@@ -4,5 +4,14 @@ export default defineConfig({
   test: {
     include: ['tests/**/*.test.ts'],
     environment: 'node',
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.ts'],
+      reporter: ['text', 'json-summary', 'lcov'],
+      thresholds: {
+        lines: 50,
+        branches: 40,
+      },
+    },
   },
 });

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "build": "tsc -b",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "lint": "eslint src/",
     "ts:check": "tsc --noEmit",
     "clean": "rm -rf dist"

--- a/packages/storage/tests/sqlite-sink.test.ts
+++ b/packages/storage/tests/sqlite-sink.test.ts
@@ -108,6 +108,20 @@ describe('SQLite EventSink', () => {
     const sink = createSqliteEventSink(db, 'run_1');
     expect(() => sink.flush?.()).not.toThrow();
   });
+
+  it('handles events with missing optional fields gracefully', () => {
+    const sink = createSqliteEventSink(db, 'run_1');
+    const minimalEvent = {
+      id: 'e_minimal',
+      kind: 'RunStarted',
+      timestamp: Date.now(),
+      fingerprint: 'fp',
+    } as DomainEvent;
+    expect(() => sink.write(minimalEvent)).not.toThrow();
+
+    const count = (db.prepare('SELECT COUNT(*) as c FROM events').get() as { c: number }).c;
+    expect(count).toBe(1);
+  });
 });
 
 describe('SQLite DecisionSink', () => {

--- a/packages/storage/tests/sqlite-store.test.ts
+++ b/packages/storage/tests/sqlite-store.test.ts
@@ -256,6 +256,27 @@ describe('SQLite EventStore', () => {
     });
   });
 
+  describe('edge cases', () => {
+    it('query returns empty array on fresh database with no events', () => {
+      const store = createSqliteEventStore(db, 'run_1');
+      expect(store.query()).toEqual([]);
+      expect(store.query({ kind: 'ActionDenied' })).toEqual([]);
+    });
+
+    it('loadRunEvents returns empty array for unknown run ID', () => {
+      const store = createSqliteEventStore(db, 'run_1');
+      store.append(makeEvent({ id: 'e1' }));
+
+      const events = loadRunEvents(db, 'nonexistent_run');
+      expect(events).toEqual([]);
+    });
+
+    it('listRunIds returns empty array when no events exist', () => {
+      const runs = listRunIds(db);
+      expect(runs).toEqual([]);
+    });
+  });
+
   describe('prepared statement caching', () => {
     it('returns correct results on repeated queries with the same filter shape', () => {
       const store = createSqliteEventStore(db, 'run_1');

--- a/packages/storage/vitest.config.ts
+++ b/packages/storage/vitest.config.ts
@@ -4,5 +4,14 @@ export default defineConfig({
   test: {
     include: ['tests/**/*.test.ts'],
     environment: 'node',
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.ts'],
+      reporter: ['text', 'json-summary', 'lcov'],
+      thresholds: {
+        lines: 50,
+        branches: 40,
+      },
+    },
   },
 });

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "build": "tsc -b",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "lint": "eslint src/",
     "ts:check": "tsc --noEmit",
     "clean": "rm -rf dist"

--- a/packages/telemetry/vitest.config.ts
+++ b/packages/telemetry/vitest.config.ts
@@ -4,5 +4,14 @@ export default defineConfig({
   test: {
     include: ['tests/**/*.test.ts'],
     environment: 'node',
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.ts'],
+      reporter: ['text', 'json-summary', 'lcov'],
+      thresholds: {
+        lines: 50,
+        branches: 40,
+      },
+    },
   },
 });

--- a/turbo.json
+++ b/turbo.json
@@ -12,6 +12,10 @@
     "test": {
       "dependsOn": ["build"]
     },
+    "test:coverage": {
+      "dependsOn": ["build"],
+      "outputs": ["coverage/**"]
+    },
     "lint": {},
     "format": {},
     "ts:check": {


### PR DESCRIPTION
- Add vitest v8 coverage configuration to all 12 packages with initial thresholds (50% lines, 40% branches)
- Add test:coverage scripts to all packages and turbo.json task
- Add coverage check step to CI workflow (size-check.yml)
- Create 4 new test files for previously untested CLI modules:
  - policy-resolver.test.ts: findDefaultPolicy, findUserPolicy, loadPolicyFile, loadComposedPolicies
  - cli-analytics.test.ts: analytics command, format/dir/query parsing
  - cli-plugin.test.ts: all 6 subcommands (list, install, remove, enable, disable, search)
  - cli-evidence-pr.test.ts: dry-run, run/last modes, PR detection, comment posting
- Create reporter-direct.test.ts: direct tests for toTerminal, toMarkdown, toJson formatters
- Add edge case tests to existing files:
  - kernel.test.ts: minimal fields, long commands, special chars, rapid sequential proposals
  - simulation-filesystem.test.ts: empty target, nested paths, .. components, no extension
  - invariant-definitions.test.ts: multiple simultaneous violations, empty invariant list
  - sqlite-sink.test.ts: minimal events with missing optional fields
  - sqlite-store.test.ts: empty DB queries, unknown run IDs

https://claude.ai/code/session_019Dr6PYuVChWkz95Uv8KHuS