### PR TITLE
fix: update swarm docs to reflect build-from-source installation

### DIFF
--- a/packages/swarm/README.md
+++ b/packages/swarm/README.md
@@ -26,10 +26,16 @@ ROADMAP.md (you write strategy)
 ## Quick Start
 
 ```bash
-# Install AgentGuard
-npm install -g @red-codes/agentguard
+# Clone and build AgentGuard
+git clone https://github.com/AgentGuardHQ/agent-guard.git
+cd agent-guard
+pnpm install && pnpm build
+
+# Link the CLI globally
+cd apps/cli && npm link && cd ../..
 
 # Scaffold the swarm into your project
+cd /path/to/your-project
 agentguard init swarm
 
 # This creates:
@@ -118,7 +124,7 @@ swarm:
     roadmap: ROADMAP.md             # Your project roadmap
     swarmState: .agentguard/swarm-state.json
     logs: logs/runtime-events.jsonl
-    cli: npx agentguard             # How to invoke the CLI
+    cli: agentguard                  # How to invoke the CLI
 
   # Behavioral thresholds
   thresholds:

--- a/site/index.html
+++ b/site/index.html
@@ -1254,14 +1254,14 @@ rules:
             <div class="space-y-3">
               <div>
                 <p class="text-muted text-xs mb-1">Scaffold all tiers:</p>
-                <pre class="bg-bg rounded-lg px-3 py-2 text-sm font-mono text-text overflow-x-auto"><code>npx agentguard init swarm</code></pre>
+                <pre class="bg-bg rounded-lg px-3 py-2 text-sm font-mono text-text overflow-x-auto"><code>agentguard init swarm</code></pre>
               </div>
               <div>
                 <p class="text-muted text-xs mb-1">Select specific tiers:</p>
-                <pre class="bg-bg rounded-lg px-3 py-2 text-sm font-mono text-text overflow-x-auto"><code>npx agentguard init swarm \
+                <pre class="bg-bg rounded-lg px-3 py-2 text-sm font-mono text-text overflow-x-auto"><code>agentguard init swarm \
   --tiers core,governance</code></pre>
               </div>
-              <p class="text-muted text-xs mt-3">Generates <span class="text-text font-mono">.claude/skills/</span>, agent prompts, and <span class="text-text font-mono">agentguard-swarm.yaml</span> config.</p>
+              <p class="text-muted text-xs mt-3">Requires <a href="https://github.com/AgentGuardHQ/agent-guard" class="text-cta hover:underline">building from source</a>. Generates <span class="text-text font-mono">.claude/skills/</span>, agent prompts, and <span class="text-text font-mono">agentguard-swarm.yaml</span> config.</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
The CLI is not yet published to npm, so `npx agentguard` and
`npm install -g @red-codes/agentguard` do not work. Updated the
swarm README and site to show clone + build + link instructions.

https://claude.ai/code/session_01Qvzj9xsSqDTKbHmsov1mFh