### PR TITLE
docs: sync documentation with codebase state

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -46,19 +46,24 @@ packages/
 ├── core/          @red-codes/core — Shared utilities (types, actions, hash, execution-log)
 ├── events/        @red-codes/events — Canonical event model (schema, bus, store, JSONL persistence)
 ├── policy/        @red-codes/policy — Policy system (composer, evaluator, loaders, pack loader)
-├── invariants/    @red-codes/invariants — Invariant system (10 built-in definitions, checker)
+├── invariants/    @red-codes/invariants — Invariant system (17 built-in definitions, checker)
 ├── kernel/        @red-codes/kernel — Governed action kernel (orchestrate, normalize, decide, escalate)
 ├── adapters/      @red-codes/adapters — Execution adapters (file, shell, git, claude-code)
 ├── analytics/     @red-codes/analytics — Cross-session violation analytics
 ├── storage/       @red-codes/storage — SQLite and Firestore backends (opt-in)
 ├── telemetry/     @red-codes/telemetry — Runtime telemetry and logging
 ├── plugins/       @red-codes/plugins — Plugin ecosystem (discovery, registry, validation, sandboxing)
-└── renderers/     @red-codes/renderers — Renderer plugin system (registry, TUI renderer)
+├── renderers/     @red-codes/renderers — Renderer plugin system (registry, TUI renderer)
+├── swarm/         @red-codes/swarm — Shareable agent swarm templates
+├── runtime/       @red-codes/runtime — Agent runtime (placeholder)
+├── sentinel01/    @red-codes/sentinel01 — Robotics/edge module (placeholder)
+├── adapter-openclaw/ @red-codes/adapter-openclaw — OpenClaw adapter (placeholder)
+└── telemetry-client/ @red-codes/telemetry-client — Telemetry client (identity, signing, queue, sender)
 
 apps/
 ├── cli/           @red-codes/agentguard — CLI entry point and commands (published npm package)
 ├── vscode-extension/  agentguard-vscode — VS Code extension (sidebar panels, notifications, diagnostics)
-└── telemetry-server/  Telemetry server (placeholder)
+└── telemetry-server/  @red-codes/telemetry-server — Telemetry ingestion server (enrollment, batch ingest)
 
 policies/          Policy packs (YAML: ci-safe, enterprise, open-source, strict)
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@ The system has one architectural spine: the **canonical event model**. All syste
 
 **Key characteristics:**
 - Governed action kernel: propose → normalize → evaluate → execute → emit
-- 10 built-in invariants (secret exposure, protected branches, blast radius, test-before-push, no force push, no skill modification, no scheduled task modification, credential file creation, package script injection, lockfile integrity)
+- 17 built-in invariants (secret exposure, protected branches, blast radius, test-before-push, no force push, no skill modification, no scheduled task modification, credential file creation, package script injection, lockfile integrity, recursive operation guard, large file write, CI/CD config modification, permission escalation, governance self-modification, container config modification, environment variable modification)
 - YAML/JSON policy format with pattern matching, scopes, and branch conditions
 - Escalation tracking: NORMAL → ELEVATED → HIGH → LOCKDOWN
 - JSONL event persistence for audit trail and replay
 - Claude Code adapter for PreToolUse/PostToolUse hooks
-- **pnpm monorepo** with Turbo orchestration: 15 packages under `packages/`, 3 apps under `apps/`
+- **pnpm monorepo** with Turbo orchestration: 16 packages under `packages/`, 3 apps under `apps/`
 - Each package compiles independently via `tsc`; CLI bundle via `esbuild` in `apps/cli`
 - Scoped npm packages: `@red-codes/*` for workspace modules, `@red-codes/agentguard` for published CLI
 - CLI has runtime dependencies (`chokidar`, `commander`, `pino`); optional `better-sqlite3` for SQLite storage backend; optional Firestore for cloud-based governance data sharing
@@ -43,6 +43,8 @@ packages/
 ├── core/src/                   # @red-codes/core — Shared utilities
 │   ├── types.ts                # Shared TypeScript type definitions
 │   ├── actions.ts              # 23 canonical action types across 8 classes
+│   ├── governance-data.ts      # Governance data loader (typed access to shared JSON data)
+│   ├── data/                   # JSON governance data (actions, blast-radius, destructive-patterns, escalation, git-action-patterns, invariant-patterns, tool-action-map)
 │   ├── hash.ts                 # Content hashing utilities
 │   ├── adapters.ts             # Adapter registry interface
 │   ├── rng.ts                  # Seeded random number generator
@@ -65,12 +67,13 @@ packages/
 │   ├── pack-loader.ts          # Policy pack loader (community policy sets)
 │   └── yaml-loader.ts          # YAML policy parser
 ├── invariants/src/             # @red-codes/invariants — Invariant system
-│   ├── definitions.ts          # 10 built-in invariant definitions
+│   ├── definitions.ts          # 17 built-in invariant definitions
 │   └── checker.ts              # Invariant evaluation engine
 ├── kernel/src/                 # @red-codes/kernel — Governed action kernel
 │   ├── kernel.ts               # Orchestrator (propose → evaluate → execute → emit)
 │   ├── aab.ts                  # Action Authorization Boundary (normalization)
 │   ├── blast-radius.ts         # Weighted blast radius computation engine
+│   ├── contract.ts             # Kernel contract definitions
 │   ├── decision.ts             # Runtime assurance engine
 │   ├── monitor.ts              # Escalation state machine
 │   ├── evidence.ts             # Evidence pack generation
@@ -99,6 +102,7 @@ packages/
 │   ├── index.ts                # Module re-exports
 │   ├── reporter.ts             # Output formatters (terminal, JSON, markdown)
 │   ├── risk-scorer.ts          # Per-run risk scoring engine
+│   ├── suggest.ts              # Analytics-based suggestions
 │   ├── trends.ts               # Violation trend computation
 │   └── types.ts                # Analytics type definitions
 ├── plugins/src/                # @red-codes/plugins — Plugin ecosystem
@@ -110,6 +114,7 @@ packages/
 │   └── index.ts                # Module re-exports
 ├── renderers/src/              # @red-codes/renderers — Renderer plugin system
 │   ├── registry.ts             # Renderer registry
+│   ├── tui-formatters.ts       # TUI formatting helpers
 │   ├── tui-renderer.ts         # TUI renderer implementation
 │   ├── types.ts                # Renderer type definitions
 │   └── index.ts                # Module re-exports
@@ -124,6 +129,7 @@ packages/
 │   ├── firestore-analytics.ts  # Firestore-backed analytics queries
 │   ├── firestore-sink.ts       # Firestore event/decision sink
 │   ├── firestore-store.ts      # Firestore event store implementation
+│   ├── webhook-sink.ts         # Webhook event sink
 │   └── types.ts                # Storage type definitions
 ├── telemetry/src/              # @red-codes/telemetry — Runtime telemetry
 │   ├── index.ts                # Module re-exports
@@ -133,8 +139,23 @@ packages/
 │   └── types.ts                # Telemetry type definitions
 ├── runtime/src/                # @red-codes/runtime — Agent runtime (placeholder)
 ├── sentinel01/src/             # @red-codes/sentinel01 — Robotics/edge module (placeholder)
+├── swarm/src/                  # @red-codes/swarm — Shareable agent swarm templates
+│   ├── config.ts               # Swarm configuration
+│   ├── manifest.ts             # Swarm manifest parsing
+│   ├── scaffolder.ts           # Swarm scaffolding
+│   ├── types.ts                # Swarm type definitions
+│   └── index.ts                # Module re-exports
 ├── adapter-openclaw/src/       # @red-codes/adapter-openclaw — OpenClaw adapter (placeholder)
-└── telemetry-client/src/       # @red-codes/telemetry-client — Telemetry client (placeholder)
+└── telemetry-client/src/       # @red-codes/telemetry-client — Telemetry client
+    ├── client.ts               # Telemetry client
+    ├── identity.ts             # Client identity management
+    ├── queue.ts                # Event queue interface
+    ├── queue-jsonl.ts          # JSONL-backed queue
+    ├── queue-sqlite.ts         # SQLite-backed queue
+    ├── sender.ts               # Event sender
+    ├── signing.ts              # Event signing
+    ├── types.ts                # Type definitions
+    └── index.ts                # Module re-exports
 
 apps/
 ├── cli/src/                    # @red-codes/agentguard — CLI (published npm package)
@@ -148,16 +169,24 @@ apps/
 │   ├── session-store.ts        # Session management
 │   ├── file-event-store.ts     # File-based event persistence
 │   ├── evidence-summary.ts     # Evidence summary generator for PR reports
-│   └── commands/               # analytics, guard, inspect, replay, export, import, simulate, ci-check, plugin, policy, claude-hook, claude-init, init, diff, evidence-pr, traces
+│   └── commands/               # analytics, guard, inspect, replay, export, import, simulate, ci-check, plugin, policy, policy-verify, claude-hook, claude-init, init, diff, evidence-pr, traces, telemetry
 ├── vscode-extension/src/       # agentguard-vscode — VS Code extension
 │   ├── extension.ts            # Extension entry point (sidebar panels, file watcher)
 │   ├── providers/              # Tree data providers (run status, run history, recent events)
 │   └── services/               # Event reader, notification formatter, notification service, diagnostics service, violation mapper
-└── telemetry-server/src/       # @red-codes/telemetry-server — Telemetry server (placeholder)
+└── telemetry-server/src/       # @red-codes/telemetry-server — Telemetry ingestion server
+    ├── app.ts                  # Express application setup
+    ├── config.ts               # Server configuration
+    ├── entry-lambda.ts         # AWS Lambda entry point
+    ├── entry-vercel.ts         # Vercel serverless entry point
+    ├── server.ts               # HTTP server
+    ├── middleware/              # API key auth, IP whitelist, rate limiter
+    ├── routes/                  # enrollment, batch ingest, events, decisions, health, traces
+    └── store/                   # In-memory store
 
 tests/
-├── *.test.js               # 14 JS test files (custom zero-dependency harness)
-└── ts/*.test.ts            # 77 TS test files (vitest)
+└── *.test.js               # 14 JS test files (custom zero-dependency harness)
+# 105 TS test files (vitest) distributed across packages/ and apps/ directories
 policy/                     # Policy configuration (JSON: action_rules, capabilities)
 policies/                   # Policy packs (YAML: ci-safe, enterprise, open-source, strict)
 docs/                       # System documentation (architecture, event model, specs)
@@ -201,7 +230,7 @@ The kernel loop is the core of AgentGuard. Every agent action passes through it:
 1. Agent proposes action (Claude Code tool call → `RawAgentAction`)
 2. AAB normalizes intent (tool → action type, detect git/destructive commands)
 3. Policy evaluator matches rules (deny/allow with scopes, branches, limits)
-4. Invariant checker verifies system state (10 defaults)
+4. Invariant checker verifies system state (17 defaults)
 5. If allowed: execute via adapter (file/shell/git handlers)
 6. Emit lifecycle events: `ACTION_REQUESTED` → `ACTION_ALLOWED/DENIED` → `ACTION_EXECUTED/FAILED`
 7. Sink all events to JSONL for audit trail
@@ -223,6 +252,8 @@ Each workspace package maps to a single architectural concept:
 - **packages/core/** — Shared utilities (types, actions, hash, execution-log)
 - **packages/storage/** — Storage backends: SQLite and Firestore (opt-in alternatives to JSONL, indexed queries)
 - **packages/telemetry/** — Runtime telemetry and logging
+- **packages/swarm/** — Shareable agent swarm templates (config, manifest, scaffolder)
+- **packages/telemetry-client/** — Telemetry client (identity, signing, queue, sender)
 
 ### CLI Commands
 - `agentguard analytics` — Analyze violation patterns across governance sessions
@@ -244,6 +275,8 @@ Each workspace package maps to a single architectural concept:
 - `agentguard evidence-pr` — Attach governance evidence summary to a pull request
 - `agentguard traces [runId]` — Display policy evaluation traces for a run
 - `agentguard init <type>` — Scaffold governance extensions (invariant, policy-pack, adapter, renderer, replay-processor, firestore)
+- `agentguard telemetry` — Manage telemetry enrollment and settings
+- `agentguard policy-verify <file>` — Verify policy file structure and rules
 
 ### Event Model
 The canonical event model is the architectural spine. Event kinds defined in `packages/events/src/schema.ts`:
@@ -312,8 +345,8 @@ pnpm test --filter=@red-codes/kernel  # Test a single package
 **Test structure:**
 - **Vitest workspace** (`vitest.workspace.ts`): orchestrates tests across all packages
 - **JS tests** (`tests/*.test.js`): 14 files using a custom zero-dependency harness (`tests/run.js` with `node:assert`)
-- **TypeScript tests** (`tests/ts/*.test.ts`): 77 files using vitest
-- **Coverage areas**: adapters, analytics (including risk scorer), kernel (AAB, engine, monitor, blast radius, heartbeat, integration, e2e pipeline), CLI commands (args, guard, inspect, init, simulate, ci-check, claude-hook, claude-init, export/import, policy-validate, diff, evidence-pr, traces), decision records, domain models, events, evidence packs, evidence summary, execution log, export-import roundtrip, impact forecast, invariants, JSONL persistence, notification formatter, plugins (discovery, registry, validation), policy evaluation (including composer, pack loader, policy packs, evaluation trace), renderers, replay (engine, comparator, processor), simulation, SQLite storage (analytics, commands, migrations, session, sink, store, factory), Firestore storage, telemetry (including tracepoint), TUI renderer, violation mapper, VS Code event reader, YAML loading
+- **TypeScript tests** (distributed across `packages/*/tests/` and `apps/*/tests/`): 105 files using vitest
+- **Coverage areas**: adapters, analytics (including risk scorer), kernel (AAB, engine, monitor, blast radius, heartbeat, integration, e2e pipeline, conformance), CLI commands (args, guard, inspect, init, simulate, ci-check, claude-hook, claude-init, export/import, policy-validate, policy-verify, diff, evidence-pr, traces, plugin), decision records, domain models, events, evidence packs, evidence summary, execution log, export-import roundtrip, impact forecast, invariants, JSONL persistence, notification formatter, plugins (discovery, registry, sandbox, validation), policy evaluation (including composer, pack loader, policy packs, evaluation trace, suggest), renderers, replay (engine, comparator, processor), simulation, SQLite storage (analytics, commands, migrations, session, sink, store, factory), Firestore storage, webhook sink, swarm (scaffolder), telemetry (including tracepoint), telemetry client (client, identity, queue, sender, signing), telemetry server (enrollment, batch, rate limiter), TUI renderer, violation mapper, VS Code event reader, YAML loading
 
 ## CI/CD & Automation
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ AI coding agents execute file writes, shell commands, and git operations autonom
 AgentGuard adds a **deterministic decision point** between proposal and execution:
 
 - **Safety policies** — declare what agents can and cannot do in YAML
-- **Invariant enforcement** — 10 built-in checks (secrets, protected branches, blast radius, skill/task protection, package script injection, lockfile integrity) run on every action
+- **Invariant enforcement** — 17 built-in checks (secrets, protected branches, blast radius, skill/task protection, package script injection, lockfile integrity, CI/CD config, permission escalation, governance self-modification, container config, environment variables, recursive operations, large file writes) run on every action
 - **Audit trail** — every decision is recorded as structured JSONL, inspectable after the fact
 - **Session debugging** — replay any agent session to see exactly what happened and why
 
@@ -60,7 +60,7 @@ AgentGuard evaluates every agent action through a **governed action kernel**:
 
 1. **Normalize** — Claude Code tool calls (Bash, Write, Edit, Read) are mapped to canonical action types (shell.exec, file.write, file.read)
 2. **Evaluate** — policies match against the action (deny git.push to main, deny destructive commands, enforce scope limits)
-3. **Check invariants** — 10 built-in safety checks run on every action
+3. **Check invariants** — 17 built-in safety checks run on every action
 4. **Execute** — if allowed, the action runs via adapters (file, shell, git handlers)
 5. **Emit events** — full lifecycle events sunk to JSONL for audit trail
 
@@ -68,7 +68,7 @@ AgentGuard evaluates every agent action through a **governed action kernel**:
 
 ```
   AgentGuard Runtime Active
-  policy: agentguard.yaml | invariants: 10 active
+  policy: agentguard.yaml | invariants: 17 active
 
   ✓ file.write src/auth/service.ts
   ✓ shell.exec npm test
@@ -108,19 +108,26 @@ Drop an `agentguard.yaml` in your repo root — the CLI picks it up automaticall
 
 ## Built-in Invariants
 
-10 safety invariants run on every action evaluation:
+17 safety invariants run on every action evaluation:
 
 | Invariant | Severity | Description |
 |-----------|----------|-------------|
 | **no-secret-exposure** | 5 (critical) | Blocks access to .env, credentials, .pem, .key files |
 | **no-credential-file-creation** | 5 (critical) | Blocks creation or modification of well-known credential files (SSH keys, cloud configs, auth tokens) |
+| **no-scheduled-task-modification** | 5 (critical) | Prevents modification of scheduled task files |
+| **no-cicd-config-modification** | 5 (critical) | Blocks writes to CI/CD pipeline configs (.github/workflows/, .gitlab-ci.yml, Jenkinsfile) |
+| **no-governance-self-modification** | 5 (critical) | Prevents agents from modifying governance config (policy files, governance data) |
 | **protected-branch** | 4 (high) | Prevents direct push to main/master |
 | **no-force-push** | 4 (high) | Forbids force push |
 | **no-skill-modification** | 4 (high) | Prevents modification of .claude/skills/ files |
-| **no-scheduled-task-modification** | 4 (high) | Prevents modification of scheduled task files |
 | **no-package-script-injection** | 4 (high) | Blocks package.json modifications that alter lifecycle script entries |
+| **no-permission-escalation** | 4 (high) | Catches chmod to world-writable, setuid/setgid, ownership changes |
 | **blast-radius-limit** | 3 (medium) | Enforces file modification limit (default 20) |
 | **test-before-push** | 3 (medium) | Requires tests pass before push |
+| **large-file-write** | 3 (medium) | Enforces per-file size limit to prevent data dumps |
+| **no-container-config-modification** | 3 (medium) | Protects Dockerfile, docker-compose.yml, .dockerignore |
+| **no-env-var-modification** | 3 (medium) | Detects attempts to modify environment variables or shell profile files |
+| **recursive-operation-guard** | 2 (low) | Flags find -exec, xargs combined with write/delete operations |
 | **lockfile-integrity** | 2 (low) | Ensures package.json changes sync with lockfiles |
 
 ## Escalation
@@ -181,9 +188,13 @@ agentguard traces --last                  # Show traces for the most recent run
 agentguard traces --last --summary       # Summary statistics only
 agentguard traces --last --json          # JSON output
 
+# === Telemetry ===
+agentguard telemetry                      # Manage telemetry enrollment and settings
+
 # === Integration ===
 agentguard claude-init                    # Set up Claude Code hook integration
 agentguard init <type>                    # Scaffold governance extensions or storage backends
+agentguard policy-verify <file>          # Verify policy file structure and rules
 agentguard help                           # Show all commands
 ```
 
@@ -245,7 +256,7 @@ packages/
 ├── core/src/               # @red-codes/core — Shared types, actions, hash, rng, execution-log
 ├── events/src/             # @red-codes/events — Canonical event model (schema, bus, store, JSONL)
 ├── policy/src/             # @red-codes/policy — Policy evaluation, YAML/JSON loaders, composition
-├── invariants/src/         # @red-codes/invariants — 10 built-in invariant definitions + checker
+├── invariants/src/         # @red-codes/invariants — 17 built-in invariant definitions + checker
 ├── kernel/src/             # @red-codes/kernel — Governed action kernel (orchestrator, AAB, decisions, simulation)
 ├── adapters/src/           # @red-codes/adapters — Execution adapters (file, shell, git, claude-code)
 ├── analytics/src/          # @red-codes/analytics — Cross-session violation analytics
@@ -255,8 +266,9 @@ packages/
 ├── renderers/src/          # @red-codes/renderers — Renderer plugin system (TUI renderer)
 ├── runtime/src/            # @red-codes/runtime — Agent runtime (placeholder)
 ├── sentinel01/src/         # @red-codes/sentinel01 — Robotics/edge module (placeholder)
+├── swarm/src/              # @red-codes/swarm — Shareable agent swarm templates
 ├── adapter-openclaw/src/   # @red-codes/adapter-openclaw — OpenClaw adapter (placeholder)
-└── telemetry-client/src/   # @red-codes/telemetry-client — Telemetry client (placeholder)
+└── telemetry-client/src/   # @red-codes/telemetry-client — Telemetry client (identity, signing, queue, sender)
 
 apps/
 ├── cli/src/                # @red-codes/agentguard — CLI (published npm package)
@@ -267,7 +279,7 @@ apps/
 │   ├── extension.ts        # Sidebar panels, file watcher, notifications
 │   ├── providers/          # Tree data providers (run status, run history, recent events)
 │   └── services/           # Event reader, notification formatter, diagnostics, violation mapper
-└── telemetry-server/src/   # Telemetry server (placeholder)
+└── telemetry-server/src/   # @red-codes/telemetry-server — Telemetry ingestion server (enrollment, batch ingest, rate limiting)
 
 policies/                   # Policy packs (YAML: ci-safe, enterprise, open-source, strict)
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -59,7 +59,7 @@ A comprehensive codebase audit assessed the current system against the strategic
 | Canonical Action Representation (23 types, 8 classes) | Implemented | `packages/core/src/actions.ts` |
 | Action Authorization Boundary (AAB) | Implemented (2 bypass vectors) | `packages/kernel/src/aab.ts` |
 | Policy Evaluator (two-phase deny/allow) | Implemented | `packages/policy/src/evaluator.ts` |
-| 10 Built-in Invariants | Fully Implemented | `packages/invariants/src/definitions.ts`, `packages/invariants/src/checker.ts` |
+| 17 Built-in Invariants | Fully Implemented | `packages/invariants/src/definitions.ts`, `packages/invariants/src/checker.ts` |
 | Event Model (49 event kinds) | Comprehensive | `packages/events/src/schema.ts` |
 | JSONL Persistence | Implemented | `packages/events/src/jsonl.ts` |
 | Simulation Engine (3 simulators + impact forecast) | Fully Implemented | `packages/kernel/src/simulation/` |
@@ -76,7 +76,7 @@ A comprehensive codebase audit assessed the current system against the strategic
 | Cross-session Analytics (aggregation, clustering, trends) | Implemented | `packages/analytics/src/` |
 | Plugin Ecosystem (discovery, registry, validation) | Implemented | `packages/plugins/src/` |
 | Renderer Plugin System | Implemented | `packages/renderers/src/` |
-| CLI (guard, inspect, events, replay, export, import, simulate, ci-check, analytics, plugin, policy, claude-hook, claude-init, init, diff, evidence-pr, traces) | Implemented | `apps/cli/src/` |
+| CLI (guard, inspect, events, replay, export, import, simulate, ci-check, analytics, plugin, policy, policy-verify, claude-hook, claude-init, init, diff, evidence-pr, traces, telemetry) | Implemented | `apps/cli/src/` |
 | Claude Code Hook Integration | Implemented | `packages/adapters/src/claude-code.ts` |
 | VS Code Extension (sidebar panels, event reader, inline diagnostics) | Implemented | `apps/vscode-extension/` |
 | Policy Pack Loader | Implemented | `packages/policy/src/pack-loader.ts` |
@@ -104,7 +104,7 @@ A comprehensive codebase audit assessed the current system against the strategic
 | Canonical Action Representation | Implemented | Production |
 | AAB Reference Monitor | Implemented | 1 bypass vector to close (missing-adapter fixed) |
 | Policy Evaluator | Implemented | Production |
-| 10 Built-in Invariants | Fully Implemented | Production |
+| 17 Built-in Invariants | Fully Implemented | Production |
 | Event Model (49 kinds) | Comprehensive | Production |
 | Simulation & Forecasting | Fully Implemented | Production |
 | Escalation State Machine | Implemented | Functional (events persisted as StateChanged) |
@@ -248,25 +248,25 @@ This is the architectural hinge. These changes transform the AAB from advisory i
 - [x] Persist escalation state changes as `StateChanged` DomainEvents in `packages/kernel/src/monitor.ts`
 - [x] Expand destructive command patterns in `packages/kernel/src/aab.ts` (expanded from 10 to 87 patterns covering sudo, pkill, docker, systemctl, database commands, and more)
 - [ ] Enforce intervention types beyond DENY (implement PAUSE and ROLLBACK behaviors in kernel execution)
-- [ ] Governance self-modification invariant — agents must not modify `agentguard.yaml`, `.agentguard/`, or `policies/` (prerequisite for tamper-resistance claim)
+- [x] Governance self-modification invariant — agents must not modify `agentguard.yaml`, `.agentguard/`, or `policies/` (`no-governance-self-modification` invariant, severity 5)
 - [ ] Performance benchmark suite — formal latency measurement (p50/p95/p99) per action type for policy evaluation, invariant checking, and simulation overhead. Publish results as a marketing asset and regression gate in CI
 
-### Phase 6.5 — Invariant Expansion `NEXT`
+### Phase 6.5 — Invariant Expansion `IN PROGRESS`
 
-> **Theme:** Close invariant coverage gaps. The current 10 invariants leave large classes of agent behavior ungoverned.
+> **Theme:** Close invariant coverage gaps. Expanded from 10 to 17 built-in invariants; remaining items cover network egress, database migration safety, and transitive effect analysis.
 
 The `SystemState` interface in `packages/invariants/src/definitions.ts` is the bottleneck for invariant expansion — it needs to become a richer context object with action-specific fields.
 
-- [ ] CI/CD config modification invariant (severity 5) — block writes to `.github/workflows/`, `.gitlab-ci.yml`, `Jenkinsfile`, `.circleci/config.yml`
+- [x] CI/CD config modification invariant (severity 5) — block writes to `.github/workflows/`, `.gitlab-ci.yml`, `Jenkinsfile`, `.circleci/config.yml` (`no-cicd-config-modification` invariant)
 - [ ] Network egress governance invariant (severity 4) — deny HTTP requests to non-allowlisted domains (extend `SystemState` with `isNetworkRequest`, `requestUrl`, `requestDomain`)
 - [x] Credential file creation invariant (severity 5) — inspect `currentTarget` for SSH keys, `.netrc`, `~/.aws/credentials`, Docker config (closes gap where `no-secret-exposure` misses new file creation)
 - [x] Package.json script injection invariant (severity 4) — flag `package.json` modifications that alter lifecycle script entries (`packages/invariants/src/definitions.ts`)
-- [ ] Large single-file write invariant (severity 3) — enforce per-file size limit (extend `SystemState` with `writeSizeBytes`)
-- [ ] Docker/container config modification invariant (severity 3) — protect `Dockerfile`, `docker-compose.yml`, `.dockerignore`
+- [x] Large single-file write invariant (severity 3) — enforce per-file size limit (`large-file-write` invariant)
+- [x] Docker/container config modification invariant (severity 3) — protect `Dockerfile`, `docker-compose.yml`, `.dockerignore` (`no-container-config-modification` invariant)
 - [ ] Database migration safety invariant (severity 3) — flag writes to migration directories containing destructive DDL
-- [ ] Permission escalation invariant (severity 4) — catch `chmod` to world-writable, `setuid`, ownership changes at invariant level (not just AAB pattern)
-- [ ] Environment variable modification invariant (severity 3) — scan for `export`, `setenv`, writes to shell profile files
-- [ ] Recursive operation guard (severity 2) — flag `find -exec`, `xargs` combined with write/delete operations
+- [x] Permission escalation invariant (severity 4) — catch `chmod` to world-writable, `setuid`, ownership changes at invariant level (`no-permission-escalation` invariant)
+- [x] Environment variable modification invariant (severity 3) — scan for `export`, `setenv`, writes to shell profile files (`no-env-var-modification` invariant)
+- [x] Recursive operation guard (severity 2) — flag `find -exec`, `xargs` combined with write/delete operations (`recursive-operation-guard` invariant)
 - [ ] Transitive effect analysis (severity 4) — when an agent writes a script or config file, analyze content for downstream effects that would violate policy (e.g., a Python script containing `open('.env').read()` or a shell script with `curl` exfiltration). Closes the creative circumvention gap where agents bypass direct restrictions via indirect file creation
 
 ### Phase 7 — Capability-Scoped Sessions & Intent Contracts `PLANNED`
@@ -470,7 +470,7 @@ The agent governance space is emerging. Several projects address overlapping pro
 
 AgentGuard is built for contributors. Here are the best places to start:
 
-- **Write an invariant pack** — Define domain-specific invariants in `packages/invariants/src/community/`. See `packages/invariants/src/definitions.ts` for the 10 built-in invariants as a reference.
+- **Write an invariant pack** — Define domain-specific invariants in `packages/invariants/src/community/`. See `packages/invariants/src/definitions.ts` for the 17 built-in invariants as a reference.
 - **Create a policy pack** — Ship a reusable policy YAML in `policies/`. See `agentguard.yaml` for the format and `packages/policy/src/pack-loader.ts` for the pack loading contract.
 - **Build an adapter** — Add support for a new agent framework in `packages/adapters/src/`. Follow the pattern in `packages/adapters/src/claude-code.ts`.
 - **Add a renderer** — Create a custom governance output renderer implementing the `GovernanceRenderer` interface in `packages/renderers/src/types.ts`.

--- a/docs/current-priorities.md
+++ b/docs/current-priorities.md
@@ -23,57 +23,57 @@ AgentGuard is a **governed action runtime for AI agents**. The kernel loop inter
 |-------|-------|--------|---------------------|
 | Phase 5 | Editor Integrations | IN PROGRESS | JetBrains plugin, deep Claude Code integration |
 | Phase 6 | Reference Monitor Hardening | NEXT | Default-deny unknown actions, PAUSE/ROLLBACK enforcement, governance self-modification invariant |
-| Phase 6.5 | Invariant Expansion | NEXT | CI/CD config, network egress, large file write, Docker config, DB migration, permission escalation, env var, recursive ops |
+| Phase 6.5 | Invariant Expansion | IN PROGRESS | Network egress, DB migration, transitive effect analysis (7 of 10 invariants implemented) |
 | Phase 10 | Structured Storage Backend | IN PROGRESS | Migration v2, composite indexes, SQL-native analytics |
 
 ## What Is Implemented
 
 ### Governed Action Kernel (Production)
-- **Kernel loop** (`src/kernel/kernel.ts`) — propose → AAB normalize → policy evaluate → invariant check → simulate → execute → emit
-- **AAB reference monitor** (`src/kernel/aab.ts`) — 87 destructive command patterns, action normalization
-- **Policy evaluator** (`src/policy/evaluator.ts`) — two-phase deny/allow, pattern matching, scopes, branch conditions
-- **10 built-in invariants** (`src/invariants/definitions.ts`) — secret exposure, protected branches, blast radius, test-before-push, no force push, no skill modification, no scheduled task modification, credential file creation, package script injection, lockfile integrity
-- **Escalation state machine** (`src/kernel/monitor.ts`) — NORMAL → ELEVATED → HIGH → LOCKDOWN
-- **Blast radius computation** (`src/kernel/blast-radius.ts`) — weighted scoring engine
-- **Evidence pack generation** (`src/kernel/evidence.ts`)
-- **Decision record factory** (`src/kernel/decisions/factory.ts`)
-- **Pre-execution simulation** (`src/kernel/simulation/`) — filesystem, git, package simulators + impact forecast
+- **Kernel loop** (`packages/kernel/src/kernel.ts`) — propose → AAB normalize → policy evaluate → invariant check → simulate → execute → emit
+- **AAB reference monitor** (`packages/kernel/src/aab.ts`) — 87 destructive command patterns, action normalization
+- **Policy evaluator** (`packages/policy/src/evaluator.ts`) — two-phase deny/allow, pattern matching, scopes, branch conditions
+- **17 built-in invariants** (`packages/invariants/src/definitions.ts`) — secret exposure, protected branches, blast radius, test-before-push, no force push, no skill modification, no scheduled task modification, credential file creation, package script injection, lockfile integrity, recursive operation guard, large file write, CI/CD config modification, permission escalation, governance self-modification, container config modification, environment variable modification
+- **Escalation state machine** (`packages/kernel/src/monitor.ts`) — NORMAL → ELEVATED → HIGH → LOCKDOWN
+- **Blast radius computation** (`packages/kernel/src/blast-radius.ts`) — weighted scoring engine
+- **Evidence pack generation** (`packages/kernel/src/evidence.ts`)
+- **Decision record factory** (`packages/kernel/src/decisions/factory.ts`)
+- **Pre-execution simulation** (`packages/kernel/src/simulation/`) — filesystem, git, package simulators + impact forecast
 
 ### Execution Adapters
-- **File, shell, git handlers** (`src/adapters/file.ts`, `shell.ts`, `git.ts`)
-- **Claude Code hook adapter** (`src/adapters/claude-code.ts`) — PreToolUse/PostToolUse integration
+- **File, shell, git handlers** (`packages/adapters/src/file.ts`, `shell.ts`, `git.ts`)
+- **Claude Code hook adapter** (`packages/adapters/src/claude-code.ts`) — PreToolUse/PostToolUse integration
 
 ### Event Model (49 event kinds)
-- **Event schema** (`src/events/schema.ts`) — governance, lifecycle, safety, reference monitor, decision, simulation, pipeline, dev activity, heartbeat events
-- **EventBus** (`src/events/bus.ts`) — generic typed pub/sub
-- **JSONL persistence** (`src/events/jsonl.ts`) — append-only audit trail
-- **Decision record persistence** (`src/events/decision-jsonl.ts`)
+- **Event schema** (`packages/events/src/schema.ts`) — governance, lifecycle, safety, reference monitor, decision, simulation, pipeline, dev activity, heartbeat events
+- **EventBus** (`packages/events/src/bus.ts`) — generic typed pub/sub
+- **JSONL persistence** (`packages/events/src/jsonl.ts`) — append-only audit trail
+- **Decision record persistence** (`packages/events/src/decision-jsonl.ts`)
 
 ### Cross-Session Analytics
-- **Violation aggregation** (`src/analytics/aggregator.ts`)
-- **Violation clustering** (`src/analytics/cluster.ts`)
-- **Trend computation** (`src/analytics/trends.ts`)
-- **Per-run risk scoring** (`src/analytics/risk-scorer.ts`)
-- **Output formatters** (`src/analytics/reporter.ts`) — terminal, JSON, markdown
+- **Violation aggregation** (`packages/analytics/src/aggregator.ts`)
+- **Violation clustering** (`packages/analytics/src/cluster.ts`)
+- **Trend computation** (`packages/analytics/src/trends.ts`)
+- **Per-run risk scoring** (`packages/analytics/src/risk-scorer.ts`)
+- **Output formatters** (`packages/analytics/src/reporter.ts`) — terminal, JSON, markdown
 
 ### Storage Backends
-- **SQLite** (`src/storage/sqlite-*.ts`) — indexed queries, analytics, session lifecycle
-- **Firestore** (`src/storage/firestore-*.ts`) — cloud-native governance data sharing
+- **SQLite** (`packages/storage/src/sqlite-*.ts`) — indexed queries, analytics, session lifecycle
+- **Firestore** (`packages/storage/src/firestore-*.ts`) — cloud-native governance data sharing
 - **JSONL** (default) — streaming, human-readable
 
 ### Plugin Ecosystem
-- **Plugin discovery, registry, validation, sandboxing** (`src/plugins/`)
-- **Renderer plugin system** (`src/renderers/`)
-- **Policy pack loader** (`src/policy/pack-loader.ts`)
+- **Plugin discovery, registry, validation, sandboxing** (`packages/plugins/src/`)
+- **Renderer plugin system** (`packages/renderers/src/`)
+- **Policy pack loader** (`packages/policy/src/pack-loader.ts`)
 
-### CLI (16 commands)
-`guard`, `inspect`, `events`, `replay`, `export`, `import`, `simulate`, `ci-check`, `analytics`, `plugin`, `policy`, `claude-hook`, `claude-init`, `init`, `diff`, `evidence-pr`, `traces`
+### CLI (19 commands)
+`guard`, `inspect`, `events`, `replay`, `export`, `import`, `simulate`, `ci-check`, `analytics`, `plugin`, `policy`, `policy-verify`, `claude-hook`, `claude-init`, `init`, `diff`, `evidence-pr`, `traces`, `telemetry`
 
 ### Editor Integration
 - **VS Code extension** (`vscode-extension/`) — sidebar panels, event reader, inline diagnostics, violation mapper
 
 ### Infrastructure
-- 77 TypeScript tests (vitest) + 14 JavaScript tests
+- 105 TypeScript tests (vitest) + 14 JavaScript tests
 - TypeScript build: tsc + esbuild
 - CI: size-check, publish, CodeQL, governance reusable workflow
 - ESLint + Prettier enforced
@@ -83,13 +83,13 @@ AgentGuard is a **governed action runtime for AI agents**. The kernel loop inter
 ### Immediate Priority — Reference Monitor Hardening (Phase 6)
 1. Default-deny unknown actions in policy evaluator (close last bypass vector)
 2. Enforce PAUSE and ROLLBACK intervention types in kernel execution
-3. Governance self-modification invariant (block agents from modifying governance config)
+3. ~~Governance self-modification invariant~~ — DONE (`no-governance-self-modification` invariant, severity 5)
 
 ### Near-Term — Invariant Expansion (Phase 6.5)
-4. CI/CD config modification invariant
+4. ~~CI/CD config modification invariant~~ — DONE (`no-cicd-config-modification`)
 5. Network egress governance invariant
-6. Large single-file write invariant
-7. Docker/container config modification invariant
+6. ~~Large single-file write invariant~~ — DONE (`large-file-write`)
+7. ~~Docker/container config modification invariant~~ — DONE (`no-container-config-modification`)
 
 ### Mid-Term — Capability-Scoped Sessions (Phase 7)
 8. RunManifest type with role and capability grants

--- a/docs/strategic-roadmap.md
+++ b/docs/strategic-roadmap.md
@@ -26,7 +26,7 @@ Software side effects and physical side effects belong to the same problem class
 
 ## Current State
 
-AgentGuard has a mature governance kernel (propose → evaluate → execute → emit), 10 built-in invariants, event-sourced JSONL audit trails, pre-execution simulation (filesystem/git/package), escalation state machine (NORMAL → LOCKDOWN), pluggable tracing, cross-session analytics (clustering, trends, risk scoring), a plugin ecosystem, a VS Code extension, SQLite and Firestore storage backends, and a fully autonomous SDLC control plane with 22+ coordinated agents. The only framework adapter is Claude Code.
+AgentGuard has a mature governance kernel (propose → evaluate → execute → emit), 17 built-in invariants, event-sourced JSONL audit trails, pre-execution simulation (filesystem/git/package), escalation state machine (NORMAL → LOCKDOWN), pluggable tracing, cross-session analytics (clustering, trends, risk scoring), a plugin ecosystem, a VS Code extension, SQLite and Firestore storage backends, and a fully autonomous SDLC control plane with 22+ coordinated agents. The only framework adapter is Claude Code.
 
 Completed technical phases: Architecture Clarity, Canonical Event Model, Governance Runtime, Event Persistence + Replay, Plugin Ecosystem (Phases 0–4 STABLE). Currently working on: Editor Integrations (Phase 5), Reference Monitor Hardening (Phase 6), Structured Storage (Phase 10).
 


### PR DESCRIPTION
## Summary

Automated documentation sync detected drift between codebase and docs:

- **Invariant count**: 10 → **17** (7 new invariants implemented in Phase 6/6.5)
- **Package count**: 15 → **16** (`@red-codes/swarm` added)
- **Test file count**: 77 → **105** TS test files across workspace
- **CLI commands**: added `telemetry` and `policy-verify` (now 19 commands)
- **Placeholder packages**: `telemetry-client` and `telemetry-server` are now functional
- **ROADMAP Phase 6.5**: 7 of 10 invariants now implemented, status updated to IN PROGRESS
- **Path corrections**: `docs/current-priorities.md` used old `src/` paths, now `packages/*/src/`

### Strategic Document Contradictions Found

- `docs/strategic-roadmap.md` stated "10 built-in invariants" — contradicts actual 17 in `packages/invariants/src/definitions.ts`
- `docs/current-priorities.md` listed Phase 6.5 items as "NEXT" priorities that are already implemented (CI/CD config, large file write, Docker config, permission escalation, env var, recursive ops, governance self-modification)
- `docs/current-priorities.md` used pre-monorepo `src/` paths instead of `packages/*/src/` paths

## Changes

- `README.md` — invariant count (10→17), invariant table (10→17 rows), structure tree (add swarm), CLI commands (add telemetry, policy-verify), telemetry-server/client descriptions
- `ARCHITECTURE.md` — invariant count (10→17), add missing packages (swarm, telemetry-client, runtime, sentinel01, adapter-openclaw), fix telemetry-server description
- `CLAUDE.md` — invariant count (10→17), package count (15→16), test count (77→105), add missing source files (governance-data.ts, data/, contract.ts, tui-formatters.ts, suggest.ts, webhook-sink.ts), add swarm/telemetry-client structure, add CLI commands, update test coverage areas
- `ROADMAP.md` — invariant count (10→17), mark 7 Phase 6/6.5 items as done, update Phase 6.5 status to IN PROGRESS, update CLI command list
- `docs/current-priorities.md` — invariant count (10→17), test count (77→105), CLI count (16→19), fix all `src/` paths to `packages/*/src/`, mark done items, update Phase 6.5 status
- `docs/strategic-roadmap.md` — invariant count (10→17)

## Source

Auto-generated by the **Scheduled Docs Sync** skill.

---
*Run: 2026-03-14*