### PR TITLE
feat(issue-334): add simulator plugin interface

### DIFF
--- a/apps/cli/src/commands/guard.ts
+++ b/apps/cli/src/commands/guard.ts
@@ -15,6 +15,7 @@ import { createPackageSimulator } from '@red-codes/kernel';
 import type { RawAgentAction } from '@red-codes/kernel';
 import { generateSeed, createSeededRng } from '@red-codes/core';
 import { simpleHash } from '@red-codes/core';
+import { createPluginRegistry, loadSimulatorPlugins } from '@red-codes/plugins';
 import { createRendererRegistry } from '@red-codes/renderers';
 import type { RendererRegistry } from '@red-codes/renderers';
 import { createTuiRenderer } from '@red-codes/renderers';
@@ -68,6 +69,14 @@ export async function guard(_args: string[], options: GuardOptions = {}): Promis
     simulators.register(createGitSimulator());
     simulators.register(createFilesystemSimulator());
     simulators.register(createPackageSimulator());
+
+    // Load community simulator plugins from the plugin registry
+    try {
+      const pluginRegistry = createPluginRegistry();
+      await loadSimulatorPlugins(pluginRegistry, (sim) => simulators.register(sim));
+    } catch {
+      // Plugin loading failures are non-fatal — built-in simulators still work
+    }
   }
 
   // Create seeded RNG — seed is stored in session metadata for deterministic replay

--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -25,6 +25,7 @@ const EXTENSION_TYPES = [
   'adapter',
   'renderer',
   'replay-processor',
+  'simulator',
 ] as const;
 
 type ExtensionType = (typeof EXTENSION_TYPES)[number];
@@ -209,6 +210,8 @@ function generateScaffold(type: ExtensionType, name: string): ScaffoldFile[] {
       return scaffoldRenderer(id, name);
     case 'replay-processor':
       return scaffoldReplayProcessor(id, name);
+    case 'simulator':
+      return scaffoldSimulator(id, name);
   }
 }
 
@@ -949,6 +952,233 @@ agentguard plugin install .
   ];
 }
 
+function scaffoldSimulator(id: string, name: string): ScaffoldFile[] {
+  return [
+    {
+      path: 'package.json',
+      content:
+        JSON.stringify(
+          {
+            name: id,
+            version: '0.1.0',
+            description: `Custom action simulator for AgentGuard`,
+            type: 'module',
+            main: 'src/index.js',
+            scripts: {
+              build: 'tsc',
+              test: 'node --test tests/',
+            },
+            agentguard: {
+              id,
+              name,
+              version: '0.1.0',
+              type: 'simulator',
+              apiVersion: '^1.0.0',
+              description: `Custom simulator: ${name}`,
+              capabilities: ['filesystem:read'],
+            },
+          },
+          null,
+          2
+        ) + '\n',
+    },
+    {
+      path: 'tsconfig.json',
+      content:
+        JSON.stringify(
+          {
+            compilerOptions: {
+              target: 'ES2022',
+              module: 'ESNext',
+              moduleResolution: 'bundler',
+              outDir: 'dist',
+              declaration: true,
+              strict: true,
+              verbatimModuleSyntax: true,
+            },
+            include: ['src'],
+          },
+          null,
+          2
+        ) + '\n',
+    },
+    {
+      path: 'src/index.ts',
+      content: `// Custom action simulator for AgentGuard
+//
+// Simulators predict the impact of an action BEFORE it executes. They are
+// invoked by the governance kernel during the evaluate phase to produce
+// structured impact forecasts used by predictive policy rules.
+//
+// Each simulator:
+// 1. Declares which action types it supports via \`supports()\`
+// 2. Returns a \`SimulationResult\` with predicted changes, blast radius, and risk
+// 3. Is registered with the SimulatorRegistry at startup
+//
+// See: https://github.com/AgentGuardHQ/agent-guard#simulators
+
+/** Normalized action intent passed to the simulator */
+export interface NormalizedIntent {
+  action: string;
+  target?: string;
+  agent?: string;
+  destructive?: boolean;
+  command?: string;
+  filesAffected?: number;
+  metadata?: Record<string, unknown>;
+}
+
+/** Result of simulating an action before execution */
+export interface SimulationResult {
+  /** Human-readable list of predicted changes */
+  predictedChanges: string[];
+  /** Estimated number of files/entities affected */
+  blastRadius: number;
+  /** Overall risk assessment */
+  riskLevel: 'low' | 'medium' | 'high';
+  /** Simulator-specific details */
+  details: Record<string, unknown>;
+  /** Which simulator produced this result */
+  simulatorId: string;
+  /** How long the simulation took (ms) */
+  durationMs: number;
+}
+
+/** An action simulator predicts the impact of an action before execution */
+export interface ActionSimulator {
+  /** Unique simulator identifier */
+  readonly id: string;
+  /** Check if this simulator can handle the given intent */
+  supports(intent: NormalizedIntent): boolean;
+  /** Simulate the action and predict its impact */
+  simulate(intent: NormalizedIntent, context: Record<string, unknown>): Promise<SimulationResult>;
+}
+
+// --- Supported action types for this simulator ---
+
+const SUPPORTED_ACTIONS = new Set([
+  // Add the action types this simulator handles, e.g.:
+  // 'shell.exec',
+  // 'deploy.trigger',
+]);
+
+/**
+ * Factory function — the plugin entry point.
+ *
+ * AgentGuard calls \`createSimulator()\` when loading your plugin.
+ * Return an object that implements the ActionSimulator interface.
+ */
+export function createSimulator(): ActionSimulator {
+  return {
+    id: '${id}',
+
+    supports(intent: NormalizedIntent): boolean {
+      return SUPPORTED_ACTIONS.has(intent.action);
+    },
+
+    async simulate(intent: NormalizedIntent): Promise<SimulationResult> {
+      const start = Date.now();
+      const target = intent.target ?? '';
+
+      // TODO: Implement your simulation logic here.
+      // Analyze the intent and predict what would happen if this action executes.
+
+      return {
+        predictedChanges: [\`Simulated: \${intent.action} on \${target}\`],
+        blastRadius: 1,
+        riskLevel: 'low',
+        details: {
+          target,
+          action: intent.action,
+        },
+        simulatorId: '${id}',
+        durationMs: Date.now() - start,
+      };
+    },
+  };
+}
+`,
+    },
+    {
+      path: 'tests/simulator.test.ts',
+      content: `import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createSimulator } from '../src/index.js';
+
+describe('${name} simulator', () => {
+  const simulator = createSimulator();
+
+  it('should have a valid id', () => {
+    assert.strictEqual(simulator.id, '${id}');
+  });
+
+  it('should report supported actions', () => {
+    // Update this test when you add supported actions
+    const result = simulator.supports({ action: 'file.read' });
+    assert.strictEqual(typeof result, 'boolean');
+  });
+
+  it('should return a valid SimulationResult', async () => {
+    const result = await simulator.simulate(
+      { action: 'test.action', target: '/tmp/test' },
+      {}
+    );
+    assert.strictEqual(typeof result.blastRadius, 'number');
+    assert.ok(Array.isArray(result.predictedChanges));
+    assert.ok(['low', 'medium', 'high'].includes(result.riskLevel));
+    assert.strictEqual(result.simulatorId, '${id}');
+    assert.strictEqual(typeof result.durationMs, 'number');
+  });
+});
+`,
+    },
+    {
+      path: 'README.md',
+      content: `# ${name}
+
+Custom action simulator for AgentGuard.
+
+## Overview
+
+This simulator predicts the impact of actions before they execute,
+enabling predictive governance decisions based on estimated blast radius
+and risk level.
+
+## Usage
+
+\`\`\`bash
+# Install as an AgentGuard plugin
+agentguard plugin install .
+
+# The simulator is automatically loaded when running the guard
+agentguard guard --policy agentguard.yaml
+\`\`\`
+
+## How It Works
+
+1. The governance kernel calls \`supports(intent)\` to check if this simulator handles the action
+2. If supported, \`simulate(intent, context)\` predicts the impact
+3. The result feeds into the impact forecast and predictive policy rules
+
+## Simulator Interface
+
+| Method | Description |
+|--------|-------------|
+| \`supports(intent)\` | Returns true if this simulator handles the action type |
+| \`simulate(intent, context)\` | Returns predicted changes, blast radius, and risk level |
+
+## Development
+
+\`\`\`bash
+npm install
+npm run build
+npm test
+\`\`\`
+`,
+    },
+  ];
+}
+
 /**
  * Scaffold Firestore backend configuration: security rules, env example, and setup guide.
  */
@@ -1171,6 +1401,7 @@ function printInitHelp(): void {
     adapter            Custom execution adapter
     renderer           Custom governance renderer
     replay-processor   Custom replay processor
+    simulator          Custom action simulator
 
   ${bold('Agent swarm:')}
     swarm              Scaffold the full agent swarm (skills, config, task definitions)
@@ -1198,6 +1429,7 @@ function printInitHelp(): void {
     agentguard init --extension renderer --name json-renderer
     agentguard init invariant --name vendor-guard
     agentguard init policy-pack --name strict-policy
+    agentguard init simulator --name docker-build
     agentguard init firestore
     agentguard init swarm
     agentguard init swarm --tiers core,governance

--- a/apps/cli/tests/cli-init.test.ts
+++ b/apps/cli/tests/cli-init.test.ts
@@ -69,6 +69,7 @@ describe('init command', () => {
       'adapter',
       'renderer',
       'replay-processor',
+      'simulator',
     ] as const;
 
     for (const type of extensionTypes) {
@@ -131,7 +132,7 @@ describe('init command', () => {
     });
 
     it('should generate test files for non-policy-pack types', async () => {
-      const typesWithTests = ['invariant', 'adapter', 'renderer', 'replay-processor'] as const;
+      const typesWithTests = ['invariant', 'adapter', 'renderer', 'replay-processor', 'simulator'] as const;
 
       for (const type of typesWithTests) {
         vi.clearAllMocks();
@@ -146,6 +147,23 @@ describe('init command', () => {
           (call) => typeof call[0] === 'string' && (call[0] as string).includes(`tests${sep}`)
         );
         expect(testCall, `Test file should be generated for ${type}`).toBeDefined();
+      }
+    });
+
+    it('should generate createSimulator export for simulator type', async () => {
+      await init(['--extension', 'simulator', '--name', 'test-simulator']);
+
+      const writeCalls = vi.mocked(writeFileSync).mock.calls;
+      const srcCall = writeCalls.find(
+        (call) => typeof call[0] === 'string' && (call[0] as string).endsWith(`src${sep}index.ts`)
+      );
+      expect(srcCall).toBeDefined();
+      if (srcCall) {
+        const content = srcCall[1] as string;
+        expect(content).toContain('createSimulator');
+        expect(content).toContain('ActionSimulator');
+        expect(content).toContain('SimulationResult');
+        expect(content).toContain('NormalizedIntent');
       }
     });
 
@@ -167,7 +185,7 @@ describe('init command', () => {
     });
 
     it('should generate TypeScript source for non-policy-pack types', async () => {
-      const typesWithTs = ['invariant', 'adapter', 'renderer', 'replay-processor'] as const;
+      const typesWithTs = ['invariant', 'adapter', 'renderer', 'replay-processor', 'simulator'] as const;
 
       for (const type of typesWithTs) {
         vi.clearAllMocks();
@@ -256,8 +274,8 @@ describe('init command', () => {
   });
 
   describe('valid extension types', () => {
-    it('should accept all five extension types', async () => {
-      const types = ['invariant', 'policy-pack', 'adapter', 'renderer', 'replay-processor'];
+    it('should accept all six extension types', async () => {
+      const types = ['invariant', 'policy-pack', 'adapter', 'renderer', 'replay-processor', 'simulator'];
       for (const type of types) {
         vi.clearAllMocks();
         vi.mocked(existsSync).mockReturnValue(false);

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -1,5 +1,6 @@
 export * from './discovery.js';
 export * from './registry.js';
 export * from './sandbox.js';
+export * from './simulator-loader.js';
 export * from './validator.js';
 export * from './types.js';

--- a/packages/plugins/src/simulator-loader.ts
+++ b/packages/plugins/src/simulator-loader.ts
@@ -1,0 +1,145 @@
+// Simulator plugin loader — bridges the plugin registry with the simulator registry.
+//
+// Discovers installed simulator plugins, dynamically imports their modules,
+// validates that they export a factory function conforming to the ActionSimulator
+// contract, and registers them with the provided registration callback.
+//
+// Uses a callback pattern to avoid a direct dependency on @red-codes/kernel.
+
+import type { InstalledPlugin, PluginRegistry } from './registry.js';
+
+/**
+ * Shape a simulator plugin module must export.
+ *
+ * The module must have a `createSimulator` factory function that returns
+ * an object conforming to the ActionSimulator interface (id, supports, simulate).
+ */
+export interface SimulatorPluginModule {
+  createSimulator: () => SimulatorPluginInstance;
+}
+
+/**
+ * Minimal simulator interface — mirrors ActionSimulator from @red-codes/kernel.
+ *
+ * Declared here to avoid a direct dependency on the kernel package.
+ * Community simulators implement this contract via the scaffolded template.
+ */
+export interface SimulatorPluginInstance {
+  readonly id: string;
+  supports(intent: { action: string; target?: string }): boolean;
+  simulate(
+    intent: { action: string; target?: string },
+    context: Record<string, unknown>
+  ): Promise<{
+    predictedChanges: string[];
+    blastRadius: number;
+    riskLevel: 'low' | 'medium' | 'high';
+    details: Record<string, unknown>;
+    simulatorId: string;
+    durationMs: number;
+  }>;
+}
+
+/** Result of loading a single simulator plugin */
+export interface SimulatorLoadResult {
+  readonly pluginId: string;
+  readonly simulatorId: string;
+  readonly success: boolean;
+  readonly error?: string;
+}
+
+/**
+ * Load simulator plugins from the plugin registry and register them.
+ *
+ * @param pluginRegistry  The plugin registry to discover simulator plugins from
+ * @param register        Callback to register each loaded simulator (typically SimulatorRegistry.register)
+ * @returns Array of load results for each discovered simulator plugin
+ */
+export async function loadSimulatorPlugins(
+  pluginRegistry: PluginRegistry,
+  register: (simulator: SimulatorPluginInstance) => void
+): Promise<readonly SimulatorLoadResult[]> {
+  const simulatorPlugins = pluginRegistry.listByType('simulator');
+  const results: SimulatorLoadResult[] = [];
+
+  for (const plugin of simulatorPlugins) {
+    if (!plugin.enabled) {
+      results.push({
+        pluginId: plugin.manifest.id,
+        simulatorId: '',
+        success: false,
+        error: 'Plugin is disabled',
+      });
+      continue;
+    }
+
+    const result = await loadSingleSimulator(plugin, register);
+    results.push(result);
+  }
+
+  return results;
+}
+
+/**
+ * Load and register a single simulator plugin.
+ */
+async function loadSingleSimulator(
+  plugin: InstalledPlugin,
+  register: (simulator: SimulatorPluginInstance) => void
+): Promise<SimulatorLoadResult> {
+  const pluginId = plugin.manifest.id;
+
+  try {
+    // Dynamic import of the plugin module
+    const mod = (await import(plugin.source)) as Partial<SimulatorPluginModule>;
+
+    if (typeof mod.createSimulator !== 'function') {
+      return {
+        pluginId,
+        simulatorId: '',
+        success: false,
+        error: 'Module does not export a createSimulator function',
+      };
+    }
+
+    const simulator = mod.createSimulator();
+
+    // Validate the simulator has the required shape
+    if (!isValidSimulator(simulator)) {
+      return {
+        pluginId,
+        simulatorId: '',
+        success: false,
+        error:
+          'createSimulator() did not return a valid ActionSimulator (missing id, supports, or simulate)',
+      };
+    }
+
+    register(simulator);
+
+    return {
+      pluginId,
+      simulatorId: simulator.id,
+      success: true,
+    };
+  } catch (err) {
+    return {
+      pluginId,
+      simulatorId: '',
+      success: false,
+      error: `Failed to load: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+/** Validate that an object conforms to the minimal ActionSimulator contract */
+export function isValidSimulator(obj: unknown): obj is SimulatorPluginInstance {
+  if (obj === null || typeof obj !== 'object') return false;
+  const candidate = obj as Record<string, unknown>;
+  return (
+    typeof candidate.id === 'string' &&
+    candidate.id.length > 0 &&
+    typeof candidate.supports === 'function' &&
+    typeof candidate.simulate === 'function'
+  );
+}

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -6,7 +6,13 @@
 // enforce security boundaries at load time and runtime.
 
 /** Supported plugin types in the AgentGuard ecosystem */
-export type PluginType = 'renderer' | 'replay-processor' | 'policy-pack' | 'invariant' | 'adapter';
+export type PluginType =
+  | 'renderer'
+  | 'replay-processor'
+  | 'policy-pack'
+  | 'invariant'
+  | 'adapter'
+  | 'simulator';
 
 /**
  * Capabilities a plugin may request.

--- a/packages/plugins/src/validator.ts
+++ b/packages/plugins/src/validator.ts
@@ -20,6 +20,7 @@ const VALID_PLUGIN_TYPES: readonly PluginType[] = [
   'policy-pack',
   'invariant',
   'adapter',
+  'simulator',
 ];
 
 /** Semver pattern: major.minor.patch with optional pre-release */

--- a/packages/plugins/tests/plugin-validation.test.ts
+++ b/packages/plugins/tests/plugin-validation.test.ts
@@ -145,6 +145,7 @@ describe('validateManifest', () => {
       expect(validateManifest(validManifest({ type: 'policy-pack' })).valid).toBe(true);
       expect(validateManifest(validManifest({ type: 'invariant' })).valid).toBe(true);
       expect(validateManifest(validManifest({ type: 'adapter' })).valid).toBe(true);
+      expect(validateManifest(validManifest({ type: 'simulator' })).valid).toBe(true);
     });
 
     it('rejects unknown plugin types', () => {

--- a/packages/plugins/tests/simulator-loader.test.ts
+++ b/packages/plugins/tests/simulator-loader.test.ts
@@ -1,0 +1,162 @@
+// Tests for the simulator plugin loader — validates discovery, loading,
+// validation, and error handling for community-contributed simulators.
+
+import { describe, it, expect, vi } from 'vitest';
+import { loadSimulatorPlugins, isValidSimulator } from '../src/simulator-loader.js';
+import type { SimulatorPluginInstance } from '../src/simulator-loader.js';
+import type { PluginRegistry, InstalledPlugin } from '../src/registry.js';
+import type { PluginManifest } from '../src/types.js';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeSimulatorManifest(id: string): PluginManifest {
+  return {
+    id,
+    name: `Test Simulator ${id}`,
+    version: '1.0.0',
+    type: 'simulator',
+    apiVersion: '^1.0.0',
+  };
+}
+
+function makeInstalledPlugin(id: string, source: string, enabled = true): InstalledPlugin {
+  return {
+    manifest: makeSimulatorManifest(id),
+    source,
+    installedAt: new Date().toISOString(),
+    enabled,
+  };
+}
+
+function makeStubSimulator(id: string): SimulatorPluginInstance {
+  return {
+    id,
+    supports: (intent: { action: string }) => intent.action === 'test.action',
+    simulate: async () => ({
+      predictedChanges: ['test change'],
+      blastRadius: 1,
+      riskLevel: 'low' as const,
+      details: {},
+      simulatorId: id,
+      durationMs: 0,
+    }),
+  };
+}
+
+function createMockPluginRegistry(plugins: InstalledPlugin[]): PluginRegistry {
+  return {
+    install: vi.fn(),
+    remove: vi.fn().mockReturnValue(false),
+    get: vi.fn(),
+    has: vi.fn().mockReturnValue(false),
+    enable: vi.fn().mockReturnValue(false),
+    disable: vi.fn().mockReturnValue(false),
+    list: vi.fn().mockReturnValue(plugins),
+    listByType: vi.fn().mockImplementation((type: string) =>
+      plugins.filter((p) => p.manifest.type === type)
+    ),
+    count: vi.fn().mockReturnValue(plugins.length),
+    save: vi.fn(),
+    reload: vi.fn(),
+  } as unknown as PluginRegistry;
+}
+
+// ===========================================================================
+// isValidSimulator
+// ===========================================================================
+
+describe('isValidSimulator', () => {
+  it('returns true for a valid simulator instance', () => {
+    const sim = makeStubSimulator('test-sim');
+    expect(isValidSimulator(sim)).toBe(true);
+  });
+
+  it('returns false for null', () => {
+    expect(isValidSimulator(null)).toBe(false);
+  });
+
+  it('returns false for non-object', () => {
+    expect(isValidSimulator('string')).toBe(false);
+  });
+
+  it('returns false for missing id', () => {
+    expect(isValidSimulator({ supports: () => false, simulate: async () => ({}) })).toBe(false);
+  });
+
+  it('returns false for empty id', () => {
+    expect(
+      isValidSimulator({ id: '', supports: () => false, simulate: async () => ({}) })
+    ).toBe(false);
+  });
+
+  it('returns false for missing supports function', () => {
+    expect(isValidSimulator({ id: 'test', simulate: async () => ({}) })).toBe(false);
+  });
+
+  it('returns false for missing simulate function', () => {
+    expect(isValidSimulator({ id: 'test', supports: () => false })).toBe(false);
+  });
+});
+
+// ===========================================================================
+// loadSimulatorPlugins
+// ===========================================================================
+
+describe('loadSimulatorPlugins', () => {
+  it('returns empty array when no simulator plugins are installed', async () => {
+    const registry = createMockPluginRegistry([]);
+    const register = vi.fn();
+    const results = await loadSimulatorPlugins(registry, register);
+    expect(results).toHaveLength(0);
+    expect(register).not.toHaveBeenCalled();
+  });
+
+  it('skips disabled plugins', async () => {
+    const disabled = makeInstalledPlugin('disabled-sim', './disabled', false);
+    const registry = createMockPluginRegistry([disabled]);
+    const register = vi.fn();
+    const results = await loadSimulatorPlugins(registry, register);
+    expect(results).toHaveLength(1);
+    expect(results[0].success).toBe(false);
+    expect(results[0].error).toContain('disabled');
+    expect(register).not.toHaveBeenCalled();
+  });
+
+  it('reports error when module does not export createSimulator', async () => {
+    // Module that exports something else
+    const plugin = makeInstalledPlugin('bad-sim', 'node:path');
+    const registry = createMockPluginRegistry([plugin]);
+    const register = vi.fn();
+    const results = await loadSimulatorPlugins(registry, register);
+    expect(results).toHaveLength(1);
+    expect(results[0].success).toBe(false);
+    expect(results[0].error).toContain('createSimulator');
+    expect(register).not.toHaveBeenCalled();
+  });
+
+  it('reports error when module cannot be imported', async () => {
+    const plugin = makeInstalledPlugin('missing-sim', './nonexistent-module-path-12345');
+    const registry = createMockPluginRegistry([plugin]);
+    const register = vi.fn();
+    const results = await loadSimulatorPlugins(registry, register);
+    expect(results).toHaveLength(1);
+    expect(results[0].success).toBe(false);
+    expect(results[0].error).toContain('Failed to load');
+    expect(register).not.toHaveBeenCalled();
+  });
+
+  it('only queries simulator plugins from registry', async () => {
+    const nonSimulator = {
+      manifest: { ...makeSimulatorManifest('renderer-plugin'), type: 'renderer' as const },
+      source: './renderer',
+      installedAt: new Date().toISOString(),
+      enabled: true,
+    };
+    const registry = createMockPluginRegistry([nonSimulator]);
+    const register = vi.fn();
+    await loadSimulatorPlugins(registry, register);
+    expect(registry.listByType).toHaveBeenCalledWith('simulator');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `simulator` as a recognized plugin type in the AgentGuard plugin ecosystem
- Creates a simulator plugin loader bridge (`loadSimulatorPlugins`) that discovers, imports, validates, and registers community-contributed simulators at runtime
- Adds `agentguard init simulator` scaffolding that generates a standalone simulator project with inline interfaces, tests, and README
- Wires plugin-based simulator loading into the `guard` command so community simulators are automatically discovered and registered alongside built-in ones
- Closes #334

## Changes
- `packages/plugins/src/types.ts` — Add `'simulator'` to `PluginType` union
- `packages/plugins/src/validator.ts` — Add `'simulator'` to `VALID_PLUGIN_TYPES` array
- `packages/plugins/src/simulator-loader.ts` — **NEW** — Simulator plugin loader (discovery, import, validation, registration via callback pattern)
- `packages/plugins/src/index.ts` — Re-export simulator-loader module
- `apps/cli/src/commands/init.ts` — Add `simulator` extension type with full scaffolding (package.json, tsconfig, src/index.ts, tests, README)
- `apps/cli/src/commands/guard.ts` — Wire plugin-based simulator loading after built-in simulator registration
- `packages/plugins/tests/simulator-loader.test.ts` — **NEW** — Tests for isValidSimulator and loadSimulatorPlugins
- `packages/plugins/tests/plugin-validation.test.ts` — Add `'simulator'` to valid type assertions
- `apps/cli/tests/cli-init.test.ts` — Add `simulator` to all extension type test arrays + content validation test

## Test Plan
- [x] TypeScript build passes (`pnpm build`) — 18/18 tasks
- [x] Type-check passes (`pnpm ts:check`) — 31/31 tasks
- [x] Vitest tests pass (`pnpm test`) — 32/33 tasks (1 pre-existing Windows failure in telemetry-client identity.test.ts)
- [x] ESLint clean (`pnpm lint`)
- [x] Prettier clean (`pnpm format`)

## Risk Assessment

| Metric | Value |
|--------|-------|
| Risk level | low |
| Blast radius | 9 files (2 new, 7 modified) |
| Simulation result | not available |

## Governance Report

| Metric | Count |
|--------|-------|
| Total events | 50377 |
| Decision records | 9877 |
| Deny outcomes | 1976 |
| Escalation events | 0 |

<details>
<summary>Governance details</summary>

**Source**: `.agentguard/events/`, `.agentguard/decisions/`

**Escalation levels observed**: NORMAL only
**Pre-push simulation**: not available
**Pre-existing test failure**: `@red-codes/telemetry-client` identity.test.ts — Unix file permission assertion on Windows (mode 438 vs 384)

</details>