### PR TITLE
feat: capture agent persona — model metadata + behavioral traits

### DIFF
--- a/apps/agentguardhq/package.json
+++ b/apps/agentguardhq/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@red-codes/agentguardhq",
+  "version": "0.1.0",
+  "private": true,
+  "description": "AgentGuardHQ — Digital office visualization for AI agents",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -b",
+    "ts:check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@red-codes/core": "workspace:*",
+    "@red-codes/telemetry": "workspace:*"
+  }
+}

--- a/apps/agentguardhq/src/index.ts
+++ b/apps/agentguardhq/src/index.ts
@@ -1,0 +1,10 @@
+// AgentGuardHQ — Digital Office for AI Agents
+// A 2D visualization of agents working together, powered by persona telemetry.
+//
+// Vision: agents as characters with customizable styles walking around a virtual
+// office, performing tasks, collaborating, and reflecting real governance activity.
+//
+// This is the data + logic layer. Frontend rendering (React, Canvas, etc.) TBD.
+
+export * from './types.js';
+export * from './office.js';

--- a/apps/agentguardhq/src/office.ts
+++ b/apps/agentguardhq/src/office.ts
@@ -1,0 +1,176 @@
+// AgentGuardHQ — Digital Office Engine
+// Transforms persona telemetry into a live 2D office visualization.
+// Stub implementation — core logic for worker lifecycle and activity mapping.
+
+import type { AgentPersona, PersonaRole } from '@red-codes/core';
+import type { TelemetryEvent } from '@red-codes/telemetry';
+import type {
+  AgentWorker,
+  AgentStyle,
+  AgentActivity,
+  AgentAction,
+  DigitalOffice,
+  ShopItem,
+} from './types.js';
+import { DEFAULT_AVATARS, TRUST_TIER_COLORS } from './types.js';
+
+/**
+ * Create a new agent worker from persona data.
+ * Assigns a default style based on role and trust tier.
+ */
+export function createWorker(
+  agentId: string,
+  persona: AgentPersona,
+  officeWidth: number,
+  officeHeight: number,
+): AgentWorker {
+  const style = resolveDefaultStyle(agentId, persona);
+  return {
+    id: agentId,
+    persona,
+    style,
+    position: {
+      x: Math.floor(Math.random() * officeWidth),
+      y: Math.floor(Math.random() * officeHeight),
+    },
+    activity: { type: 'idle' },
+    recentActions: [],
+    stats: { totalActions: 0, allowedActions: 0, deniedActions: 0, trustScore: 100, uptime: 0 },
+  };
+}
+
+/** Resolve a default visual style based on persona traits. */
+function resolveDefaultStyle(agentId: string, persona: AgentPersona): AgentStyle {
+  const role: PersonaRole = persona.role ?? 'developer';
+  const avatar = DEFAULT_AVATARS[role] ?? 'robot-blue';
+  const color = TRUST_TIER_COLORS[persona.trustTier ?? 'standard'];
+
+  return {
+    name: formatAgentName(agentId, persona),
+    avatar,
+    color,
+    animation: persona.riskTolerance === 'aggressive' ? 'energetic' : 'default',
+    accessories: [],
+    premium: false,
+  };
+}
+
+/** Generate a friendly display name for an agent. */
+function formatAgentName(agentId: string, persona: AgentPersona): string {
+  const model = persona.modelMeta?.model;
+  if (model) {
+    // "Claude Sonnet" from "claude-sonnet-4-6"
+    const parts = model.split('-');
+    const name = parts.slice(0, 2).map((p) => p.charAt(0).toUpperCase() + p.slice(1)).join(' ');
+    return name;
+  }
+  // Fallback: use agent ID prefix
+  const prefix = agentId.split(':')[0] ?? agentId;
+  return prefix.charAt(0).toUpperCase() + prefix.slice(1);
+}
+
+/**
+ * Map a telemetry event to an agent activity.
+ * Used to animate what the worker is "doing" in the office.
+ */
+export function mapTelemetryToActivity(event: TelemetryEvent): AgentActivity {
+  if (event.policy_result === 'deny') {
+    return { type: 'blocked', reason: `${event.syscall} denied` };
+  }
+
+  switch (event.syscall) {
+    case 'file.write':
+    case 'file.read':
+      return { type: 'coding', file: event.target };
+    case 'git.push':
+    case 'git.commit':
+      return { type: 'pushing', branch: event.target };
+    case 'test.run':
+    case 'test.run.unit':
+    case 'test.run.integration':
+      return { type: 'testing', suite: event.target };
+    default:
+      return { type: 'coding', file: event.target };
+  }
+}
+
+/** Convert a telemetry event into an action for the activity feed. */
+export function telemetryToAction(event: TelemetryEvent): AgentAction {
+  return {
+    timestamp: new Date(event.timestamp).getTime(),
+    syscall: event.syscall,
+    target: event.target,
+    result: event.policy_result,
+  };
+}
+
+/** Create an empty digital office. */
+export function createOffice(
+  width = 800,
+  height = 600,
+  theme: DigitalOffice['theme'] = 'day',
+): DigitalOffice {
+  return { workers: [], width, height, theme };
+}
+
+/** Stub freemium content catalog. */
+export function getShopCatalog(): ShopItem[] {
+  return [
+    {
+      id: 'avatar-cat-hacker',
+      name: 'Cat Hacker',
+      category: 'avatar',
+      preview: '🐱‍💻',
+      tier: 'free',
+      description: 'A mischievous cat with a laptop',
+    },
+    {
+      id: 'avatar-ninja-coder',
+      name: 'Ninja Coder',
+      category: 'avatar',
+      preview: '🥷',
+      tier: 'free',
+      description: 'Silent but deadly (at writing code)',
+    },
+    {
+      id: 'accessory-coffee',
+      name: 'Coffee Cup',
+      category: 'accessory',
+      preview: '☕',
+      tier: 'free',
+      description: 'Every agent needs fuel',
+    },
+    {
+      id: 'accessory-headphones',
+      name: 'Headphones',
+      category: 'accessory',
+      preview: '🎧',
+      tier: 'free',
+      description: 'In the zone',
+    },
+    {
+      id: 'avatar-dragon-dev',
+      name: 'Dragon Developer',
+      category: 'avatar',
+      preview: '🐲',
+      tier: 'premium',
+      description: 'Breathes fire and ships features',
+    },
+    {
+      id: 'animation-party',
+      name: 'Party Mode',
+      category: 'animation',
+      preview: '🎉',
+      tier: 'premium',
+      description: 'Celebrate every successful push',
+    },
+    {
+      id: 'theme-cyberpunk',
+      name: 'Cyberpunk Office',
+      category: 'workspace-theme',
+      preview: '🌃',
+      tier: 'premium',
+      description: 'Neon-lit workspace for the future',
+    },
+  ];
+}

--- a/apps/agentguardhq/src/types.ts
+++ b/apps/agentguardhq/src/types.ts
@@ -1,0 +1,105 @@
+// AgentGuardHQ — Digital Office Types
+// 2D agent workers visualization powered by persona telemetry.
+// Agents walk around, perform tasks, and have customizable styles.
+
+import type { AgentPersona, TrustTier, PersonaRole } from '@red-codes/core';
+
+/** Visual style for an agent worker in the digital office */
+export interface AgentStyle {
+  /** Display name shown above the agent sprite */
+  readonly name: string;
+  /** Sprite/avatar identifier (e.g. 'robot-blue', 'cat-hacker', 'ninja-coder') */
+  readonly avatar: string;
+  /** Color theme for the agent's workspace area */
+  readonly color: string;
+  /** Animation set identifier */
+  readonly animation: 'default' | 'energetic' | 'chill' | 'focused';
+  /** Accessory items (hats, tools, pets) — freemium content */
+  readonly accessories: readonly string[];
+  /** Whether this style is a premium/freemium item */
+  readonly premium: boolean;
+}
+
+/** Predefined avatar styles by role — the starting collection */
+export const DEFAULT_AVATARS: Record<PersonaRole, string> = {
+  developer: 'robot-blue',
+  reviewer: 'owl-wise',
+  ops: 'hardhat-orange',
+  security: 'shield-guard',
+  ci: 'gears-bot',
+};
+
+/** Trust tier badge colors */
+export const TRUST_TIER_COLORS: Record<TrustTier, string> = {
+  untrusted: '#ef4444',
+  limited: '#f59e0b',
+  standard: '#3b82f6',
+  elevated: '#8b5cf6',
+  admin: '#10b981',
+};
+
+/** An agent worker in the digital office */
+export interface AgentWorker {
+  /** Unique worker ID (derived from agent identity hash) */
+  readonly id: string;
+  /** Agent persona from governance telemetry */
+  readonly persona: AgentPersona;
+  /** Visual style and customization */
+  readonly style: AgentStyle;
+  /** Current position in the 2D office grid */
+  position: { x: number; y: number };
+  /** Current activity state */
+  activity: AgentActivity;
+  /** Activity log — recent actions for the feed */
+  readonly recentActions: readonly AgentAction[];
+  /** Stats from telemetry */
+  readonly stats: AgentStats;
+}
+
+/** What the agent is currently doing */
+export type AgentActivity =
+  | { type: 'idle' }
+  | { type: 'coding'; file: string }
+  | { type: 'reviewing'; target: string }
+  | { type: 'pushing'; branch: string }
+  | { type: 'testing'; suite: string }
+  | { type: 'blocked'; reason: string }
+  | { type: 'walking'; destination: { x: number; y: number } };
+
+/** A recorded agent action for the activity feed */
+export interface AgentAction {
+  readonly timestamp: number;
+  readonly syscall: string;
+  readonly target: string;
+  readonly result: 'allow' | 'deny';
+}
+
+/** Aggregated stats for an agent worker */
+export interface AgentStats {
+  readonly totalActions: number;
+  readonly allowedActions: number;
+  readonly deniedActions: number;
+  readonly trustScore: number;
+  readonly uptime: number;
+}
+
+/** The full digital office state */
+export interface DigitalOffice {
+  /** All active agent workers */
+  readonly workers: AgentWorker[];
+  /** Office layout dimensions */
+  readonly width: number;
+  readonly height: number;
+  /** Office theme */
+  readonly theme: 'day' | 'night' | 'sunset';
+}
+
+/** Freemium content catalog item */
+export interface ShopItem {
+  readonly id: string;
+  readonly name: string;
+  readonly category: 'avatar' | 'accessory' | 'animation' | 'workspace-theme';
+  readonly preview: string;
+  readonly tier: 'free' | 'premium';
+  readonly description: string;
+}

--- a/apps/agentguardhq/tsconfig.json
+++ b/apps/agentguardhq/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declarationDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "../../packages/core" },
+    { "path": "../../packages/telemetry" }
+  ]
+}

--- a/apps/cli/src/commands/claude-hook.ts
+++ b/apps/cli/src/commands/claude-hook.ts
@@ -123,7 +123,13 @@ async function handlePreToolUse(payload: ClaudeCodeHookPayload, cliArgs: string[
     });
   }
 
-  const result = await processClaudeCodeHook(kernel, normalizedPayload);
+  // Resolve agent persona from environment variables.
+  // Persona enriches telemetry and enables persona-based policy conditions.
+  const { personaFromEnv: readPersonaFromEnv, resolvePersona } = await import('@red-codes/core');
+  const envPersona = readPersonaFromEnv();
+  const resolvedPersona = envPersona ? resolvePersona(undefined, envPersona) : undefined;
+
+  const result = await processClaudeCodeHook(kernel, normalizedPayload, {}, resolvedPersona);
   kernel.shutdown();
 
   // Close storage (important for SQLite to flush WAL)

--- a/apps/cli/src/session-store.ts
+++ b/apps/cli/src/session-store.ts
@@ -4,6 +4,7 @@
 import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
+import type { AgentPersona } from '@red-codes/core';
 
 const AGENTGUARD_DIR = join(homedir(), '.agentguard');
 const SESSIONS_DIR = join(AGENTGUARD_DIR, 'sessions');
@@ -25,6 +26,8 @@ interface SessionMeta {
   repo?: string;
   /** Seed used by the kernel RNG — stored for deterministic replay */
   seed?: number;
+  /** Agent persona active during this session */
+  persona?: AgentPersona;
 }
 
 interface SessionEvent {
@@ -40,6 +43,8 @@ interface SessionData {
   repo: string | null;
   /** Seed used by the kernel RNG — enables deterministic replay */
   seed: number | null;
+  /** Agent persona active during this session */
+  persona: AgentPersona | null;
   events: SessionEvent[];
   summary: Record<string, unknown> | null;
   endedAt: string | null;
@@ -63,6 +68,7 @@ export function createSession(meta: SessionMeta = {}): SessionWriter {
     command: meta.command || null,
     repo: meta.repo || null,
     seed: meta.seed ?? null,
+    persona: meta.persona ?? null,
     events: [],
     summary: null,
     endedAt: null,

--- a/packages/adapters/src/claude-code.ts
+++ b/packages/adapters/src/claude-code.ts
@@ -4,7 +4,8 @@
 
 import type { RawAgentAction } from '@red-codes/kernel';
 import type { Kernel, KernelResult } from '@red-codes/kernel';
-import { simpleHash } from '@red-codes/core';
+import type { AgentPersona } from '@red-codes/core';
+import { simpleHash, personaFromEnv } from '@red-codes/core';
 
 export interface ClaudeCodeToolUse {
   tool_name: string;
@@ -32,22 +33,30 @@ export function resolveAgentIdentity(sessionId?: string): string {
   return `claude-code:${simpleHash(sessionId.trim())}`;
 }
 
-export function normalizeClaudeCodeAction(payload: ClaudeCodeHookPayload): RawAgentAction {
+export function normalizeClaudeCodeAction(
+  payload: ClaudeCodeHookPayload,
+  persona?: AgentPersona,
+): RawAgentAction {
   const input = payload.tool_input || {};
   const agent = resolveAgentIdentity(payload.session_id);
+  const envPersona = personaFromEnv();
+  const resolvedPersona = persona || (envPersona as AgentPersona | undefined);
+
+  let baseAction: RawAgentAction;
 
   switch (payload.tool_name) {
     case 'Write':
-      return {
+      baseAction = {
         tool: 'Write',
         file: input.file_path as string | undefined,
         content: input.content as string | undefined,
         agent,
         metadata: { hook: payload.hook, sessionId: payload.session_id },
       };
+      break;
 
     case 'Edit':
-      return {
+      baseAction = {
         tool: 'Edit',
         file: input.file_path as string | undefined,
         content: input.new_string as string | undefined,
@@ -58,18 +67,20 @@ export function normalizeClaudeCodeAction(payload: ClaudeCodeHookPayload): RawAg
           sessionId: payload.session_id,
         },
       };
+      break;
 
     case 'Read':
-      return {
+      baseAction = {
         tool: 'Read',
         file: input.file_path as string | undefined,
         agent,
         metadata: { hook: payload.hook, sessionId: payload.session_id },
       };
+      break;
 
     case 'Bash': {
       const command = input.command as string | undefined;
-      return {
+      baseAction = {
         tool: 'Bash',
         command,
         target: command?.slice(0, 100),
@@ -81,65 +92,73 @@ export function normalizeClaudeCodeAction(payload: ClaudeCodeHookPayload): RawAg
           sessionId: payload.session_id,
         },
       };
+      break;
     }
 
     case 'Glob':
-      return {
+      baseAction = {
         tool: 'Glob',
         target: input.pattern as string | undefined,
         agent,
         metadata: { hook: payload.hook, path: input.path, sessionId: payload.session_id },
       };
+      break;
 
     case 'Grep':
-      return {
+      baseAction = {
         tool: 'Grep',
         target: input.pattern as string | undefined,
         agent,
         metadata: { hook: payload.hook, path: input.path, sessionId: payload.session_id },
       };
+      break;
 
     case 'NotebookEdit':
-      return {
+      baseAction = {
         tool: 'NotebookEdit',
         file: input.notebook_path as string | undefined,
         agent,
         metadata: { hook: payload.hook, cell_id: input.cell_id, sessionId: payload.session_id },
       };
+      break;
 
     case 'TodoWrite':
-      return {
+      baseAction = {
         tool: 'TodoWrite',
         agent,
         metadata: { hook: payload.hook, todos: input.todos, sessionId: payload.session_id },
       };
+      break;
 
     case 'WebFetch':
-      return {
+      baseAction = {
         tool: 'WebFetch',
         target: input.url as string | undefined,
         agent,
         metadata: { hook: payload.hook, prompt: input.prompt, sessionId: payload.session_id },
       };
+      break;
 
     case 'WebSearch':
-      return {
+      baseAction = {
         tool: 'WebSearch',
         target: input.query as string | undefined,
         agent,
         metadata: { hook: payload.hook, query: input.query, sessionId: payload.session_id },
       };
+      break;
 
     case 'Agent':
-      return {
+      baseAction = {
         tool: 'Agent',
         target: (input.prompt as string | undefined)?.slice(0, 100),
         agent,
         metadata: { hook: payload.hook, prompt: input.prompt, sessionId: payload.session_id },
       };
+      break;
 
     case 'Skill':
-      return {
+      baseAction = {
         tool: 'Skill',
         target: input.skill as string | undefined,
         agent,
@@ -150,22 +169,30 @@ export function normalizeClaudeCodeAction(payload: ClaudeCodeHookPayload): RawAg
           sessionId: payload.session_id,
         },
       };
+      break;
 
     default:
-      return {
+      baseAction = {
         tool: payload.tool_name,
         agent,
         metadata: { hook: payload.hook, input, sessionId: payload.session_id },
       };
+      break;
   }
+
+  if (resolvedPersona) {
+    return { ...baseAction, persona: resolvedPersona };
+  }
+  return baseAction;
 }
 
 export async function processClaudeCodeHook(
   kernel: Kernel,
   payload: ClaudeCodeHookPayload,
-  systemContext: Record<string, unknown> = {}
+  systemContext: Record<string, unknown> = {},
+  persona?: AgentPersona,
 ): Promise<KernelResult> {
-  const rawAction = normalizeClaudeCodeAction(payload);
+  const rawAction = normalizeClaudeCodeAction(payload, persona);
   return kernel.propose(rawAction, systemContext);
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,3 +5,4 @@ export * from './rng.js';
 export * from './adapters.js';
 export * from './execution-log/index.js';
 export * from './governance-data.js';
+export * from './persona.js';

--- a/packages/core/src/persona.ts
+++ b/packages/core/src/persona.ts
@@ -1,0 +1,166 @@
+// Agent persona resolver — merges persona from multiple sources (policy, env, per-action).
+// Layered: policy defaults < environment overrides < per-action overrides.
+
+import type {
+  AgentPersona,
+  AgentModelMeta,
+  TrustTier,
+  AutonomyLevel,
+  RiskTolerance,
+  PersonaRole,
+} from './types.js';
+
+const TRUST_TIERS: readonly string[] = ['untrusted', 'limited', 'standard', 'elevated', 'admin'];
+const AUTONOMY_LEVELS: readonly string[] = ['supervised', 'semi-autonomous', 'autonomous'];
+const RISK_TOLERANCES: readonly string[] = ['conservative', 'moderate', 'aggressive'];
+const PERSONA_ROLES: readonly string[] = ['developer', 'reviewer', 'ops', 'security', 'ci'];
+
+function isValidTrustTier(v: string): v is TrustTier {
+  return TRUST_TIERS.includes(v);
+}
+
+function isValidAutonomy(v: string): v is AutonomyLevel {
+  return AUTONOMY_LEVELS.includes(v);
+}
+
+function isValidRiskTolerance(v: string): v is RiskTolerance {
+  return RISK_TOLERANCES.includes(v);
+}
+
+function isValidRole(v: string): v is PersonaRole {
+  return PERSONA_ROLES.includes(v);
+}
+
+function mergeTags(
+  ...sources: (readonly string[] | undefined)[]
+): readonly string[] | undefined {
+  const merged = new Set<string>();
+  for (const tags of sources) {
+    if (tags) {
+      for (const t of tags) merged.add(t);
+    }
+  }
+  return merged.size > 0 ? [...merged] : undefined;
+}
+
+function mergeModelMeta(
+  ...sources: (AgentModelMeta | undefined)[]
+): AgentModelMeta | undefined {
+  const result: Record<string, string> = {};
+  for (const meta of sources) {
+    if (!meta) continue;
+    if (meta.model) result.model = meta.model;
+    if (meta.provider) result.provider = meta.provider;
+    if (meta.runtime) result.runtime = meta.runtime;
+    if (meta.version) result.version = meta.version;
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+/**
+ * Merge persona from multiple sources. Later sources override earlier ones.
+ * Order: policy defaults < environment overrides < per-action overrides.
+ */
+export function resolvePersona(
+  policyPersona?: Partial<AgentPersona>,
+  envPersona?: Partial<AgentPersona>,
+  actionPersona?: Partial<AgentPersona>,
+): AgentPersona {
+  const result: AgentPersona = {
+    modelMeta: mergeModelMeta(
+      policyPersona?.modelMeta,
+      envPersona?.modelMeta,
+      actionPersona?.modelMeta,
+    ),
+    trustTier:
+      actionPersona?.trustTier ?? envPersona?.trustTier ?? policyPersona?.trustTier,
+    autonomy:
+      actionPersona?.autonomy ?? envPersona?.autonomy ?? policyPersona?.autonomy,
+    riskTolerance:
+      actionPersona?.riskTolerance ?? envPersona?.riskTolerance ?? policyPersona?.riskTolerance,
+    role: actionPersona?.role ?? envPersona?.role ?? policyPersona?.role,
+    tags: mergeTags(policyPersona?.tags, envPersona?.tags, actionPersona?.tags),
+  };
+
+  return result;
+}
+
+/**
+ * Read persona fields from environment variables.
+ * Returns undefined if no persona env vars are set.
+ *
+ * Supported variables:
+ * - AGENTGUARD_PERSONA_MODEL
+ * - AGENTGUARD_PERSONA_PROVIDER
+ * - AGENTGUARD_PERSONA_RUNTIME
+ * - AGENTGUARD_PERSONA_VERSION
+ * - AGENTGUARD_PERSONA_TRUST_TIER
+ * - AGENTGUARD_PERSONA_AUTONOMY
+ * - AGENTGUARD_PERSONA_RISK_TOLERANCE
+ * - AGENTGUARD_PERSONA_ROLE
+ * - AGENTGUARD_PERSONA_TAGS (comma-separated)
+ */
+export function personaFromEnv(
+  env: Record<string, string | undefined> = process.env,
+): Partial<AgentPersona> | undefined {
+  const model = env.AGENTGUARD_PERSONA_MODEL;
+  const provider = env.AGENTGUARD_PERSONA_PROVIDER;
+  const runtime = env.AGENTGUARD_PERSONA_RUNTIME;
+  const version = env.AGENTGUARD_PERSONA_VERSION;
+  const trustTier = env.AGENTGUARD_PERSONA_TRUST_TIER;
+  const autonomy = env.AGENTGUARD_PERSONA_AUTONOMY;
+  const riskTolerance = env.AGENTGUARD_PERSONA_RISK_TOLERANCE;
+  const role = env.AGENTGUARD_PERSONA_ROLE;
+  const tagsRaw = env.AGENTGUARD_PERSONA_TAGS;
+
+  let hasAny = false;
+  const result: Record<string, unknown> = {};
+
+  // Model metadata
+  const modelMeta: Record<string, string> = {};
+  if (model) { modelMeta.model = model; hasAny = true; }
+  if (provider) { modelMeta.provider = provider; hasAny = true; }
+  if (runtime) { modelMeta.runtime = runtime; hasAny = true; }
+  if (version) { modelMeta.version = version; hasAny = true; }
+  if (Object.keys(modelMeta).length > 0) {
+    result.modelMeta = modelMeta;
+  }
+
+  // Behavioral traits
+  if (trustTier && isValidTrustTier(trustTier)) {
+    result.trustTier = trustTier;
+    hasAny = true;
+  }
+  if (autonomy && isValidAutonomy(autonomy)) {
+    result.autonomy = autonomy;
+    hasAny = true;
+  }
+  if (riskTolerance && isValidRiskTolerance(riskTolerance)) {
+    result.riskTolerance = riskTolerance;
+    hasAny = true;
+  }
+  if (role && isValidRole(role)) {
+    result.role = role;
+    hasAny = true;
+  }
+  if (tagsRaw) {
+    const tags = tagsRaw.split(',').map((t) => t.trim()).filter((t) => t.length > 0);
+    if (tags.length > 0) {
+      result.tags = tags;
+      hasAny = true;
+    }
+  }
+
+  return hasAny ? (result as Partial<AgentPersona>) : undefined;
+}
+
+export {
+  TRUST_TIERS,
+  AUTONOMY_LEVELS,
+  RISK_TOLERANCES,
+  PERSONA_ROLES,
+  isValidTrustTier,
+  isValidAutonomy,
+  isValidRiskTolerance,
+  isValidRole,
+};

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -739,6 +739,36 @@ export interface AdapterRegistry {
 // AgentGuard Types
 // ---------------------------------------------------------------------------
 
+/** Model metadata — structured info about the AI agent's underlying model */
+export interface AgentModelMeta {
+  readonly model?: string;
+  readonly provider?: string;
+  readonly runtime?: string;
+  readonly version?: string;
+}
+
+/** Trust tier — governs what actions an agent is allowed to take */
+export type TrustTier = 'untrusted' | 'limited' | 'standard' | 'elevated' | 'admin';
+
+/** Autonomy level — how independently the agent operates */
+export type AutonomyLevel = 'supervised' | 'semi-autonomous' | 'autonomous';
+
+/** Risk tolerance — how the agent approaches risky operations */
+export type RiskTolerance = 'conservative' | 'moderate' | 'aggressive';
+
+/** Agent persona role */
+export type PersonaRole = 'developer' | 'reviewer' | 'ops' | 'security' | 'ci';
+
+/** Agent persona — model metadata + behavioral traits for governance and visualization */
+export interface AgentPersona {
+  readonly modelMeta?: AgentModelMeta;
+  readonly trustTier?: TrustTier;
+  readonly autonomy?: AutonomyLevel;
+  readonly riskTolerance?: RiskTolerance;
+  readonly role?: PersonaRole;
+  readonly tags?: readonly string[];
+}
+
 /** Raw agent action before normalization */
 export interface RawAgentAction {
   readonly tool?: string;
@@ -747,6 +777,7 @@ export interface RawAgentAction {
   readonly content?: string;
   readonly branch?: string;
   readonly agent?: string;
+  readonly persona?: AgentPersona;
   [key: string]: unknown;
 }
 
@@ -758,6 +789,7 @@ export interface NormalizedIntent {
   readonly branch?: string;
   readonly command?: string;
   readonly filesAffected?: number;
+  readonly persona?: AgentPersona;
   readonly destructive: boolean;
 }
 
@@ -999,6 +1031,7 @@ export interface GovernanceDecisionRecord {
     agent: string;
     destructive: boolean;
     command?: string;
+    persona?: AgentPersona;
   };
   /** Final governance outcome */
   outcome: 'allow' | 'deny';

--- a/packages/core/tests/persona.test.ts
+++ b/packages/core/tests/persona.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import { resolvePersona, personaFromEnv } from '../src/persona.js';
+import type { AgentPersona } from '../src/types.js';
+
+describe('resolvePersona', () => {
+  it('returns empty persona when no sources provided', () => {
+    const result = resolvePersona();
+    expect(result.trustTier).toBeUndefined();
+    expect(result.role).toBeUndefined();
+    expect(result.modelMeta).toBeUndefined();
+  });
+
+  it('uses policy defaults when only policy persona provided', () => {
+    const policy: Partial<AgentPersona> = {
+      trustTier: 'standard',
+      role: 'developer',
+      modelMeta: { model: 'claude-sonnet-4-6', provider: 'anthropic' },
+    };
+    const result = resolvePersona(policy);
+    expect(result.trustTier).toBe('standard');
+    expect(result.role).toBe('developer');
+    expect(result.modelMeta?.model).toBe('claude-sonnet-4-6');
+  });
+
+  it('env overrides policy defaults', () => {
+    const policy: Partial<AgentPersona> = { trustTier: 'standard', role: 'developer' };
+    const env: Partial<AgentPersona> = { trustTier: 'elevated' };
+    const result = resolvePersona(policy, env);
+    expect(result.trustTier).toBe('elevated');
+    expect(result.role).toBe('developer'); // Falls through from policy
+  });
+
+  it('action overrides env and policy', () => {
+    const policy: Partial<AgentPersona> = { trustTier: 'standard' };
+    const env: Partial<AgentPersona> = { trustTier: 'elevated' };
+    const action: Partial<AgentPersona> = { trustTier: 'admin' };
+    const result = resolvePersona(policy, env, action);
+    expect(result.trustTier).toBe('admin');
+  });
+
+  it('merges tags from all sources', () => {
+    const policy: Partial<AgentPersona> = { tags: ['team-a'] };
+    const env: Partial<AgentPersona> = { tags: ['fast'] };
+    const action: Partial<AgentPersona> = { tags: ['urgent'] };
+    const result = resolvePersona(policy, env, action);
+    expect(result.tags).toContain('team-a');
+    expect(result.tags).toContain('fast');
+    expect(result.tags).toContain('urgent');
+  });
+
+  it('deduplicates tags', () => {
+    const a: Partial<AgentPersona> = { tags: ['x'] };
+    const b: Partial<AgentPersona> = { tags: ['x'] };
+    const result = resolvePersona(a, b);
+    expect(result.tags).toEqual(['x']);
+  });
+
+  it('merges model meta across sources', () => {
+    const policy: Partial<AgentPersona> = {
+      modelMeta: { model: 'claude-sonnet-4-6', provider: 'anthropic' },
+    };
+    const env: Partial<AgentPersona> = {
+      modelMeta: { runtime: 'claude-code' },
+    };
+    const result = resolvePersona(policy, env);
+    expect(result.modelMeta?.model).toBe('claude-sonnet-4-6');
+    expect(result.modelMeta?.provider).toBe('anthropic');
+    expect(result.modelMeta?.runtime).toBe('claude-code');
+  });
+});
+
+describe('personaFromEnv', () => {
+  it('returns undefined when no env vars set', () => {
+    expect(personaFromEnv({})).toBeUndefined();
+  });
+
+  it('reads model metadata from env', () => {
+    const result = personaFromEnv({
+      AGENTGUARD_PERSONA_MODEL: 'claude-sonnet-4-6',
+      AGENTGUARD_PERSONA_PROVIDER: 'anthropic',
+    });
+    expect(result).toBeDefined();
+    expect(result!.modelMeta?.model).toBe('claude-sonnet-4-6');
+    expect(result!.modelMeta?.provider).toBe('anthropic');
+  });
+
+  it('reads behavioral traits from env', () => {
+    const result = personaFromEnv({
+      AGENTGUARD_PERSONA_TRUST_TIER: 'elevated',
+      AGENTGUARD_PERSONA_ROLE: 'ops',
+      AGENTGUARD_PERSONA_AUTONOMY: 'autonomous',
+      AGENTGUARD_PERSONA_RISK_TOLERANCE: 'conservative',
+    });
+    expect(result).toBeDefined();
+    expect(result!.trustTier).toBe('elevated');
+    expect(result!.role).toBe('ops');
+    expect(result!.autonomy).toBe('autonomous');
+    expect(result!.riskTolerance).toBe('conservative');
+  });
+
+  it('reads comma-separated tags', () => {
+    const result = personaFromEnv({
+      AGENTGUARD_PERSONA_TAGS: 'team-a,fast,nightly',
+    });
+    expect(result).toBeDefined();
+    expect(result!.tags).toEqual(['team-a', 'fast', 'nightly']);
+  });
+
+  it('ignores invalid trust tier values', () => {
+    const result = personaFromEnv({
+      AGENTGUARD_PERSONA_TRUST_TIER: 'invalid-tier',
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it('ignores invalid role values', () => {
+    const result = personaFromEnv({
+      AGENTGUARD_PERSONA_ROLE: 'chef',
+    });
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/kernel/src/aab.ts
+++ b/packages/kernel/src/aab.ts
@@ -2,7 +2,7 @@
 // The central gatekeeper in the Runtime Assurance Architecture.
 // Pure domain logic. No DOM, no Node.js-specific APIs.
 
-import type { DomainEvent } from '@red-codes/core';
+import type { DomainEvent, AgentPersona } from '@red-codes/core';
 import {
   TOOL_ACTION_MAP_DATA,
   getDestructivePatterns,
@@ -28,6 +28,7 @@ export interface RawAgentAction {
   content?: string;
   branch?: string;
   agent?: string;
+  persona?: AgentPersona;
   filesAffected?: number;
   metadata?: Record<string, unknown>;
 }
@@ -106,6 +107,7 @@ export function normalizeIntent(rawAction: RawAgentAction | null): NormalizedInt
     command: rawAction.command || undefined,
     filesAffected: rawAction.filesAffected || undefined,
     metadata: rawAction.metadata || undefined,
+    persona: rawAction.persona || undefined,
     destructive: action === 'shell.exec' && isDestructiveCommand(rawAction.command || ''),
   };
 }

--- a/packages/kernel/src/decisions/factory.ts
+++ b/packages/kernel/src/decisions/factory.ts
@@ -34,6 +34,7 @@ export function buildDecisionRecord(input: DecisionFactoryInput): GovernanceDeci
       agent: intent.agent,
       destructive: intent.destructive,
       command: intent.command,
+      persona: intent.persona,
     },
     outcome: decision.allowed ? 'allow' : 'deny',
     reason: decision.decision.reason,

--- a/packages/kernel/src/kernel.ts
+++ b/packages/kernel/src/kernel.ts
@@ -149,7 +149,7 @@ export function createKernel(config: KernelConfig = {}): Kernel {
           justification: (rawAction.metadata?.justification as string) || 'agent action',
           actionId: undefined,
           agentId: rawAction.agent || 'unknown',
-          metadata: { runId, command: rawAction.command },
+          metadata: { runId, command: rawAction.command, persona: rawAction.persona },
         });
         allEvents.push(requestedEvent);
 

--- a/packages/policy/src/evaluator.ts
+++ b/packages/policy/src/evaluator.ts
@@ -1,6 +1,16 @@
 // Policy evaluator — matches actions against loaded policies.
 // Pure domain logic. No DOM, no Node.js-specific APIs.
 
+import type { AgentPersona } from '@red-codes/core';
+
+export interface PersonaCondition {
+  trustTier?: string[];
+  role?: string[];
+  autonomy?: string[];
+  riskTolerance?: string[];
+  tags?: string[];
+}
+
 export interface PolicyRule {
   action: string | string[];
   effect: 'allow' | 'deny';
@@ -9,6 +19,7 @@ export interface PolicyRule {
     limit?: number;
     branches?: string[];
     requireTests?: boolean;
+    persona?: PersonaCondition;
   };
   reason?: string;
 }
@@ -19,6 +30,7 @@ export interface LoadedPolicy {
   description?: string;
   rules: PolicyRule[];
   severity: number;
+  persona?: AgentPersona;
 }
 
 export interface NormalizedIntent {
@@ -29,6 +41,7 @@ export interface NormalizedIntent {
   command?: string;
   filesAffected?: number;
   metadata?: Record<string, unknown>;
+  persona?: AgentPersona;
   destructive: boolean;
 }
 
@@ -44,6 +57,7 @@ export interface RuleEvaluation {
     scopeMatched?: boolean;
     limitExceeded?: boolean;
     branchMatched?: boolean;
+    personaMatched?: boolean;
   };
   outcome: 'match' | 'no-match' | 'skipped';
 }
@@ -101,6 +115,34 @@ interface ConditionMatchResult {
   scopeMatched?: boolean;
   limitExceeded?: boolean;
   branchMatched?: boolean;
+  personaMatched?: boolean;
+}
+
+function matchPersonaCondition(
+  personaCond: PersonaCondition,
+  persona: AgentPersona | undefined,
+): boolean {
+  if (!persona) return false;
+
+  if (personaCond.trustTier && personaCond.trustTier.length > 0) {
+    if (!persona.trustTier || !personaCond.trustTier.includes(persona.trustTier)) return false;
+  }
+  if (personaCond.role && personaCond.role.length > 0) {
+    if (!persona.role || !personaCond.role.includes(persona.role)) return false;
+  }
+  if (personaCond.autonomy && personaCond.autonomy.length > 0) {
+    if (!persona.autonomy || !personaCond.autonomy.includes(persona.autonomy)) return false;
+  }
+  if (personaCond.riskTolerance && personaCond.riskTolerance.length > 0) {
+    if (!persona.riskTolerance || !personaCond.riskTolerance.includes(persona.riskTolerance)) {
+      return false;
+    }
+  }
+  if (personaCond.tags && personaCond.tags.length > 0) {
+    if (!persona.tags || !personaCond.tags.some((t) => persona.tags!.includes(t))) return false;
+  }
+
+  return true;
 }
 
 function matchConditions(
@@ -116,6 +158,7 @@ function matchConditions(
   const scopeMatched = conditions.scope ? true : undefined;
   let limitExceeded: boolean | undefined;
   let branchMatched: boolean | undefined;
+  let personaMatched: boolean | undefined;
 
   if (conditions.limit !== undefined && intent.filesAffected !== undefined) {
     limitExceeded = intent.filesAffected > conditions.limit;
@@ -131,7 +174,14 @@ function matchConditions(
     }
   }
 
-  return { matched: true, scopeMatched, limitExceeded, branchMatched };
+  if (conditions.persona) {
+    personaMatched = matchPersonaCondition(conditions.persona, intent.persona);
+    if (!personaMatched) {
+      return { matched: false, scopeMatched, limitExceeded, branchMatched, personaMatched };
+    }
+  }
+
+  return { matched: true, scopeMatched, limitExceeded, branchMatched, personaMatched };
 }
 
 function ruleKey(policyId: string, ruleIndex: number): string {
@@ -158,6 +208,7 @@ function createRuleEval(
           scopeMatched: conditionResult.scopeMatched,
           limitExceeded: conditionResult.limitExceeded,
           branchMatched: conditionResult.branchMatched,
+          personaMatched: conditionResult.personaMatched,
         }
       : {},
     outcome,
@@ -311,4 +362,4 @@ export function evaluate(intent: NormalizedIntent, policies: LoadedPolicy[]): Ev
   };
 }
 
-export { matchAction, matchScope };
+export { matchAction, matchScope, matchPersonaCondition };

--- a/packages/policy/src/yaml-loader.ts
+++ b/packages/policy/src/yaml-loader.ts
@@ -2,7 +2,20 @@
 // Supports the subset of YAML needed for AgentGuard policy definitions.
 // No external dependencies — minimal line-based parser for constrained format.
 
-import type { PolicyRule, LoadedPolicy } from './evaluator.js';
+import type { PolicyRule, LoadedPolicy, PersonaCondition } from './evaluator.js';
+import type { AgentPersona } from '@red-codes/core';
+
+export interface YamlPersonaDef {
+  model?: string;
+  provider?: string;
+  runtime?: string;
+  version?: string;
+  trustTier?: string;
+  autonomy?: string;
+  riskTolerance?: string;
+  role?: string;
+  tags?: string[];
+}
 
 export interface YamlPolicyDef {
   id?: string;
@@ -10,6 +23,7 @@ export interface YamlPolicyDef {
   description?: string;
   severity?: number;
   extends?: string[];
+  persona?: YamlPersonaDef;
   rules?: YamlRule[];
 }
 
@@ -21,6 +35,7 @@ interface YamlRule {
   reason?: string;
   limit?: number;
   requireTests?: boolean;
+  persona?: PersonaCondition;
 }
 
 function trimQuotes(s: string): string {
@@ -55,6 +70,80 @@ function indentLevel(line: string): number {
   return match ? match[1].length : 0;
 }
 
+function applyPersonaField(persona: PersonaCondition, key: string, val: string): void {
+  switch (key) {
+    case 'trustTier': {
+      const arr = parseInlineArray(val);
+      if (arr.length > 0) persona.trustTier = arr;
+      else if (val) persona.trustTier = [trimQuotes(val)];
+      break;
+    }
+    case 'role': {
+      const arr = parseInlineArray(val);
+      if (arr.length > 0) persona.role = arr;
+      else if (val) persona.role = [trimQuotes(val)];
+      break;
+    }
+    case 'autonomy': {
+      const arr = parseInlineArray(val);
+      if (arr.length > 0) persona.autonomy = arr;
+      else if (val) persona.autonomy = [trimQuotes(val)];
+      break;
+    }
+    case 'riskTolerance': {
+      const arr = parseInlineArray(val);
+      if (arr.length > 0) persona.riskTolerance = arr;
+      else if (val) persona.riskTolerance = [trimQuotes(val)];
+      break;
+    }
+    case 'tags': {
+      const arr = parseInlineArray(val);
+      if (arr.length > 0) persona.tags = arr;
+      else if (val) persona.tags = [trimQuotes(val)];
+      break;
+    }
+  }
+}
+
+function applyTopLevelPersonaField(
+  persona: YamlPersonaDef,
+  key: string,
+  val: string,
+): void {
+  switch (key) {
+    case 'model':
+      persona.model = trimQuotes(val);
+      break;
+    case 'provider':
+      persona.provider = trimQuotes(val);
+      break;
+    case 'runtime':
+      persona.runtime = trimQuotes(val);
+      break;
+    case 'version':
+      persona.version = trimQuotes(val);
+      break;
+    case 'trustTier':
+      persona.trustTier = trimQuotes(val);
+      break;
+    case 'autonomy':
+      persona.autonomy = trimQuotes(val);
+      break;
+    case 'riskTolerance':
+      persona.riskTolerance = trimQuotes(val);
+      break;
+    case 'role':
+      persona.role = trimQuotes(val);
+      break;
+    case 'tags': {
+      const arr = parseInlineArray(val);
+      if (arr.length > 0) persona.tags = arr;
+      else if (val) persona.tags = [trimQuotes(val)];
+      break;
+    }
+  }
+}
+
 export function parseYamlPolicy(yaml: string): YamlPolicyDef {
   const lines = yaml.split('\n');
   const result: YamlPolicyDef = {};
@@ -63,6 +152,8 @@ export function parseYamlPolicy(yaml: string): YamlPolicyDef {
   let inRules = false;
   let inBranches = false;
   let inExtends = false;
+  let inTopLevelPersona = false;
+  let inRulePersona = false;
 
   for (const rawLine of lines) {
     const line = rawLine.replace(/\r$/, '');
@@ -78,6 +169,8 @@ export function parseYamlPolicy(yaml: string): YamlPolicyDef {
       inRules = false;
       inBranches = false;
       inExtends = false;
+      inTopLevelPersona = false;
+      inRulePersona = false;
       if (currentRule) {
         rules.push(currentRule);
         currentRule = null;
@@ -115,9 +208,25 @@ export function parseYamlPolicy(yaml: string): YamlPolicyDef {
             result.extends = [];
           }
           break;
+        case 'persona':
+          inTopLevelPersona = true;
+          result.persona = result.persona || {};
+          break;
         case 'rules':
           inRules = true;
           break;
+      }
+      continue;
+    }
+
+    // Inside top-level persona block
+    if (inTopLevelPersona && !inRules) {
+      const colonIdx = trimmed.indexOf(':');
+      if (colonIdx !== -1) {
+        const key = trimmed.slice(0, colonIdx).trim();
+        const val = trimmed.slice(colonIdx + 1).trim();
+        result.persona = result.persona || {};
+        applyTopLevelPersonaField(result.persona, key, val);
       }
       continue;
     }
@@ -136,6 +245,7 @@ export function parseYamlPolicy(yaml: string): YamlPolicyDef {
         if (currentRule) rules.push(currentRule);
         currentRule = {};
         inBranches = false;
+        inRulePersona = false;
 
         const rest = trimmed.slice(2).trim();
         const colonIdx = rest.indexOf(':');
@@ -143,6 +253,18 @@ export function parseYamlPolicy(yaml: string): YamlPolicyDef {
           const key = rest.slice(0, colonIdx).trim();
           const val = rest.slice(colonIdx + 1).trim();
           applyRuleField(currentRule, key, val);
+        }
+        continue;
+      }
+
+      // Inside rule-level persona block
+      if (inRulePersona && currentRule) {
+        const colonIdx = trimmed.indexOf(':');
+        if (colonIdx !== -1) {
+          const key = trimmed.slice(0, colonIdx).trim();
+          const val = trimmed.slice(colonIdx + 1).trim();
+          currentRule.persona = currentRule.persona || {};
+          applyPersonaField(currentRule.persona, key, val);
         }
         continue;
       }
@@ -165,6 +287,12 @@ export function parseYamlPolicy(yaml: string): YamlPolicyDef {
           if (key === 'branches' && !val) {
             inBranches = true;
             currentRule.branches = [];
+            continue;
+          }
+
+          if (key === 'persona' && !val) {
+            inRulePersona = true;
+            currentRule.persona = {};
             continue;
           }
 
@@ -234,6 +362,11 @@ function convertRule(yamlRule: YamlRule): PolicyRule {
     hasConditions = true;
   }
 
+  if (yamlRule.persona) {
+    conditions.persona = yamlRule.persona;
+    hasConditions = true;
+  }
+
   return {
     action: yamlRule.action || '*',
     effect: (yamlRule.effect as 'allow' | 'deny') || 'deny',
@@ -242,16 +375,43 @@ function convertRule(yamlRule: YamlRule): PolicyRule {
   };
 }
 
+/** Convert a YamlPersonaDef to an AgentPersona (for policy defaults). */
+export function yamlPersonaToAgentPersona(def: YamlPersonaDef): AgentPersona {
+  const persona: Record<string, unknown> = {};
+  const modelMeta: Record<string, string> = {};
+
+  if (def.model) modelMeta.model = def.model;
+  if (def.provider) modelMeta.provider = def.provider;
+  if (def.runtime) modelMeta.runtime = def.runtime;
+  if (def.version) modelMeta.version = def.version;
+  if (Object.keys(modelMeta).length > 0) persona.modelMeta = modelMeta;
+
+  if (def.trustTier) persona.trustTier = def.trustTier;
+  if (def.autonomy) persona.autonomy = def.autonomy;
+  if (def.riskTolerance) persona.riskTolerance = def.riskTolerance;
+  if (def.role) persona.role = def.role;
+  if (def.tags) persona.tags = def.tags;
+
+  return persona as AgentPersona;
+}
+
 export function loadYamlPolicy(yaml: string, defaultId?: string): LoadedPolicy {
   const def = parseYamlPolicy(yaml);
 
-  return {
+  const policy: LoadedPolicy = {
     id: def.id || defaultId || 'yaml-policy',
     name: def.name || 'YAML Policy',
     description: def.description,
     rules: (def.rules || []).map(convertRule),
     severity: def.severity ?? 3,
   };
+
+  if (def.persona) {
+    (policy as LoadedPolicy & { persona?: AgentPersona }).persona =
+      yamlPersonaToAgentPersona(def.persona);
+  }
+
+  return policy;
 }
 
 export function loadYamlPolicies(yaml: string): LoadedPolicy[] {

--- a/packages/policy/tests/evaluator-persona.test.ts
+++ b/packages/policy/tests/evaluator-persona.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'vitest';
+import { evaluate } from '../src/evaluator.js';
+import type { NormalizedIntent, LoadedPolicy } from '../src/evaluator.js';
+
+function makeIntent(overrides: Partial<NormalizedIntent> = {}): NormalizedIntent {
+  return {
+    action: 'git.push',
+    target: 'main',
+    agent: 'test-agent',
+    destructive: false,
+    ...overrides,
+  };
+}
+
+function makePolicy(overrides: Partial<LoadedPolicy> = {}): LoadedPolicy {
+  return {
+    id: 'test-policy',
+    name: 'Test Policy',
+    rules: [],
+    severity: 3,
+    ...overrides,
+  };
+}
+
+describe('policy evaluator — persona conditions', () => {
+  it('denies when persona trustTier matches deny rule', () => {
+    const intent = makeIntent({
+      persona: { trustTier: 'untrusted', role: 'developer' },
+    });
+    const policy = makePolicy({
+      rules: [
+        {
+          action: 'git.push',
+          effect: 'deny',
+          conditions: { persona: { trustTier: ['untrusted', 'limited'] } },
+          reason: 'Low-trust agents cannot push',
+        },
+      ],
+    });
+    const result = evaluate(intent, [policy]);
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toBe('Low-trust agents cannot push');
+  });
+
+  it('allows when persona trustTier does not match deny rule', () => {
+    const intent = makeIntent({
+      persona: { trustTier: 'standard' },
+    });
+    const policy = makePolicy({
+      rules: [
+        {
+          action: 'git.push',
+          effect: 'deny',
+          conditions: { persona: { trustTier: ['untrusted'] } },
+          reason: 'Untrusted cannot push',
+        },
+      ],
+    });
+    const result = evaluate(intent, [policy]);
+    expect(result.allowed).toBe(true);
+  });
+
+  it('does not match persona condition when intent has no persona', () => {
+    const intent = makeIntent(); // no persona
+    const policy = makePolicy({
+      rules: [
+        {
+          action: 'git.push',
+          effect: 'deny',
+          conditions: { persona: { trustTier: ['untrusted'] } },
+          reason: 'Should not match without persona',
+        },
+      ],
+    });
+    const result = evaluate(intent, [policy]);
+    expect(result.allowed).toBe(true);
+  });
+
+  it('matches on role condition', () => {
+    const intent = makeIntent({
+      persona: { role: 'ci' },
+    });
+    const policy = makePolicy({
+      rules: [
+        {
+          action: 'git.push',
+          effect: 'deny',
+          conditions: { persona: { role: ['ci'] } },
+          reason: 'CI agents cannot push directly',
+        },
+      ],
+    });
+    const result = evaluate(intent, [policy]);
+    expect(result.allowed).toBe(false);
+  });
+
+  it('matches on tags condition (any match)', () => {
+    const intent = makeIntent({
+      persona: { tags: ['nightly', 'team-a'] },
+    });
+    const policy = makePolicy({
+      rules: [
+        {
+          action: '*',
+          effect: 'deny',
+          conditions: { persona: { tags: ['nightly'] } },
+          reason: 'Nightly agents restricted',
+        },
+      ],
+    });
+    const result = evaluate(intent, [policy]);
+    expect(result.allowed).toBe(false);
+  });
+
+  it('requires all persona sub-conditions to match (AND semantics)', () => {
+    const intent = makeIntent({
+      persona: { trustTier: 'untrusted', role: 'developer' },
+    });
+    const policy = makePolicy({
+      rules: [
+        {
+          action: 'git.push',
+          effect: 'deny',
+          conditions: { persona: { trustTier: ['untrusted'], role: ['ci'] } },
+          reason: 'Must match both',
+        },
+      ],
+    });
+    // trustTier matches but role doesn't → should NOT match
+    const result = evaluate(intent, [policy]);
+    expect(result.allowed).toBe(true);
+  });
+
+  it('includes personaMatched in evaluation trace', () => {
+    const intent = makeIntent({
+      persona: { trustTier: 'untrusted' },
+    });
+    const policy = makePolicy({
+      rules: [
+        {
+          action: 'git.push',
+          effect: 'deny',
+          conditions: { persona: { trustTier: ['untrusted'] } },
+          reason: 'Denied',
+        },
+      ],
+    });
+    const result = evaluate(intent, [policy]);
+    expect(result.trace).toBeDefined();
+    const matchedRule = result.trace!.rulesEvaluated.find((r) => r.outcome === 'match');
+    expect(matchedRule).toBeDefined();
+    expect(matchedRule!.conditionDetails.personaMatched).toBe(true);
+  });
+});

--- a/packages/policy/tests/yaml-persona.test.ts
+++ b/packages/policy/tests/yaml-persona.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { parseYamlPolicy, loadYamlPolicy, yamlPersonaToAgentPersona } from '../src/yaml-loader.js';
+
+describe('YAML loader — persona parsing', () => {
+  it('parses top-level persona section', () => {
+    const yaml = `
+id: test-policy
+name: Test
+persona:
+  trustTier: standard
+  role: developer
+  model: claude-sonnet-4-6
+  provider: anthropic
+rules:
+  - action: git.push
+    effect: deny
+`;
+    const def = parseYamlPolicy(yaml);
+    expect(def.persona).toBeDefined();
+    expect(def.persona!.trustTier).toBe('standard');
+    expect(def.persona!.role).toBe('developer');
+    expect(def.persona!.model).toBe('claude-sonnet-4-6');
+    expect(def.persona!.provider).toBe('anthropic');
+  });
+
+  it('parses per-rule persona conditions with inline arrays', () => {
+    const yaml = `
+rules:
+  - action: git.push
+    effect: deny
+    persona:
+      trustTier: [untrusted, limited]
+      role: [ci]
+    reason: Low-trust or CI agents cannot push
+`;
+    const def = parseYamlPolicy(yaml);
+    expect(def.rules).toHaveLength(1);
+    expect(def.rules![0].persona).toBeDefined();
+    expect(def.rules![0].persona!.trustTier).toEqual(['untrusted', 'limited']);
+    expect(def.rules![0].persona!.role).toEqual(['ci']);
+  });
+
+  it('parses per-rule persona with single values', () => {
+    const yaml = `
+rules:
+  - action: shell.exec
+    effect: deny
+    persona:
+      trustTier: untrusted
+    reason: Untrusted agents cannot exec
+`;
+    const def = parseYamlPolicy(yaml);
+    expect(def.rules![0].persona!.trustTier).toEqual(['untrusted']);
+  });
+
+  it('converts persona conditions in loaded policy rules', () => {
+    const yaml = `
+rules:
+  - action: git.push
+    effect: deny
+    persona:
+      trustTier: [untrusted]
+    reason: Denied
+`;
+    const policy = loadYamlPolicy(yaml);
+    expect(policy.rules).toHaveLength(1);
+    expect(policy.rules[0].conditions?.persona).toBeDefined();
+    expect(policy.rules[0].conditions!.persona!.trustTier).toEqual(['untrusted']);
+  });
+
+  it('converts top-level persona to AgentPersona', () => {
+    const def = {
+      model: 'claude-opus-4-6',
+      provider: 'anthropic',
+      runtime: 'claude-code',
+      trustTier: 'elevated',
+      role: 'security',
+      tags: ['audit', 'production'],
+    };
+    const persona = yamlPersonaToAgentPersona(def);
+    expect(persona.modelMeta?.model).toBe('claude-opus-4-6');
+    expect(persona.modelMeta?.provider).toBe('anthropic');
+    expect(persona.modelMeta?.runtime).toBe('claude-code');
+    expect(persona.trustTier).toBe('elevated');
+    expect(persona.role).toBe('security');
+    expect(persona.tags).toEqual(['audit', 'production']);
+  });
+
+  it('parses persona with tags', () => {
+    const yaml = `
+rules:
+  - action: '*'
+    effect: deny
+    persona:
+      tags: [nightly, canary]
+    reason: Special agents restricted
+`;
+    const def = parseYamlPolicy(yaml);
+    expect(def.rules![0].persona!.tags).toEqual(['nightly', 'canary']);
+  });
+});

--- a/packages/telemetry/src/runtimeLogger.ts
+++ b/packages/telemetry/src/runtimeLogger.ts
@@ -12,7 +12,7 @@ const DEFAULT_LOG_FILE = 'runtime-events.jsonl';
 
 /** Map a GovernanceDecisionRecord to a flattened TelemetryEvent. */
 export function buildTelemetryEvent(record: GovernanceDecisionRecord): TelemetryEvent {
-  return {
+  const event: TelemetryEvent = {
     timestamp: new Date(record.timestamp).toISOString(),
     agent: record.action.agent,
     run_id: record.runId,
@@ -22,6 +22,16 @@ export function buildTelemetryEvent(record: GovernanceDecisionRecord): Telemetry
     policy_result: record.outcome,
     invariant_result: record.invariants.allHold ? 'pass' : 'fail',
   };
+
+  const persona = record.action.persona;
+  if (persona) {
+    if (persona.modelMeta?.model) event.model = persona.modelMeta.model;
+    if (persona.modelMeta?.provider) event.provider = persona.modelMeta.provider;
+    if (persona.trustTier) event.trust_tier = persona.trustTier;
+    if (persona.role) event.role = persona.role;
+  }
+
+  return event;
 }
 
 /** Create a TelemetrySink that appends JSON lines to a single shared log file. */

--- a/packages/telemetry/src/types.ts
+++ b/packages/telemetry/src/types.ts
@@ -12,6 +12,10 @@ export interface TelemetryEvent {
   invariant_result: 'pass' | 'fail';
   issue_id?: number;
   diff_size?: number;
+  model?: string;
+  provider?: string;
+  trust_tier?: string;
+  role?: string;
   metadata?: Record<string, unknown>;
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,15 @@ importers:
         specifier: ^4.0.18
         version: 4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
+  apps/agentguardhq:
+    dependencies:
+      '@red-codes/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@red-codes/telemetry':
+        specifier: workspace:*
+        version: link:../../packages/telemetry
+
   apps/cli:
     dependencies:
       '@red-codes/adapters':

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
     { "path": "packages/renderers" },
     { "path": "packages/swarm" },
     { "path": "apps/cli" },
-    { "path": "apps/telemetry-server" }
+    { "path": "apps/telemetry-server" },
+    { "path": "apps/agentguardhq" }
   ]
 }


### PR DESCRIPTION
Add AgentPersona type system with model metadata (model, provider, runtime,
version) and behavioral traits (trustTier, autonomy, riskTolerance, role, tags).
Persona flows through the full governance pipeline:

- Core: AgentPersona type, resolvePersona() merger, personaFromEnv() reader
- Policy: persona conditions on rules (trustTier, role, autonomy, tags matching)
- YAML: top-level persona defaults + per-rule persona condition blocks
- Kernel: persona threaded through AAB normalization and decision records
- Telemetry: model, provider, trust_tier, role fields in TelemetryEvent
- Adapter: Claude Code adapter resolves persona from environment
- Session: persona stored in session metadata

Also stubs apps/agentguardhq — the digital office visualization concept where
agents appear as 2D workers with customizable styles, walking around and
performing tasks powered by persona telemetry. Includes freemium content catalog.

https://claude.ai/code/session_01QQdCTqba7jXxAP3ohjbbwy