### PR TITLE
feat(telemetry): implement privacy-first telemetry system with enrollment, signing, and batch ingestion

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -42,6 +42,7 @@
     "@red-codes/storage": "workspace:*",
     "@red-codes/analytics": "workspace:*",
     "@red-codes/telemetry": "workspace:*",
+    "@red-codes/telemetry-client": "workspace:*",
     "@red-codes/plugins": "workspace:*",
     "@red-codes/renderers": "workspace:*",
     "commander": "^14.0.3",

--- a/apps/cli/src/bin.ts
+++ b/apps/cli/src/bin.ts
@@ -278,6 +278,23 @@ const COMMANDS: Record<string, CommandHelp> = {
       'agentguard traces run_1234567890_abc',
     ],
   },
+  telemetry: {
+    name: 'agentguard telemetry',
+    description: 'Manage telemetry enrollment and settings',
+    usage: 'agentguard telemetry <command> [flags]',
+    flags: [
+      { flag: '--server, -s <url>', description: 'Telemetry server URL (enroll command)' },
+      { flag: '--mode, -m <mode>', description: 'Telemetry mode: anonymous or verified (enable command)' },
+    ],
+    examples: [
+      'agentguard telemetry status',
+      'agentguard telemetry enable',
+      'agentguard telemetry enable --mode verified',
+      'agentguard telemetry enroll --server https://telemetry.agentguard.dev',
+      'agentguard telemetry disable',
+      'agentguard telemetry reset',
+    ],
+  },
   'evidence-pr': {
     name: 'agentguard evidence-pr',
     description: 'Attach governance evidence report to a pull request',
@@ -488,6 +505,18 @@ async function main() {
       break;
     }
 
+    case 'telemetry': {
+      if (wantsHelp) {
+        const { telemetry: telemetryCmd } = await import('./commands/telemetry.js');
+        await telemetryCmd(['help']);
+        break;
+      }
+      const { telemetry: telemetryCmd } = await import('./commands/telemetry.js');
+      const code = await telemetryCmd(args.slice(1));
+      process.exit(code);
+      break;
+    }
+
     case 'claude-init': {
       const { claudeInit } = await import('./commands/claude-init.js');
       await claudeInit(args.slice(1));
@@ -598,6 +627,14 @@ function printHelp(): void {
     agentguard ci-check <session>             Verify governance session in CI
     agentguard ci-check --last                Check most recent run locally
 
+
+  \x1b[1mTelemetry:\x1b[0m
+    agentguard telemetry status               Show telemetry mode and identity
+    agentguard telemetry enable               Enable telemetry (anonymous mode)
+    agentguard telemetry enable --mode verified  Enable verified telemetry
+    agentguard telemetry enroll --server <url>   Enroll for verified telemetry
+    agentguard telemetry disable              Disable telemetry
+    agentguard telemetry reset                Delete identity and queue data
 
   \x1b[1mIntegration:\x1b[0m
     agentguard claude-init                    Set up Claude Code hook integration

--- a/apps/cli/src/commands/guard.ts
+++ b/apps/cli/src/commands/guard.ts
@@ -26,6 +26,8 @@ import type { StorageConfig } from '@red-codes/storage';
 import type { PolicyTracePayload } from '@red-codes/renderers';
 import { createTracer } from '@red-codes/telemetry';
 import { createWebhookTraceBackend } from '@red-codes/storage';
+import { createTelemetryClient } from '@red-codes/telemetry-client';
+import type { TelemetryClient } from '@red-codes/telemetry-client';
 
 export interface GuardOptions {
   /** Single policy path (backwards compatible) */
@@ -112,6 +114,17 @@ export async function guard(_args: string[], options: GuardOptions = {}): Promis
 
   const kernel = createKernel(kernelConfig);
 
+  // Initialize telemetry client (non-blocking, never affects guard operation)
+  let telemetryClient: TelemetryClient | null = null;
+  try {
+    telemetryClient = await createTelemetryClient({
+      serverUrl: process.env.AGENTGUARD_TELEMETRY_SERVER,
+    });
+    telemetryClient.start();
+  } catch {
+    // Telemetry initialization failure is silently ignored
+  }
+
   // Emit PolicyComposed event when multiple policies are composed
   if (useComposition) {
     const composition = loadComposedPolicies(explicitPaths);
@@ -165,13 +178,21 @@ export async function guard(_args: string[], options: GuardOptions = {}): Promis
     process.stderr.write(`  ${'\x1b[2m'}Press Ctrl+C to stop.${'\x1b[0m'}\n\n`);
   }
 
-  return processStdin(kernel, renderers, storage);
+  return processStdin(kernel, renderers, storage, telemetryClient);
+}
+
+/** Detect execution environment */
+function detectEnvironment(): 'local' | 'ci' | 'container' {
+  if (process.env.CI) return 'ci';
+  if (process.env.KUBERNETES_SERVICE_HOST) return 'container';
+  return 'local';
 }
 
 async function processStdin(
   kernel: ReturnType<typeof createKernel>,
   renderers: RendererRegistry,
-  storage: StorageBundle
+  storage: StorageBundle,
+  telemetryClient: TelemetryClient | null
 ): Promise<number> {
   const startTime = Date.now();
   let totalActions = 0;
@@ -194,12 +215,30 @@ async function processStdin(
 
         try {
           const rawAction = JSON.parse(trimmed) as RawAgentAction;
+          const proposeStart = Date.now();
           const result = await kernel.propose(rawAction);
+          const latencyMs = Date.now() - proposeStart;
 
           totalActions++;
           if (result.allowed) allowedCount++;
           else deniedCount++;
           violationCount += result.decision.violations.length;
+
+          // Track telemetry event (non-blocking, errors swallowed)
+          try {
+            if (telemetryClient) {
+              telemetryClient.track({
+                runtime: 'claude-code',
+                environment: detectEnvironment(),
+                event_type: result.allowed ? 'execution_allowed' : 'policy_denied',
+                policy: result.decision.decision.reason ?? 'default',
+                result: result.allowed ? 'allowed' : 'denied',
+                latency_ms: latencyMs,
+              });
+            }
+          } catch {
+            // Telemetry must never affect guard operation
+          }
 
           // Dispatch to all registered renderers
           renderers.notifyActionResult(result);
@@ -237,6 +276,13 @@ async function processStdin(
 
     const shutdown = () => {
       kernel.shutdown();
+
+      // Stop telemetry client (flushes remaining events)
+      try {
+        telemetryClient?.stop();
+      } catch {
+        // Ignore
+      }
 
       // Record session end in the sessions table (SQLite only)
       if (storage.sessions) {

--- a/apps/cli/src/commands/telemetry.ts
+++ b/apps/cli/src/commands/telemetry.ts
@@ -1,0 +1,218 @@
+// CLI command: agentguard telemetry — manage telemetry enrollment and settings.
+
+import { bold, color, dim } from '../colors.js';
+
+export async function telemetry(args: string[]): Promise<number> {
+  const subcommand = args[0];
+
+  switch (subcommand) {
+    case 'enroll':
+      return enrollSubcommand(args.slice(1));
+    case 'status':
+      return statusSubcommand();
+    case 'enable':
+      return enableSubcommand(args.slice(1));
+    case 'disable':
+      return disableSubcommand();
+    case 'reset':
+      return resetSubcommand();
+    case 'help':
+    case '--help':
+    case '-h':
+    case undefined:
+      printTelemetryHelp();
+      return 0;
+    default:
+      process.stderr.write(`  ${color('Error:', 'red')} Unknown telemetry subcommand: ${subcommand}\n`);
+      process.stderr.write(`  Run ${dim('agentguard telemetry help')} for usage info.\n`);
+      return 1;
+  }
+}
+
+async function enrollSubcommand(args: string[]): Promise<number> {
+  const serverIdx = args.findIndex((a) => a === '--server' || a === '-s');
+  const serverUrl = serverIdx !== -1 ? args[serverIdx + 1] : process.env.AGENTGUARD_TELEMETRY_SERVER;
+
+  if (!serverUrl) {
+    process.stderr.write(
+      `  ${color('Error:', 'red')} Server URL required.\n` +
+        `  Use ${dim('--server <url>')} or set ${dim('AGENTGUARD_TELEMETRY_SERVER')} env var.\n`
+    );
+    return 1;
+  }
+
+  const {
+    createTelemetryClient,
+    loadIdentity,
+    generateIdentity,
+    saveIdentity,
+  } = await import('@red-codes/telemetry-client');
+
+  process.stderr.write(`  ${dim('Enrolling with server:')} ${serverUrl}\n`);
+
+  // Ensure identity exists
+  let identity = loadIdentity();
+  if (!identity) {
+    identity = generateIdentity('verified');
+    saveIdentity(identity);
+    process.stderr.write(`  ${dim('Generated new install identity:')} ${identity.install_id}\n`);
+  }
+
+  try {
+    const client = await createTelemetryClient({
+      serverUrl,
+      mode: 'verified',
+    });
+    await client.enroll(serverUrl);
+    process.stderr.write(`\n  ${color('✓', 'green')} ${bold('Enrolled successfully')}\n`);
+    process.stderr.write(`  ${dim('Install ID:')} ${identity.install_id}\n`);
+    process.stderr.write(`  ${dim('Mode:')} verified\n\n`);
+    return 0;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`  ${color('Error:', 'red')} Enrollment failed: ${message}\n`);
+    return 1;
+  }
+}
+
+async function statusSubcommand(): Promise<number> {
+  const { loadIdentity, resolveMode } = await import('@red-codes/telemetry-client');
+
+  const identity = loadIdentity();
+  const mode = resolveMode(identity);
+
+  process.stderr.write(`\n  ${bold('AgentGuard Telemetry Status')}\n\n`);
+  process.stderr.write(`  ${dim('Mode:')}        ${formatMode(mode)}\n`);
+
+  if (identity) {
+    process.stderr.write(`  ${dim('Install ID:')} ${identity.install_id}\n`);
+    process.stderr.write(`  ${dim('Enrolled:')}   ${identity.enrollment_token ? color('yes', 'green') : color('no', 'yellow')}\n`);
+    if (identity.enrolled_at) {
+      process.stderr.write(`  ${dim('Enrolled at:')} ${identity.enrolled_at}\n`);
+    }
+  } else {
+    process.stderr.write(`  ${dim('Install ID:')} ${color('none', 'gray')}\n`);
+  }
+
+  // Try to show queue info
+  try {
+    const { createTelemetryClient } = await import('@red-codes/telemetry-client');
+    const client = await createTelemetryClient({ mode: mode === 'off' ? 'anonymous' : mode });
+    const status = client.status();
+    process.stderr.write(`  ${dim('Queue size:')} ${status.queueSize} events (${formatBytes(status.queueSizeBytes)})\n`);
+    client.stop();
+  } catch {
+    // Queue not available
+  }
+
+  process.stderr.write('\n');
+  return 0;
+}
+
+async function enableSubcommand(args: string[]): Promise<number> {
+  const modeIdx = args.findIndex((a) => a === '--mode' || a === '-m');
+  const modeArg = modeIdx !== -1 ? args[modeIdx + 1] : 'anonymous';
+
+  if (modeArg !== 'anonymous' && modeArg !== 'verified') {
+    process.stderr.write(`  ${color('Error:', 'red')} Mode must be 'anonymous' or 'verified'\n`);
+    return 1;
+  }
+
+  const { loadIdentity, generateIdentity, saveIdentity } =
+    await import('@red-codes/telemetry-client');
+
+  let identity = loadIdentity();
+  if (!identity) {
+    identity = generateIdentity(modeArg);
+    process.stderr.write(`  ${dim('Generated new install identity:')} ${identity.install_id}\n`);
+  } else {
+    identity = { ...identity, mode: modeArg };
+  }
+
+  saveIdentity(identity);
+  process.stderr.write(`  ${color('✓', 'green')} Telemetry ${bold('enabled')} (mode: ${modeArg})\n`);
+  return 0;
+}
+
+async function disableSubcommand(): Promise<number> {
+  const { loadIdentity, saveIdentity } = await import('@red-codes/telemetry-client');
+
+  const identity = loadIdentity();
+  if (identity) {
+    saveIdentity({ ...identity, mode: 'off' });
+  }
+
+  process.stderr.write(`  ${color('✓', 'green')} Telemetry ${bold('disabled')}\n`);
+  return 0;
+}
+
+async function resetSubcommand(): Promise<number> {
+  const { deleteIdentity, getDefaultIdentityPath } = await import('@red-codes/telemetry-client');
+  const { unlinkSync } = await import('node:fs');
+  const { homedir } = await import('node:os');
+  const { join } = await import('node:path');
+
+  deleteIdentity();
+  process.stderr.write(`  ${dim('Deleted identity file:')} ${getDefaultIdentityPath()}\n`);
+
+  // Remove queue files
+  const dir = join(homedir(), '.agentguard');
+  for (const f of ['telemetry-queue.db', 'telemetry-queue.jsonl']) {
+    try {
+      unlinkSync(join(dir, f));
+      process.stderr.write(`  ${dim('Deleted queue file:')} ${join(dir, f)}\n`);
+    } catch {
+      // Ignore
+    }
+  }
+
+  process.stderr.write(`  ${color('✓', 'green')} Telemetry ${bold('reset')} complete\n`);
+  return 0;
+}
+
+function formatMode(mode: string): string {
+  switch (mode) {
+    case 'off':
+      return color('OFF', 'red');
+    case 'anonymous':
+      return color('ANONYMOUS', 'yellow');
+    case 'verified':
+      return color('VERIFIED', 'green');
+    default:
+      return mode;
+  }
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function printTelemetryHelp(): void {
+  process.stderr.write(`
+  ${bold('agentguard telemetry')} — Manage telemetry settings
+
+  ${bold('Commands:')}
+    enroll          Enroll this installation for verified telemetry
+    status          Show current telemetry mode and identity
+    enable          Enable telemetry (default: anonymous mode)
+    disable         Disable telemetry
+    reset           Delete identity and queue data
+
+  ${bold('Enroll flags:')}
+    --server, -s    Telemetry server URL (or AGENTGUARD_TELEMETRY_SERVER env)
+
+  ${bold('Enable flags:')}
+    --mode, -m      Mode: anonymous (default) or verified
+
+  ${bold('Examples:')}
+    agentguard telemetry status
+    agentguard telemetry enable
+    agentguard telemetry enable --mode verified
+    agentguard telemetry enroll --server https://telemetry.agentguard.dev
+    agentguard telemetry disable
+    agentguard telemetry reset
+
+`);
+}

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -16,6 +16,7 @@
     { "path": "../../packages/storage" },
     { "path": "../../packages/analytics" },
     { "path": "../../packages/telemetry" },
+    { "path": "../../packages/telemetry-client" },
     { "path": "../../packages/plugins" },
     { "path": "../../packages/renderers" }
   ]

--- a/apps/telemetry-server/package.json
+++ b/apps/telemetry-server/package.json
@@ -17,6 +17,7 @@
     "build": "tsc -b",
     "dev": "tsx src/server.ts",
     "start": "node dist/server.js",
+    "test": "vitest run",
     "lint": "eslint src/",
     "ts:check": "tsc --noEmit",
     "clean": "rm -rf dist"
@@ -24,6 +25,7 @@
   "dependencies": {
     "@red-codes/core": "workspace:*",
     "@red-codes/telemetry": "workspace:*",
+    "@red-codes/telemetry-client": "workspace:*",
     "hono": "^4.7.0",
     "@hono/node-server": "^1.14.0"
   }

--- a/apps/telemetry-server/src/app.ts
+++ b/apps/telemetry-server/src/app.ts
@@ -4,11 +4,14 @@ import { Hono } from 'hono';
 import { loadConfig } from './config.js';
 import { ipWhitelist } from './middleware/ip-whitelist.js';
 import { apiKeyAuth } from './middleware/api-key.js';
+import { createRateLimiter } from './middleware/rate-limiter.js';
 import { healthRoutes } from './routes/health.js';
 import { ingestRoutes } from './routes/ingest.js';
 import { eventRoutes } from './routes/events.js';
 import { decisionRoutes } from './routes/decisions.js';
 import { traceRoutes } from './routes/traces.js';
+import { enrollRoutes } from './routes/enroll.js';
+import { telemetryBatchRoutes } from './routes/telemetry-batch.js';
 import { createMemoryStore } from './store/memory-store.js';
 
 const config = loadConfig();
@@ -19,7 +22,24 @@ const app = new Hono();
 // Health check — no auth required
 app.route('/api', healthRoutes);
 
-// Auth middleware on all other /api routes
+// Rate limiting on telemetry endpoints (before auth)
+const ipLimiter = createRateLimiter(
+  { windowMs: 60_000, maxRequests: config.rateLimitPerIp },
+  (c) => c.req.header('x-forwarded-for')?.split(',')[0]?.trim() ?? c.req.header('x-real-ip') ?? 'unknown'
+);
+const installLimiter = createRateLimiter(
+  { windowMs: 60_000, maxRequests: config.rateLimitPerInstall },
+  (c) => c.req.header('x-agentguard-install-id') ?? null
+);
+
+app.use('/api/v1/telemetry/*', ipLimiter);
+app.use('/api/v1/telemetry/*', installLimiter);
+
+// Telemetry routes — use enrollment tokens, not API key auth
+app.route('/api', enrollRoutes(store, config));
+app.route('/api', telemetryBatchRoutes(store, config));
+
+// Auth middleware on all other /api routes (excluding health and telemetry)
 app.use('/api/*', ipWhitelist(config));
 app.use('/api/*', apiKeyAuth(config));
 

--- a/apps/telemetry-server/src/config.ts
+++ b/apps/telemetry-server/src/config.ts
@@ -5,6 +5,11 @@ export interface ServerConfig {
   readonly allowedIps: string[];
   readonly apiKey: string | undefined;
   readonly isDev: boolean;
+  readonly enrollmentEnabled: boolean;
+  readonly maxRequestSizeMb: number;
+  readonly rateLimitPerIp: number;
+  readonly rateLimitPerInstall: number;
+  readonly antiReplayWindowMs: number;
 }
 
 export function loadConfig(): ServerConfig {
@@ -19,5 +24,10 @@ export function loadConfig(): ServerConfig {
       : [],
     apiKey: env.API_KEY || undefined,
     isDev: env.NODE_ENV === 'development',
+    enrollmentEnabled: env.ENROLLMENT_ENABLED !== 'false',
+    maxRequestSizeMb: env.MAX_REQUEST_SIZE_MB ? Number(env.MAX_REQUEST_SIZE_MB) : 1,
+    rateLimitPerIp: env.RATE_LIMIT_PER_IP ? Number(env.RATE_LIMIT_PER_IP) : 100,
+    rateLimitPerInstall: env.RATE_LIMIT_PER_INSTALL ? Number(env.RATE_LIMIT_PER_INSTALL) : 60,
+    antiReplayWindowMs: env.ANTI_REPLAY_WINDOW_MS ? Number(env.ANTI_REPLAY_WINDOW_MS) : 300_000,
   };
 }

--- a/apps/telemetry-server/src/middleware/rate-limiter.ts
+++ b/apps/telemetry-server/src/middleware/rate-limiter.ts
@@ -1,0 +1,60 @@
+// In-memory sliding window rate limiter middleware.
+
+import type { Context, Next } from 'hono';
+
+export interface RateLimiterConfig {
+  readonly windowMs: number;
+  readonly maxRequests: number;
+}
+
+/**
+ * Create a rate limiter middleware.
+ * @param config - Window size and max request count
+ * @param keyFn - Function to extract the rate limit key from the request context
+ */
+export function createRateLimiter(
+  config: RateLimiterConfig,
+  keyFn: (c: Context) => string | null
+) {
+  const windows = new Map<string, number[]>();
+
+  // Periodic cleanup to prevent memory leaks
+  const cleanupInterval = setInterval(() => {
+    const cutoff = Date.now() - config.windowMs;
+    for (const [key, timestamps] of windows) {
+      const filtered = timestamps.filter((t) => t > cutoff);
+      if (filtered.length === 0) {
+        windows.delete(key);
+      } else {
+        windows.set(key, filtered);
+      }
+    }
+  }, config.windowMs);
+
+  if (cleanupInterval && typeof cleanupInterval === 'object' && 'unref' in cleanupInterval) {
+    cleanupInterval.unref();
+  }
+
+  return async (c: Context, next: Next) => {
+    const key = keyFn(c);
+    if (!key) {
+      await next();
+      return;
+    }
+
+    const now = Date.now();
+    const cutoff = now - config.windowMs;
+    const timestamps = (windows.get(key) ?? []).filter((t) => t > cutoff);
+
+    if (timestamps.length >= config.maxRequests) {
+      const retryAfter = Math.ceil((timestamps[0] + config.windowMs - now) / 1000);
+      c.header('Retry-After', String(retryAfter));
+      return c.json({ error: 'Too many requests' }, 429);
+    }
+
+    timestamps.push(now);
+    windows.set(key, timestamps);
+
+    await next();
+  };
+}

--- a/apps/telemetry-server/src/routes/enroll.ts
+++ b/apps/telemetry-server/src/routes/enroll.ts
@@ -1,0 +1,78 @@
+// Enrollment route — register an AgentGuard installation for verified telemetry.
+
+import { Hono } from 'hono';
+import { createHash, randomBytes, createPublicKey } from 'node:crypto';
+import type { TelemetryDataStore } from '../store/types.js';
+import type { ServerConfig } from '../config.js';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function enrollRoutes(store: TelemetryDataStore, config: ServerConfig) {
+  const app = new Hono();
+
+  app.post('/v1/telemetry/enroll', async (c) => {
+    if (!config.enrollmentEnabled) {
+      return c.json({ error: 'Enrollment is disabled' }, 403);
+    }
+
+    let body: { install_id?: string; public_key?: string; version?: string };
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: 'Invalid JSON body' }, 400);
+    }
+
+    const { install_id, public_key, version } = body;
+
+    // Validate install_id
+    if (!install_id || !UUID_RE.test(install_id)) {
+      return c.json({ error: 'Invalid or missing install_id (must be UUID v4)' }, 400);
+    }
+
+    // Validate public_key
+    if (!public_key || typeof public_key !== 'string') {
+      return c.json({ error: 'Missing public_key' }, 400);
+    }
+
+    try {
+      createPublicKey(public_key);
+    } catch {
+      return c.json({ error: 'Invalid Ed25519 public key' }, 400);
+    }
+
+    // Validate version
+    if (!version || typeof version !== 'string') {
+      return c.json({ error: 'Missing version' }, 400);
+    }
+
+    // Check for existing install (idempotent)
+    const existing = store.findInstallById(install_id);
+    if (existing) {
+      // Re-generate token for existing install
+      const newToken = randomBytes(32).toString('hex');
+      const newTokenHash = createHash('sha256').update(newToken).digest('hex');
+      store.createInstall({
+        ...existing,
+        token_hash: newTokenHash,
+        version,
+      });
+      return c.json({ ok: true, token: newToken });
+    }
+
+    // Generate installation token
+    const token = randomBytes(32).toString('hex');
+    const tokenHash = createHash('sha256').update(token).digest('hex');
+
+    store.createInstall({
+      install_id,
+      public_key,
+      token_hash: tokenHash,
+      version,
+      enrolled_at: new Date().toISOString(),
+    });
+
+    return c.json({ ok: true, token });
+  });
+
+  return app;
+}

--- a/apps/telemetry-server/src/routes/telemetry-batch.ts
+++ b/apps/telemetry-server/src/routes/telemetry-batch.ts
@@ -1,0 +1,155 @@
+// Telemetry batch route — accept batched telemetry events from clients.
+
+import { Hono } from 'hono';
+import { createHash } from 'node:crypto';
+import { verifySignature, canonicalize } from '@red-codes/telemetry-client';
+import type { TelemetryDataStore } from '../store/types.js';
+import type { ServerConfig } from '../config.js';
+
+const MAX_BATCH_SIZE = 50;
+const VALID_RUNTIMES = new Set(['claude-code', 'copilot', 'ci', 'unknown']);
+const VALID_ENVIRONMENTS = new Set(['local', 'ci', 'container']);
+const VALID_EVENT_TYPES = new Set(['guard_triggered', 'policy_denied', 'execution_allowed', 'error']);
+const VALID_RESULTS = new Set(['allowed', 'denied', 'error']);
+
+interface BatchPayloadEvent {
+  event_id?: string;
+  timestamp?: number;
+  version?: string;
+  runtime?: string;
+  environment?: string;
+  event_type?: string;
+  policy?: string;
+  result?: string;
+  latency_ms?: number;
+}
+
+interface BatchRequestBody {
+  mode?: string;
+  events?: BatchPayloadEvent[];
+}
+
+function validateEvent(event: BatchPayloadEvent): string | null {
+  if (!event.event_id || typeof event.event_id !== 'string') return 'missing event_id';
+  if (!event.timestamp || typeof event.timestamp !== 'number') return 'missing timestamp';
+  if (!event.version || typeof event.version !== 'string') return 'missing version';
+  if (!event.runtime || !VALID_RUNTIMES.has(event.runtime)) return 'invalid runtime';
+  if (!event.environment || !VALID_ENVIRONMENTS.has(event.environment)) return 'invalid environment';
+  if (!event.event_type || !VALID_EVENT_TYPES.has(event.event_type)) return 'invalid event_type';
+  if (!event.policy || typeof event.policy !== 'string') return 'missing policy';
+  if (!event.result || !VALID_RESULTS.has(event.result)) return 'invalid result';
+  if (typeof event.latency_ms !== 'number' || event.latency_ms < 0) return 'invalid latency_ms';
+
+  // Reject extra fields
+  const allowedFields = new Set([
+    'event_id',
+    'timestamp',
+    'version',
+    'runtime',
+    'environment',
+    'event_type',
+    'policy',
+    'result',
+    'latency_ms',
+  ]);
+  for (const key of Object.keys(event)) {
+    if (!allowedFields.has(key)) return `unexpected field: ${key}`;
+  }
+
+  return null;
+}
+
+export function telemetryBatchRoutes(store: TelemetryDataStore, config: ServerConfig) {
+  const app = new Hono();
+
+  app.post('/v1/telemetry/batch', async (c) => {
+    // Check content length
+    const contentLength = c.req.header('content-length');
+    if (contentLength && Number(contentLength) > config.maxRequestSizeMb * 1024 * 1024) {
+      return c.json({ error: 'Request body too large' }, 413);
+    }
+
+    let body: BatchRequestBody;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: 'Invalid JSON body' }, 400);
+    }
+
+    const mode = body.mode;
+    if (mode !== 'anonymous' && mode !== 'verified') {
+      return c.json({ error: 'Invalid mode (must be anonymous or verified)' }, 400);
+    }
+
+    const events = body.events;
+    if (!Array.isArray(events) || events.length === 0) {
+      return c.json({ error: 'Events array is required and must not be empty' }, 400);
+    }
+
+    if (events.length > MAX_BATCH_SIZE) {
+      return c.json({ error: `Batch size exceeds maximum of ${MAX_BATCH_SIZE}` }, 413);
+    }
+
+    // Validate each event
+    for (const event of events) {
+      const err = validateEvent(event);
+      if (err) {
+        return c.json({ error: `Invalid event: ${err}` }, 400);
+      }
+    }
+
+    // Anti-replay: reject events with timestamps outside the window
+    const now = Math.floor(Date.now() / 1000);
+    const windowSec = Math.floor(config.antiReplayWindowMs / 1000);
+    for (const event of events) {
+      if (event.timestamp && Math.abs(now - event.timestamp) > windowSec) {
+        return c.json({ error: 'Event timestamp outside acceptable window' }, 400);
+      }
+    }
+
+    // Verify authentication for verified mode
+    let installId: string | null = null;
+
+    if (mode === 'verified') {
+      const authHeader = c.req.header('Authorization');
+      if (!authHeader || !authHeader.startsWith('Bearer ')) {
+        return c.json({ error: 'Missing Authorization header for verified mode' }, 401);
+      }
+
+      const token = authHeader.slice(7);
+      const tokenHash = createHash('sha256').update(token).digest('hex');
+      const install = store.findInstallByTokenHash(tokenHash);
+
+      if (!install) {
+        return c.json({ error: 'Invalid or unknown installation token' }, 401);
+      }
+
+      // Verify signature
+      const signature = c.req.header('X-AgentGuard-Signature');
+      if (signature) {
+        const rawBody = canonicalize(body);
+        const valid = verifySignature(rawBody, signature, install.public_key);
+        if (!valid) {
+          return c.json({ error: 'Invalid signature' }, 403);
+        }
+      }
+
+      installId = install.install_id;
+    }
+
+    // Store events
+    const receivedAt = new Date().toISOString();
+    const records = events.map((event) => ({
+      event_id: event.event_id!,
+      install_id: installId,
+      event_json: JSON.stringify(event),
+      received_at: receivedAt,
+    }));
+
+    store.appendTelemetryPayloads(records);
+
+    return c.json({ ok: true, accepted: events.length });
+  });
+
+  return app;
+}

--- a/apps/telemetry-server/src/store/memory-store.ts
+++ b/apps/telemetry-server/src/store/memory-store.ts
@@ -4,11 +4,14 @@
 import type { DomainEvent, GovernanceDecisionRecord } from '@red-codes/core';
 import type { TraceSpan } from '@red-codes/telemetry';
 import type {
-  TelemetryStore,
+  TelemetryDataStore,
   EventQueryFilter,
   DecisionQueryFilter,
   TraceQueryFilter,
+  QueryFilter,
   QueryResult,
+  InstallRecord,
+  TelemetryPayloadRecord,
 } from './types.js';
 
 interface StoredEvent {
@@ -45,10 +48,12 @@ function matchesTimeRange(
   return true;
 }
 
-export function createMemoryStore(maxSize = DEFAULT_MAX_SIZE): TelemetryStore {
+export function createMemoryStore(maxSize = DEFAULT_MAX_SIZE): TelemetryDataStore {
   const events: StoredEvent[] = [];
   const decisions: StoredDecision[] = [];
   const traces: TraceSpan[] = [];
+  const installs: InstallRecord[] = [];
+  const payloads: TelemetryPayloadRecord[] = [];
 
   function evict<T>(arr: T[]): void {
     if (arr.length > maxSize) {
@@ -140,6 +145,51 @@ export function createMemoryStore(maxSize = DEFAULT_MAX_SIZE): TelemetryStore {
       if (filter.since || filter.until) {
         filtered = filtered.filter((s) =>
           matchesTimeRange(s.startTime, filter.since, filter.until)
+        );
+      }
+
+      const total = filtered.length;
+      const limit = clampLimit(filter.limit);
+      const offset = clampOffset(filter.offset);
+      const data = filtered.slice(offset, offset + limit);
+
+      return { data, total, limit, offset };
+    },
+
+    // --- Enrollment & payload telemetry ---
+
+    createInstall(record: InstallRecord): void {
+      // Upsert: replace if install_id already exists
+      const idx = installs.findIndex((i) => i.install_id === record.install_id);
+      if (idx >= 0) {
+        installs[idx] = record;
+      } else {
+        installs.push(record);
+        evict(installs);
+      }
+    },
+
+    findInstallById(installId: string): InstallRecord | null {
+      return installs.find((i) => i.install_id === installId) ?? null;
+    },
+
+    findInstallByTokenHash(tokenHash: string): InstallRecord | null {
+      return installs.find((i) => i.token_hash === tokenHash) ?? null;
+    },
+
+    appendTelemetryPayloads(records: TelemetryPayloadRecord[]): void {
+      for (const record of records) {
+        payloads.push(record);
+      }
+      evict(payloads);
+    },
+
+    queryTelemetryPayloads(filter: QueryFilter): QueryResult<TelemetryPayloadRecord> {
+      let filtered = [...payloads];
+
+      if (filter.since || filter.until) {
+        filtered = filtered.filter((p) =>
+          matchesTimeRange(p.received_at, filter.since, filter.until)
         );
       }
 

--- a/apps/telemetry-server/src/store/types.ts
+++ b/apps/telemetry-server/src/store/types.ts
@@ -39,3 +39,29 @@ export interface TelemetryStore {
   queryDecisions(filter: DecisionQueryFilter): QueryResult<GovernanceDecisionRecord>;
   queryTraces(filter: TraceQueryFilter): QueryResult<TraceSpan>;
 }
+
+/** Install record for enrolled telemetry clients */
+export interface InstallRecord {
+  readonly install_id: string;
+  readonly public_key: string; // PEM-encoded Ed25519
+  readonly token_hash: string; // SHA-256 hex of the installation token
+  readonly version: string;
+  readonly enrolled_at: string; // ISO 8601
+}
+
+/** Stored telemetry payload event */
+export interface TelemetryPayloadRecord {
+  readonly event_id: string;
+  readonly install_id: string | null; // null for anonymous
+  readonly event_json: string;
+  readonly received_at: string; // ISO 8601
+}
+
+/** Extended store with enrollment and payload telemetry support */
+export interface TelemetryDataStore extends TelemetryStore {
+  createInstall(record: InstallRecord): void;
+  findInstallById(installId: string): InstallRecord | null;
+  findInstallByTokenHash(tokenHash: string): InstallRecord | null;
+  appendTelemetryPayloads(records: TelemetryPayloadRecord[]): void;
+  queryTelemetryPayloads(filter: QueryFilter): QueryResult<TelemetryPayloadRecord>;
+}

--- a/apps/telemetry-server/tests/enrollment.test.ts
+++ b/apps/telemetry-server/tests/enrollment.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { Hono } from 'hono';
+import { generateKeyPairSync } from 'node:crypto';
+import { enrollRoutes } from '../src/routes/enroll.js';
+import { createMemoryStore } from '../src/store/memory-store.js';
+import { loadConfig } from '../src/config.js';
+
+function makeApp() {
+  const config = loadConfig();
+  const store = createMemoryStore();
+  const app = new Hono();
+  app.route('/api', enrollRoutes(store, config));
+  return { app, store };
+}
+
+function generateTestKey() {
+  const { publicKey } = generateKeyPairSync('ed25519', {
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  });
+  return publicKey;
+}
+
+describe('POST /api/v1/telemetry/enroll', () => {
+  it('enrolls successfully with valid data', async () => {
+    const { app } = makeApp();
+    const res = await app.request('/api/v1/telemetry/enroll', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        install_id: '550e8400-e29b-41d4-a716-446655440000',
+        public_key: generateTestKey(),
+        version: '1.0.0',
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.token).toBeDefined();
+    expect(typeof body.token).toBe('string');
+    expect(body.token.length).toBeGreaterThan(0);
+  });
+
+  it('rejects invalid install_id', async () => {
+    const { app } = makeApp();
+    const res = await app.request('/api/v1/telemetry/enroll', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        install_id: 'not-a-uuid',
+        public_key: generateTestKey(),
+        version: '1.0.0',
+      }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects invalid public key', async () => {
+    const { app } = makeApp();
+    const res = await app.request('/api/v1/telemetry/enroll', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        install_id: '550e8400-e29b-41d4-a716-446655440000',
+        public_key: 'not-a-key',
+        version: '1.0.0',
+      }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('handles duplicate install_id idempotently', async () => {
+    const { app } = makeApp();
+    const body = {
+      install_id: '550e8400-e29b-41d4-a716-446655440000',
+      public_key: generateTestKey(),
+      version: '1.0.0',
+    };
+
+    const res1 = await app.request('/api/v1/telemetry/enroll', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    expect(res1.status).toBe(200);
+
+    const res2 = await app.request('/api/v1/telemetry/enroll', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    expect(res2.status).toBe(200);
+  });
+
+  it('rejects missing version', async () => {
+    const { app } = makeApp();
+    const res = await app.request('/api/v1/telemetry/enroll', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        install_id: '550e8400-e29b-41d4-a716-446655440000',
+        public_key: generateTestKey(),
+      }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/telemetry-server/tests/rate-limiter.test.ts
+++ b/apps/telemetry-server/tests/rate-limiter.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { Hono } from 'hono';
+import { createRateLimiter } from '../src/middleware/rate-limiter.js';
+
+describe('rate limiter', () => {
+  it('allows requests under the limit', async () => {
+    const app = new Hono();
+    const limiter = createRateLimiter(
+      { windowMs: 60_000, maxRequests: 3 },
+      (c) => c.req.header('x-test-key') ?? null
+    );
+    app.use('/*', limiter);
+    app.get('/test', (c) => c.text('ok'));
+
+    for (let i = 0; i < 3; i++) {
+      const res = await app.request('/test', {
+        headers: { 'x-test-key': 'client-1' },
+      });
+      expect(res.status).toBe(200);
+    }
+  });
+
+  it('returns 429 when limit exceeded', async () => {
+    const app = new Hono();
+    const limiter = createRateLimiter(
+      { windowMs: 60_000, maxRequests: 2 },
+      (c) => c.req.header('x-test-key') ?? null
+    );
+    app.use('/*', limiter);
+    app.get('/test', (c) => c.text('ok'));
+
+    // First 2 should pass
+    await app.request('/test', { headers: { 'x-test-key': 'client-a' } });
+    await app.request('/test', { headers: { 'x-test-key': 'client-a' } });
+
+    // Third should be rate limited
+    const res = await app.request('/test', { headers: { 'x-test-key': 'client-a' } });
+    expect(res.status).toBe(429);
+    expect(res.headers.get('Retry-After')).toBeDefined();
+  });
+
+  it('tracks different keys independently', async () => {
+    const app = new Hono();
+    const limiter = createRateLimiter(
+      { windowMs: 60_000, maxRequests: 1 },
+      (c) => c.req.header('x-test-key') ?? null
+    );
+    app.use('/*', limiter);
+    app.get('/test', (c) => c.text('ok'));
+
+    const res1 = await app.request('/test', { headers: { 'x-test-key': 'a' } });
+    expect(res1.status).toBe(200);
+
+    const res2 = await app.request('/test', { headers: { 'x-test-key': 'b' } });
+    expect(res2.status).toBe(200);
+  });
+
+  it('skips rate limiting when key function returns null', async () => {
+    const app = new Hono();
+    const limiter = createRateLimiter(
+      { windowMs: 60_000, maxRequests: 1 },
+      () => null
+    );
+    app.use('/*', limiter);
+    app.get('/test', (c) => c.text('ok'));
+
+    // Both should pass since no key → no limiting
+    const res1 = await app.request('/test');
+    const res2 = await app.request('/test');
+    expect(res1.status).toBe(200);
+    expect(res2.status).toBe(200);
+  });
+});

--- a/apps/telemetry-server/tests/telemetry-batch.test.ts
+++ b/apps/telemetry-server/tests/telemetry-batch.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from 'vitest';
+import { Hono } from 'hono';
+import { createHash, generateKeyPairSync, randomUUID } from 'node:crypto';
+import { telemetryBatchRoutes } from '../src/routes/telemetry-batch.js';
+import { enrollRoutes } from '../src/routes/enroll.js';
+import { createMemoryStore } from '../src/store/memory-store.js';
+import { loadConfig } from '../src/config.js';
+import { canonicalize, signPayload } from '@red-codes/telemetry-client';
+
+function makeApp() {
+  const config = { ...loadConfig(), antiReplayWindowMs: 300_000, maxRequestSizeMb: 1 };
+  const store = createMemoryStore();
+  const app = new Hono();
+  app.route('/api', enrollRoutes(store, config));
+  app.route('/api', telemetryBatchRoutes(store, config));
+  return { app, store, config };
+}
+
+function makeValidEvent() {
+  return {
+    event_id: randomUUID(),
+    timestamp: Math.floor(Date.now() / 1000),
+    version: '1.0.0',
+    runtime: 'claude-code',
+    environment: 'local',
+    event_type: 'guard_triggered',
+    policy: 'default',
+    result: 'allowed',
+    latency_ms: 42,
+  };
+}
+
+describe('POST /api/v1/telemetry/batch', () => {
+  it('accepts valid anonymous batch', async () => {
+    const { app } = makeApp();
+    const res = await app.request('/api/v1/telemetry/batch', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        mode: 'anonymous',
+        events: [makeValidEvent(), makeValidEvent()],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.accepted).toBe(2);
+  });
+
+  it('rejects empty events array', async () => {
+    const { app } = makeApp();
+    const res = await app.request('/api/v1/telemetry/batch', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ mode: 'anonymous', events: [] }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects invalid mode', async () => {
+    const { app } = makeApp();
+    const res = await app.request('/api/v1/telemetry/batch', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ mode: 'invalid', events: [makeValidEvent()] }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects events with extra fields', async () => {
+    const { app } = makeApp();
+    const event = { ...makeValidEvent(), secret: 'should-not-be-here' };
+    const res = await app.request('/api/v1/telemetry/batch', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ mode: 'anonymous', events: [event] }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects stale timestamps (anti-replay)', async () => {
+    const { app } = makeApp();
+    const event = {
+      ...makeValidEvent(),
+      timestamp: Math.floor(Date.now() / 1000) - 600, // 10 min old
+    };
+    const res = await app.request('/api/v1/telemetry/batch', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ mode: 'anonymous', events: [event] }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects batch exceeding max size', async () => {
+    const { app } = makeApp();
+    const events = Array.from({ length: 51 }, () => makeValidEvent());
+    const res = await app.request('/api/v1/telemetry/batch', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ mode: 'anonymous', events }),
+    });
+
+    expect(res.status).toBe(413);
+  });
+
+  it('rejects verified mode without auth header', async () => {
+    const { app } = makeApp();
+    const res = await app.request('/api/v1/telemetry/batch', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ mode: 'verified', events: [makeValidEvent()] }),
+    });
+
+    expect(res.status).toBe(401);
+  });
+
+  it('accepts verified mode with valid token and signature', async () => {
+    const { app } = makeApp();
+
+    // First enroll
+    const { publicKey, privateKey } = generateKeyPairSync('ed25519', {
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    });
+
+    const installId = '550e8400-e29b-41d4-a716-446655440000';
+    const enrollRes = await app.request('/api/v1/telemetry/enroll', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        install_id: installId,
+        public_key: publicKey,
+        version: '1.0.0',
+      }),
+    });
+    const { token } = await enrollRes.json();
+
+    // Now send batch with signature
+    const batchBody = { mode: 'verified', events: [makeValidEvent()] };
+    const canonical = canonicalize(batchBody);
+    const signature = signPayload(canonical, privateKey);
+
+    const res = await app.request('/api/v1/telemetry/batch', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+        'X-AgentGuard-Install-ID': installId,
+        'X-AgentGuard-Signature': signature,
+      },
+      body: canonical,
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+  });
+
+  it('rejects verified mode with invalid signature', async () => {
+    const { app } = makeApp();
+
+    const { publicKey } = generateKeyPairSync('ed25519', {
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    });
+
+    const installId = '550e8400-e29b-41d4-a716-446655440001';
+    const enrollRes = await app.request('/api/v1/telemetry/enroll', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        install_id: installId,
+        public_key: publicKey,
+        version: '1.0.0',
+      }),
+    });
+    const { token } = await enrollRes.json();
+
+    const batchBody = { mode: 'verified', events: [makeValidEvent()] };
+
+    const res = await app.request('/api/v1/telemetry/batch', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+        'X-AgentGuard-Install-ID': installId,
+        'X-AgentGuard-Signature': 'invalid-signature',
+      },
+      body: JSON.stringify(batchBody),
+    });
+
+    expect(res.status).toBe(403);
+  });
+});

--- a/apps/telemetry-server/tsconfig.json
+++ b/apps/telemetry-server/tsconfig.json
@@ -8,6 +8,7 @@
   "include": ["src/**/*.ts"],
   "references": [
     { "path": "../../packages/core" },
-    { "path": "../../packages/telemetry" }
+    { "path": "../../packages/telemetry" },
+    { "path": "../../packages/telemetry-client" }
   ]
 }

--- a/apps/telemetry-server/vitest.config.ts
+++ b/apps/telemetry-server/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts'],
+    environment: 'node',
+  },
+});

--- a/packages/telemetry-client/package.json
+++ b/packages/telemetry-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@red-codes/telemetry-client",
   "version": "0.1.0",
-  "description": "Telemetry client SDK for AgentGuard (placeholder)",
+  "description": "Privacy-first telemetry client SDK for AgentGuard",
   "type": "module",
   "license": "Apache-2.0",
   "main": "./dist/index.js",
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "build": "tsc -b",
-    
+    "test": "vitest run",
     "lint": "eslint src/",
     "ts:check": "tsc --noEmit",
     "clean": "rm -rf dist"

--- a/packages/telemetry-client/src/client.ts
+++ b/packages/telemetry-client/src/client.ts
@@ -1,0 +1,181 @@
+// Telemetry client facade — main entry point for the telemetry SDK.
+
+import { randomUUID } from 'node:crypto';
+import { unlinkSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import type {
+  TelemetryClient,
+  TelemetryClientConfig,
+  TelemetryStatus,
+  TrackableEvent,
+  TelemetryPayloadEvent,
+  TelemetryQueue,
+} from './types.js';
+import {
+  loadIdentity,
+  saveIdentity,
+  deleteIdentity,
+  generateIdentity,
+  resolveMode,
+} from './identity.js';
+import { createQueue } from './queue.js';
+import { createTelemetrySender } from './sender.js';
+import type { TelemetrySender } from './sender.js';
+
+/** Read the AgentGuard version from a best-effort approach */
+function getVersion(): string {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    return (require('../../package.json') as { version: string }).version;
+  } catch {
+    return '0.0.0';
+  }
+}
+
+function createNoopClient(): TelemetryClient {
+  return {
+    track(): void {
+      // No-op
+    },
+    async enroll(): Promise<void> {
+      // No-op
+    },
+    start(): void {
+      // No-op
+    },
+    stop(): void {
+      // No-op
+    },
+    status(): TelemetryStatus {
+      return { mode: 'off', installId: null, enrolled: false, queueSize: 0, queueSizeBytes: 0 };
+    },
+    reset(): void {
+      // No-op
+    },
+  };
+}
+
+/** Create a telemetry client. Returns a no-op client when mode is 'off'. */
+export async function createTelemetryClient(
+  config?: Partial<TelemetryClientConfig>
+): Promise<TelemetryClient> {
+  const identityPath = config?.identityPath;
+  const identity = loadIdentity(identityPath);
+  const mode = config?.mode ?? resolveMode(identity);
+
+  if (mode === 'off') return createNoopClient();
+
+  const fullConfig: TelemetryClientConfig = {
+    serverUrl: config?.serverUrl,
+    mode,
+    flushIntervalMs: config?.flushIntervalMs ?? 60_000,
+    batchSize: config?.batchSize ?? 50,
+    maxRetries: config?.maxRetries ?? 3,
+    maxQueueSizeMb: config?.maxQueueSizeMb ?? 10,
+    identityPath: config?.identityPath,
+    queuePath: config?.queuePath,
+  };
+
+  let queue: TelemetryQueue;
+  try {
+    queue = await createQueue(fullConfig.queuePath);
+  } catch {
+    return createNoopClient();
+  }
+
+  let sender: TelemetrySender | null = null;
+  const version = getVersion();
+
+  return {
+    track(event: TrackableEvent): void {
+      try {
+        const payload: TelemetryPayloadEvent = {
+          event_id: randomUUID(),
+          timestamp: Math.floor(Date.now() / 1000),
+          version,
+          ...event,
+        };
+        queue.enqueue(payload);
+      } catch {
+        // Never crash
+      }
+    },
+
+    async enroll(serverUrl: string): Promise<void> {
+      let current = identity ?? generateIdentity('verified');
+      current = { ...current, mode: 'verified' };
+
+      const url = serverUrl.replace(/\/+$/, '') + '/api/v1/telemetry/enroll';
+      const response = await globalThis.fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          install_id: current.install_id,
+          public_key: current.public_key,
+          version,
+        }),
+        signal: AbortSignal.timeout(15_000),
+      });
+
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(`Enrollment failed (${response.status}): ${text}`);
+      }
+
+      const result = (await response.json()) as { ok: boolean; token: string };
+      current.enrollment_token = result.token;
+      current.enrolled_at = new Date().toISOString();
+
+      saveIdentity(current, identityPath);
+    },
+
+    start(): void {
+      if (sender) return;
+      sender = createTelemetrySender(fullConfig, identity, queue);
+      sender.start();
+    },
+
+    stop(): void {
+      if (sender) {
+        // Fire one last flush, but don't await it
+        sender.flush().catch(() => {
+          // Swallow
+        });
+        sender.stop();
+        sender = null;
+      }
+      queue.close();
+    },
+
+    status(): TelemetryStatus {
+      return {
+        mode,
+        installId: identity?.install_id ?? null,
+        enrolled: !!identity?.enrollment_token,
+        queueSize: queue.size(),
+        queueSizeBytes: queue.sizeBytes(),
+      };
+    },
+
+    reset(): void {
+      if (sender) {
+        sender.stop();
+        sender = null;
+      }
+      queue.clear();
+      queue.close();
+      deleteIdentity(identityPath);
+
+      // Also remove queue files
+      const defaultQueueDir = join(homedir(), '.agentguard');
+      for (const f of ['telemetry-queue.db', 'telemetry-queue.jsonl']) {
+        try {
+          unlinkSync(join(defaultQueueDir, f));
+        } catch {
+          // Ignore
+        }
+      }
+    },
+  };
+}

--- a/packages/telemetry-client/src/identity.ts
+++ b/packages/telemetry-client/src/identity.ts
@@ -1,0 +1,77 @@
+// Identity management — Ed25519 keypair generation and persistence.
+
+import { generateKeyPairSync, randomUUID } from 'node:crypto';
+import { readFileSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, dirname } from 'node:path';
+import type { TelemetryIdentity, TelemetryMode } from './types.js';
+
+const DEFAULT_IDENTITY_PATH = join(homedir(), '.agentguard', 'telemetry.json');
+
+/** Generate a new Ed25519 identity with a fresh install_id */
+export function generateIdentity(mode: TelemetryMode = 'anonymous'): TelemetryIdentity {
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519', {
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  });
+
+  return {
+    install_id: randomUUID(),
+    public_key: publicKey,
+    private_key: privateKey,
+    mode,
+  };
+}
+
+/** Load identity from disk. Returns null if not found or invalid. */
+export function loadIdentity(path?: string): TelemetryIdentity | null {
+  const filePath = path ?? DEFAULT_IDENTITY_PATH;
+  try {
+    const raw = readFileSync(filePath, 'utf8');
+    const data = JSON.parse(raw) as TelemetryIdentity;
+    if (!data.install_id || !data.public_key || !data.private_key) return null;
+    return data;
+  } catch {
+    return null;
+  }
+}
+
+/** Save identity to disk */
+export function saveIdentity(identity: TelemetryIdentity, path?: string): void {
+  const filePath = path ?? DEFAULT_IDENTITY_PATH;
+  try {
+    mkdirSync(dirname(filePath), { recursive: true });
+    writeFileSync(filePath, JSON.stringify(identity, null, 2), { mode: 0o600 });
+  } catch (err) {
+    process.stderr.write(
+      `[agentguard] Warning: failed to save telemetry identity: ${err}\n`
+    );
+  }
+}
+
+/** Delete identity from disk */
+export function deleteIdentity(path?: string): void {
+  const filePath = path ?? DEFAULT_IDENTITY_PATH;
+  try {
+    unlinkSync(filePath);
+  } catch {
+    // Ignore if file doesn't exist
+  }
+}
+
+/** Resolve the effective telemetry mode */
+export function resolveMode(identity?: TelemetryIdentity | null): TelemetryMode {
+  const envMode = process.env.AGENTGUARD_TELEMETRY;
+  if (envMode === 'off' || envMode === 'anonymous' || envMode === 'verified') {
+    return envMode;
+  }
+  if (identity) {
+    return identity.mode;
+  }
+  return 'off';
+}
+
+/** Get the default identity file path */
+export function getDefaultIdentityPath(): string {
+  return DEFAULT_IDENTITY_PATH;
+}

--- a/packages/telemetry-client/src/index.ts
+++ b/packages/telemetry-client/src/index.ts
@@ -1,1 +1,34 @@
-export const VERSION = '0.0.1';
+// @red-codes/telemetry-client — Telemetry client SDK for AgentGuard.
+
+export const VERSION = '0.1.0';
+
+export type {
+  TelemetryMode,
+  TelemetryPayloadEvent,
+  TrackableEvent,
+  TelemetryIdentity,
+  TelemetryClientConfig,
+  TelemetryQueue,
+  TelemetryClient,
+  TelemetryStatus,
+} from './types.js';
+
+export {
+  generateIdentity,
+  loadIdentity,
+  saveIdentity,
+  deleteIdentity,
+  resolveMode,
+  getDefaultIdentityPath,
+} from './identity.js';
+
+export { canonicalize, signPayload, verifySignature } from './signing.js';
+
+export { createSqliteQueue } from './queue-sqlite.js';
+export { createJsonlQueue } from './queue-jsonl.js';
+export { createQueue } from './queue.js';
+
+export { createTelemetrySender } from './sender.js';
+export type { TelemetrySender } from './sender.js';
+
+export { createTelemetryClient } from './client.js';

--- a/packages/telemetry-client/src/queue-jsonl.ts
+++ b/packages/telemetry-client/src/queue-jsonl.ts
@@ -1,0 +1,108 @@
+// JSONL-backed telemetry event queue — fallback when SQLite is unavailable.
+
+import { homedir } from 'node:os';
+import { join, dirname } from 'node:path';
+import {
+  appendFileSync,
+  readFileSync,
+  writeFileSync,
+  unlinkSync,
+  statSync,
+  mkdirSync,
+} from 'node:fs';
+import type { TelemetryQueue, TelemetryPayloadEvent } from './types.js';
+
+const DEFAULT_QUEUE_PATH = join(homedir(), '.agentguard', 'telemetry-queue.jsonl');
+const MAX_QUEUE_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB
+
+/** Create a JSONL-backed telemetry queue */
+export function createJsonlQueue(path?: string): TelemetryQueue {
+  const filePath = path ?? DEFAULT_QUEUE_PATH;
+  try {
+    mkdirSync(dirname(filePath), { recursive: true });
+  } catch {
+    // Ignore
+  }
+
+  function readLines(): string[] {
+    try {
+      const content = readFileSync(filePath, 'utf8');
+      return content
+        .split('\n')
+        .filter((l) => l.trim().length > 0);
+    } catch {
+      return [];
+    }
+  }
+
+  function writeLines(lines: string[]): void {
+    try {
+      writeFileSync(filePath, lines.length > 0 ? lines.join('\n') + '\n' : '');
+    } catch {
+      // Ignore
+    }
+  }
+
+  function getFileSize(): number {
+    try {
+      return statSync(filePath).size;
+    } catch {
+      return 0;
+    }
+  }
+
+  function evictIfNeeded(): void {
+    if (getFileSize() <= MAX_QUEUE_SIZE_BYTES) return;
+    const lines = readLines();
+    // Remove oldest 20% of lines
+    const removeCount = Math.max(1, Math.floor(lines.length * 0.2));
+    writeLines(lines.slice(removeCount));
+  }
+
+  return {
+    enqueue(event: TelemetryPayloadEvent): void {
+      try {
+        evictIfNeeded();
+        appendFileSync(filePath, JSON.stringify(event) + '\n');
+      } catch {
+        // Never crash the kernel
+      }
+    },
+
+    dequeue(count: number): TelemetryPayloadEvent[] {
+      try {
+        const lines = readLines();
+        if (lines.length === 0) return [];
+
+        const take = Math.min(count, lines.length);
+        const taken = lines.slice(0, take);
+        const remaining = lines.slice(take);
+        writeLines(remaining);
+
+        return taken.map((l) => JSON.parse(l) as TelemetryPayloadEvent);
+      } catch {
+        return [];
+      }
+    },
+
+    size(): number {
+      return readLines().length;
+    },
+
+    sizeBytes(): number {
+      return getFileSize();
+    },
+
+    clear(): void {
+      try {
+        unlinkSync(filePath);
+      } catch {
+        // Ignore
+      }
+    },
+
+    close(): void {
+      // No-op for JSONL
+    },
+  };
+}

--- a/packages/telemetry-client/src/queue-sqlite.ts
+++ b/packages/telemetry-client/src/queue-sqlite.ts
@@ -1,0 +1,130 @@
+// SQLite-backed telemetry event queue — crash-safe, persistent, bounded.
+
+import { homedir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { mkdirSync } from 'node:fs';
+import type { TelemetryQueue, TelemetryPayloadEvent } from './types.js';
+
+const DEFAULT_QUEUE_PATH = join(homedir(), '.agentguard', 'telemetry-queue.db');
+const MAX_QUEUE_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB
+const EVICTION_BATCH = 100;
+
+/** Create a SQLite-backed telemetry queue. Throws if better-sqlite3 is not available. */
+export async function createSqliteQueue(path?: string): Promise<TelemetryQueue> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let Database: any;
+  try {
+    // Dynamic import to avoid compile-time resolution — better-sqlite3 is optional
+    const moduleName = 'better-sqlite3';
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const mod = await (Function('m', 'return import(m)')(moduleName) as Promise<
+      Record<string, unknown>
+    >);
+    Database = mod.default ?? mod;
+  } catch {
+    throw new Error(
+      'SQLite telemetry queue requires better-sqlite3. Install it with: npm install better-sqlite3'
+    );
+  }
+
+  const dbPath = path ?? DEFAULT_QUEUE_PATH;
+  try {
+    mkdirSync(dirname(dbPath), { recursive: true });
+  } catch {
+    // Ignore
+  }
+
+  const db = new Database(dbPath);
+  db.pragma('journal_mode = WAL');
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS telemetry_queue (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      event_json TEXT NOT NULL,
+      created_at INTEGER NOT NULL
+    )
+  `);
+
+  const insertStmt = db.prepare(
+    'INSERT INTO telemetry_queue (event_json, created_at) VALUES (?, ?)'
+  );
+  const selectStmt = db.prepare(
+    'SELECT id, event_json FROM telemetry_queue ORDER BY id ASC LIMIT ?'
+  );
+  const deleteStmt = db.prepare('DELETE FROM telemetry_queue WHERE id <= ?');
+  const countStmt = db.prepare('SELECT COUNT(*) as cnt FROM telemetry_queue');
+  const clearStmt = db.prepare('DELETE FROM telemetry_queue');
+  const evictStmt = db.prepare(
+    'DELETE FROM telemetry_queue WHERE id IN (SELECT id FROM telemetry_queue ORDER BY id ASC LIMIT ?)'
+  );
+
+  function getSizeBytes(): number {
+    try {
+      const pageCount = db.pragma('page_count', { simple: true }) as number;
+      const pageSize = db.pragma('page_size', { simple: true }) as number;
+      return pageCount * pageSize;
+    } catch {
+      return 0;
+    }
+  }
+
+  function evictIfNeeded(): void {
+    while (getSizeBytes() > MAX_QUEUE_SIZE_BYTES) {
+      const result = evictStmt.run(EVICTION_BATCH);
+      if (result.changes === 0) break;
+    }
+  }
+
+  return {
+    enqueue(event: TelemetryPayloadEvent): void {
+      try {
+        evictIfNeeded();
+        insertStmt.run(JSON.stringify(event), Date.now());
+      } catch {
+        // Never crash the kernel
+      }
+    },
+
+    dequeue(count: number): TelemetryPayloadEvent[] {
+      try {
+        const rows = selectStmt.all(count) as Array<{ id: number; event_json: string }>;
+        if (rows.length === 0) return [];
+
+        const maxId = rows[rows.length - 1].id;
+        deleteStmt.run(maxId);
+
+        return rows.map((r) => JSON.parse(r.event_json) as TelemetryPayloadEvent);
+      } catch {
+        return [];
+      }
+    },
+
+    size(): number {
+      try {
+        const row = countStmt.get() as { cnt: number };
+        return row.cnt;
+      } catch {
+        return 0;
+      }
+    },
+
+    sizeBytes(): number {
+      return getSizeBytes();
+    },
+
+    clear(): void {
+      try {
+        clearStmt.run();
+      } catch {
+        // Ignore
+      }
+    },
+
+    close(): void {
+      try {
+        db.close();
+      } catch {
+        // Ignore
+      }
+    },
+  };
+}

--- a/packages/telemetry-client/src/queue.ts
+++ b/packages/telemetry-client/src/queue.ts
@@ -1,0 +1,14 @@
+// Queue factory — tries SQLite first, falls back to JSONL.
+
+import type { TelemetryQueue } from './types.js';
+import { createJsonlQueue } from './queue-jsonl.js';
+
+/** Create a telemetry queue. Prefers SQLite; falls back to JSONL. */
+export async function createQueue(path?: string): Promise<TelemetryQueue> {
+  try {
+    const { createSqliteQueue } = await import('./queue-sqlite.js');
+    return await createSqliteQueue(path);
+  } catch {
+    return createJsonlQueue(path);
+  }
+}

--- a/packages/telemetry-client/src/sender.ts
+++ b/packages/telemetry-client/src/sender.ts
@@ -1,0 +1,133 @@
+// Batched telemetry sender — non-blocking background transmission with retry.
+
+import type {
+  TelemetryQueue,
+  TelemetryIdentity,
+  TelemetryClientConfig,
+  TelemetryPayloadEvent,
+} from './types.js';
+import { canonicalize, signPayload } from './signing.js';
+
+const DEFAULT_FLUSH_INTERVAL_MS = 60_000;
+const DEFAULT_BATCH_SIZE = 50;
+const DEFAULT_MAX_RETRIES = 3;
+
+export interface TelemetrySender {
+  start(): void;
+  stop(): void;
+  flush(): Promise<void>;
+}
+
+/** Create a batched background sender */
+export function createTelemetrySender(
+  config: TelemetryClientConfig,
+  identity: TelemetryIdentity | null,
+  queue: TelemetryQueue
+): TelemetrySender {
+  const flushInterval = config.flushIntervalMs ?? DEFAULT_FLUSH_INTERVAL_MS;
+  const batchSize = config.batchSize ?? DEFAULT_BATCH_SIZE;
+  const maxRetries = config.maxRetries ?? DEFAULT_MAX_RETRIES;
+  const serverUrl = config.serverUrl;
+
+  let timer: ReturnType<typeof setInterval> | null = null;
+  let flushing = false;
+
+  async function sendBatch(events: TelemetryPayloadEvent[]): Promise<boolean> {
+    if (!serverUrl || events.length === 0) return true;
+
+    const mode = identity?.mode ?? 'anonymous';
+    const body = { mode, events };
+    const canonical = canonicalize(body);
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+
+    if (mode === 'verified' && identity) {
+      if (identity.enrollment_token) {
+        headers['Authorization'] = `Bearer ${identity.enrollment_token}`;
+      }
+      headers['X-AgentGuard-Install-ID'] = identity.install_id;
+      try {
+        headers['X-AgentGuard-Signature'] = signPayload(canonical, identity.private_key);
+      } catch {
+        // If signing fails, send without signature
+      }
+    }
+
+    const url = serverUrl.replace(/\/+$/, '') + '/api/v1/telemetry/batch';
+
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      try {
+        const response = await globalThis.fetch(url, {
+          method: 'POST',
+          headers,
+          body: canonical,
+          signal: AbortSignal.timeout(10_000),
+        });
+
+        if (response.ok) return true;
+        if (response.status === 429 || response.status >= 500) {
+          // Retryable
+          if (attempt < maxRetries) {
+            await sleep(1000 * Math.pow(2, attempt));
+            continue;
+          }
+        }
+        return false;
+      } catch {
+        if (attempt < maxRetries) {
+          await sleep(1000 * Math.pow(2, attempt));
+          continue;
+        }
+        return false;
+      }
+    }
+
+    return false;
+  }
+
+  async function flush(): Promise<void> {
+    if (flushing) return;
+    flushing = true;
+    try {
+      const events = queue.dequeue(batchSize);
+      if (events.length > 0) {
+        await sendBatch(events);
+        // Events are dropped on failure (already dequeued)
+      }
+    } catch {
+      // Never crash
+    } finally {
+      flushing = false;
+    }
+  }
+
+  return {
+    start(): void {
+      if (timer) return;
+      timer = setInterval(() => {
+        flush().catch(() => {
+          // Swallow
+        });
+      }, flushInterval);
+      // Prevent the timer from keeping the process alive
+      if (timer && typeof timer === 'object' && 'unref' in timer) {
+        timer.unref();
+      }
+    },
+
+    stop(): void {
+      if (timer) {
+        clearInterval(timer);
+        timer = null;
+      }
+    },
+
+    flush,
+  };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/telemetry-client/src/signing.ts
+++ b/packages/telemetry-client/src/signing.ts
@@ -1,0 +1,41 @@
+// Payload signing — Ed25519 sign/verify for tamper-resistant telemetry.
+
+import { sign, verify, createPrivateKey, createPublicKey } from 'node:crypto';
+
+/**
+ * Canonicalize an object to a deterministic JSON string.
+ * Sorts keys alphabetically at all levels, no whitespace.
+ */
+export function canonicalize(obj: unknown): string {
+  return JSON.stringify(obj, (_key, value: unknown) => {
+    if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+      const sorted: Record<string, unknown> = {};
+      for (const k of Object.keys(value as Record<string, unknown>).sort()) {
+        sorted[k] = (value as Record<string, unknown>)[k];
+      }
+      return sorted;
+    }
+    return value;
+  });
+}
+
+/** Sign a canonical JSON body with an Ed25519 private key. Returns base64 signature. */
+export function signPayload(body: string, privateKeyPem: string): string {
+  const key = createPrivateKey(privateKeyPem);
+  const signature = sign(null, Buffer.from(body, 'utf8'), key);
+  return signature.toString('base64');
+}
+
+/** Verify an Ed25519 signature against a canonical JSON body. */
+export function verifySignature(
+  body: string,
+  signature: string,
+  publicKeyPem: string
+): boolean {
+  try {
+    const key = createPublicKey(publicKeyPem);
+    return verify(null, Buffer.from(body, 'utf8'), key, Buffer.from(signature, 'base64'));
+  } catch {
+    return false;
+  }
+}

--- a/packages/telemetry-client/src/types.ts
+++ b/packages/telemetry-client/src/types.ts
@@ -1,0 +1,73 @@
+// Telemetry client types — shared across client SDK modules.
+
+/** Telemetry operating mode */
+export type TelemetryMode = 'off' | 'anonymous' | 'verified';
+
+/** Event payload sent to the telemetry server */
+export interface TelemetryPayloadEvent {
+  readonly event_id: string;
+  readonly timestamp: number; // Unix epoch seconds
+  readonly version: string;
+  readonly runtime: 'claude-code' | 'copilot' | 'ci' | 'unknown';
+  readonly environment: 'local' | 'ci' | 'container';
+  readonly event_type: 'guard_triggered' | 'policy_denied' | 'execution_allowed' | 'error';
+  readonly policy: string;
+  readonly result: 'allowed' | 'denied' | 'error';
+  readonly latency_ms: number;
+}
+
+/** Trackable event fields (auto-filled fields omitted) */
+export type TrackableEvent = Omit<TelemetryPayloadEvent, 'event_id' | 'timestamp' | 'version'>;
+
+/** Persisted identity stored at ~/.agentguard/telemetry.json */
+export interface TelemetryIdentity {
+  install_id: string;
+  public_key: string; // PEM-encoded Ed25519
+  private_key: string; // PEM-encoded Ed25519
+  mode: TelemetryMode;
+  enrollment_token?: string;
+  enrolled_at?: string; // ISO 8601
+}
+
+/** Telemetry client configuration */
+export interface TelemetryClientConfig {
+  serverUrl?: string;
+  mode?: TelemetryMode;
+  flushIntervalMs?: number; // default 60000
+  batchSize?: number; // default 50
+  maxRetries?: number; // default 3
+  maxQueueSizeMb?: number; // default 10
+  /** Override identity file path (for testing) */
+  identityPath?: string;
+  /** Override queue path (for testing) */
+  queuePath?: string;
+}
+
+/** Persistent event queue interface */
+export interface TelemetryQueue {
+  enqueue(event: TelemetryPayloadEvent): void;
+  dequeue(count: number): TelemetryPayloadEvent[];
+  size(): number;
+  sizeBytes(): number;
+  clear(): void;
+  close(): void;
+}
+
+/** Telemetry client interface */
+export interface TelemetryClient {
+  track(event: TrackableEvent): void;
+  enroll(serverUrl: string): Promise<void>;
+  start(): void;
+  stop(): void;
+  status(): TelemetryStatus;
+  reset(): void;
+}
+
+/** Telemetry status snapshot */
+export interface TelemetryStatus {
+  mode: TelemetryMode;
+  installId: string | null;
+  enrolled: boolean;
+  queueSize: number;
+  queueSizeBytes: number;
+}

--- a/packages/telemetry-client/tests/client.test.ts
+++ b/packages/telemetry-client/tests/client.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { createTelemetryClient } from '../src/client.js';
+
+describe('TelemetryClient', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'ag-client-'));
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+    vi.unstubAllGlobals();
+    delete process.env.AGENTGUARD_TELEMETRY;
+  });
+
+  it('returns no-op client when mode is off', async () => {
+    process.env.AGENTGUARD_TELEMETRY = 'off';
+    const client = await createTelemetryClient({
+      identityPath: join(tempDir, 'identity.json'),
+    });
+
+    const status = client.status();
+    expect(status.mode).toBe('off');
+    expect(status.queueSize).toBe(0);
+
+    // track should be safe (no-op)
+    client.track({
+      runtime: 'claude-code',
+      environment: 'local',
+      event_type: 'guard_triggered',
+      policy: 'default',
+      result: 'allowed',
+      latency_ms: 10,
+    });
+
+    client.stop();
+  });
+
+  it('tracks events when mode is anonymous', async () => {
+    process.env.AGENTGUARD_TELEMETRY = 'anonymous';
+    const client = await createTelemetryClient({
+      identityPath: join(tempDir, 'identity.json'),
+      queuePath: join(tempDir, 'queue.jsonl'),
+    });
+
+    client.track({
+      runtime: 'claude-code',
+      environment: 'local',
+      event_type: 'guard_triggered',
+      policy: 'default',
+      result: 'allowed',
+      latency_ms: 10,
+    });
+
+    const status = client.status();
+    expect(status.mode).toBe('anonymous');
+    expect(status.queueSize).toBe(1);
+
+    client.stop();
+  });
+
+  it('status returns correct info', async () => {
+    process.env.AGENTGUARD_TELEMETRY = 'anonymous';
+    const client = await createTelemetryClient({
+      identityPath: join(tempDir, 'identity.json'),
+      queuePath: join(tempDir, 'queue.jsonl'),
+    });
+
+    const status = client.status();
+    expect(status.mode).toBe('anonymous');
+    expect(status.enrolled).toBe(false);
+    expect(status.queueSize).toBe(0);
+
+    client.stop();
+  });
+
+  it('reset cleans up files', async () => {
+    process.env.AGENTGUARD_TELEMETRY = 'anonymous';
+    const client = await createTelemetryClient({
+      identityPath: join(tempDir, 'identity.json'),
+      queuePath: join(tempDir, 'queue.jsonl'),
+    });
+
+    client.track({
+      runtime: 'claude-code',
+      environment: 'local',
+      event_type: 'guard_triggered',
+      policy: 'default',
+      result: 'allowed',
+      latency_ms: 10,
+    });
+
+    client.reset();
+
+    // After reset, re-creating the client should start fresh
+    const client2 = await createTelemetryClient({
+      identityPath: join(tempDir, 'identity.json'),
+      queuePath: join(tempDir, 'queue.jsonl'),
+    });
+
+    expect(client2.status().queueSize).toBe(0);
+    client2.stop();
+  });
+});

--- a/packages/telemetry-client/tests/identity.test.ts
+++ b/packages/telemetry-client/tests/identity.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, existsSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  generateIdentity,
+  loadIdentity,
+  saveIdentity,
+  deleteIdentity,
+  resolveMode,
+} from '../src/identity.js';
+
+describe('generateIdentity', () => {
+  it('generates a valid identity with Ed25519 keypair', () => {
+    const identity = generateIdentity();
+    expect(identity.install_id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    );
+    expect(identity.public_key).toContain('-----BEGIN PUBLIC KEY-----');
+    expect(identity.private_key).toContain('-----BEGIN PRIVATE KEY-----');
+    expect(identity.mode).toBe('anonymous');
+  });
+
+  it('respects the provided mode', () => {
+    const identity = generateIdentity('verified');
+    expect(identity.mode).toBe('verified');
+  });
+
+  it('generates unique install_ids', () => {
+    const a = generateIdentity();
+    const b = generateIdentity();
+    expect(a.install_id).not.toBe(b.install_id);
+  });
+});
+
+describe('save/load/delete identity', () => {
+  let tempDir: string;
+  let identityPath: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'ag-test-'));
+    identityPath = join(tempDir, 'telemetry.json');
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('save and load roundtrip', () => {
+    const identity = generateIdentity('verified');
+    saveIdentity(identity, identityPath);
+
+    const loaded = loadIdentity(identityPath);
+    expect(loaded).not.toBeNull();
+    expect(loaded!.install_id).toBe(identity.install_id);
+    expect(loaded!.public_key).toBe(identity.public_key);
+    expect(loaded!.private_key).toBe(identity.private_key);
+    expect(loaded!.mode).toBe('verified');
+  });
+
+  it('loadIdentity returns null for missing file', () => {
+    const result = loadIdentity(join(tempDir, 'nonexistent.json'));
+    expect(result).toBeNull();
+  });
+
+  it('loadIdentity returns null for invalid JSON', () => {
+    const path = join(tempDir, 'bad.json');
+    require('node:fs').writeFileSync(path, 'not json');
+    const result = loadIdentity(path);
+    expect(result).toBeNull();
+  });
+
+  it('deleteIdentity removes the file', () => {
+    const identity = generateIdentity();
+    saveIdentity(identity, identityPath);
+    expect(existsSync(identityPath)).toBe(true);
+
+    deleteIdentity(identityPath);
+    expect(existsSync(identityPath)).toBe(false);
+  });
+
+  it('deleteIdentity is safe for missing files', () => {
+    expect(() => deleteIdentity(join(tempDir, 'nope.json'))).not.toThrow();
+  });
+
+  it('saveIdentity creates parent directories', () => {
+    const nestedPath = join(tempDir, 'a', 'b', 'c', 'identity.json');
+    const identity = generateIdentity();
+    saveIdentity(identity, nestedPath);
+    expect(existsSync(nestedPath)).toBe(true);
+  });
+
+  it('sets restrictive file permissions', () => {
+    const identity = generateIdentity();
+    saveIdentity(identity, identityPath);
+    const stats = require('node:fs').statSync(identityPath);
+    // 0o600 = owner read/write only
+    expect(stats.mode & 0o777).toBe(0o600);
+  });
+});
+
+describe('resolveMode', () => {
+  const originalEnv = process.env.AGENTGUARD_TELEMETRY;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.AGENTGUARD_TELEMETRY;
+    } else {
+      process.env.AGENTGUARD_TELEMETRY = originalEnv;
+    }
+  });
+
+  it('defaults to off when no identity and no env', () => {
+    delete process.env.AGENTGUARD_TELEMETRY;
+    expect(resolveMode(null)).toBe('off');
+  });
+
+  it('uses env var when set', () => {
+    process.env.AGENTGUARD_TELEMETRY = 'anonymous';
+    expect(resolveMode(null)).toBe('anonymous');
+  });
+
+  it('env var overrides identity mode', () => {
+    process.env.AGENTGUARD_TELEMETRY = 'verified';
+    const identity = generateIdentity('anonymous');
+    expect(resolveMode(identity)).toBe('verified');
+  });
+
+  it('falls back to identity mode', () => {
+    delete process.env.AGENTGUARD_TELEMETRY;
+    const identity = generateIdentity('verified');
+    expect(resolveMode(identity)).toBe('verified');
+  });
+
+  it('ignores invalid env values', () => {
+    process.env.AGENTGUARD_TELEMETRY = 'invalid';
+    const identity = generateIdentity('anonymous');
+    expect(resolveMode(identity)).toBe('anonymous');
+  });
+});

--- a/packages/telemetry-client/tests/queue-jsonl.test.ts
+++ b/packages/telemetry-client/tests/queue-jsonl.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { createJsonlQueue } from '../src/queue-jsonl.js';
+import type { TelemetryPayloadEvent } from '../src/types.js';
+
+function makeEvent(id: string): TelemetryPayloadEvent {
+  return {
+    event_id: id,
+    timestamp: Math.floor(Date.now() / 1000),
+    version: '1.0.0',
+    runtime: 'claude-code',
+    environment: 'local',
+    event_type: 'guard_triggered',
+    policy: 'default',
+    result: 'allowed',
+    latency_ms: 10,
+  };
+}
+
+describe('JSONL queue', () => {
+  let tempDir: string;
+  let queuePath: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'ag-queue-'));
+    queuePath = join(tempDir, 'queue.jsonl');
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('enqueue and dequeue preserves order', () => {
+    const queue = createJsonlQueue(queuePath);
+    queue.enqueue(makeEvent('a'));
+    queue.enqueue(makeEvent('b'));
+    queue.enqueue(makeEvent('c'));
+
+    const events = queue.dequeue(2);
+    expect(events).toHaveLength(2);
+    expect(events[0].event_id).toBe('a');
+    expect(events[1].event_id).toBe('b');
+
+    const remaining = queue.dequeue(10);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].event_id).toBe('c');
+  });
+
+  it('dequeue from empty queue returns empty array', () => {
+    const queue = createJsonlQueue(queuePath);
+    expect(queue.dequeue(10)).toEqual([]);
+  });
+
+  it('size tracks events correctly', () => {
+    const queue = createJsonlQueue(queuePath);
+    expect(queue.size()).toBe(0);
+
+    queue.enqueue(makeEvent('x'));
+    expect(queue.size()).toBe(1);
+
+    queue.enqueue(makeEvent('y'));
+    expect(queue.size()).toBe(2);
+
+    queue.dequeue(1);
+    expect(queue.size()).toBe(1);
+  });
+
+  it('sizeBytes returns file size', () => {
+    const queue = createJsonlQueue(queuePath);
+    expect(queue.sizeBytes()).toBe(0);
+
+    queue.enqueue(makeEvent('x'));
+    expect(queue.sizeBytes()).toBeGreaterThan(0);
+  });
+
+  it('clear removes all events', () => {
+    const queue = createJsonlQueue(queuePath);
+    queue.enqueue(makeEvent('a'));
+    queue.enqueue(makeEvent('b'));
+
+    queue.clear();
+    expect(queue.size()).toBe(0);
+  });
+
+  it('close is a no-op', () => {
+    const queue = createJsonlQueue(queuePath);
+    expect(() => queue.close()).not.toThrow();
+  });
+});

--- a/packages/telemetry-client/tests/sender.test.ts
+++ b/packages/telemetry-client/tests/sender.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createTelemetrySender } from '../src/sender.js';
+import type { TelemetryQueue, TelemetryPayloadEvent, TelemetryClientConfig } from '../src/types.js';
+
+function makeEvent(id: string): TelemetryPayloadEvent {
+  return {
+    event_id: id,
+    timestamp: Math.floor(Date.now() / 1000),
+    version: '1.0.0',
+    runtime: 'claude-code',
+    environment: 'local',
+    event_type: 'guard_triggered',
+    policy: 'default',
+    result: 'allowed',
+    latency_ms: 10,
+  };
+}
+
+function createMockQueue(events: TelemetryPayloadEvent[] = []): TelemetryQueue {
+  const items = [...events];
+  return {
+    enqueue(event: TelemetryPayloadEvent) {
+      items.push(event);
+    },
+    dequeue(count: number) {
+      return items.splice(0, count);
+    },
+    size() {
+      return items.length;
+    },
+    sizeBytes() {
+      return JSON.stringify(items).length;
+    },
+    clear() {
+      items.length = 0;
+    },
+    close() {
+      // no-op
+    },
+  };
+}
+
+describe('TelemetrySender', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchSpy);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('flush sends batched events to server', async () => {
+    const queue = createMockQueue([makeEvent('a'), makeEvent('b')]);
+    const config: TelemetryClientConfig = {
+      serverUrl: 'https://telemetry.test',
+      batchSize: 50,
+      maxRetries: 0,
+    };
+
+    const sender = createTelemetrySender(config, null, queue);
+    await sender.flush();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, options] = fetchSpy.mock.calls[0];
+    expect(url).toBe('https://telemetry.test/api/v1/telemetry/batch');
+    expect(options.method).toBe('POST');
+
+    const body = JSON.parse(options.body);
+    expect(body.mode).toBe('anonymous');
+    expect(body.events).toHaveLength(2);
+  });
+
+  it('does not send when queue is empty', async () => {
+    const queue = createMockQueue();
+    const config: TelemetryClientConfig = {
+      serverUrl: 'https://telemetry.test',
+    };
+
+    const sender = createTelemetrySender(config, null, queue);
+    await sender.flush();
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not send when no server URL', async () => {
+    const queue = createMockQueue([makeEvent('a')]);
+    const config: TelemetryClientConfig = {};
+
+    const sender = createTelemetrySender(config, null, queue);
+    await sender.flush();
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('swallows fetch errors gracefully', async () => {
+    fetchSpy.mockRejectedValue(new Error('network down'));
+
+    const queue = createMockQueue([makeEvent('a')]);
+    const config: TelemetryClientConfig = {
+      serverUrl: 'https://telemetry.test',
+      maxRetries: 0,
+    };
+
+    const sender = createTelemetrySender(config, null, queue);
+    await expect(sender.flush()).resolves.toBeUndefined();
+  });
+
+  it('start and stop manage the interval', () => {
+    const queue = createMockQueue();
+    const config: TelemetryClientConfig = {
+      serverUrl: 'https://telemetry.test',
+      flushIntervalMs: 1000,
+    };
+
+    const sender = createTelemetrySender(config, null, queue);
+    sender.start();
+    sender.start(); // idempotent
+    sender.stop();
+    sender.stop(); // idempotent
+  });
+
+  it('includes auth headers for verified mode', async () => {
+    const queue = createMockQueue([makeEvent('a')]);
+    const { generateIdentity } = await import('../src/identity.js');
+    const identity = {
+      ...generateIdentity('verified'),
+      enrollment_token: 'test-token-123',
+    };
+
+    const config: TelemetryClientConfig = {
+      serverUrl: 'https://telemetry.test',
+      maxRetries: 0,
+    };
+
+    const sender = createTelemetrySender(config, identity, queue);
+    await sender.flush();
+
+    const [, options] = fetchSpy.mock.calls[0];
+    expect(options.headers['Authorization']).toBe('Bearer test-token-123');
+    expect(options.headers['X-AgentGuard-Install-ID']).toBe(identity.install_id);
+    expect(options.headers['X-AgentGuard-Signature']).toBeDefined();
+  });
+});

--- a/packages/telemetry-client/tests/signing.test.ts
+++ b/packages/telemetry-client/tests/signing.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { generateKeyPairSync } from 'node:crypto';
+import { canonicalize, signPayload, verifySignature } from '../src/signing.js';
+
+function generateTestKeypair() {
+  return generateKeyPairSync('ed25519', {
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  });
+}
+
+describe('canonicalize', () => {
+  it('sorts keys alphabetically', () => {
+    const result = canonicalize({ z: 1, a: 2, m: 3 });
+    expect(result).toBe('{"a":2,"m":3,"z":1}');
+  });
+
+  it('sorts nested objects', () => {
+    const result = canonicalize({ b: { z: 1, a: 2 }, a: 1 });
+    expect(result).toBe('{"a":1,"b":{"a":2,"z":1}}');
+  });
+
+  it('preserves array order', () => {
+    const result = canonicalize({ items: [3, 1, 2] });
+    expect(result).toBe('{"items":[3,1,2]}');
+  });
+
+  it('produces deterministic output', () => {
+    const obj = { mode: 'verified', events: [{ id: '1', ts: 100 }] };
+    expect(canonicalize(obj)).toBe(canonicalize(obj));
+  });
+
+  it('handles null values', () => {
+    const result = canonicalize({ a: null, b: 1 });
+    expect(result).toBe('{"a":null,"b":1}');
+  });
+});
+
+describe('signPayload / verifySignature', () => {
+  it('sign then verify succeeds', () => {
+    const { publicKey, privateKey } = generateTestKeypair();
+    const body = canonicalize({ mode: 'verified', events: [] });
+    const signature = signPayload(body, privateKey);
+
+    expect(typeof signature).toBe('string');
+    expect(signature.length).toBeGreaterThan(0);
+
+    const valid = verifySignature(body, signature, publicKey);
+    expect(valid).toBe(true);
+  });
+
+  it('tampered body fails verification', () => {
+    const { publicKey, privateKey } = generateTestKeypair();
+    const body = canonicalize({ mode: 'verified', events: [] });
+    const signature = signPayload(body, privateKey);
+
+    const tampered = canonicalize({ mode: 'anonymous', events: [] });
+    expect(verifySignature(tampered, signature, publicKey)).toBe(false);
+  });
+
+  it('wrong key fails verification', () => {
+    const keypair1 = generateTestKeypair();
+    const keypair2 = generateTestKeypair();
+    const body = 'test body';
+    const signature = signPayload(body, keypair1.privateKey);
+
+    expect(verifySignature(body, signature, keypair2.publicKey)).toBe(false);
+  });
+
+  it('invalid signature returns false', () => {
+    const { publicKey } = generateTestKeypair();
+    expect(verifySignature('body', 'invalid-sig', publicKey)).toBe(false);
+  });
+
+  it('invalid key returns false', () => {
+    expect(verifySignature('body', 'sig', 'not-a-key')).toBe(false);
+  });
+});

--- a/packages/telemetry-client/vitest.config.ts
+++ b/packages/telemetry-client/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts'],
+    environment: 'node',
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.ts'],
+      reporter: ['text', 'json-summary', 'lcov'],
+      thresholds: {
+        lines: 50,
+        branches: 40,
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       '@red-codes/telemetry':
         specifier: workspace:*
         version: link:../../packages/telemetry
+      '@red-codes/telemetry-client':
+        specifier: workspace:*
+        version: link:../../packages/telemetry-client
       chokidar:
         specifier: ^5.0.0
         version: 5.0.0
@@ -100,6 +103,9 @@ importers:
       '@red-codes/telemetry':
         specifier: workspace:*
         version: link:../../packages/telemetry
+      '@red-codes/telemetry-client':
+        specifier: workspace:*
+        version: link:../../packages/telemetry-client
       hono:
         specifier: ^4.7.0
         version: 4.12.8


### PR DESCRIPTION
Implements a production-grade telemetry pipeline for AgentGuard:

Client SDK (packages/telemetry-client):
- Ed25519 keypair generation and identity management (~/.agentguard/telemetry.json)
- Three modes: OFF (default), ANONYMOUS, VERIFIED
- Persistent event queue (SQLite preferred, JSONL fallback) with 10MB cap
- Batched background sender with exponential backoff retry
- Ed25519 request signing for tamper-resistant verified telemetry
- Canonical JSON serialization for deterministic signatures
- Non-blocking design: telemetry failures never affect guard operation

Server (apps/telemetry-server):
- POST /api/v1/telemetry/enroll — Ed25519 public key registration with hashed tokens
- POST /api/v1/telemetry/batch — Batched event ingestion with schema validation
- In-memory sliding window rate limiter (per-IP and per-install)
- Anti-replay protection via timestamp window (5min default)
- Signature verification for verified mode requests
- Strict schema validation rejecting extra fields

CLI (apps/cli):
- `agentguard telemetry enroll|status|enable|disable|reset` subcommands
- Guard command integration: tracks governance decisions as telemetry events

Tests: 59 new tests (41 client + 18 server) covering identity, signing,
queues, sender, enrollment, batch validation, rate limiting, and signatures.

https://claude.ai/code/session_01FmooZQpjPUAhmi2RpHyXh7