### PR TITLE
Fix SessionStart hook to use pnpm and install deps before building

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "test -f apps/cli/dist/bin.js || npm run build",
+            "command": "test -f apps/cli/dist/bin.js || (pnpm install --frozen-lockfile && pnpm build)",
             "timeout": 120000,
             "blocking": true
           }


### PR DESCRIPTION
The hook used `npm run build` which failed because turbo wasn't
installed (pnpm install had never run). Switch to pnpm install +
pnpm build to match the monorepo tooling.

https://claude.ai/code/session_017BZkuuQx9esdQzWbiZGpFf