### PR TITLE
feat: add `agentguard status` command and auto-run on SessionStart

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,6 +8,12 @@
             "command": "test -f apps/cli/dist/bin.js || (pnpm install --frozen-lockfile && pnpm build)",
             "timeout": 120000,
             "blocking": true
+          },
+          {
+            "type": "command",
+            "command": "npx agentguard status",
+            "timeout": 10000,
+            "blocking": false
           }
         ]
       }

--- a/apps/cli/src/bin.ts
+++ b/apps/cli/src/bin.ts
@@ -280,6 +280,15 @@ const COMMANDS: Record<string, CommandHelp> = {
       'agentguard traces run_1234567890_abc',
     ],
   },
+  status: {
+    name: 'agentguard status',
+    description: 'Check AgentGuard governance readiness (hooks, policy, directories)',
+    usage: 'agentguard status [flags]',
+    flags: [
+      { flag: '--quiet, -q', description: 'Machine-readable output (exit 0 if ready, 1 if not)' },
+    ],
+    examples: ['agentguard status', 'agentguard status --quiet'],
+  },
   telemetry: {
     name: 'agentguard telemetry',
     description: 'Manage telemetry enrollment and settings',
@@ -528,6 +537,17 @@ async function main() {
       break;
     }
 
+    case 'status': {
+      if (wantsHelp) {
+        console.log(formatHelp(COMMANDS.status));
+        break;
+      }
+      const { status: statusCmd } = await import('./commands/status.js');
+      const code = await statusCmd(args.slice(1));
+      process.exit(code);
+      break;
+    }
+
     case 'claude-init': {
       const { claudeInit } = await import('./commands/claude-init.js');
       await claudeInit(args.slice(1));
@@ -651,6 +671,8 @@ function printHelp(): void {
   \x1b[1mIntegration:\x1b[0m
     agentguard claude-init                    Set up Claude Code hook integration
     agentguard claude-hook                    PreToolUse/PostToolUse hook handler (internal)
+    agentguard status                         Check governance readiness (hooks, policy, dirs)
+    agentguard status --quiet                 Machine-readable check (exit code only)
 
   \x1b[1mMeta:\x1b[0m
     agentguard --version                      Show version

--- a/apps/cli/src/commands/claude-init.ts
+++ b/apps/cli/src/commands/claude-init.ts
@@ -103,7 +103,7 @@ export async function claudeInit(args: string[] = []): Promise<void> {
     ],
   });
 
-  // SessionStart — ensure CLI is built so hook commands resolve
+  // SessionStart — ensure CLI is built, then show governance status
   if (!settings.hooks.SessionStart) settings.hooks.SessionStart = [];
   settings.hooks.SessionStart.push({
     hooks: [
@@ -113,6 +113,12 @@ export async function claudeInit(args: string[] = []): Promise<void> {
         timeout: 120000,
         blocking: true,
       },
+      {
+        type: 'command',
+        command: `agentguard status`,
+        timeout: 10000,
+        blocking: false,
+      },
     ],
   });
 
@@ -121,7 +127,7 @@ export async function claudeInit(args: string[] = []): Promise<void> {
   process.stderr.write(
     `  ${FG.green}✓${RESET}  Hooks installed in ${FG.cyan}${settingsLabel}${RESET}\n`
   );
-  process.stderr.write(`  ${DIM}SessionStart: auto-build if CLI not compiled${RESET}\n`);
+  process.stderr.write(`  ${DIM}SessionStart: auto-build + status check${RESET}\n`);
   process.stderr.write(`  ${DIM}PreToolUse:   governance enforcement (all tools)${RESET}\n`);
   process.stderr.write(`  ${DIM}PostToolUse:  error monitoring (Bash)${RESET}\n`);
   if (storeBackend) {

--- a/apps/cli/src/commands/status.ts
+++ b/apps/cli/src/commands/status.ts
@@ -1,0 +1,119 @@
+// agentguard status — quick health check for AgentGuard governance runtime
+
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { RESET, BOLD, DIM, FG } from '../colors.js';
+import { findDefaultPolicy } from '../policy-resolver.js';
+
+interface HookEntry {
+  hooks?: Array<{ type?: string; command?: string }>;
+}
+
+interface Settings {
+  hooks?: {
+    PreToolUse?: HookEntry[];
+    PostToolUse?: HookEntry[];
+    SessionStart?: HookEntry[];
+  };
+}
+
+const HOOK_MARKER = 'claude-hook';
+
+export async function status(args: string[]): Promise<number> {
+  const quiet = args.includes('--quiet') || args.includes('-q');
+
+  const checks = {
+    hooks: checkHooksInstalled(),
+    policy: checkPolicyFound(),
+    dirs: checkDirsExist(),
+  };
+
+  const allOk = checks.hooks.ok && checks.policy.ok && checks.dirs.ok;
+
+  if (quiet) {
+    // Machine-readable: exit 0 if all checks pass, 1 otherwise
+    if (!allOk) {
+      process.stderr.write('AgentGuard: not ready\n');
+      return 1;
+    }
+    process.stderr.write('AgentGuard: ready\n');
+    return 0;
+  }
+
+  process.stderr.write('\n');
+  process.stderr.write(`  ${BOLD}AgentGuard Status${RESET}\n\n`);
+
+  // Hooks
+  printCheck(checks.hooks.ok, 'Claude Code hooks', checks.hooks.detail);
+
+  // Policy
+  printCheck(checks.policy.ok, 'Policy file', checks.policy.detail);
+
+  // Directories
+  printCheck(checks.dirs.ok, 'Event directories', checks.dirs.detail);
+
+  process.stderr.write('\n');
+
+  if (allOk) {
+    process.stderr.write(
+      `  ${FG.green}${BOLD}AgentGuard is active.${RESET} ${DIM}All tool calls are governed.${RESET}\n`
+    );
+  } else {
+    process.stderr.write(
+      `  ${FG.yellow}${BOLD}AgentGuard is not fully configured.${RESET} ${DIM}Run "agentguard claude-init" to set up.${RESET}\n`
+    );
+  }
+
+  process.stderr.write('\n');
+  return allOk ? 0 : 1;
+}
+
+function printCheck(ok: boolean, label: string, detail: string): void {
+  const icon = ok ? `${FG.green}✓${RESET}` : `${FG.red}✗${RESET}`;
+  process.stderr.write(`  ${icon}  ${label} ${DIM}${detail}${RESET}\n`);
+}
+
+function checkHooksInstalled(): { ok: boolean; detail: string } {
+  // Check local settings first, then global
+  const localPath = join(process.cwd(), '.claude', 'settings.json');
+  const globalPath = join(homedir(), '.claude', 'settings.json');
+
+  for (const settingsPath of [localPath, globalPath]) {
+    if (existsSync(settingsPath)) {
+      try {
+        const settings = JSON.parse(readFileSync(settingsPath, 'utf8')) as Settings;
+        const preToolUse = settings?.hooks?.PreToolUse || [];
+        const hasHook = preToolUse.some((entry) => {
+          const hooks = entry.hooks || [];
+          return hooks.some((h) => h.command && h.command.includes(HOOK_MARKER));
+        });
+        if (hasHook) {
+          const location = settingsPath === localPath ? 'local' : 'global';
+          return { ok: true, detail: `(${location} .claude/settings.json)` };
+        }
+      } catch {
+        // Continue to next path
+      }
+    }
+  }
+
+  return { ok: false, detail: '(not found — run "agentguard claude-init")' };
+}
+
+function checkPolicyFound(): { ok: boolean; detail: string } {
+  const policyPath = findDefaultPolicy();
+  if (policyPath) {
+    return { ok: true, detail: `(${policyPath})` };
+  }
+  return { ok: false, detail: '(no agentguard.yaml found)' };
+}
+
+function checkDirsExist(): { ok: boolean; detail: string } {
+  const required = ['.agentguard/events', '.agentguard/decisions'];
+  const missing = required.filter((dir) => !existsSync(join(process.cwd(), dir)));
+  if (missing.length === 0) {
+    return { ok: true, detail: '(.agentguard/)' };
+  }
+  return { ok: false, detail: `(missing: ${missing.join(', ')})` };
+}


### PR DESCRIPTION
Adds a new `status` CLI command that checks governance readiness:
- Claude Code hooks installed (PreToolUse/PostToolUse)
- Policy file found (agentguard.yaml)
- Event directories exist (.agentguard/)

The status check now runs automatically during SessionStart so users
see confirmation that AgentGuard is active when a Claude Code session begins.

https://claude.ai/code/session_017XfF7uYThaaSv6qv2EA7gh