### PR TITLE
feat: add AgentGuard MCP server with 15 governance tools

### DIFF
--- a/apps/mcp-server/esbuild.config.ts
+++ b/apps/mcp-server/esbuild.config.ts
@@ -1,0 +1,19 @@
+import * as esbuild from 'esbuild';
+
+const shared: esbuild.BuildOptions = {
+  bundle: true,
+  platform: 'node',
+  target: 'node18',
+  format: 'esm',
+  sourcemap: true,
+  outdir: 'dist',
+  packages: 'external',
+};
+
+await esbuild.build({
+  ...shared,
+  entryPoints: ['src/server.ts'],
+  banner: { js: '#!/usr/bin/env node' },
+});
+
+console.log('MCP server build complete.');

--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@red-codes/agentguard-mcp",
+  "version": "0.1.0",
+  "description": "AgentGuard MCP server — governance tools for AI coding agents",
+  "type": "module",
+  "license": "Apache-2.0",
+  "private": true,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "agentguard-mcp": "./dist/server.js"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc -b && tsx esbuild.config.ts",
+    "dev": "tsx src/server.ts",
+    "test": "vitest run",
+    "lint": "eslint src/",
+    "ts:check": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.1",
+    "@red-codes/analytics": "workspace:*",
+    "@red-codes/adapters": "workspace:*",
+    "@red-codes/core": "workspace:*",
+    "@red-codes/events": "workspace:*",
+    "@red-codes/invariants": "workspace:*",
+    "@red-codes/kernel": "workspace:*",
+    "@red-codes/policy": "workspace:*",
+    "@red-codes/storage": "workspace:*",
+    "@red-codes/telemetry": "workspace:*",
+    "zod": "^3.25.0"
+  }
+}

--- a/apps/mcp-server/src/backends/firestore.ts
+++ b/apps/mcp-server/src/backends/firestore.ts
@@ -1,0 +1,59 @@
+// Firestore data source — reads governance data from Firestore via @red-codes/storage.
+// Requires AGENTGUARD_FIRESTORE_PROJECT env var.
+
+import type { DomainEvent, GovernanceDecisionRecord } from '@red-codes/core';
+import type { DataSource } from './types.js';
+import type { McpConfig } from '../config.js';
+
+export async function createFirestoreDataSource(config: McpConfig): Promise<DataSource> {
+  const { createStorageBundle } = await import('@red-codes/storage');
+  const bundle = await createStorageBundle({
+    backend: 'firestore',
+    firestoreProjectId: config.firestoreProject,
+  });
+
+  const store = bundle as {
+    listRunIds?: (limit?: number) => Promise<string[]>;
+    loadRunEvents?: (runId: string) => Promise<DomainEvent[]>;
+    loadRunDecisions?: (runId: string) => Promise<GovernanceDecisionRecord[]>;
+  };
+
+  const loadEvents = async (runId: string): Promise<DomainEvent[]> => {
+    if (store.loadRunEvents) {
+      return store.loadRunEvents(runId);
+    }
+    return [];
+  };
+
+  return {
+    async listRuns(limit?: number): Promise<string[]> {
+      if (store.listRunIds) {
+        return store.listRunIds(limit);
+      }
+      return [];
+    },
+
+    loadEvents,
+
+    async loadDecisions(runId: string): Promise<GovernanceDecisionRecord[]> {
+      if (store.loadRunDecisions) {
+        return store.loadRunDecisions(runId);
+      }
+      return [];
+    },
+
+    async queryEvents(opts: {
+      runId?: string;
+      kind?: string;
+      limit?: number;
+    }): Promise<DomainEvent[]> {
+      if (opts.runId) {
+        let events = await loadEvents(opts.runId);
+        if (opts.kind) events = events.filter((e: DomainEvent) => e.kind === opts.kind);
+        if (opts.limit) events = events.slice(0, opts.limit);
+        return events;
+      }
+      return [];
+    },
+  };
+}

--- a/apps/mcp-server/src/backends/local.ts
+++ b/apps/mcp-server/src/backends/local.ts
@@ -1,0 +1,79 @@
+// Local data source — reads governance data from JSONL files or SQLite.
+
+import { readFileSync, existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import type { DomainEvent, GovernanceDecisionRecord } from '@red-codes/core';
+import { getEventFilePath, getDecisionFilePath } from '@red-codes/events';
+import type { DataSource } from './types.js';
+import type { McpConfig } from '../config.js';
+
+function parseJsonlFile<T>(filePath: string): T[] {
+  if (!existsSync(filePath)) return [];
+  const content = readFileSync(filePath, 'utf8');
+  const items: T[] = [];
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      items.push(JSON.parse(trimmed) as T);
+    } catch {
+      // Skip malformed lines
+    }
+  }
+  return items;
+}
+
+export function createLocalDataSource(config: McpConfig): DataSource {
+  const baseDir = config.baseDir;
+  const eventsDir = join(baseDir, 'events');
+
+  return {
+    async listRuns(limit?: number): Promise<string[]> {
+      if (!existsSync(eventsDir)) return [];
+      const files = readdirSync(eventsDir)
+        .filter((f) => f.endsWith('.jsonl'))
+        .map((f) => f.replace('.jsonl', ''))
+        .sort()
+        .reverse();
+      return limit ? files.slice(0, limit) : files;
+    },
+
+    async loadEvents(runId: string): Promise<DomainEvent[]> {
+      const filePath = getEventFilePath(runId, baseDir);
+      return parseJsonlFile<DomainEvent>(filePath);
+    },
+
+    async loadDecisions(runId: string): Promise<GovernanceDecisionRecord[]> {
+      const filePath = getDecisionFilePath(runId, baseDir);
+      return parseJsonlFile<GovernanceDecisionRecord>(filePath);
+    },
+
+    async queryEvents(opts: {
+      runId?: string;
+      kind?: string;
+      limit?: number;
+    }): Promise<DomainEvent[]> {
+      let events: DomainEvent[] = [];
+
+      if (opts.runId) {
+        events = await this.loadEvents(opts.runId);
+      } else {
+        // Load from all runs (most recent first)
+        const runs = await this.listRuns(10);
+        for (const runId of runs) {
+          events.push(...(await this.loadEvents(runId)));
+        }
+      }
+
+      if (opts.kind) {
+        events = events.filter((e) => e.kind === opts.kind);
+      }
+
+      if (opts.limit) {
+        events = events.slice(0, opts.limit);
+      }
+
+      return events;
+    },
+  };
+}

--- a/apps/mcp-server/src/backends/remote.ts
+++ b/apps/mcp-server/src/backends/remote.ts
@@ -1,0 +1,63 @@
+// Remote data source — fetches governance data from the telemetry-server API.
+// Requires AGENTGUARD_REMOTE_URL and optional AGENTGUARD_REMOTE_API_KEY.
+
+import type { DomainEvent, GovernanceDecisionRecord } from '@red-codes/core';
+import type { DataSource } from './types.js';
+import type { McpConfig } from '../config.js';
+
+export function createRemoteDataSource(config: McpConfig): DataSource {
+  const baseUrl = config.remoteUrl?.replace(/\/$/, '') || '';
+  const apiKey = config.remoteApiKey;
+
+  async function fetchJson<T>(path: string): Promise<T> {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+    if (apiKey) {
+      headers['x-api-key'] = apiKey;
+    }
+
+    const response = await fetch(`${baseUrl}${path}`, { headers });
+    if (!response.ok) {
+      throw new Error(`Remote API error: ${response.status} ${response.statusText}`);
+    }
+    return (await response.json()) as T;
+  }
+
+  return {
+    async listRuns(limit?: number): Promise<string[]> {
+      const params = limit ? `?limit=${limit}` : '';
+      const result = await fetchJson<{ runs: string[] }>(`/api/v1/events/runs${params}`);
+      return result.runs || [];
+    },
+
+    async loadEvents(runId: string): Promise<DomainEvent[]> {
+      const result = await fetchJson<{ events: DomainEvent[] }>(
+        `/api/v1/events?runId=${encodeURIComponent(runId)}`
+      );
+      return result.events || [];
+    },
+
+    async loadDecisions(runId: string): Promise<GovernanceDecisionRecord[]> {
+      const result = await fetchJson<{ decisions: GovernanceDecisionRecord[] }>(
+        `/api/v1/decisions?runId=${encodeURIComponent(runId)}`
+      );
+      return result.decisions || [];
+    },
+
+    async queryEvents(opts: {
+      runId?: string;
+      kind?: string;
+      limit?: number;
+    }): Promise<DomainEvent[]> {
+      const params = new URLSearchParams();
+      if (opts.runId) params.set('runId', opts.runId);
+      if (opts.kind) params.set('kind', opts.kind);
+      if (opts.limit) params.set('limit', String(opts.limit));
+      const result = await fetchJson<{ events: DomainEvent[] }>(
+        `/api/v1/events?${params.toString()}`
+      );
+      return result.events || [];
+    },
+  };
+}

--- a/apps/mcp-server/src/backends/types.ts
+++ b/apps/mcp-server/src/backends/types.ts
@@ -1,0 +1,10 @@
+// Backend data source interface — unified abstraction over JSONL, SQLite, Firestore, and remote.
+
+import type { DomainEvent, GovernanceDecisionRecord } from '@red-codes/core';
+
+export interface DataSource {
+  listRuns(limit?: number): Promise<string[]>;
+  loadEvents(runId: string): Promise<DomainEvent[]>;
+  loadDecisions(runId: string): Promise<GovernanceDecisionRecord[]>;
+  queryEvents(opts: { runId?: string; kind?: string; limit?: number }): Promise<DomainEvent[]>;
+}

--- a/apps/mcp-server/src/config.ts
+++ b/apps/mcp-server/src/config.ts
@@ -1,0 +1,28 @@
+// MCP server configuration — resolved from environment variables.
+
+export type BackendType = 'local' | 'firestore' | 'remote';
+export type LocalStoreType = 'jsonl' | 'sqlite';
+
+export interface McpConfig {
+  backend: BackendType;
+  localStore: LocalStoreType;
+  baseDir: string;
+  dbPath?: string;
+  firestoreProject?: string;
+  remoteUrl?: string;
+  remoteApiKey?: string;
+  policyPath?: string;
+}
+
+export function resolveConfig(): McpConfig {
+  return {
+    backend: (process.env.AGENTGUARD_MCP_BACKEND as BackendType) || 'local',
+    localStore: (process.env.AGENTGUARD_STORE as LocalStoreType) || 'jsonl',
+    baseDir: process.env.AGENTGUARD_DIR || '.agentguard',
+    dbPath: process.env.AGENTGUARD_DB_PATH,
+    firestoreProject: process.env.AGENTGUARD_FIRESTORE_PROJECT,
+    remoteUrl: process.env.AGENTGUARD_REMOTE_URL,
+    remoteApiKey: process.env.AGENTGUARD_REMOTE_API_KEY,
+    policyPath: process.env.AGENTGUARD_POLICY,
+  };
+}

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -1,0 +1,8 @@
+export { resolveConfig } from './config.js';
+export type { McpConfig, BackendType, LocalStoreType } from './config.js';
+export type { DataSource } from './backends/types.js';
+export { createLocalDataSource } from './backends/local.js';
+export { registerGovernanceTools } from './tools/governance.js';
+export { registerMonitoringTools } from './tools/monitoring.js';
+export { registerPolicyTools } from './tools/policy.js';
+export { registerAnalyticsTools } from './tools/analytics.js';

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -1,0 +1,61 @@
+// AgentGuard MCP Server — exposes governance tools via the Model Context Protocol.
+// Supports stdio transport for Claude Code integration.
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { resolveConfig } from './config.js';
+import type { DataSource } from './backends/types.js';
+import { createLocalDataSource } from './backends/local.js';
+import { registerGovernanceTools } from './tools/governance.js';
+import { registerMonitoringTools } from './tools/monitoring.js';
+import { registerPolicyTools } from './tools/policy.js';
+import { registerAnalyticsTools } from './tools/analytics.js';
+
+async function resolveDataSource(): Promise<DataSource> {
+  const config = resolveConfig();
+
+  switch (config.backend) {
+    case 'firestore': {
+      const { createFirestoreDataSource } = await import('./backends/firestore.js');
+      return createFirestoreDataSource(config);
+    }
+    case 'remote': {
+      const { createRemoteDataSource } = await import('./backends/remote.js');
+      return createRemoteDataSource(config);
+    }
+    case 'local':
+    default:
+      return createLocalDataSource(config);
+  }
+}
+
+async function main(): Promise<void> {
+  const config = resolveConfig();
+  const dataSource = await resolveDataSource();
+
+  const server = new McpServer(
+    { name: 'agentguard', version: '0.1.0' },
+    {
+      capabilities: { tools: {} },
+      instructions:
+        'AgentGuard governance tools for AI coding agents. ' +
+        'Propose actions through the governance kernel, evaluate policies, ' +
+        'check invariants, simulate impact, inspect sessions, and analyze violations.',
+    }
+  );
+
+  // Register all tool categories
+  registerGovernanceTools(server, config);
+  registerMonitoringTools(server, dataSource);
+  registerPolicyTools(server);
+  registerAnalyticsTools(server);
+
+  // Start stdio transport
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err) => {
+  process.stderr.write(`AgentGuard MCP server error: ${err}\n`);
+  process.exit(1);
+});

--- a/apps/mcp-server/src/tools/analytics.ts
+++ b/apps/mcp-server/src/tools/analytics.ts
@@ -1,0 +1,137 @@
+// Analytics tools — violation analysis, risk scoring, rule suggestions.
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { analyze, analyzeRisk, generateSuggestions, toYaml } from '@red-codes/analytics';
+
+export function registerAnalyticsTools(server: McpServer): void {
+  // analyze_violations — run the full analytics pipeline
+  server.tool(
+    'analyze_violations',
+    'Analyze violation patterns across governance sessions (clusters, trends, risk scores)',
+    {
+      baseDir: z
+        .string()
+        .optional()
+        .default('.agentguard')
+        .describe('Base directory for governance data'),
+      minClusterSize: z
+        .number()
+        .optional()
+        .default(2)
+        .describe('Minimum violations to form a cluster'),
+    },
+    async (args) => {
+      try {
+        const report = analyze({
+          baseDir: args.baseDir,
+          minClusterSize: args.minClusterSize,
+        });
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  sessionsAnalyzed: report.sessionsAnalyzed,
+                  totalViolations: report.totalViolations,
+                  violationsByKind: report.violationsByKind,
+                  clusters: report.clusters,
+                  trends: report.trends,
+                  topInferredCauses: report.topInferredCauses,
+                  failureAnalysis: report.failureAnalysis,
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      } catch (err) {
+        return {
+          content: [{ type: 'text', text: JSON.stringify({ error: String(err) }) }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // risk_scores — per-session risk assessment
+  server.tool(
+    'risk_scores',
+    'Compute per-session governance risk scores',
+    {
+      baseDir: z
+        .string()
+        .optional()
+        .default('.agentguard')
+        .describe('Base directory for governance data'),
+    },
+    async (args) => {
+      try {
+        const scores = analyzeRisk({ baseDir: args.baseDir });
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({ count: scores.length, scores }, null, 2),
+            },
+          ],
+        };
+      } catch (err) {
+        return {
+          content: [{ type: 'text', text: JSON.stringify({ error: String(err) }) }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // suggest_rules — generate policy improvements from violation data
+  server.tool(
+    'suggest_rules',
+    'Generate policy rule suggestions based on violation patterns',
+    {
+      baseDir: z
+        .string()
+        .optional()
+        .default('.agentguard')
+        .describe('Base directory for governance data'),
+      minClusterSize: z.number().optional().default(2).describe('Minimum cluster size'),
+    },
+    async (args) => {
+      try {
+        const report = analyze({
+          baseDir: args.baseDir,
+          minClusterSize: args.minClusterSize,
+        });
+        const suggestions = generateSuggestions(report);
+        const yaml = toYaml(suggestions);
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  suggestionCount: suggestions.suggestions.length,
+                  suggestions: suggestions.suggestions,
+                  yaml,
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      } catch (err) {
+        return {
+          content: [{ type: 'text', text: JSON.stringify({ error: String(err) }) }],
+          isError: true,
+        };
+      }
+    }
+  );
+}

--- a/apps/mcp-server/src/tools/governance.ts
+++ b/apps/mcp-server/src/tools/governance.ts
@@ -1,0 +1,300 @@
+// Governance tools — propose actions, evaluate policy, check invariants, simulate.
+
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { createKernel } from '@red-codes/kernel';
+import type { KernelResult, RawAgentAction } from '@red-codes/kernel';
+import { normalizeIntent } from '@red-codes/kernel';
+import { evaluate, loadYamlPolicy } from '@red-codes/policy';
+import type { LoadedPolicy } from '@red-codes/policy';
+import { checkAllInvariants, buildSystemState, DEFAULT_INVARIANTS } from '@red-codes/invariants';
+import {
+  createSimulatorRegistry,
+  createGitSimulator,
+  createFilesystemSimulator,
+  createPackageSimulator,
+  createDependencyGraphSimulator,
+} from '@red-codes/kernel';
+import type { McpConfig } from '../config.js';
+
+function loadPoliciesFromPath(policyPath?: string): LoadedPolicy[] {
+  if (!policyPath) return [];
+  try {
+    const absPath = resolve(policyPath);
+    if (!existsSync(absPath)) return [];
+    const content = readFileSync(absPath, 'utf8');
+    if (absPath.endsWith('.yaml') || absPath.endsWith('.yml')) {
+      const policy = loadYamlPolicy(content, policyPath);
+      return [{ id: policy.id, name: policy.name, rules: policy.rules, severity: policy.severity }];
+    }
+    const parsed = JSON.parse(content) as unknown;
+    return (Array.isArray(parsed) ? parsed : [parsed]) as LoadedPolicy[];
+  } catch {
+    return [];
+  }
+}
+
+function buildSimulatorRegistry() {
+  const registry = createSimulatorRegistry();
+  registry.register(createGitSimulator());
+  registry.register(createFilesystemSimulator());
+  registry.register(createPackageSimulator());
+  registry.register(createDependencyGraphSimulator());
+  return registry;
+}
+
+function serializeResult(result: KernelResult): object {
+  return {
+    allowed: result.allowed,
+    executed: result.executed,
+    decision: result.decision,
+    runId: result.runId,
+    action: result.action,
+    events: result.events.map((e) => ({ kind: e.kind, timestamp: e.timestamp })),
+    decisionRecord: result.decisionRecord
+      ? {
+          recordId: result.decisionRecord.recordId,
+          outcome: result.decisionRecord.outcome,
+          reason: result.decisionRecord.reason,
+          invariants: result.decisionRecord.invariants,
+          simulation: result.decisionRecord.simulation,
+        }
+      : undefined,
+  };
+}
+
+export function registerGovernanceTools(server: McpServer, config: McpConfig): void {
+  // propose_action — submit an action through the governance kernel
+  server.tool(
+    'propose_action',
+    'Submit an action through the AgentGuard governance kernel for policy and invariant evaluation',
+    {
+      tool: z.string().describe('Tool name (e.g. Bash, Write, Edit, Read)'),
+      command: z.string().optional().describe('Shell command (for Bash tool)'),
+      file: z.string().optional().describe('Target file path'),
+      content: z.string().optional().describe('File content (for Write/Edit)'),
+      target: z.string().optional().describe('Action target'),
+      branch: z.string().optional().describe('Git branch'),
+      agent: z.string().optional().describe('Agent identity'),
+      dryRun: z
+        .boolean()
+        .optional()
+        .default(true)
+        .describe('Evaluate only, do not execute (default: true)'),
+      policyPath: z.string().optional().describe('Path to policy file'),
+    },
+    async (args) => {
+      try {
+        const policies = loadPoliciesFromPath(args.policyPath || config.policyPath);
+
+        const rawAction: RawAgentAction = {
+          tool: args.tool,
+          command: args.command,
+          file: args.file,
+          content: args.content,
+          target: args.target,
+          branch: args.branch,
+          agent: args.agent || 'mcp-client',
+        };
+
+        const kernel = createKernel({
+          policyDefs: policies,
+          invariants: DEFAULT_INVARIANTS,
+          dryRun: args.dryRun ?? true,
+          simulators: buildSimulatorRegistry(),
+        });
+
+        const result = await kernel.propose(rawAction);
+        kernel.shutdown();
+
+        return {
+          content: [{ type: 'text', text: JSON.stringify(serializeResult(result), null, 2) }],
+        };
+      } catch (err) {
+        return {
+          content: [{ type: 'text', text: JSON.stringify({ error: String(err) }) }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // evaluate_policy — test an action against policy rules without kernel
+  server.tool(
+    'evaluate_policy',
+    'Evaluate an action against policy rules (standalone, no kernel overhead)',
+    {
+      action: z
+        .string()
+        .describe('Canonical action type (e.g. git.push, file.write, shell.exec)'),
+      target: z.string().optional().default('').describe('Target path or branch'),
+      command: z.string().optional().describe('Shell command'),
+      branch: z.string().optional().describe('Git branch'),
+      agent: z.string().optional().default('mcp-client').describe('Agent identity'),
+      policyPath: z.string().optional().describe('Path to policy file'),
+    },
+    async (args) => {
+      try {
+        const policies = loadPoliciesFromPath(args.policyPath || config.policyPath);
+        const intent = normalizeIntent({
+          tool: args.action,
+          target: args.target,
+          command: args.command,
+          branch: args.branch,
+          agent: args.agent,
+        });
+
+        const result = evaluate(intent, policies);
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  allowed: result.allowed,
+                  decision: result.decision,
+                  reason: result.reason,
+                  severity: result.severity,
+                  matchedRule: result.matchedRule,
+                  matchedPolicy: result.matchedPolicy,
+                  trace: result.trace,
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      } catch (err) {
+        return {
+          content: [{ type: 'text', text: JSON.stringify({ error: String(err) }) }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // check_invariants — evaluate system state against all 17 built-in invariants
+  server.tool(
+    'check_invariants',
+    'Check system state against all 17 built-in AgentGuard invariants',
+    {
+      modifiedFiles: z.array(z.string()).optional().describe('File paths being modified'),
+      targetBranch: z.string().optional().describe('Target git branch'),
+      directPush: z.boolean().optional().describe('Is this a direct push?'),
+      forcePush: z.boolean().optional().describe('Is this a force push?'),
+      isPush: z.boolean().optional().describe('Is this a push operation?'),
+      testsPass: z.boolean().optional().describe('Have tests passed?'),
+      filesAffected: z.number().optional().describe('Number of files affected'),
+      currentTarget: z.string().optional().describe('Current file target'),
+      currentCommand: z.string().optional().describe('Current shell command'),
+      currentActionType: z.string().optional().describe('Canonical action type'),
+    },
+    async (args) => {
+      try {
+        const state = buildSystemState(args);
+        const result = checkAllInvariants(DEFAULT_INVARIANTS, state);
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  allHold: result.allHold,
+                  violationCount: result.violations.length,
+                  violations: result.violations.map((v) => ({
+                    id: v.invariant.id,
+                    name: v.invariant.name,
+                    severity: v.invariant.severity,
+                    expected: v.result.expected,
+                    actual: v.result.actual,
+                  })),
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      } catch (err) {
+        return {
+          content: [{ type: 'text', text: JSON.stringify({ error: String(err) }) }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // simulate_action — predict impact without executing
+  server.tool(
+    'simulate_action',
+    'Simulate an action and predict its impact without executing',
+    {
+      action: z.string().describe('Canonical action type (e.g. git.push, file.write)'),
+      target: z.string().optional().default('').describe('Target path'),
+      command: z.string().optional().describe('Shell command'),
+      branch: z.string().optional().describe('Git branch'),
+    },
+    async (args) => {
+      try {
+        const intent = normalizeIntent({
+          tool: args.action,
+          target: args.target,
+          command: args.command,
+          branch: args.branch,
+          agent: 'mcp-client',
+        });
+
+        const registry = buildSimulatorRegistry();
+        const simulator = registry.find(intent);
+
+        if (!simulator) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({
+                  message: 'No simulator supports this action type',
+                  action: intent.action,
+                  target: intent.target,
+                }),
+              },
+            ],
+          };
+        }
+
+        const result = await simulator.simulate(intent, {});
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  simulatorId: result.simulatorId,
+                  riskLevel: result.riskLevel,
+                  blastRadius: result.blastRadius,
+                  predictedChanges: result.predictedChanges,
+                  durationMs: result.durationMs,
+                  forecast: result.forecast,
+                  details: result.details,
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      } catch (err) {
+        return {
+          content: [{ type: 'text', text: JSON.stringify({ error: String(err) }) }],
+          isError: true,
+        };
+      }
+    }
+  );
+}

--- a/apps/mcp-server/src/tools/monitoring.ts
+++ b/apps/mcp-server/src/tools/monitoring.ts
@@ -1,0 +1,213 @@
+// Monitoring tools — inspect runs, list runs, query events, compare, traces.
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import type { DomainEvent } from '@red-codes/core';
+import { compareReplaySessions, buildReplaySession } from '@red-codes/kernel';
+import type { DataSource } from '../backends/types.js';
+
+export function registerMonitoringTools(server: McpServer, dataSource: DataSource): void {
+  // list_runs — enumerate recorded governance sessions
+  server.tool(
+    'list_runs',
+    'List recorded AgentGuard governance sessions',
+    {
+      limit: z.number().optional().default(20).describe('Maximum runs to return (default: 20)'),
+    },
+    async (args) => {
+      try {
+        const runs = await dataSource.listRuns(args.limit);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({ runs, count: runs.length }, null, 2),
+            },
+          ],
+        };
+      } catch (err) {
+        return {
+          content: [{ type: 'text', text: JSON.stringify({ error: String(err) }) }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // inspect_run — load and display run details
+  server.tool(
+    'inspect_run',
+    'Inspect a governance session: view events, decisions, and action graph',
+    {
+      runId: z.string().describe('Run ID to inspect'),
+    },
+    async (args) => {
+      try {
+        const events = await dataSource.loadEvents(args.runId);
+        const decisions = await dataSource.loadDecisions(args.runId);
+
+        const summary = {
+          runId: args.runId,
+          totalEvents: events.length,
+          totalDecisions: decisions.length,
+          eventKinds: countByKind(events),
+          decisions: decisions.map((d) => ({
+            recordId: d.recordId,
+            outcome: d.outcome,
+            action: d.action,
+            reason: d.reason,
+          })),
+          timeline: events.slice(0, 50).map((e) => ({
+            kind: e.kind,
+            timestamp: e.timestamp,
+          })),
+        };
+
+        return {
+          content: [{ type: 'text', text: JSON.stringify(summary, null, 2) }],
+        };
+      } catch (err) {
+        return {
+          content: [{ type: 'text', text: JSON.stringify({ error: String(err) }) }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // query_events — search events by kind, run, with limit
+  server.tool(
+    'query_events',
+    'Search governance events by run ID, event kind, and limit',
+    {
+      runId: z.string().optional().describe('Filter by run ID'),
+      kind: z.string().optional().describe('Filter by event kind (e.g. PolicyDenied, ActionExecuted)'),
+      limit: z.number().optional().default(50).describe('Maximum events to return (default: 50)'),
+    },
+    async (args) => {
+      try {
+        const events = await dataSource.queryEvents({
+          runId: args.runId,
+          kind: args.kind,
+          limit: args.limit,
+        });
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({ count: events.length, events }, null, 2),
+            },
+          ],
+        };
+      } catch (err) {
+        return {
+          content: [{ type: 'text', text: JSON.stringify({ error: String(err) }) }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // compare_runs — diff two governance sessions
+  server.tool(
+    'compare_runs',
+    'Compare two governance sessions side-by-side (action counts, denials, violations)',
+    {
+      runId1: z.string().describe('First run ID'),
+      runId2: z.string().describe('Second run ID'),
+    },
+    async (args) => {
+      try {
+        const events1 = await dataSource.loadEvents(args.runId1);
+        const events2 = await dataSource.loadEvents(args.runId2);
+
+        const session1 = buildReplaySession(args.runId1, events1);
+        const session2 = buildReplaySession(args.runId2, events2);
+        const comparison = compareReplaySessions(session1, session2);
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  totalComparisons: comparison.totalComparisons,
+                  matches: comparison.matches,
+                  divergences: comparison.divergences,
+                  missing: comparison.missing,
+                  extra: comparison.extra,
+                  identical: comparison.identical,
+                  comparisons: comparison.comparisons.slice(0, 50),
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      } catch (err) {
+        return {
+          content: [{ type: 'text', text: JSON.stringify({ error: String(err) }) }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // get_traces — display policy evaluation traces for a run
+  server.tool(
+    'get_traces',
+    'Get policy evaluation traces for a governance session',
+    {
+      runId: z.string().describe('Run ID'),
+      actionFilter: z.string().optional().describe('Filter by action type'),
+      decisionFilter: z
+        .string()
+        .optional()
+        .describe('Filter by decision (allow or deny)'),
+    },
+    async (args) => {
+      try {
+        const events = await dataSource.loadEvents(args.runId);
+        let traces = events.filter((e) => e.kind === 'PolicyTraceRecorded');
+
+        if (args.actionFilter) {
+          traces = traces.filter((e) => {
+            const payload = e as Record<string, unknown>;
+            return String(payload.action || '').includes(args.actionFilter!);
+          });
+        }
+
+        if (args.decisionFilter) {
+          traces = traces.filter((e) => {
+            const payload = e as Record<string, unknown>;
+            return String(payload.decision || '') === args.decisionFilter;
+          });
+        }
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({ count: traces.length, traces }, null, 2),
+            },
+          ],
+        };
+      } catch (err) {
+        return {
+          content: [{ type: 'text', text: JSON.stringify({ error: String(err) }) }],
+          isError: true,
+        };
+      }
+    }
+  );
+}
+
+function countByKind(events: DomainEvent[]): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const e of events) {
+    counts[e.kind] = (counts[e.kind] ?? 0) + 1;
+  }
+  return counts;
+}

--- a/apps/mcp-server/src/tools/policy.ts
+++ b/apps/mcp-server/src/tools/policy.ts
@@ -1,0 +1,100 @@
+// Policy tools — validate policies, list invariants.
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { loadYamlPolicy, validatePolicy } from '@red-codes/policy';
+import { DEFAULT_INVARIANTS } from '@red-codes/invariants';
+
+export function registerPolicyTools(server: McpServer): void {
+  // validate_policy — check policy file syntax
+  server.tool(
+    'validate_policy',
+    'Validate AgentGuard policy content (YAML or JSON) for syntax and structure',
+    {
+      content: z.string().describe('Policy content (YAML or JSON string)'),
+      format: z.enum(['yaml', 'json']).optional().default('yaml').describe('Policy format'),
+    },
+    async (args) => {
+      try {
+        if (args.format === 'yaml') {
+          const policy = loadYamlPolicy(args.content, 'inline');
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify(
+                  {
+                    valid: true,
+                    policy: {
+                      id: policy.id,
+                      name: policy.name,
+                      ruleCount: policy.rules.length,
+                      rules: policy.rules.map((r) => ({
+                        action: r.action,
+                        effect: r.effect,
+                        reason: r.reason,
+                      })),
+                    },
+                  },
+                  null,
+                  2
+                ),
+              },
+            ],
+          };
+        }
+
+        // JSON format
+        const parsed = JSON.parse(args.content) as unknown;
+        const policies = Array.isArray(parsed) ? parsed : [parsed];
+        const result = validatePolicy(policies);
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      } catch (err) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                { valid: false, error: String(err) },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      }
+    }
+  );
+
+  // list_invariants — show all 17 built-in invariant definitions
+  server.tool(
+    'list_invariants',
+    'List all 17 built-in AgentGuard invariants with their IDs, names, and descriptions',
+    {},
+    async () => {
+      const invariants = DEFAULT_INVARIANTS.map((inv) => ({
+        id: inv.id,
+        name: inv.name,
+        description: inv.description,
+        severity: inv.severity,
+      }));
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({ count: invariants.length, invariants }, null, 2),
+          },
+        ],
+      };
+    }
+  );
+}

--- a/apps/mcp-server/tests/governance.test.ts
+++ b/apps/mcp-server/tests/governance.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { resolveConfig } from '../src/config.js';
+import { registerGovernanceTools } from '../src/tools/governance.js';
+import { checkAllInvariants, buildSystemState, DEFAULT_INVARIANTS } from '@red-codes/invariants';
+import { normalizeIntent, createKernel } from '@red-codes/kernel';
+import { evaluate } from '@red-codes/policy';
+import type { LoadedPolicy } from '@red-codes/policy';
+
+function createTestServer() {
+  const config = resolveConfig();
+  const server = new McpServer({ name: 'test', version: '0.0.1' }, { capabilities: { tools: {} } });
+  registerGovernanceTools(server, config);
+  return server;
+}
+
+describe('Governance tools registration', () => {
+  it('registers all governance tools', () => {
+    const server = createTestServer();
+    expect(server).toBeDefined();
+  });
+});
+
+describe('check_invariants via kernel', () => {
+  it('detects force push violation', () => {
+    const state = buildSystemState({
+      forcePush: true,
+      isPush: true,
+      targetBranch: 'main',
+    });
+    const result = checkAllInvariants(DEFAULT_INVARIANTS, state);
+    expect(result.allHold).toBe(false);
+    const forcePushViolation = result.violations.find(
+      (v) => v.invariant.id === 'no-force-push'
+    );
+    expect(forcePushViolation).toBeDefined();
+  });
+
+  it('passes with safe state', () => {
+    const state = buildSystemState({
+      modifiedFiles: ['src/foo.ts'],
+      targetBranch: 'feature',
+      filesAffected: 1,
+    });
+    const result = checkAllInvariants(DEFAULT_INVARIANTS, state);
+    expect(result.allHold).toBe(true);
+  });
+});
+
+describe('evaluate_policy via kernel', () => {
+  it('evaluates action against policy', () => {
+    const policies: LoadedPolicy[] = [
+      {
+        id: 'test-deny-push',
+        name: 'No Push',
+        rules: [{ action: 'git.push', effect: 'deny' as const, reason: 'No pushing allowed' }],
+        severity: 5,
+      },
+    ];
+
+    const intent = normalizeIntent({ tool: 'Bash', command: 'git push origin main' });
+    const result = evaluate(intent, policies);
+    expect(result.allowed).toBe(false);
+    expect(result.decision).toBe('deny');
+  });
+
+  it('allows action with explicit allow rule', () => {
+    const policies: LoadedPolicy[] = [
+      {
+        id: 'test-mixed',
+        name: 'Mixed',
+        rules: [
+          { action: 'git.push', effect: 'deny' as const, reason: 'No pushing' },
+          { action: 'file.read', effect: 'allow' as const, reason: 'Reads OK' },
+        ],
+        severity: 5,
+      },
+    ];
+
+    const intent = normalizeIntent({ tool: 'Read', file: 'README.md' });
+    const result = evaluate(intent, policies);
+    expect(result.allowed).toBe(true);
+  });
+});
+
+describe('propose_action via kernel', () => {
+  it('proposes and evaluates an action', async () => {
+    const kernel = createKernel({
+      policyDefs: [
+        {
+          id: 'test',
+          name: 'Test',
+          rules: [{ action: 'git.push', effect: 'deny', reason: 'No push' }],
+          severity: 5,
+        },
+      ],
+      invariants: DEFAULT_INVARIANTS,
+      dryRun: true,
+    });
+
+    const result = await kernel.propose({
+      tool: 'Bash',
+      command: 'git push origin main',
+    });
+
+    expect(result.allowed).toBe(false);
+    expect(result.executed).toBe(false);
+    kernel.shutdown();
+  });
+});

--- a/apps/mcp-server/tests/monitoring.test.ts
+++ b/apps/mcp-server/tests/monitoring.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { createLocalDataSource } from '../src/backends/local.js';
+import type { McpConfig } from '../src/config.js';
+
+const TEST_DIR = '/tmp/agentguard-mcp-test';
+const EVENTS_DIR = join(TEST_DIR, 'events');
+const DECISIONS_DIR = join(TEST_DIR, 'decisions');
+
+function makeConfig(): McpConfig {
+  return {
+    backend: 'local',
+    localStore: 'jsonl',
+    baseDir: TEST_DIR,
+  };
+}
+
+function writeEvents(runId: string, events: object[]): void {
+  const content = events.map((e) => JSON.stringify(e)).join('\n') + '\n';
+  writeFileSync(join(EVENTS_DIR, `${runId}.jsonl`), content);
+}
+
+function writeDecisions(runId: string, decisions: object[]): void {
+  const content = decisions.map((d) => JSON.stringify(d)).join('\n') + '\n';
+  writeFileSync(join(DECISIONS_DIR, `${runId}.jsonl`), content);
+}
+
+beforeEach(() => {
+  mkdirSync(EVENTS_DIR, { recursive: true });
+  mkdirSync(DECISIONS_DIR, { recursive: true });
+});
+
+afterEach(() => {
+  if (existsSync(TEST_DIR)) {
+    rmSync(TEST_DIR, { recursive: true });
+  }
+});
+
+describe('Local data source - monitoring', () => {
+  it('lists runs from events directory', async () => {
+    writeEvents('run_001', [{ kind: 'RunStarted', timestamp: 1000 }]);
+    writeEvents('run_002', [{ kind: 'RunStarted', timestamp: 2000 }]);
+
+    const ds = createLocalDataSource(makeConfig());
+    const runs = await ds.listRuns();
+    expect(runs).toContain('run_001');
+    expect(runs).toContain('run_002');
+    expect(runs.length).toBe(2);
+  });
+
+  it('respects limit on listRuns', async () => {
+    writeEvents('run_001', [{ kind: 'RunStarted', timestamp: 1000 }]);
+    writeEvents('run_002', [{ kind: 'RunStarted', timestamp: 2000 }]);
+    writeEvents('run_003', [{ kind: 'RunStarted', timestamp: 3000 }]);
+
+    const ds = createLocalDataSource(makeConfig());
+    const runs = await ds.listRuns(2);
+    expect(runs.length).toBe(2);
+  });
+
+  it('loads events for a run', async () => {
+    const events = [
+      { kind: 'RunStarted', timestamp: 1000 },
+      { kind: 'ActionRequested', timestamp: 1001 },
+      { kind: 'ActionAllowed', timestamp: 1002 },
+    ];
+    writeEvents('run_001', events);
+
+    const ds = createLocalDataSource(makeConfig());
+    const loaded = await ds.loadEvents('run_001');
+    expect(loaded.length).toBe(3);
+    expect(loaded[0].kind).toBe('RunStarted');
+    expect(loaded[2].kind).toBe('ActionAllowed');
+  });
+
+  it('returns empty for nonexistent run', async () => {
+    const ds = createLocalDataSource(makeConfig());
+    const events = await ds.loadEvents('nonexistent');
+    expect(events).toEqual([]);
+  });
+
+  it('loads decisions for a run', async () => {
+    const decisions = [
+      {
+        recordId: 'dec_001',
+        outcome: 'allow',
+        action: { type: 'file.read', target: 'foo.ts' },
+        reason: 'Allowed by policy',
+      },
+    ];
+    writeDecisions('run_001', decisions);
+
+    const ds = createLocalDataSource(makeConfig());
+    const loaded = await ds.loadDecisions('run_001');
+    expect(loaded.length).toBe(1);
+    expect(loaded[0].recordId).toBe('dec_001');
+  });
+
+  it('queries events by kind', async () => {
+    const events = [
+      { kind: 'ActionRequested', timestamp: 1000 },
+      { kind: 'PolicyDenied', timestamp: 1001 },
+      { kind: 'ActionRequested', timestamp: 1002 },
+    ];
+    writeEvents('run_001', events);
+
+    const ds = createLocalDataSource(makeConfig());
+    const filtered = await ds.queryEvents({ runId: 'run_001', kind: 'PolicyDenied' });
+    expect(filtered.length).toBe(1);
+    expect(filtered[0].kind).toBe('PolicyDenied');
+  });
+
+  it('queries events with limit', async () => {
+    const events = Array.from({ length: 10 }, (_, i) => ({
+      kind: 'ActionRequested',
+      timestamp: 1000 + i,
+    }));
+    writeEvents('run_001', events);
+
+    const ds = createLocalDataSource(makeConfig());
+    const limited = await ds.queryEvents({ runId: 'run_001', limit: 3 });
+    expect(limited.length).toBe(3);
+  });
+});

--- a/apps/mcp-server/tests/server.test.ts
+++ b/apps/mcp-server/tests/server.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { resolveConfig } from '../src/config.js';
+import { createLocalDataSource } from '../src/backends/local.js';
+
+describe('MCP server config', () => {
+  it('resolves default config', () => {
+    const config = resolveConfig();
+    expect(config.backend).toBe('local');
+    expect(config.localStore).toBe('jsonl');
+    expect(config.baseDir).toBe('.agentguard');
+  });
+
+  it('resolves config from env vars', () => {
+    const orig = process.env.AGENTGUARD_MCP_BACKEND;
+    process.env.AGENTGUARD_MCP_BACKEND = 'firestore';
+    try {
+      const config = resolveConfig();
+      expect(config.backend).toBe('firestore');
+    } finally {
+      if (orig) process.env.AGENTGUARD_MCP_BACKEND = orig;
+      else delete process.env.AGENTGUARD_MCP_BACKEND;
+    }
+  });
+});
+
+describe('Local data source', () => {
+  it('creates a local data source', () => {
+    const config = resolveConfig();
+    const ds = createLocalDataSource(config);
+    expect(ds).toBeDefined();
+    expect(typeof ds.listRuns).toBe('function');
+    expect(typeof ds.loadEvents).toBe('function');
+    expect(typeof ds.loadDecisions).toBe('function');
+    expect(typeof ds.queryEvents).toBe('function');
+  });
+
+  it('returns empty runs for nonexistent directory', async () => {
+    const config = { ...resolveConfig(), baseDir: '/tmp/nonexistent-agentguard-test' };
+    const ds = createLocalDataSource(config);
+    const runs = await ds.listRuns();
+    expect(runs).toEqual([]);
+  });
+});

--- a/apps/mcp-server/tsconfig.json
+++ b/apps/mcp-server/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "composite": true
+  },
+  "include": ["src/**/*.ts"],
+  "references": [
+    { "path": "../../packages/core" },
+    { "path": "../../packages/events" },
+    { "path": "../../packages/policy" },
+    { "path": "../../packages/invariants" },
+    { "path": "../../packages/kernel" },
+    { "path": "../../packages/analytics" },
+    { "path": "../../packages/storage" },
+    { "path": "../../packages/adapters" },
+    { "path": "../../packages/telemetry" }
+  ]
+}

--- a/apps/mcp-server/vitest.config.ts
+++ b/apps/mcp-server/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,42 @@ importers:
         specifier: ^7.6.0
         version: 7.6.13
 
+  apps/mcp-server:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.12.1
+        version: 1.27.1(zod@3.25.76)
+      '@red-codes/adapters':
+        specifier: workspace:*
+        version: link:../../packages/adapters
+      '@red-codes/analytics':
+        specifier: workspace:*
+        version: link:../../packages/analytics
+      '@red-codes/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@red-codes/events':
+        specifier: workspace:*
+        version: link:../../packages/events
+      '@red-codes/invariants':
+        specifier: workspace:*
+        version: link:../../packages/invariants
+      '@red-codes/kernel':
+        specifier: workspace:*
+        version: link:../../packages/kernel
+      '@red-codes/policy':
+        specifier: workspace:*
+        version: link:../../packages/policy
+      '@red-codes/storage':
+        specifier: workspace:*
+        version: link:../../packages/storage
+      '@red-codes/telemetry':
+        specifier: workspace:*
+        version: link:../../packages/telemetry
+      zod:
+        specifier: ^3.25.0
+        version: 3.25.76
+
   apps/telemetry-server:
     dependencies:
       '@hono/node-server':
@@ -553,6 +589,16 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@modelcontextprotocol/sdk@1.27.1':
+    resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+
   '@neondatabase/serverless@0.9.5':
     resolution: {integrity: sha512-siFas6gItqv6wD/pZnvdu34wEqgG3nSE6zWZdq5j2DEsa+VvX8i/5HXJOo06qrw5axPXn+lGCxeR+NLaSPIXug==}
 
@@ -845,6 +891,10 @@ packages:
   '@vitest/utils@4.1.0':
     resolution: {integrity: sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -855,8 +905,19 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
+
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -886,6 +947,10 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
   brace-expansion@5.0.4:
     resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
     engines: {node: 18 || 20 || >=22}
@@ -900,9 +965,21 @@ packages:
     resolution: {integrity: sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==}
     engines: {node: '>=6.14.2'}
 
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
@@ -930,8 +1007,28 @@ packages:
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
+  content-disposition@1.0.1:
+    resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -961,12 +1058,35 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
@@ -974,10 +1094,17 @@ packages:
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
   esbuild@0.27.4:
     resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -1028,6 +1155,18 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eventsource-parser@3.0.6:
+    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
@@ -1035,6 +1174,16 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.3.1:
+    resolution: {integrity: sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1044,6 +1193,9 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1061,6 +1213,10 @@ packages:
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -1072,6 +1228,14 @@ packages:
   flatted@3.3.4:
     resolution: {integrity: sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==}
 
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
@@ -1079,6 +1243,17 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   get-tsconfig@4.13.6:
     resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
@@ -1090,9 +1265,21 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
 
   hono@4.12.8:
     resolution: {integrity: sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==}
@@ -1100,6 +1287,14 @@ packages:
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -1122,6 +1317,14 @@ packages:
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -1129,6 +1332,9 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -1145,6 +1351,9 @@ packages:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
 
+  jose@6.2.1:
+    resolution: {integrity: sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==}
+
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
@@ -1156,6 +1365,12 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -1183,6 +1398,26 @@ packages:
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
@@ -1212,6 +1447,10 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   node-abi@3.88.0:
     resolution: {integrity: sha512-At6b4UqIEVudaqPsXjmUO1r/N5BUr4yhDGs5PkBE8/oG5+TfLPhFechiskFsnT6Ql0VfUXbalUUCbfXxtj7K+w==}
     engines: {node: '>=10'}
@@ -1219,6 +1458,14 @@ packages:
   node-gyp-build@4.8.4:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
     hasBin: true
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
 
   obuf@1.1.2:
     resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
@@ -1229,6 +1476,10 @@ packages:
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -1245,6 +1496,10 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1252,6 +1507,9 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-to-regexp@8.3.0:
+    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1291,6 +1549,10 @@ packages:
   pino@10.3.1:
     resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
     hasBin: true
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
@@ -1333,6 +1595,10 @@ packages:
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
@@ -1340,8 +1606,20 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  qs@6.15.0:
+    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+    engines: {node: '>=0.6'}
+
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -1359,6 +1637,10 @@ packages:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
@@ -1367,6 +1649,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
@@ -1374,10 +1660,24 @@ packages:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
 
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -1386,6 +1686,22 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  side-channel-list@1.0.0:
+    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -1416,6 +1732,10 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
@@ -1483,6 +1803,10 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   ts-api-utils@2.4.0:
     resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
     engines: {node: '>=18.12'}
@@ -1535,6 +1859,10 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
+
   typescript-eslint@8.57.0:
     resolution: {integrity: sha512-W8GcigEMEeB07xEZol8oJ26rigm3+bfPHxHvwbYUlu1fUDsGuQ7Hiskx5xGW/xM4USc9Ephe3jtv7ZYPQntHeA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1550,11 +1878,19 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -1701,6 +2037,14 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod-to-json-schema@3.25.1:
+    resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
+    peerDependencies:
+      zod: ^3.25 || ^4
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
 
@@ -1862,6 +2206,28 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.11(hono@4.12.8)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.3.1(express@5.2.1)
+      hono: 4.12.8
+      jose: 6.2.1
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
 
   '@neondatabase/serverless@0.9.5':
     dependencies:
@@ -2171,11 +2537,20 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
+
+  ajv-formats@3.0.1(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
 
   ajv@6.14.0:
     dependencies:
@@ -2183,6 +2558,13 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   assertion-error@2.0.1: {}
 
@@ -2217,6 +2599,20 @@ snapshots:
       readable-stream: 3.6.2
     optional: true
 
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.0
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   brace-expansion@5.0.4:
     dependencies:
       balanced-match: 4.0.4
@@ -2234,7 +2630,19 @@ snapshots:
     dependencies:
       node-gyp-build: 4.8.4
 
+  bytes@3.1.2: {}
+
   cac@6.7.14: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   chai@5.3.3:
     dependencies:
@@ -2260,7 +2668,20 @@ snapshots:
   commander@2.20.3:
     optional: true
 
+  content-disposition@1.0.1: {}
+
+  content-type@1.0.5: {}
+
   convert-source-map@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cross-spawn@7.0.6:
     dependencies:
@@ -2284,17 +2705,37 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  depd@2.0.0: {}
+
   detect-libc@2.1.2:
     optional: true
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ee-first@1.1.1: {}
+
+  encodeurl@2.0.0: {}
 
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
     optional: true
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@1.7.0: {}
 
   es-module-lexer@2.0.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
 
   esbuild@0.27.4:
     optionalDependencies:
@@ -2324,6 +2765,8 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.4
       '@esbuild/win32-ia32': 0.27.4
       '@esbuild/win32-x64': 0.27.4
+
+  escape-html@1.0.3: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -2395,16 +2838,64 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  etag@1.8.1: {}
+
+  eventsource-parser@3.0.6: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.6
+
   expand-template@2.0.3:
     optional: true
 
   expect-type@1.3.0: {}
+
+  express-rate-limit@8.3.1(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.1.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.0.1
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.0
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   fast-deep-equal@3.1.3: {}
 
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-uri@3.1.0: {}
 
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
@@ -2416,6 +2907,17 @@ snapshots:
 
   file-uri-to-path@1.0.0:
     optional: true
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   find-up@5.0.0:
     dependencies:
@@ -2429,11 +2931,35 @@ snapshots:
 
   flatted@3.3.4: {}
 
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
+
   fs-constants@1.0.0:
     optional: true
 
   fsevents@2.3.3:
     optional: true
+
+  function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
 
   get-tsconfig@4.13.6:
     dependencies:
@@ -2446,11 +2972,31 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  gopd@1.2.0: {}
+
   has-flag@4.0.0: {}
+
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
 
   hono@4.12.8: {}
 
   html-escaper@2.0.2: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ieee754@1.2.1:
     optional: true
@@ -2461,17 +3007,22 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
-  inherits@2.0.4:
-    optional: true
+  inherits@2.0.4: {}
 
   ini@1.3.8:
     optional: true
+
+  ip-address@10.1.0: {}
+
+  ipaddr.js@1.9.1: {}
 
   is-extglob@2.1.1: {}
 
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-promise@4.0.0: {}
 
   isexe@2.0.0: {}
 
@@ -2488,6 +3039,8 @@ snapshots:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
 
+  jose@6.2.1: {}
+
   js-tokens@10.0.0: {}
 
   js-tokens@9.0.1: {}
@@ -2495,6 +3048,10 @@ snapshots:
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -2527,6 +3084,18 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
+  math-intrinsics@1.1.0: {}
+
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
   mimic-response@3.1.0:
     optional: true
 
@@ -2549,6 +3118,8 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  negotiator@1.0.0: {}
+
   node-abi@3.88.0:
     dependencies:
       semver: 7.7.4
@@ -2556,16 +3127,23 @@ snapshots:
 
   node-gyp-build@4.8.4: {}
 
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
   obuf@1.1.2: {}
 
   obug@2.1.1: {}
 
   on-exit-leak-free@2.1.2: {}
 
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
-    optional: true
 
   optionator@0.9.4:
     dependencies:
@@ -2584,9 +3162,13 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  parseurl@1.3.3: {}
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  path-to-regexp@8.3.0: {}
 
   pathe@2.0.3: {}
 
@@ -2632,6 +3214,8 @@ snapshots:
       sonic-boom: 4.2.1
       thread-stream: 4.0.0
 
+  pkce-challenge@5.0.1: {}
+
   postcss@8.5.8:
     dependencies:
       nanoid: 3.3.11
@@ -2672,6 +3256,11 @@ snapshots:
 
   process-warning@5.0.0: {}
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
@@ -2680,7 +3269,20 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  qs@6.15.0:
+    dependencies:
+      side-channel: 1.1.0
+
   quick-format-unescaped@4.0.4: {}
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
 
   rc@1.2.8:
     dependencies:
@@ -2700,6 +3302,8 @@ snapshots:
   readdirp@5.0.0: {}
 
   real-require@0.2.0: {}
+
+  require-from-string@2.0.2: {}
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -2734,18 +3338,85 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.59.0
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.3.0
+    transitivePeerDependencies:
+      - supports-color
+
   safe-buffer@5.2.1:
     optional: true
 
   safe-stable-stringify@2.5.0: {}
 
+  safer-buffer@2.1.2: {}
+
   semver@7.7.4: {}
+
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
 
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.0
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
 
@@ -2777,6 +3448,8 @@ snapshots:
   split2@4.2.0: {}
 
   stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
 
   std-env@3.10.0: {}
 
@@ -2846,6 +3519,8 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  toidentifier@1.0.1: {}
+
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
@@ -2893,6 +3568,12 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
   typescript-eslint@8.57.0(eslint@10.0.3)(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/eslint-plugin': 8.57.0(@typescript-eslint/parser@8.57.0(eslint@10.0.3)(typescript@5.9.3))(eslint@10.0.3)(typescript@5.9.3)
@@ -2908,12 +3589,16 @@ snapshots:
 
   undici-types@7.18.2: {}
 
+  unpipe@1.0.0: {}
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
 
   util-deprecate@1.0.2:
     optional: true
+
+  vary@1.1.2: {}
 
   vite-node@3.2.4(@types/node@25.5.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
@@ -3030,8 +3715,7 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
-  wrappy@1.0.2:
-    optional: true
+  wrappy@1.0.2: {}
 
   ws@8.19.0(bufferutil@4.1.0):
     optionalDependencies:
@@ -3040,3 +3724,9 @@ snapshots:
   yaml@2.8.2: {}
 
   yocto-queue@0.1.0: {}
+
+  zod-to-json-schema@3.25.1(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
+
+  zod@3.25.76: {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
     { "path": "packages/swarm" },
     { "path": "apps/cli" },
     { "path": "apps/telemetry-server" },
-    { "path": "apps/agentguardhq" }
+    { "path": "apps/agentguardhq" },
+    { "path": "apps/mcp-server" }
   ]
 }


### PR DESCRIPTION
New `apps/mcp-server/` package exposing AgentGuard governance capabilities
via Model Context Protocol (stdio transport for Claude Code integration).

Tools across 4 categories:
- Governance: propose_action, evaluate_policy, check_invariants, simulate_action
- Monitoring: list_runs, inspect_run, query_events, compare_runs, get_traces
- Analytics: analyze_violations, risk_scores, suggest_rules
- Policy: validate_policy, list_invariants

Supports 3 backends via env config:
- Local (JSONL/SQLite) — default
- Firestore — cloud-based shared governance
- Remote — telemetry-server API

All tools reuse existing @red-codes/* packages with no duplicated logic.

https://claude.ai/code/session_016Yn7opofXxM6eQ1z1ZnPfh