### PR TITLE
fix: skip file permissions test on Windows where chmod is not enforced

### DIFF
--- a/packages/telemetry-client/tests/identity.test.ts
+++ b/packages/telemetry-client/tests/identity.test.ts
@@ -90,7 +90,7 @@ describe('save/load/delete identity', () => {
     expect(existsSync(nestedPath)).toBe(true);
   });
 
-  it('sets restrictive file permissions', () => {
+  it.skipIf(process.platform === 'win32')('sets restrictive file permissions', () => {
     const identity = generateIdentity();
     saveIdentity(identity, identityPath);
     const stats = require('node:fs').statSync(identityPath);


### PR DESCRIPTION
The identity test asserting 0o600 permissions always gets 0o666 on Windows
since Unix-style chmod is not supported. Added platform guard via skipIf.

https://claude.ai/code/session_01LsvjoGguR2XZ8ggXz7jvN2