### PR TITLE
docs: document hook-based integration architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,13 +202,31 @@ Install globally: `npm i -g @red-codes/agentguard`
 
 ## Claude Code Integration
 
-AgentGuard hooks into [Claude Code](https://docs.anthropic.com/en/docs/claude-code) sessions via PreToolUse/PostToolUse hooks. Every tool call is normalized into a canonical action and evaluated by the kernel.
+AgentGuard integrates with [Claude Code](https://docs.anthropic.com/en/docs/claude-code) via **inline hooks** — not a separate daemon or background process. When a Claude Code session starts, AgentGuard's hooks fire on every tool call, routing each one through the governance kernel for policy and invariant evaluation before Claude Code executes it.
+
+This design is intentional: no daemon to crash, no ports to manage, no IPC. Each hook invocation is self-contained — load policy, evaluate, respond, exit. If anything fails, the hook exits cleanly and Claude Code continues (fail-open).
 
 ```bash
 npx @red-codes/agentguard claude-init    # Set up Claude Code hooks
 ```
 
-Tool call mapping:
+**Three hooks are installed:**
+
+| Hook | Purpose |
+|------|---------|
+| `PreToolUse` | Governance enforcement — evaluates every tool call against policies and invariants, blocks denied actions |
+| `PostToolUse` | Error monitoring — reports Bash stderr errors (informational only) |
+| `SessionStart` | Build check + governance status display on session start |
+
+**How PreToolUse works:**
+
+```
+Claude Code tool call → stdin (JSON) → AgentGuard kernel → stdout (deny) or silent (allow)
+```
+
+The kernel runs in evaluation-only mode (`dryRun: true`) — it checks policies and invariants but doesn't execute actions. Claude Code handles execution; AgentGuard only governs.
+
+**Tool call mapping:**
 
 | Claude Code Tool | AgentGuard Action |
 |-----------------|-------------------|
@@ -218,6 +236,8 @@ Tool call mapping:
 | Bash | shell.exec (or git.push, git.commit if git command detected) |
 | Glob | file.read |
 | Grep | file.read |
+
+See [Hook Architecture](docs/hook-architecture.md) for the full design, configuration options, and debugging guide.
 
 ## Event Trail
 
@@ -300,6 +320,7 @@ pnpm test               # Run all tests (turbo test)
 |----------|-------------|
 | [AgentGuard Spec](docs/agentguard.md) | Governance runtime specification |
 | [Architecture](docs/unified-architecture.md) | Governed action kernel model |
+| [Hook Architecture](docs/hook-architecture.md) | Claude Code hook integration design |
 | [Priorities](docs/current-priorities.md) | Current roadmap and next steps |
 | [Product Positioning](docs/product-positioning.md) | What this is and isn't |
 | [Event Model](docs/event-model.md) | Canonical event schema |

--- a/docs/hook-architecture.md
+++ b/docs/hook-architecture.md
@@ -1,0 +1,194 @@
+# Hook Architecture — How AgentGuard Integrates with Claude Code
+
+## Design: Inline Hooks, Not a Daemon
+
+AgentGuard does **not** run as a separate long-lived process. Instead, it integrates with Claude Code via **inline hooks** — lightweight commands that fire on every tool call and evaluate governance in-process.
+
+This is intentional. A daemon-based approach would require process management, health checks, IPC, and would risk silently crashing mid-session. The hook-based design is:
+
+- **Stateless per invocation** — each hook call is self-contained (load policy, evaluate, respond, exit)
+- **Fail-open by default** — if policy loading or storage fails, the hook exits cleanly and Claude Code continues
+- **Zero infrastructure** — no daemon, no sidecar, no port binding. Just a CLI command wired into Claude Code's hook system
+- **Always exits 0** — hooks must never block Claude Code. Denial is communicated via stdout; errors are swallowed
+
+## The Three-Hook Pattern
+
+AgentGuard registers three hooks in `.claude/settings.json`:
+
+### 1. `PreToolUse` — Governance Enforcement
+
+Fires **before** every Claude Code tool call (Bash, Write, Edit, Read, Glob, Grep). The hook:
+
+1. Reads the tool call payload from stdin (JSON with tool name, parameters)
+2. Normalizes it into a canonical action type via the AAB (Action Authorization Boundary)
+3. Evaluates policies and invariants through the kernel
+4. If **denied**: writes a block response to stdout, which tells Claude Code to prevent execution
+5. If **allowed**: exits silently, Claude Code proceeds normally
+6. Emits governance events to the configured storage backend (JSONL, SQLite, or webhook)
+
+```
+Claude Code tool call → stdin (JSON) → AgentGuard kernel → stdout (deny) or silent (allow)
+```
+
+### 2. `PostToolUse` — Error Monitoring
+
+Fires **after** Bash tool calls complete. Reports stderr errors for visibility. This hook is informational only — it does not block or modify behavior.
+
+### 3. `SessionStart` — Build & Status Check
+
+Fires once when a Claude Code session begins. Ensures the CLI is built and displays governance status. The build step is blocking (waits up to 2 minutes); the status check is non-blocking.
+
+## Hook Configuration
+
+Running `agentguard claude-init` writes this to `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "agentguard claude-hook pre"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "agentguard claude-hook post"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "test -f apps/cli/dist/bin.js || npm run build",
+            "timeout": 120000,
+            "blocking": true
+          },
+          {
+            "type": "command",
+            "command": "agentguard status",
+            "timeout": 10000,
+            "blocking": false
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Options:
+
+- `agentguard claude-init --global` — install to `~/.claude/settings.json` (all projects)
+- `agentguard claude-init --store sqlite` — use SQLite storage backend
+- `agentguard claude-init --remove` — uninstall hooks
+
+## How PreToolUse Governance Works
+
+Each PreToolUse invocation runs through this sequence:
+
+```
+stdin JSON payload
+  ↓
+Parse tool call (tool name, input parameters)
+  ↓
+AAB normalization (Bash → shell.exec or git.push, Write → file.write, etc.)
+  ↓
+Policy evaluation (match rules from agentguard.yaml)
+  ↓
+Invariant checks (17 built-in safety checks)
+  ↓
+Decision: ALLOW or DENY
+  ↓
+Emit events to storage (JSONL / SQLite / webhook)
+  ↓
+If denied → stdout response (Claude Code blocks the action)
+If allowed → silent exit (Claude Code proceeds)
+```
+
+The kernel runs with `dryRun: true` — it evaluates policies and invariants but does not execute the action itself. Claude Code handles actual execution; AgentGuard only governs.
+
+## Tool-to-Action Mapping
+
+The AAB normalizes Claude Code tool calls into canonical action types:
+
+| Claude Code Tool | AgentGuard Action | Notes |
+|-----------------|-------------------|-------|
+| Write | `file.write` | |
+| Edit | `file.write` | |
+| Read | `file.read` | |
+| Bash | `shell.exec` | Default for shell commands |
+| Bash | `git.push`, `git.commit`, etc. | Auto-detected when command contains git operations |
+| Glob | `file.read` | |
+| Grep | `file.read` | |
+
+## Session Identity
+
+Hook invocations are correlated by session ID:
+
+- Resolved from the payload's `session_id` field, or the `CLAUDE_SESSION_ID` environment variable
+- Multiple tool calls in the same Claude Code session share one session record
+- Enables cross-tool governance decisions and session-level analytics
+
+## Storage Backends
+
+The hook supports multiple storage backends for event and decision persistence:
+
+| Backend | Flag | Description |
+|---------|------|-------------|
+| JSONL (default) | — | File-based event stream in `.agentguard/events/` |
+| SQLite | `--store sqlite` | Indexed storage for analytics queries |
+| Webhook | `--store webhook` | Forward events to an external endpoint |
+
+Storage failures are non-fatal — governance evaluation continues regardless.
+
+## Error Handling & Fail-Open Semantics
+
+The hook is designed to **never break Claude Code**:
+
+- All errors are caught and swallowed — the hook always exits 0
+- Policy loading failures result in an empty policy (all actions allowed)
+- Storage backend failures are non-fatal (events may be lost, but governance continues)
+- Invalid stdin (non-JSON, empty input) causes a clean exit
+
+This fail-open design prioritizes developer experience over strict enforcement. If you need fail-closed semantics, monitor the event trail for gaps.
+
+## Debugging
+
+```bash
+# Check if hooks are installed
+cat .claude/settings.json | jq '.hooks'
+
+# View recent governance decisions
+agentguard inspect --last
+
+# View raw event stream
+agentguard events --last
+
+# View policy evaluation traces
+agentguard traces --last
+
+# Test a specific action against your policy
+echo '{"tool":"Bash","input":{"command":"git push origin main"}}' | agentguard claude-hook pre
+```
+
+## Key Source Files
+
+| File | Purpose |
+|------|---------|
+| `apps/cli/src/commands/claude-hook.ts` | Hook command (PreToolUse governance + PostToolUse monitoring) |
+| `apps/cli/src/commands/claude-init.ts` | Hook setup and teardown |
+| `packages/adapters/src/claude-code.ts` | Payload normalization and action mapping |
+| `packages/kernel/src/kernel.ts` | Governed action kernel (policy + invariant evaluation) |
+| `packages/kernel/src/aab.ts` | Action Authorization Boundary (tool → action type) |

--- a/site/index.html
+++ b/site/index.html
@@ -1094,9 +1094,14 @@ rules:
               <svg class="w-6 h-6 text-cta" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
             </div>
             <h3 class="font-mono font-bold text-text text-lg mb-2">Claude Code</h3>
-            <p class="text-muted text-sm leading-relaxed mb-4">PreToolUse/PostToolUse hook integration. Every tool call is normalized and evaluated by the governance kernel.</p>
-            <div class="relative group">
+            <p class="text-muted text-sm leading-relaxed mb-4">Inline hook integration &mdash; no daemon, no sidecar. AgentGuard fires on every tool call via PreToolUse/PostToolUse hooks, evaluates policies and invariants in-process, and exits. Fail-open by design.</p>
+            <div class="relative group mb-4">
               <pre class="bg-bg/50 rounded-lg p-3 font-mono text-xs overflow-x-auto"><code class="text-muted"><span class="text-cta">$</span> npx agentguard claude-init</code></pre>
+            </div>
+            <div class="flex flex-wrap gap-2">
+              <span class="text-xs font-mono text-muted bg-surface-light/50 px-2 py-1 rounded">PreToolUse</span>
+              <span class="text-xs font-mono text-muted bg-surface-light/50 px-2 py-1 rounded">PostToolUse</span>
+              <span class="text-xs font-mono text-muted bg-surface-light/50 px-2 py-1 rounded">SessionStart</span>
             </div>
           </div>
 


### PR DESCRIPTION
Add docs/hook-architecture.md explaining why AgentGuard uses inline
hooks instead of a daemon — stateless per invocation, fail-open,
zero infrastructure. Covers the three-hook pattern (PreToolUse,
PostToolUse, SessionStart), configuration, debugging, and fail-open
semantics.

Expand Claude Code Integration section in README with design rationale
and hook table. Update site landing page integration card with richer
description and hook badges.

https://claude.ai/code/session_019irbi9jgufjaqwhe3hP8DL