### PR TITLE
feat: add tamper-resistant hash-chained audit trail and enforcement reports

### DIFF
--- a/apps/cli/src/bin.ts
+++ b/apps/cli/src/bin.ts
@@ -326,6 +326,24 @@ const COMMANDS: Record<string, CommandHelp> = {
       'agentguard evidence-pr --run run_1234567890_abc',
     ],
   },
+  'audit-verify': {
+    name: 'agentguard audit-verify',
+    description: 'Verify tamper-resistant audit chain integrity and generate enforcement report',
+    usage: 'agentguard audit-verify [runId] [flags]',
+    flags: [
+      { flag: '--last', description: 'Verify the most recent chained audit trail' },
+      { flag: '--list', description: 'List all chained audit trails' },
+      { flag: '--report', description: 'Generate full enforcement audit report' },
+      { flag: '--json', description: 'Output as JSON' },
+    ],
+    examples: [
+      'agentguard audit-verify --last',
+      'agentguard audit-verify --list',
+      'agentguard audit-verify --last --report',
+      'agentguard audit-verify --last --report --json',
+      'agentguard audit-verify run_1234567890_abc',
+    ],
+  },
   'session-viewer': {
     name: 'agentguard session-viewer',
     description: 'Generate an interactive HTML visualization of a governance session',
@@ -567,6 +585,17 @@ async function main() {
       break;
     }
 
+    case 'audit-verify': {
+      if (wantsHelp) {
+        console.log(formatHelp(COMMANDS['audit-verify']));
+        break;
+      }
+      const { auditVerify } = await import('./commands/audit-verify.js');
+      const code = await auditVerify(args.slice(1));
+      process.exit(code);
+      break;
+    }
+
     case 'session-viewer': {
       if (wantsHelp) {
         console.log(formatHelp(COMMANDS['session-viewer']));
@@ -679,6 +708,12 @@ function printHelp(): void {
     agentguard session-viewer --last          Open session viewer in browser
     agentguard session-viewer <runId>         Visualize a specific run
     agentguard session-viewer --last -o f.html  Save to file without opening
+
+  \x1b[1mAudit:\x1b[0m
+    agentguard audit-verify --last            Verify audit chain integrity
+    agentguard audit-verify --list            List chained audit trails
+    agentguard audit-verify --last --report   Full enforcement audit report
+    agentguard audit-verify ... --json        Output as JSON
 
   \x1b[1mEvidence:\x1b[0m
     agentguard evidence-pr                    Attach governance evidence to a PR

--- a/apps/cli/src/commands/audit-verify.ts
+++ b/apps/cli/src/commands/audit-verify.ts
@@ -1,0 +1,145 @@
+// CLI command: agentguard audit-verify — verify tamper-resistant audit chain
+// and generate enforcement audit report.
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  verifyChainedJsonl,
+  getChainedEventFilePath,
+} from '@red-codes/events';
+import { getDecisionFilePath } from '@red-codes/events';
+import {
+  generateEnforcementAudit,
+  formatEnforcementAudit,
+} from '@red-codes/kernel';
+import type { GovernanceDecisionRecord } from '@red-codes/core';
+
+const BASE_DIR = '.agentguard';
+const EVENTS_DIR = join(BASE_DIR, 'events');
+
+function listChainedRuns(): string[] {
+  if (!existsSync(EVENTS_DIR)) return [];
+  return readdirSync(EVENTS_DIR)
+    .filter((f) => f.endsWith('.chained.jsonl'))
+    .map((f) => f.replace('.chained.jsonl', ''))
+    .sort();
+}
+
+function findLastChainedRun(): string | null {
+  const runs = listChainedRuns();
+  return runs.length > 0 ? runs[runs.length - 1] : null;
+}
+
+function loadDecisions(runId: string): GovernanceDecisionRecord[] {
+  const filePath = getDecisionFilePath(runId);
+  if (!existsSync(filePath)) return [];
+  const content = readFileSync(filePath, 'utf8');
+  const records: GovernanceDecisionRecord[] = [];
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      records.push(JSON.parse(trimmed) as GovernanceDecisionRecord);
+    } catch {
+      // skip malformed
+    }
+  }
+  return records;
+}
+
+export async function auditVerify(args: string[]): Promise<number> {
+  const wantsJson = args.includes('--json');
+  const wantsReport = args.includes('--report');
+  const wantsList = args.includes('--list');
+  const wantsLast = args.includes('--last');
+
+  // List available chained runs
+  if (wantsList) {
+    const runs = listChainedRuns();
+    if (runs.length === 0) {
+      console.log('  No chained audit trails found.');
+      return 0;
+    }
+    console.log(`\n  Chained audit trails (${runs.length}):\n`);
+    for (const r of runs) {
+      console.log(`    ${r}`);
+    }
+    console.log('');
+    return 0;
+  }
+
+  // Resolve run ID
+  let runId: string | null = null;
+  if (wantsLast) {
+    runId = findLastChainedRun();
+    if (!runId) {
+      console.error('  No chained audit trails found.');
+      return 1;
+    }
+  } else {
+    // First positional argument that isn't a flag
+    runId = args.find((a) => !a.startsWith('--')) || null;
+    if (!runId) {
+      runId = findLastChainedRun();
+      if (!runId) {
+        console.error('  Usage: agentguard audit-verify [runId] [--last] [--report] [--json]');
+        return 1;
+      }
+    }
+  }
+
+  // Verify chain integrity
+  const chainPath = getChainedEventFilePath(runId);
+  const verification = verifyChainedJsonl(chainPath);
+
+  if (wantsJson && !wantsReport) {
+    console.log(JSON.stringify(verification, null, 2));
+    return verification.valid ? 0 : 1;
+  }
+
+  if (!wantsReport) {
+    // Just show verification result
+    console.log('');
+    console.log('  Audit Chain Verification');
+    console.log('  ========================');
+    console.log(`  Run:      ${runId}`);
+    console.log(`  File:     ${chainPath}`);
+    console.log(`  Records:  ${verification.totalRecords}`);
+    console.log(`  Verified: ${verification.verifiedRecords}`);
+
+    if (verification.valid) {
+      console.log(`  Status:   \x1b[32mINTEGRITY VERIFIED\x1b[0m`);
+    } else {
+      console.log(`  Status:   \x1b[31mINTEGRITY FAILURE\x1b[0m`);
+      if (verification.brokenAt) {
+        console.log(`  Broken at seq ${verification.brokenAt.seq}: ${verification.brokenAt.reason}`);
+      }
+    }
+
+    if (verification.timeRange) {
+      const first = new Date(verification.timeRange.first).toISOString();
+      const last = new Date(verification.timeRange.last).toISOString();
+      console.log(`  From:     ${first}`);
+      console.log(`  To:       ${last}`);
+    }
+
+    console.log('');
+    return verification.valid ? 0 : 1;
+  }
+
+  // Full enforcement audit report
+  const decisions = loadDecisions(runId);
+  const report = generateEnforcementAudit({
+    runId,
+    decisions,
+    chainVerified: verification.valid,
+  });
+
+  if (wantsJson) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    console.log(formatEnforcementAudit(report));
+  }
+
+  return verification.valid ? 0 : 1;
+}

--- a/packages/events/src/chained-jsonl.ts
+++ b/packages/events/src/chained-jsonl.ts
@@ -1,0 +1,272 @@
+// Hash-chained JSONL sink — tamper-resistant audit trail.
+// Each record includes a chain hash that incorporates the previous record's hash,
+// creating an immutable sequence. Any insertion, deletion, or modification
+// of a record breaks the chain and is detectable via verification.
+
+import { createHash } from 'node:crypto';
+import { mkdirSync, appendFileSync, readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import type { DomainEvent, EventSink } from '@red-codes/core';
+
+const DEFAULT_BASE_DIR = '.agentguard';
+const EVENTS_DIR = 'events';
+
+/** A chained record wrapping a domain event with integrity metadata */
+export interface ChainedRecord {
+  /** Sequence number (0-indexed, monotonically increasing) */
+  seq: number;
+  /** SHA-256 hash of this record's content + previous hash */
+  chainHash: string;
+  /** Hash of the previous record (genesis record uses a well-known seed) */
+  prevHash: string;
+  /** The domain event payload */
+  event: DomainEvent;
+}
+
+/** Result of verifying a chained audit trail */
+export interface ChainVerificationResult {
+  /** Whether the entire chain is valid */
+  valid: boolean;
+  /** Total number of records in the chain */
+  totalRecords: number;
+  /** Number of records that passed verification */
+  verifiedRecords: number;
+  /** Details of the first broken link, if any */
+  brokenAt?: {
+    seq: number;
+    expectedHash: string;
+    actualHash: string;
+    reason: string;
+  };
+  /** Run ID extracted from the file name */
+  runId?: string;
+  /** Time span covered by the chain */
+  timeRange?: {
+    first: number;
+    last: number;
+  };
+}
+
+/** Well-known seed for the genesis record's prevHash */
+const GENESIS_PREV_HASH = '0000000000000000000000000000000000000000000000000000000000000000';
+
+/**
+ * Compute the chain hash for a record.
+ * Hash = SHA-256(prevHash + seq + JSON(event))
+ */
+function computeChainHash(prevHash: string, seq: number, event: DomainEvent): string {
+  const content = `${prevHash}:${seq}:${JSON.stringify(event)}`;
+  return createHash('sha256').update(content, 'utf8').digest('hex');
+}
+
+export interface ChainedJsonlSinkOptions {
+  baseDir?: string;
+  runId: string;
+  /** Optional callback invoked when a write fails. Errors are never thrown to avoid crashing the kernel. */
+  onError?: (error: Error) => void;
+}
+
+export interface ChainedJsonlSink extends EventSink {
+  /** Get the current chain length */
+  length(): number;
+  /** Get the current chain head hash */
+  headHash(): string;
+}
+
+export function createChainedJsonlSink(options: ChainedJsonlSinkOptions): ChainedJsonlSink {
+  const baseDir = options.baseDir || DEFAULT_BASE_DIR;
+  const eventsDir = join(baseDir, EVENTS_DIR);
+  const filePath = join(eventsDir, `${options.runId}.chained.jsonl`);
+
+  let initialized = false;
+  let seq = 0;
+  let prevHash = GENESIS_PREV_HASH;
+
+  function ensureDir(): void {
+    if (initialized) return;
+    try {
+      mkdirSync(eventsDir, { recursive: true });
+      initialized = true;
+    } catch {
+      initialized = true;
+    }
+  }
+
+  return {
+    write(event: DomainEvent): void {
+      ensureDir();
+      const chainHash = computeChainHash(prevHash, seq, event);
+      const record: ChainedRecord = {
+        seq,
+        chainHash,
+        prevHash,
+        event,
+      };
+
+      const line = JSON.stringify(record) + '\n';
+
+      try {
+        appendFileSync(filePath, line, 'utf8');
+        prevHash = chainHash;
+        seq++;
+      } catch (err) {
+        options.onError?.(err as Error);
+      }
+    },
+
+    flush(): void {
+      // Writes are immediate for durability — nothing to flush
+    },
+
+    length(): number {
+      return seq;
+    },
+
+    headHash(): string {
+      return prevHash;
+    },
+  };
+}
+
+/**
+ * Verify the integrity of a chained JSONL audit file.
+ * Returns detailed verification result including the first broken link.
+ */
+export function verifyChainedJsonl(filePath: string): ChainVerificationResult {
+  if (!existsSync(filePath)) {
+    return {
+      valid: false,
+      totalRecords: 0,
+      verifiedRecords: 0,
+      brokenAt: {
+        seq: 0,
+        expectedHash: '',
+        actualHash: '',
+        reason: `File not found: ${filePath}`,
+      },
+    };
+  }
+
+  const content = readFileSync(filePath, 'utf8');
+  const lines = content.trim().split('\n').filter((l) => l.length > 0);
+
+  if (lines.length === 0) {
+    return { valid: true, totalRecords: 0, verifiedRecords: 0 };
+  }
+
+  let expectedPrevHash = GENESIS_PREV_HASH;
+  let firstTimestamp: number | undefined;
+  let lastTimestamp: number | undefined;
+
+  for (let i = 0; i < lines.length; i++) {
+    let record: ChainedRecord;
+    try {
+      record = JSON.parse(lines[i]) as ChainedRecord;
+    } catch {
+      return {
+        valid: false,
+        totalRecords: lines.length,
+        verifiedRecords: i,
+        brokenAt: {
+          seq: i,
+          expectedHash: '',
+          actualHash: '',
+          reason: `Invalid JSON at line ${i + 1}`,
+        },
+      };
+    }
+
+    // Verify sequence number
+    if (record.seq !== i) {
+      return {
+        valid: false,
+        totalRecords: lines.length,
+        verifiedRecords: i,
+        brokenAt: {
+          seq: i,
+          expectedHash: `seq=${i}`,
+          actualHash: `seq=${record.seq}`,
+          reason: `Sequence gap: expected seq=${i}, found seq=${record.seq}`,
+        },
+      };
+    }
+
+    // Verify previous hash linkage
+    if (record.prevHash !== expectedPrevHash) {
+      return {
+        valid: false,
+        totalRecords: lines.length,
+        verifiedRecords: i,
+        brokenAt: {
+          seq: i,
+          expectedHash: expectedPrevHash,
+          actualHash: record.prevHash,
+          reason: 'Previous hash mismatch — record may have been inserted or prior record modified',
+        },
+      };
+    }
+
+    // Recompute and verify the chain hash
+    const recomputed = computeChainHash(record.prevHash, record.seq, record.event);
+    if (record.chainHash !== recomputed) {
+      return {
+        valid: false,
+        totalRecords: lines.length,
+        verifiedRecords: i,
+        brokenAt: {
+          seq: i,
+          expectedHash: recomputed,
+          actualHash: record.chainHash,
+          reason: 'Chain hash mismatch — event data may have been tampered with',
+        },
+      };
+    }
+
+    // Track timestamps
+    if (record.event.timestamp) {
+      if (firstTimestamp === undefined) firstTimestamp = record.event.timestamp;
+      lastTimestamp = record.event.timestamp;
+    }
+
+    expectedPrevHash = record.chainHash;
+  }
+
+  // Extract runId from file path
+  const fileName = filePath.split('/').pop() || '';
+  const runId = fileName.replace('.chained.jsonl', '');
+
+  return {
+    valid: true,
+    totalRecords: lines.length,
+    verifiedRecords: lines.length,
+    runId: runId || undefined,
+    timeRange:
+      firstTimestamp !== undefined && lastTimestamp !== undefined
+        ? { first: firstTimestamp, last: lastTimestamp }
+        : undefined,
+  };
+}
+
+/**
+ * Read all events from a chained JSONL file after verification.
+ * Throws if the chain is broken.
+ */
+export function readChainedJsonl(filePath: string): DomainEvent[] {
+  const verification = verifyChainedJsonl(filePath);
+  if (!verification.valid) {
+    const reason = verification.brokenAt?.reason || 'Unknown integrity failure';
+    throw new Error(`Audit chain integrity failure: ${reason}`);
+  }
+
+  const content = readFileSync(filePath, 'utf8');
+  const lines = content.trim().split('\n').filter((l) => l.length > 0);
+
+  return lines.map((line) => {
+    const record = JSON.parse(line) as ChainedRecord;
+    return record.event;
+  });
+}
+
+export function getChainedEventFilePath(runId: string, baseDir?: string): string {
+  return join(baseDir || DEFAULT_BASE_DIR, EVENTS_DIR, `${runId}.chained.jsonl`);
+}

--- a/packages/events/src/index.ts
+++ b/packages/events/src/index.ts
@@ -3,3 +3,4 @@ export { EventBus } from './bus.js';
 export * from './store.js';
 export * from './jsonl.js';
 export * from './decision-jsonl.js';
+export * from './chained-jsonl.js';

--- a/packages/events/tests/chained-jsonl.test.ts
+++ b/packages/events/tests/chained-jsonl.test.ts
@@ -1,0 +1,299 @@
+// Tests for hash-chained JSONL sink — tamper-resistant audit trail
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, appendFileSync, readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+import type { DomainEvent } from '@red-codes/core';
+
+// We need real fs for verification tests, so we use a mixed approach:
+// - Mock fs for sink creation tests
+// - Use the verification function's logic directly for integrity tests
+
+vi.mock('node:fs', () => ({
+  mkdirSync: vi.fn(),
+  appendFileSync: vi.fn(),
+  readFileSync: vi.fn(),
+  existsSync: vi.fn(),
+}));
+
+import {
+  createChainedJsonlSink,
+  verifyChainedJsonl,
+  getChainedEventFilePath,
+} from '@red-codes/events';
+import type { ChainedRecord } from '@red-codes/events';
+
+const GENESIS_PREV_HASH =
+  '0000000000000000000000000000000000000000000000000000000000000000';
+
+function makeFakeEvent(overrides: Partial<DomainEvent> = {}): DomainEvent {
+  return {
+    id: 'evt_1',
+    kind: 'ActionRequested',
+    timestamp: 1700000000000,
+    fingerprint: 'fp_1',
+    actionType: 'file.read',
+    target: 'test.ts',
+    justification: 'test',
+    ...overrides,
+  } as DomainEvent;
+}
+
+function computeChainHash(prevHash: string, seq: number, event: DomainEvent): string {
+  const content = `${prevHash}:${seq}:${JSON.stringify(event)}`;
+  return createHash('sha256').update(content, 'utf8').digest('hex');
+}
+
+function buildChainedLines(events: DomainEvent[]): string {
+  const lines: string[] = [];
+  let prevHash = GENESIS_PREV_HASH;
+  for (let i = 0; i < events.length; i++) {
+    const chainHash = computeChainHash(prevHash, i, events[i]);
+    const record: ChainedRecord = { seq: i, chainHash, prevHash, event: events[i] };
+    lines.push(JSON.stringify(record));
+    prevHash = chainHash;
+  }
+  return lines.join('\n');
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('createChainedJsonlSink', () => {
+  it('creates directory on first write', () => {
+    const sink = createChainedJsonlSink({ runId: 'run_chain_1' });
+    sink.write(makeFakeEvent());
+
+    expect(mkdirSync).toHaveBeenCalledWith(
+      expect.stringContaining('events'),
+      { recursive: true }
+    );
+  });
+
+  it('writes chained records with seq, chainHash, prevHash', () => {
+    const written: string[] = [];
+    vi.mocked(appendFileSync).mockImplementation((_path, data) => {
+      written.push(data as string);
+    });
+
+    const sink = createChainedJsonlSink({ runId: 'run_chain_1' });
+    const evt1 = makeFakeEvent({ id: 'evt_1' });
+    const evt2 = makeFakeEvent({ id: 'evt_2' });
+
+    sink.write(evt1);
+    sink.write(evt2);
+
+    expect(written.length).toBe(2);
+
+    const record1 = JSON.parse(written[0]) as ChainedRecord;
+    expect(record1.seq).toBe(0);
+    expect(record1.prevHash).toBe(GENESIS_PREV_HASH);
+    expect(record1.event).toEqual(evt1);
+    expect(record1.chainHash).toBeTruthy();
+
+    const record2 = JSON.parse(written[1]) as ChainedRecord;
+    expect(record2.seq).toBe(1);
+    expect(record2.prevHash).toBe(record1.chainHash);
+    expect(record2.event).toEqual(evt2);
+  });
+
+  it('computes chain hash correctly', () => {
+    const written: string[] = [];
+    vi.mocked(appendFileSync).mockImplementation((_path, data) => {
+      written.push(data as string);
+    });
+
+    const sink = createChainedJsonlSink({ runId: 'run_chain_1' });
+    const evt = makeFakeEvent();
+    sink.write(evt);
+
+    const record = JSON.parse(written[0]) as ChainedRecord;
+    const expected = computeChainHash(GENESIS_PREV_HASH, 0, evt);
+    expect(record.chainHash).toBe(expected);
+  });
+
+  it('tracks length and headHash', () => {
+    vi.mocked(appendFileSync).mockImplementation(() => {});
+
+    const sink = createChainedJsonlSink({ runId: 'run_chain_1' });
+    expect(sink.length()).toBe(0);
+    expect(sink.headHash()).toBe(GENESIS_PREV_HASH);
+
+    sink.write(makeFakeEvent());
+    expect(sink.length()).toBe(1);
+    expect(sink.headHash()).not.toBe(GENESIS_PREV_HASH);
+  });
+
+  it('swallows write errors without crashing', () => {
+    vi.mocked(appendFileSync).mockImplementation(() => {
+      throw new Error('ENOSPC');
+    });
+
+    const sink = createChainedJsonlSink({ runId: 'run_chain_1' });
+    expect(() => sink.write(makeFakeEvent())).not.toThrow();
+  });
+
+  it('calls onError callback on write failure', () => {
+    const onError = vi.fn();
+    vi.mocked(appendFileSync).mockImplementation(() => {
+      throw new Error('ENOSPC');
+    });
+
+    const sink = createChainedJsonlSink({ runId: 'run_chain_1', onError });
+    sink.write(makeFakeEvent());
+
+    expect(onError).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it('writes to .chained.jsonl file', () => {
+    const sink = createChainedJsonlSink({ runId: 'run_chain_1' });
+    sink.write(makeFakeEvent());
+
+    expect(appendFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('run_chain_1.chained.jsonl'),
+      expect.any(String),
+      'utf8'
+    );
+  });
+});
+
+describe('verifyChainedJsonl', () => {
+  it('returns valid for empty file', () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue('');
+
+    const result = verifyChainedJsonl('/test/empty.chained.jsonl');
+    expect(result.valid).toBe(true);
+    expect(result.totalRecords).toBe(0);
+  });
+
+  it('returns error for missing file', () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    const result = verifyChainedJsonl('/test/missing.chained.jsonl');
+    expect(result.valid).toBe(false);
+    expect(result.brokenAt?.reason).toContain('File not found');
+  });
+
+  it('verifies a valid chain', () => {
+    const events = [
+      makeFakeEvent({ id: 'evt_1', timestamp: 1700000000000 }),
+      makeFakeEvent({ id: 'evt_2', timestamp: 1700000001000 }),
+      makeFakeEvent({ id: 'evt_3', timestamp: 1700000002000 }),
+    ];
+    const content = buildChainedLines(events);
+
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(content);
+
+    const result = verifyChainedJsonl('/test/valid.chained.jsonl');
+    expect(result.valid).toBe(true);
+    expect(result.totalRecords).toBe(3);
+    expect(result.verifiedRecords).toBe(3);
+    expect(result.timeRange?.first).toBe(1700000000000);
+    expect(result.timeRange?.last).toBe(1700000002000);
+  });
+
+  it('detects tampered event data', () => {
+    const events = [
+      makeFakeEvent({ id: 'evt_1' }),
+      makeFakeEvent({ id: 'evt_2' }),
+    ];
+    const content = buildChainedLines(events);
+    const lines = content.split('\n');
+
+    // Tamper with the second record's event data
+    const record = JSON.parse(lines[1]) as ChainedRecord;
+    record.event.id = 'evt_TAMPERED';
+    lines[1] = JSON.stringify(record);
+
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(lines.join('\n'));
+
+    const result = verifyChainedJsonl('/test/tampered.chained.jsonl');
+    expect(result.valid).toBe(false);
+    expect(result.brokenAt?.seq).toBe(1);
+    expect(result.brokenAt?.reason).toContain('Chain hash mismatch');
+  });
+
+  it('detects deleted record (sequence gap)', () => {
+    const events = [
+      makeFakeEvent({ id: 'evt_1' }),
+      makeFakeEvent({ id: 'evt_2' }),
+      makeFakeEvent({ id: 'evt_3' }),
+    ];
+    const content = buildChainedLines(events);
+    const lines = content.split('\n');
+
+    // Remove the middle record
+    lines.splice(1, 1);
+
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(lines.join('\n'));
+
+    const result = verifyChainedJsonl('/test/deleted.chained.jsonl');
+    expect(result.valid).toBe(false);
+    // Either sequence gap or prev hash mismatch will be detected
+    expect(result.brokenAt).toBeDefined();
+    expect(result.verifiedRecords).toBeLessThan(3);
+  });
+
+  it('detects inserted record (prev hash mismatch)', () => {
+    const events = [
+      makeFakeEvent({ id: 'evt_1' }),
+      makeFakeEvent({ id: 'evt_2' }),
+    ];
+    const content = buildChainedLines(events);
+    const lines = content.split('\n');
+
+    // Insert a fake record between them
+    const fakeRecord: ChainedRecord = {
+      seq: 1,
+      chainHash: 'fakehash',
+      prevHash: 'fakeprev',
+      event: makeFakeEvent({ id: 'evt_inserted' }),
+    };
+    lines.splice(1, 0, JSON.stringify(fakeRecord));
+
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(lines.join('\n'));
+
+    const result = verifyChainedJsonl('/test/inserted.chained.jsonl');
+    expect(result.valid).toBe(false);
+  });
+
+  it('detects invalid JSON', () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue('not valid json\n');
+
+    const result = verifyChainedJsonl('/test/bad.chained.jsonl');
+    expect(result.valid).toBe(false);
+    expect(result.brokenAt?.reason).toContain('Invalid JSON');
+  });
+
+  it('extracts runId from file path', () => {
+    const events = [makeFakeEvent({ id: 'evt_1' })];
+    const content = buildChainedLines(events);
+
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(content);
+
+    const result = verifyChainedJsonl('/test/run_abc123.chained.jsonl');
+    expect(result.runId).toBe('run_abc123');
+  });
+});
+
+describe('getChainedEventFilePath', () => {
+  it('returns default path with .chained.jsonl extension', () => {
+    const path = getChainedEventFilePath('run_42');
+    expect(path).toContain('.agentguard');
+    expect(path).toContain('events');
+    expect(path).toContain('run_42.chained.jsonl');
+  });
+
+  it('uses custom baseDir', () => {
+    const path = getChainedEventFilePath('run_42', '/audit');
+    expect(path).toBe(join('/audit', 'events', 'run_42.chained.jsonl'));
+  });
+});

--- a/packages/kernel/src/enforcement-audit.ts
+++ b/packages/kernel/src/enforcement-audit.ts
@@ -1,0 +1,277 @@
+// Enforcement Audit Report — generates a structured summary of runtime
+// enforcement activity from governance decision records and events.
+// Answers: "What was attempted, what was blocked, and can we prove it?"
+
+import type { GovernanceDecisionRecord, DomainEvent } from '@red-codes/core';
+
+/** Summary of enforcement activity for a governance session */
+export interface EnforcementAuditReport {
+  /** Report format version */
+  schemaVersion: '1.0.0';
+  /** Session/run identifier */
+  runId: string;
+  /** When the report was generated */
+  generatedAt: string;
+  /** Time range of the audited session */
+  timeRange: {
+    first: number;
+    last: number;
+    durationMs: number;
+  };
+  /** Overall enforcement statistics */
+  summary: {
+    totalActions: number;
+    allowed: number;
+    denied: number;
+    denialRate: number;
+    totalViolations: number;
+    uniqueViolationTypes: number;
+    peakEscalationLevel: number;
+    destructiveActionsBlocked: number;
+    chainIntegrityVerified: boolean;
+  };
+  /** Breakdown by action type */
+  actionBreakdown: Record<
+    string,
+    {
+      total: number;
+      allowed: number;
+      denied: number;
+    }
+  >;
+  /** All denial records with full context */
+  denials: Array<{
+    timestamp: number;
+    actionType: string;
+    target: string;
+    agent: string;
+    reason: string;
+    intervention: string | null;
+    violations: Array<{
+      invariantId: string;
+      name: string;
+      severity: number;
+    }>;
+    policyMatched: string | null;
+    destructive: boolean;
+  }>;
+  /** Invariant violation summary */
+  invariantSummary: Record<
+    string,
+    {
+      name: string;
+      count: number;
+      maxSeverity: number;
+    }
+  >;
+  /** Escalation timeline */
+  escalationTimeline: Array<{
+    timestamp: number;
+    fromLevel: number;
+    toLevel: number;
+    trigger: string;
+  }>;
+  /** Provenance — where enforcement decisions came from */
+  enforcementSources: {
+    policyDenials: number;
+    invariantDenials: number;
+    simulationDenials: number;
+  };
+}
+
+/**
+ * Generate an enforcement audit report from decision records and events.
+ */
+export function generateEnforcementAudit(params: {
+  runId: string;
+  decisions: GovernanceDecisionRecord[];
+  events?: DomainEvent[];
+  chainVerified?: boolean;
+}): EnforcementAuditReport {
+  const { runId, decisions, events = [], chainVerified = false } = params;
+
+  // Time range
+  const timestamps = decisions.map((d) => d.timestamp);
+  const eventTimestamps = events.map((e) => e.timestamp);
+  const allTimestamps = [...timestamps, ...eventTimestamps].filter(Boolean);
+  const first = allTimestamps.length > 0 ? Math.min(...allTimestamps) : 0;
+  const last = allTimestamps.length > 0 ? Math.max(...allTimestamps) : 0;
+
+  // Counts
+  const allowed = decisions.filter((d) => d.outcome === 'allow');
+  const denied = decisions.filter((d) => d.outcome === 'deny');
+  const destructiveBlocked = denied.filter((d) => d.action.destructive);
+
+  // All violations across all decisions
+  const allViolations = decisions.flatMap((d) => d.invariants.violations);
+  const uniqueViolationTypes = new Set(allViolations.map((v) => v.invariantId));
+
+  // Peak escalation
+  const peakEscalation = Math.max(0, ...decisions.map((d) => d.monitor.escalationLevel));
+
+  // Action breakdown
+  const actionBreakdown: Record<string, { total: number; allowed: number; denied: number }> = {};
+  for (const d of decisions) {
+    const type = d.action.type;
+    if (!actionBreakdown[type]) {
+      actionBreakdown[type] = { total: 0, allowed: 0, denied: 0 };
+    }
+    actionBreakdown[type].total++;
+    if (d.outcome === 'allow') actionBreakdown[type].allowed++;
+    else actionBreakdown[type].denied++;
+  }
+
+  // Denial details
+  const denials = denied.map((d) => ({
+    timestamp: d.timestamp,
+    actionType: d.action.type,
+    target: d.action.target,
+    agent: d.action.agent,
+    reason: d.reason,
+    intervention: d.intervention,
+    violations: d.invariants.violations.map((v) => ({
+      invariantId: v.invariantId,
+      name: v.name,
+      severity: v.severity,
+    })),
+    policyMatched: d.policy.matchedPolicyId,
+    destructive: d.action.destructive,
+  }));
+
+  // Invariant summary
+  const invariantSummary: Record<string, { name: string; count: number; maxSeverity: number }> = {};
+  for (const v of allViolations) {
+    if (!invariantSummary[v.invariantId]) {
+      invariantSummary[v.invariantId] = { name: v.name, count: 0, maxSeverity: 0 };
+    }
+    invariantSummary[v.invariantId].count++;
+    if (v.severity > invariantSummary[v.invariantId].maxSeverity) {
+      invariantSummary[v.invariantId].maxSeverity = v.severity;
+    }
+  }
+
+  // Escalation timeline from events
+  const escalationTimeline = events
+    .filter((e) => e.kind === 'StateChanged')
+    .map((e) => ({
+      timestamp: e.timestamp,
+      fromLevel: (e as Record<string, unknown>).from as number,
+      toLevel: (e as Record<string, unknown>).to as number,
+      trigger: ((e as Record<string, unknown>).trigger as string) || 'threshold',
+    }));
+
+  // Enforcement sources
+  let policyDenials = 0;
+  let invariantDenials = 0;
+  let simulationDenials = 0;
+  for (const d of denied) {
+    if (d.invariants.violations.length > 0) invariantDenials++;
+    if (d.policy.matchedPolicyId) policyDenials++;
+    if (d.simulation && d.simulation.riskLevel === 'high') simulationDenials++;
+  }
+
+  return {
+    schemaVersion: '1.0.0',
+    runId,
+    generatedAt: new Date().toISOString(),
+    timeRange: {
+      first,
+      last,
+      durationMs: last - first,
+    },
+    summary: {
+      totalActions: decisions.length,
+      allowed: allowed.length,
+      denied: denied.length,
+      denialRate: decisions.length > 0 ? denied.length / decisions.length : 0,
+      totalViolations: allViolations.length,
+      uniqueViolationTypes: uniqueViolationTypes.size,
+      peakEscalationLevel: peakEscalation,
+      destructiveActionsBlocked: destructiveBlocked.length,
+      chainIntegrityVerified: chainVerified,
+    },
+    actionBreakdown,
+    denials,
+    invariantSummary,
+    escalationTimeline,
+    enforcementSources: {
+      policyDenials,
+      invariantDenials,
+      simulationDenials,
+    },
+  };
+}
+
+/**
+ * Format an enforcement audit report as human-readable text.
+ */
+export function formatEnforcementAudit(report: EnforcementAuditReport): string {
+  const lines: string[] = [];
+  const s = report.summary;
+
+  lines.push('');
+  lines.push('  Enforcement Audit Report');
+  lines.push('  ========================');
+  lines.push(`  Run:       ${report.runId}`);
+  lines.push(`  Generated: ${report.generatedAt}`);
+  if (report.timeRange.durationMs > 0) {
+    const durSec = (report.timeRange.durationMs / 1000).toFixed(1);
+    lines.push(`  Duration:  ${durSec}s`);
+  }
+  lines.push('');
+
+  // Summary
+  lines.push('  Summary');
+  lines.push('  -------');
+  lines.push(`  Total actions:          ${s.totalActions}`);
+  lines.push(`  Allowed:                ${s.allowed}`);
+  lines.push(`  Denied:                 ${s.denied}`);
+  lines.push(`  Denial rate:            ${(s.denialRate * 100).toFixed(1)}%`);
+  lines.push(`  Violations:             ${s.totalViolations} (${s.uniqueViolationTypes} types)`);
+  lines.push(`  Destructive blocked:    ${s.destructiveActionsBlocked}`);
+  lines.push(`  Peak escalation:        ${s.peakEscalationLevel}`);
+  lines.push(
+    `  Chain integrity:        ${s.chainIntegrityVerified ? 'VERIFIED' : 'NOT VERIFIED'}`
+  );
+  lines.push('');
+
+  // Action breakdown
+  const actionTypes = Object.keys(report.actionBreakdown);
+  if (actionTypes.length > 0) {
+    lines.push('  Action Breakdown');
+    lines.push('  ----------------');
+    for (const type of actionTypes.sort()) {
+      const b = report.actionBreakdown[type];
+      lines.push(`  ${type.padEnd(20)} ${b.allowed} allowed, ${b.denied} denied`);
+    }
+    lines.push('');
+  }
+
+  // Denials
+  if (report.denials.length > 0) {
+    lines.push('  Denials');
+    lines.push('  -------');
+    for (const d of report.denials) {
+      const ts = new Date(d.timestamp).toISOString();
+      const flag = d.destructive ? ' [DESTRUCTIVE]' : '';
+      lines.push(`  ${ts} ${d.actionType} → ${d.target}${flag}`);
+      lines.push(`    Reason: ${d.reason}`);
+      if (d.violations.length > 0) {
+        const names = d.violations.map((v) => `${v.name} (sev:${v.severity})`).join(', ');
+        lines.push(`    Violations: ${names}`);
+      }
+    }
+    lines.push('');
+  }
+
+  // Enforcement sources
+  const src = report.enforcementSources;
+  lines.push('  Enforcement Sources');
+  lines.push('  -------------------');
+  lines.push(`  Policy denials:      ${src.policyDenials}`);
+  lines.push(`  Invariant denials:   ${src.invariantDenials}`);
+  lines.push(`  Simulation denials:  ${src.simulationDenials}`);
+  lines.push('');
+
+  return lines.join('\n');
+}

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -19,3 +19,4 @@ export * from './simulation/package-simulator.js';
 export * from './simulation/plan-simulator.js';
 export * from './simulation/dependency-graph-simulator.js';
 export * from './contract.js';
+export * from './enforcement-audit.js';

--- a/packages/kernel/tests/enforcement-audit.test.ts
+++ b/packages/kernel/tests/enforcement-audit.test.ts
@@ -1,0 +1,331 @@
+// Tests for enforcement audit report generation
+import { describe, it, expect } from 'vitest';
+import {
+  generateEnforcementAudit,
+  formatEnforcementAudit,
+} from '../src/enforcement-audit.js';
+import type { GovernanceDecisionRecord, DomainEvent } from '@red-codes/core';
+
+function makeDecision(
+  overrides: Partial<GovernanceDecisionRecord> = {}
+): GovernanceDecisionRecord {
+  return {
+    recordId: 'dec_1',
+    runId: 'run_test',
+    timestamp: 1700000000000,
+    action: { type: 'file.write', target: 'test.ts', agent: 'test-agent', destructive: false },
+    outcome: 'allow',
+    reason: 'Allowed by default',
+    intervention: null,
+    policy: { matchedPolicyId: null, matchedPolicyName: null, severity: 0 },
+    invariants: { allHold: true, violations: [] },
+    simulation: null,
+    evidencePackId: null,
+    monitor: { escalationLevel: 0, totalEvaluations: 1, totalDenials: 0 },
+    execution: { executed: true, success: true, durationMs: 10, error: null },
+    ...overrides,
+  } as GovernanceDecisionRecord;
+}
+
+describe('generateEnforcementAudit', () => {
+  it('generates report for empty decisions', () => {
+    const report = generateEnforcementAudit({
+      runId: 'run_empty',
+      decisions: [],
+    });
+
+    expect(report.schemaVersion).toBe('1.0.0');
+    expect(report.runId).toBe('run_empty');
+    expect(report.summary.totalActions).toBe(0);
+    expect(report.summary.allowed).toBe(0);
+    expect(report.summary.denied).toBe(0);
+    expect(report.summary.denialRate).toBe(0);
+  });
+
+  it('counts allowed and denied actions', () => {
+    const decisions = [
+      makeDecision({ outcome: 'allow', timestamp: 1700000000000 }),
+      makeDecision({ outcome: 'allow', timestamp: 1700000001000 }),
+      makeDecision({
+        outcome: 'deny',
+        timestamp: 1700000002000,
+        reason: 'Policy denied',
+        policy: { matchedPolicyId: 'pol_1', matchedPolicyName: 'strict', severity: 3 },
+      }),
+    ];
+
+    const report = generateEnforcementAudit({ runId: 'run_mix', decisions });
+
+    expect(report.summary.totalActions).toBe(3);
+    expect(report.summary.allowed).toBe(2);
+    expect(report.summary.denied).toBe(1);
+    expect(report.summary.denialRate).toBeCloseTo(1 / 3);
+  });
+
+  it('tracks action breakdown by type', () => {
+    const decisions = [
+      makeDecision({
+        action: { type: 'file.write', target: 'a.ts', agent: 'agent', destructive: false },
+        outcome: 'allow',
+      }),
+      makeDecision({
+        action: { type: 'file.write', target: 'b.ts', agent: 'agent', destructive: false },
+        outcome: 'deny',
+        reason: 'Denied',
+      }),
+      makeDecision({
+        action: { type: 'git.push', target: 'main', agent: 'agent', destructive: true },
+        outcome: 'deny',
+        reason: 'Protected branch',
+      }),
+    ];
+
+    const report = generateEnforcementAudit({ runId: 'run_bd', decisions });
+
+    expect(report.actionBreakdown['file.write']).toEqual({
+      total: 2,
+      allowed: 1,
+      denied: 1,
+    });
+    expect(report.actionBreakdown['git.push']).toEqual({
+      total: 1,
+      allowed: 0,
+      denied: 1,
+    });
+  });
+
+  it('records denial details', () => {
+    const decisions = [
+      makeDecision({
+        outcome: 'deny',
+        reason: 'Secret exposure detected',
+        intervention: 'deny',
+        action: { type: 'file.write', target: '.env', agent: 'agent', destructive: false },
+        invariants: {
+          allHold: false,
+          violations: [
+            {
+              invariantId: 'no-secret-exposure',
+              name: 'No Secret Exposure',
+              severity: 5,
+              expected: 'No sensitive file modifications',
+              actual: 'Writing to .env',
+            },
+          ],
+        },
+      }),
+    ];
+
+    const report = generateEnforcementAudit({ runId: 'run_denial', decisions });
+
+    expect(report.denials.length).toBe(1);
+    expect(report.denials[0].reason).toBe('Secret exposure detected');
+    expect(report.denials[0].violations.length).toBe(1);
+    expect(report.denials[0].violations[0].invariantId).toBe('no-secret-exposure');
+  });
+
+  it('builds invariant summary', () => {
+    const decisions = [
+      makeDecision({
+        outcome: 'deny',
+        reason: 'Violation',
+        invariants: {
+          allHold: false,
+          violations: [
+            {
+              invariantId: 'no-force-push',
+              name: 'No Force Push',
+              severity: 4,
+              expected: 'No force push',
+              actual: 'Force push detected',
+            },
+          ],
+        },
+      }),
+      makeDecision({
+        outcome: 'deny',
+        reason: 'Violation',
+        invariants: {
+          allHold: false,
+          violations: [
+            {
+              invariantId: 'no-force-push',
+              name: 'No Force Push',
+              severity: 4,
+              expected: 'No force push',
+              actual: 'Force push detected',
+            },
+            {
+              invariantId: 'protected-branch',
+              name: 'Protected Branch',
+              severity: 5,
+              expected: 'No push to protected',
+              actual: 'Push to main',
+            },
+          ],
+        },
+      }),
+    ];
+
+    const report = generateEnforcementAudit({ runId: 'run_inv', decisions });
+
+    expect(report.invariantSummary['no-force-push'].count).toBe(2);
+    expect(report.invariantSummary['no-force-push'].maxSeverity).toBe(4);
+    expect(report.invariantSummary['protected-branch'].count).toBe(1);
+    expect(report.invariantSummary['protected-branch'].maxSeverity).toBe(5);
+    expect(report.summary.uniqueViolationTypes).toBe(2);
+  });
+
+  it('counts destructive actions blocked', () => {
+    const decisions = [
+      makeDecision({
+        outcome: 'deny',
+        reason: 'Blocked',
+        action: { type: 'git.push', target: 'main', agent: 'agent', destructive: true },
+      }),
+      makeDecision({
+        outcome: 'deny',
+        reason: 'Blocked',
+        action: { type: 'shell.exec', target: 'rm -rf /', agent: 'agent', destructive: true },
+      }),
+      makeDecision({
+        outcome: 'allow',
+        action: { type: 'file.read', target: 'safe.ts', agent: 'agent', destructive: false },
+      }),
+    ];
+
+    const report = generateEnforcementAudit({ runId: 'run_destr', decisions });
+    expect(report.summary.destructiveActionsBlocked).toBe(2);
+  });
+
+  it('tracks peak escalation level', () => {
+    const decisions = [
+      makeDecision({ monitor: { escalationLevel: 0, totalEvaluations: 1, totalDenials: 0 } }),
+      makeDecision({ monitor: { escalationLevel: 2, totalEvaluations: 10, totalDenials: 5 } }),
+      makeDecision({ monitor: { escalationLevel: 1, totalEvaluations: 15, totalDenials: 6 } }),
+    ];
+
+    const report = generateEnforcementAudit({ runId: 'run_esc', decisions });
+    expect(report.summary.peakEscalationLevel).toBe(2);
+  });
+
+  it('tracks chain integrity flag', () => {
+    const report1 = generateEnforcementAudit({
+      runId: 'run_1',
+      decisions: [],
+      chainVerified: true,
+    });
+    expect(report1.summary.chainIntegrityVerified).toBe(true);
+
+    const report2 = generateEnforcementAudit({
+      runId: 'run_2',
+      decisions: [],
+      chainVerified: false,
+    });
+    expect(report2.summary.chainIntegrityVerified).toBe(false);
+  });
+
+  it('categorizes enforcement sources', () => {
+    const decisions = [
+      makeDecision({
+        outcome: 'deny',
+        reason: 'Policy denied',
+        policy: { matchedPolicyId: 'pol_1', matchedPolicyName: 'strict', severity: 3 },
+        invariants: { allHold: true, violations: [] },
+      }),
+      makeDecision({
+        outcome: 'deny',
+        reason: 'Invariant violation',
+        invariants: {
+          allHold: false,
+          violations: [
+            {
+              invariantId: 'test-inv',
+              name: 'Test',
+              severity: 3,
+              expected: 'x',
+              actual: 'y',
+            },
+          ],
+        },
+      }),
+      makeDecision({
+        outcome: 'deny',
+        reason: 'Simulation risk',
+        simulation: {
+          predictedChanges: ['a.ts'],
+          blastRadius: 50,
+          riskLevel: 'high',
+          simulatorId: 'fs-sim',
+          durationMs: 10,
+        },
+      }),
+    ];
+
+    const report = generateEnforcementAudit({ runId: 'run_src', decisions });
+    expect(report.enforcementSources.policyDenials).toBe(1);
+    expect(report.enforcementSources.invariantDenials).toBe(1);
+    expect(report.enforcementSources.simulationDenials).toBe(1);
+  });
+
+  it('computes time range from decisions', () => {
+    const decisions = [
+      makeDecision({ timestamp: 1700000010000 }),
+      makeDecision({ timestamp: 1700000020000 }),
+      makeDecision({ timestamp: 1700000015000 }),
+    ];
+
+    const report = generateEnforcementAudit({ runId: 'run_time', decisions });
+    expect(report.timeRange.first).toBe(1700000010000);
+    expect(report.timeRange.last).toBe(1700000020000);
+    expect(report.timeRange.durationMs).toBe(10000);
+  });
+});
+
+describe('formatEnforcementAudit', () => {
+  it('produces readable text output', () => {
+    const decisions = [
+      makeDecision({ outcome: 'allow' }),
+      makeDecision({
+        outcome: 'deny',
+        reason: 'Force push blocked',
+        action: { type: 'git.push', target: 'main', agent: 'agent', destructive: true },
+        invariants: {
+          allHold: false,
+          violations: [
+            {
+              invariantId: 'no-force-push',
+              name: 'No Force Push',
+              severity: 4,
+              expected: 'No force push',
+              actual: 'Force push detected',
+            },
+          ],
+        },
+      }),
+    ];
+
+    const report = generateEnforcementAudit({
+      runId: 'run_fmt',
+      decisions,
+      chainVerified: true,
+    });
+    const output = formatEnforcementAudit(report);
+
+    expect(output).toContain('Enforcement Audit Report');
+    expect(output).toContain('run_fmt');
+    expect(output).toContain('Total actions:');
+    expect(output).toContain('VERIFIED');
+    expect(output).toContain('Force push blocked');
+    expect(output).toContain('No Force Push');
+    expect(output).toContain('[DESTRUCTIVE]');
+  });
+
+  it('handles empty report', () => {
+    const report = generateEnforcementAudit({ runId: 'run_empty', decisions: [] });
+    const output = formatEnforcementAudit(report);
+
+    expect(output).toContain('Total actions:          0');
+    expect(output).toContain('NOT VERIFIED');
+  });
+});


### PR DESCRIPTION
Add cryptographic hash chaining to the JSONL audit trail so that any
insertion, deletion, or modification of audit records is detectable.
Each record includes a SHA-256 chain hash incorporating the previous
record's hash, creating an immutable sequence (CloudTrail for agents).

- Hash-chained JSONL sink (packages/events/src/chained-jsonl.ts)
- Chain verification with detailed break detection
- Enforcement audit report generator (packages/kernel/src/enforcement-audit.ts)
- CLI `audit-verify` command with --report and --json flags
- Full test coverage for both components (640 tests pass)

https://claude.ai/code/session_01KqdjiZdCnhfeh3jUGcnrLt