### PR TITLE
Add Agent Swarm section to site documentation

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -1220,14 +1220,16 @@ rules:
             <div class="flex items-center gap-2 mb-3">
               <span class="w-2 h-2 rounded-full bg-info"></span>
               <h3 class="font-mono font-semibold text-info text-xs uppercase tracking-wider">Quality</h3>
-              <span class="ml-auto text-muted text-xs font-mono">5 agents</span>
+              <span class="ml-auto text-muted text-xs font-mono">7 agents</span>
             </div>
             <ul class="space-y-2 text-sm font-mono">
-              <li class="text-muted"><span class="text-text">Testing</span> &mdash; Expands test coverage</li>
-              <li class="text-muted"><span class="text-text">Security</span> &mdash; Scans for vulnerabilities</li>
+              <li class="text-muted"><span class="text-text">Testing</span> &mdash; Runs &amp; expands test suites</li>
+              <li class="text-muted"><span class="text-text">Test Generation</span> &mdash; Generates new tests</li>
+              <li class="text-muted"><span class="text-text">Security Audit</span> &mdash; Scans for vulnerabilities</li>
               <li class="text-muted"><span class="text-text">Architecture Review</span> &mdash; Detects drift &amp; debt</li>
               <li class="text-muted"><span class="text-text">CI/CD Hardener</span> &mdash; Strengthens pipelines</li>
-              <li class="text-muted"><span class="text-text">Audit</span> &mdash; Audits merged PRs</li>
+              <li class="text-muted"><span class="text-text">PR Audit</span> &mdash; Audits merged PRs</li>
+              <li class="text-muted"><span class="text-text">Infra Health</span> &mdash; Infrastructure checks</li>
             </ul>
           </div>
 
@@ -1236,12 +1238,10 @@ rules:
             <div class="flex items-center gap-2 mb-3">
               <span class="w-2 h-2 rounded-full bg-surface-light"></span>
               <h3 class="font-mono font-semibold text-muted text-xs uppercase tracking-wider">Marketing</h3>
-              <span class="ml-auto text-muted text-xs font-mono">3 agents</span>
+              <span class="ml-auto text-muted text-xs font-mono">1 agent</span>
             </div>
             <ul class="space-y-2 text-sm font-mono">
-              <li class="text-muted"><span class="text-text">Changelog</span> &mdash; Generates release notes</li>
-              <li class="text-muted"><span class="text-text">Social Content</span> &mdash; Drafts announcements</li>
-              <li class="text-muted"><span class="text-text">Community</span> &mdash; Engages discussions</li>
+              <li class="text-muted"><span class="text-text">Content Agent</span> &mdash; Changelogs, social posts &amp; community engagement from project activity</li>
             </ul>
           </div>
 


### PR DESCRIPTION
The site had no mention of the @red-codes/swarm package, which provides
26 specialized agents across 5 tiers (core, governance, ops, quality,
marketing) with 60+ skill templates. Adds a new "Swarm" section with
tier cards, agent listings, stats, and quick start commands. Also adds
navigation links in header, mobile menu, and footer.

https://claude.ai/code/session_01SBmsteXPxbQ4BtEp1Y7tkE