### PR TITLE
fix(invariants): exclude read-only operations from skill/scheduled-task modification checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,11 @@
     "type": "git",
     "url": "git+https://github.com/AgentGuardHQ/agent-guard.git"
   },
+  "pnpm": {
+    "overrides": {
+      "flatted": ">=3.4.1"
+    }
+  },
   "author": "jpleva91",
   "license": "Apache-2.0"
 }

--- a/packages/invariants/src/definitions.ts
+++ b/packages/invariants/src/definitions.ts
@@ -404,6 +404,37 @@ export const DEFAULT_INVARIANTS: AgentGuardInvariant[] = [
     description: 'Agent skill files (.claude/skills/) must not be modified by governed actions',
     severity: 4,
     check(state) {
+      const actionType = state.currentActionType || '';
+      const READ_ONLY_ACTIONS = ['file.read', 'git.diff'];
+
+      // Skip read-only action types (Read, Glob, Grep tools all map to file.read)
+      if (READ_ONLY_ACTIONS.includes(actionType)) {
+        return { holds: true, expected: 'N/A', actual: `Action type ${actionType} is read-only` };
+      }
+
+      // For shell.exec, skip read-only commands (ls, cat, find, etc.)
+      if (actionType === 'shell.exec') {
+        const command = (state.currentCommand || '').trim();
+        const baseCmd = command.split(/\s+/)[0]?.replace(/^.*\//, '') || '';
+        const READ_ONLY_CMDS = [
+          'ls',
+          'cat',
+          'head',
+          'tail',
+          'find',
+          'grep',
+          'rg',
+          'tree',
+          'stat',
+          'file',
+          'wc',
+          'diff',
+        ];
+        if (READ_ONLY_CMDS.includes(baseCmd) && !command.includes('>')) {
+          return { holds: true, expected: 'N/A', actual: 'Read-only shell command' };
+        }
+      }
+
       const SKILL_PATTERNS = ['.claude/skills/', '.claude\\skills\\'];
       const matchesSkillPath = (path: string) => SKILL_PATTERNS.some((p) => path.includes(p));
 
@@ -439,6 +470,37 @@ export const DEFAULT_INVARIANTS: AgentGuardInvariant[] = [
       'Agents must not modify scheduled task definitions (.claude/scheduled-tasks/) directly',
     severity: 5,
     check(state) {
+      const actionType = state.currentActionType || '';
+      const READ_ONLY_ACTIONS = ['file.read', 'git.diff'];
+
+      // Skip read-only action types (Read, Glob, Grep tools all map to file.read)
+      if (READ_ONLY_ACTIONS.includes(actionType)) {
+        return { holds: true, expected: 'N/A', actual: `Action type ${actionType} is read-only` };
+      }
+
+      // For shell.exec, skip read-only commands (ls, cat, find, etc.)
+      if (actionType === 'shell.exec') {
+        const command = (state.currentCommand || '').trim();
+        const baseCmd = command.split(/\s+/)[0]?.replace(/^.*\//, '') || '';
+        const READ_ONLY_CMDS = [
+          'ls',
+          'cat',
+          'head',
+          'tail',
+          'find',
+          'grep',
+          'rg',
+          'tree',
+          'stat',
+          'file',
+          'wc',
+          'diff',
+        ];
+        if (READ_ONLY_CMDS.includes(baseCmd) && !command.includes('>')) {
+          return { holds: true, expected: 'N/A', actual: 'Read-only shell command' };
+        }
+      }
+
       const SCHEDULED_TASK_PATTERNS = ['.claude/scheduled-tasks/', '.claude\\scheduled-tasks\\'];
       const matchesScheduledPath = (path: string) =>
         SCHEDULED_TASK_PATTERNS.some((p) => path.includes(p));

--- a/packages/invariants/tests/invariant-definitions.test.ts
+++ b/packages/invariants/tests/invariant-definitions.test.ts
@@ -277,6 +277,49 @@ describe('no-skill-modification', () => {
     const result = inv.check({ currentTarget: '.claude/settings.json' });
     expect(result.holds).toBe(true);
   });
+
+  it('holds when currentActionType is file.read on skill path', () => {
+    const result = inv.check({
+      currentActionType: 'file.read',
+      currentTarget: '.claude/skills/my-skill/SKILL.md',
+    });
+    expect(result.holds).toBe(true);
+    expect(result.actual).toContain('read-only');
+  });
+
+  it('holds when currentActionType is git.diff on skill path', () => {
+    const result = inv.check({
+      currentActionType: 'git.diff',
+      currentTarget: '.claude/skills/my-skill/SKILL.md',
+    });
+    expect(result.holds).toBe(true);
+    expect(result.actual).toContain('read-only');
+  });
+
+  it('holds when shell.exec command is ls on skill path', () => {
+    const result = inv.check({
+      currentActionType: 'shell.exec',
+      currentCommand: 'ls .claude/skills/',
+    });
+    expect(result.holds).toBe(true);
+    expect(result.actual).toContain('Read-only shell command');
+  });
+
+  it('still fails when shell.exec rm targets skill path', () => {
+    const result = inv.check({
+      currentActionType: 'shell.exec',
+      currentCommand: 'rm -rf .claude/skills/old-skill',
+    });
+    expect(result.holds).toBe(false);
+  });
+
+  it('still fails when file.write targets skill path', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      currentTarget: '.claude/skills/my-skill/SKILL.md',
+    });
+    expect(result.holds).toBe(false);
+  });
 });
 
 describe('no-scheduled-task-modification', () => {
@@ -333,6 +376,49 @@ describe('no-scheduled-task-modification', () => {
   it('holds when .claude path does not include scheduled-tasks', () => {
     const result = inv.check({ currentTarget: '.claude/settings.json' });
     expect(result.holds).toBe(true);
+  });
+
+  it('holds when currentActionType is file.read on scheduled task path', () => {
+    const result = inv.check({
+      currentActionType: 'file.read',
+      currentTarget: '.claude/scheduled-tasks/daily-sync/SKILL.md',
+    });
+    expect(result.holds).toBe(true);
+    expect(result.actual).toContain('read-only');
+  });
+
+  it('holds when currentActionType is git.diff on scheduled task path', () => {
+    const result = inv.check({
+      currentActionType: 'git.diff',
+      currentTarget: '.claude/scheduled-tasks/daily-sync/SKILL.md',
+    });
+    expect(result.holds).toBe(true);
+    expect(result.actual).toContain('read-only');
+  });
+
+  it('holds when shell.exec command is ls on scheduled task path', () => {
+    const result = inv.check({
+      currentActionType: 'shell.exec',
+      currentCommand: 'ls .claude/scheduled-tasks/',
+    });
+    expect(result.holds).toBe(true);
+    expect(result.actual).toContain('Read-only shell command');
+  });
+
+  it('still fails when shell.exec rm targets scheduled task path', () => {
+    const result = inv.check({
+      currentActionType: 'shell.exec',
+      currentCommand: 'rm -rf .claude/scheduled-tasks/old-task',
+    });
+    expect(result.holds).toBe(false);
+  });
+
+  it('still fails when file.write targets scheduled task path', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      currentTarget: '.claude/scheduled-tasks/daily-sync/SKILL.md',
+    });
+    expect(result.holds).toBe(false);
   });
 
   it('holds when path contains "scheduled" but not "scheduled-tasks/"', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  flatted: '>=3.4.1'
+
 importers:
 
   .:
@@ -1207,8 +1210,8 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
-  flatted@3.3.4:
-    resolution: {integrity: sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==}
+  flatted@3.4.1:
+    resolution: {integrity: sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -2833,10 +2836,10 @@ snapshots:
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.3.4
+      flatted: 3.4.1
       keyv: 4.5.4
 
-  flatted@3.3.4: {}
+  flatted@3.4.1: {}
 
   forwarded@0.2.0: {}
 


### PR DESCRIPTION
The no-skill-modification and no-scheduled-task-modification invariants were
generating false positives on file.read, git.diff, and read-only shell commands
(ls, cat, etc.) that merely referenced .claude/skills/ or .claude/scheduled-tasks/
paths. This adds early-return guards for read-only action types, matching the
pattern established by no-credential-file-creation. Also patches CVE-2026-32141
(flatted DoS) via pnpm override to >=3.4.1.

https://claude.ai/code/session_01B1NaXA4K83DVtwJGgywXQA