### PR TITLE
feat(claude-init): add SessionStart hook to auto-build CLI on session start

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,11 +1,23 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "test -f apps/cli/dist/bin.js || npm run build",
+            "timeout": 120000,
+            "blocking": true
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "hooks": [
           {
             "type": "command",
-            "command": "node apps/cli/dist/bin.js claude-hook pre"
+            "command": "npx agentguard claude-hook pre"
           }
         ]
       }
@@ -16,7 +28,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node apps/cli/dist/bin.js claude-hook post"
+            "command": "npx agentguard claude-hook post"
           }
         ]
       }

--- a/apps/cli/src/commands/claude-init.ts
+++ b/apps/cli/src/commands/claude-init.ts
@@ -7,16 +7,22 @@ import { homedir } from 'node:os';
 import { RESET, BOLD, DIM, FG } from '../colors.js';
 
 const HOOK_MARKER = 'claude-hook';
+const BUILD_MARKER = 'apps/cli/dist/bin.js';
 
 interface HookEntry {
   matcher?: string;
   hooks?: Array<{ type?: string; command?: string }>;
 }
 
+interface SessionStartHookEntry {
+  hooks?: Array<{ type?: string; command?: string; timeout?: number; blocking?: boolean }>;
+}
+
 interface Settings {
   hooks?: {
     PreToolUse?: HookEntry[];
     PostToolUse?: HookEntry[];
+    SessionStart?: SessionStartHookEntry[];
     [key: string]: unknown;
   };
   [key: string]: unknown;
@@ -97,13 +103,27 @@ export async function claudeInit(args: string[] = []): Promise<void> {
     ],
   });
 
+  // SessionStart — ensure CLI is built so hook commands resolve
+  if (!settings.hooks.SessionStart) settings.hooks.SessionStart = [];
+  settings.hooks.SessionStart.push({
+    hooks: [
+      {
+        type: 'command',
+        command: `test -f apps/cli/dist/bin.js || npm run build`,
+        timeout: 120000,
+        blocking: true,
+      },
+    ],
+  });
+
   writeFileSync(settingsPath, JSON.stringify(settings, null, 2), 'utf8');
 
   process.stderr.write(
     `  ${FG.green}✓${RESET}  Hooks installed in ${FG.cyan}${settingsLabel}${RESET}\n`
   );
-  process.stderr.write(`  ${DIM}PreToolUse:  governance enforcement (all tools)${RESET}\n`);
-  process.stderr.write(`  ${DIM}PostToolUse: error monitoring (Bash)${RESET}\n`);
+  process.stderr.write(`  ${DIM}SessionStart: auto-build if CLI not compiled${RESET}\n`);
+  process.stderr.write(`  ${DIM}PreToolUse:   governance enforcement (all tools)${RESET}\n`);
+  process.stderr.write(`  ${DIM}PostToolUse:  error monitoring (Bash)${RESET}\n`);
   if (storeBackend) {
     process.stderr.write(`  ${DIM}Storage:     ${storeBackend}${RESET}\n`);
   }
@@ -171,22 +191,34 @@ function removeHook(settingsPath: string, settingsLabel: string): void {
     return;
   }
 
-  const filterAgentGuard = (entries: HookEntry[]) =>
+  const filterByCommand = (entries: HookEntry[], marker: string) =>
     entries.filter((entry) => {
       const hooks = entry.hooks || [];
-      return !hooks.some((h) => h.command && h.command.includes(HOOK_MARKER));
+      return !hooks.some((h) => h.command && h.command.includes(marker));
     });
 
   const preToolUse = settings.hooks?.PreToolUse || [];
-  settings.hooks!.PreToolUse = filterAgentGuard(preToolUse);
+  settings.hooks!.PreToolUse = filterByCommand(preToolUse, HOOK_MARKER);
   if (settings.hooks!.PreToolUse!.length === 0) {
     delete settings.hooks!.PreToolUse;
   }
 
   const postToolUse = settings.hooks?.PostToolUse || [];
-  settings.hooks!.PostToolUse = filterAgentGuard(postToolUse);
+  settings.hooks!.PostToolUse = filterByCommand(postToolUse, HOOK_MARKER);
   if (settings.hooks!.PostToolUse!.length === 0) {
     delete settings.hooks!.PostToolUse;
+  }
+
+  // Remove SessionStart build hook
+  const sessionStart = (settings.hooks?.SessionStart as HookEntry[]) || [];
+  (settings.hooks as Record<string, unknown>).SessionStart = filterByCommand(
+    sessionStart,
+    BUILD_MARKER
+  );
+  if (
+    ((settings.hooks as Record<string, unknown>).SessionStart as HookEntry[]).length === 0
+  ) {
+    delete (settings.hooks as Record<string, unknown>).SessionStart;
   }
 
   if (Object.keys(settings.hooks!).length === 0) {
@@ -206,7 +238,7 @@ function removeHook(settingsPath: string, settingsLabel: string): void {
 function hasAgentGuardHook(settings: Settings): boolean {
   const preToolUse = settings?.hooks?.PreToolUse || [];
   const postToolUse = settings?.hooks?.PostToolUse || [];
-  const allEntries = [...preToolUse, ...postToolUse];
+  const allEntries = [...preToolUse, ...postToolUse] as HookEntry[];
   return allEntries.some((entry) => {
     const hooks = entry.hooks || [];
     return hooks.some((h) => h.command && h.command.includes(HOOK_MARKER));

--- a/apps/cli/tests/cli-claude-init.test.ts
+++ b/apps/cli/tests/cli-claude-init.test.ts
@@ -48,6 +48,20 @@ describe('claudeInit', () => {
     expect(written.hooks.PostToolUse[0].hooks[0].command).toContain('post');
   });
 
+  it('installs SessionStart build hook on first install', async () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    await claudeInit([]);
+
+    const written = JSON.parse(vi.mocked(writeFileSync).mock.calls[0][1] as string);
+    expect(written.hooks.SessionStart).toHaveLength(1);
+    expect(written.hooks.SessionStart[0].hooks[0].type).toBe('command');
+    expect(written.hooks.SessionStart[0].hooks[0].command).toContain('apps/cli/dist/bin.js');
+    expect(written.hooks.SessionStart[0].hooks[0].command).toContain('npm run build');
+    expect(written.hooks.SessionStart[0].hooks[0].blocking).toBe(true);
+    expect(written.hooks.SessionStart[0].hooks[0].timeout).toBe(120000);
+  });
+
   it('detects already-configured hook in PreToolUse and warns', async () => {
     vi.mocked(existsSync).mockReturnValue(true);
     vi.mocked(readFileSync).mockReturnValue(
@@ -133,11 +147,23 @@ describe('claudeInit', () => {
     );
   });
 
-  it('removes hooks from both PreToolUse and PostToolUse with --remove flag', async () => {
+  it('removes hooks from PreToolUse, PostToolUse, and SessionStart with --remove flag', async () => {
     vi.mocked(existsSync).mockReturnValue(true);
     vi.mocked(readFileSync).mockReturnValue(
       JSON.stringify({
         hooks: {
+          SessionStart: [
+            {
+              hooks: [
+                {
+                  type: 'command',
+                  command: 'test -f apps/cli/dist/bin.js || npm run build',
+                  timeout: 120000,
+                  blocking: true,
+                },
+              ],
+            },
+          ],
           PreToolUse: [
             {
               hooks: [{ type: 'command', command: 'node /path/to/claude-hook.js pre' }],
@@ -157,7 +183,7 @@ describe('claudeInit', () => {
 
     expect(writeFileSync).toHaveBeenCalledTimes(1);
     const written = JSON.parse(vi.mocked(writeFileSync).mock.calls[0][1] as string);
-    // Both hook types should be cleaned up
+    // All hook types should be cleaned up
     expect(written.hooks).toBeUndefined();
   });
 


### PR DESCRIPTION
The PreToolUse/PostToolUse hooks reference apps/cli/dist/bin.js, which
doesn't exist until the project is built. This caused AgentGuard governance
to silently fail in new sessions. Add a SessionStart hook that runs
`npm run build` if the CLI artifact is missing, ensuring hooks work
automatically. Also updates .claude/settings.json to use npx and includes
the SessionStart hook, and cleans up the build hook on --remove.

https://claude.ai/code/session_01CVAc7rw6suTNfiLndAnahX