### PR TITLE
fix(issue-401): fix Windows path separators and harden vitest workspace

### DIFF
--- a/packages/events/tests/decision-jsonl.test.ts
+++ b/packages/events/tests/decision-jsonl.test.ts
@@ -116,7 +116,7 @@ describe('createDecisionJsonlSink', () => {
     sink.write(makeRecord());
 
     expect(mockedMkdirSync).toHaveBeenCalledWith(
-      expect.stringContaining('/custom'),
+      expect.stringContaining('custom'),
       { recursive: true }
     );
   });
@@ -131,8 +131,8 @@ describe('getDecisionFilePath', () => {
   });
 
   it('returns correct path with custom base dir', () => {
-    const path = getDecisionFilePath('run-1', '/custom');
-    expect(path).toContain('/custom');
-    expect(path).toContain('run-1.jsonl');
+    const filePath = getDecisionFilePath('run-1', '/custom');
+    expect(filePath).toContain('custom');
+    expect(filePath).toContain('run-1.jsonl');
   });
 });

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -3,4 +3,6 @@ import { defineWorkspace } from 'vitest/config';
 export default defineWorkspace([
   'packages/*/vitest.config.ts',
   'apps/*/vitest.config.ts',
+  '!.claude/**',
+  '!**/node_modules/**',
 ]);


### PR DESCRIPTION
## Summary
- Fix cross-platform path separator assertions in `decision-jsonl.test.ts` that fail on Windows
- Add defensive `.claude/**` exclusion to `vitest.workspace.ts` to prevent worktree test discovery
- Invariant count assertion already correct at 17 on main (no change needed)
- Closes #401

## Changes
- `packages/events/tests/decision-jsonl.test.ts` — Replace `/custom` assertions with platform-agnostic `custom` substring checks (lines 119, 135)
- `vitest.workspace.ts` — Add `!.claude/**` and `!**/node_modules/**` negation patterns to workspace globs

## Test Plan
- [x] TypeScript build passes (`pnpm build`)
- [x] Vitest tests pass (`pnpm test`) — events: 59/59, kernel: 522/522
- [x] ESLint clean (`pnpm lint`)
- [x] Prettier clean (`pnpm format`)
- [x] Type-check clean (`pnpm ts:check`)
- [ ] Pre-existing: `@red-codes/telemetry-client` identity test fails on Windows (file permissions `0o600` not supported)

## Risk Assessment

| Metric | Value |
|--------|-------|
| Risk level | low |
| Blast radius | 2 files (test + config) |
| Simulation result | not available |

## Governance Report

| Metric | Count |
|--------|-------|
| Total events (aggregate) | 50,371 |
| Actions allowed | 7,919 |
| Actions denied | 1,992 |
| Invariant violations | 830 |
| Decision records | 9,876 |

<details>
<summary>Governance details</summary>

**Source**: `.agentguard/events/`, `.agentguard/decisions/`, `logs/runtime-events.jsonl`

**Note**: Telemetry counts are aggregate across all governance sessions, not specific to this PR.
**Escalation levels observed**: NORMAL only
**Pre-push simulation**: not available

No governance denials or violations specific to this change.

</details>