### PR TITLE
fix: auto-open session viewer on session end

### DIFF
--- a/apps/cli/src/commands/claude-hook.ts
+++ b/apps/cli/src/commands/claude-hook.ts
@@ -207,7 +207,7 @@ async function handleStop(cliArgs: string[]): Promise<void> {
     const { sessionViewer } = await import('./session-viewer.js');
     const { resolveStorageConfig } = await import('@red-codes/storage');
     const storageConfig = resolveStorageConfig(cliArgs);
-    await sessionViewer(['--last', '--no-open', ...cliArgs], storageConfig);
+    await sessionViewer(['--last', ...cliArgs], storageConfig);
     process.stderr.write(
       '  \x1b[36m\u2139\x1b[0m  Session viewer ready. Run \x1b[1magentguard session-viewer --last\x1b[0m to open in browser.\n\n'
     );


### PR DESCRIPTION
## Summary
- Remove `--no-open` flag from the Stop hook's session viewer invocation so the browser opens automatically when a Claude Code session ends
- Previously users had to manually run `agentguard session-viewer --last` after every session — now it just opens

## Test plan
- [ ] Start a Claude Code session with AgentGuard hooks configured
- [ ] End the session and verify the session viewer HTML opens in the default browser
- [ ] Verify the PostToolUse quiet generation still uses `--no-open` (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)