### PR TITLE
feat: auto-open session viewer on agent pause via Notification hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -39,6 +39,18 @@
         ]
       }
     ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node apps/cli/dist/bin.js claude-hook notify --store sqlite",
+            "timeout": 15000,
+            "blocking": false
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/apps/cli/src/commands/claude-hook.ts
+++ b/apps/cli/src/commands/claude-hook.ts
@@ -1,6 +1,8 @@
-// AgentGuard Claude Code hook — PreToolUse governance + PostToolUse error monitoring.
+// AgentGuard Claude Code hook — PreToolUse governance + PostToolUse error monitoring + Notification session viewer.
 // PreToolUse: routes actions through the kernel for policy/invariant enforcement.
 // PostToolUse: reports Bash stderr errors (informational only).
+// Notification: auto-opens the session viewer when the agent pauses for human input.
+// Stop: generates session viewer HTML (no browser open — Notification handles that).
 // Always exits 0 — hooks must never fail.
 // Supports both JSONL (default) and SQLite storage backends via --store flag or AGENTGUARD_STORE env var.
 
@@ -20,9 +22,17 @@ function resolveCliCommand(): string {
 
 export async function claudeHook(hookType?: string, extraArgs: string[] = []): Promise<void> {
   try {
-    // Stop hook has no stdin payload — it fires when the session ends
+    // Stop hook has no stdin payload — generates session viewer HTML quietly (no browser open)
     if (hookType === 'stop') {
       await handleStop(extraArgs);
+      process.exit(0);
+      return;
+    }
+
+    // Notification hook — fires when the agent pauses for human input.
+    // Auto-opens the session viewer in the browser so the user can review governance decisions.
+    if (hookType === 'notify') {
+      await handleNotification(extraArgs);
       process.exit(0);
       return;
     }
@@ -211,13 +221,27 @@ function generateSessionViewerQuietly(cliArgs: string[]): void {
   }
 }
 
-async function handleStop(cliArgs: string[]): Promise<void> {
-  // On session end, generate the session viewer HTML and auto-open in the browser
+async function handleNotification(cliArgs: string[]): Promise<void> {
+  // Agent paused for human input — open the session viewer in the browser.
+  // This gives the user a visual overview of governance decisions from the agent's turn.
   try {
     const { sessionViewer } = await import('./session-viewer.js');
     const { resolveStorageConfig } = await import('@red-codes/storage');
     const storageConfig = resolveStorageConfig(cliArgs);
     await sessionViewer(['--last', ...cliArgs], storageConfig);
+  } catch {
+    // Non-fatal — viewer generation is best-effort
+  }
+}
+
+async function handleStop(cliArgs: string[]): Promise<void> {
+  // On session end, generate the session viewer HTML quietly (no browser open).
+  // The Notification hook already opened the browser when the agent last paused.
+  try {
+    const { sessionViewer } = await import('./session-viewer.js');
+    const { resolveStorageConfig } = await import('@red-codes/storage');
+    const storageConfig = resolveStorageConfig(cliArgs);
+    await sessionViewer(['--last', '--no-open', ...cliArgs], storageConfig);
   } catch {
     // Non-fatal — viewer generation is best-effort
   }

--- a/apps/cli/src/commands/claude-init.ts
+++ b/apps/cli/src/commands/claude-init.ts
@@ -141,7 +141,23 @@ export async function claudeInit(args: string[] = []): Promise<void> {
   });
   settings.hooks.SessionStart.push({ hooks: sessionStartHooks });
 
-  // Stop — generate session viewer on session end
+  // Notification — auto-open session viewer when agent pauses for human input
+  if (!settings.hooks.Notification)
+    (settings.hooks as Record<string, unknown>).Notification = [];
+  (
+    (settings.hooks as Record<string, unknown>).Notification as SessionStartHookEntry[]
+  ).push({
+    hooks: [
+      {
+        type: 'command',
+        command: `${cli} claude-hook notify${storeSuffix}${dbPathSuffix}`,
+        timeout: 15000,
+        blocking: false,
+      },
+    ],
+  });
+
+  // Stop — generate session viewer HTML on session end (no browser open — Notification handles that)
   if (!settings.hooks.Stop) (settings.hooks as Record<string, unknown>).Stop = [];
   ((settings.hooks as Record<string, unknown>).Stop as SessionStartHookEntry[]).push({
     hooks: [
@@ -159,10 +175,13 @@ export async function claudeInit(args: string[] = []): Promise<void> {
   process.stderr.write(
     `  ${FG.green}✓${RESET}  Hooks installed in ${FG.cyan}${settingsLabel}${RESET}\n`
   );
-  process.stderr.write(`  ${DIM}SessionStart: auto-build + status check${RESET}\n`);
-  process.stderr.write(`  ${DIM}PreToolUse:   governance enforcement (all tools)${RESET}\n`);
-  process.stderr.write(`  ${DIM}PostToolUse:  error monitoring (Bash)${RESET}\n`);
-  process.stderr.write(`  ${DIM}Stop:         session viewer generation${RESET}\n`);
+  process.stderr.write(`  ${DIM}SessionStart:  auto-build + status check${RESET}\n`);
+  process.stderr.write(`  ${DIM}PreToolUse:    governance enforcement (all tools)${RESET}\n`);
+  process.stderr.write(`  ${DIM}PostToolUse:   error monitoring (Bash)${RESET}\n`);
+  process.stderr.write(
+    `  ${DIM}Notification:  auto-open session viewer on agent pause${RESET}\n`
+  );
+  process.stderr.write(`  ${DIM}Stop:          session viewer HTML archival${RESET}\n`);
   if (storeBackend) {
     process.stderr.write(`  ${DIM}Storage:     ${storeBackend}${RESET}\n`);
   }
@@ -256,6 +275,19 @@ function removeHook(settingsPath: string, settingsLabel: string): void {
   );
   if (((settings.hooks as Record<string, unknown>).SessionStart as HookEntry[]).length === 0) {
     delete (settings.hooks as Record<string, unknown>).SessionStart;
+  }
+
+  // Remove Notification hook
+  const notifHooks =
+    ((settings.hooks as Record<string, unknown>)?.Notification as HookEntry[]) || [];
+  (settings.hooks as Record<string, unknown>).Notification = filterByCommand(
+    notifHooks,
+    HOOK_MARKER
+  );
+  if (
+    ((settings.hooks as Record<string, unknown>).Notification as HookEntry[]).length === 0
+  ) {
+    delete (settings.hooks as Record<string, unknown>).Notification;
   }
 
   // Remove Stop hook
@@ -427,8 +459,16 @@ function showProtectionSummary(policyGenerated: boolean): void {
 function hasAgentGuardHook(settings: Settings): boolean {
   const preToolUse = settings?.hooks?.PreToolUse || [];
   const postToolUse = settings?.hooks?.PostToolUse || [];
+  const notifHooks = (
+    (settings?.hooks as Record<string, unknown>)?.Notification || []
+  ) as HookEntry[];
   const stopHooks = ((settings?.hooks as Record<string, unknown>)?.Stop || []) as HookEntry[];
-  const allEntries = [...preToolUse, ...postToolUse, ...stopHooks] as HookEntry[];
+  const allEntries = [
+    ...preToolUse,
+    ...postToolUse,
+    ...notifHooks,
+    ...stopHooks,
+  ] as HookEntry[];
   return allEntries.some((entry) => {
     const hooks = entry.hooks || [];
     return hooks.some((h) => h.command && h.command.includes(HOOK_MARKER));


### PR DESCRIPTION
## Summary
- Adds a `Notification` hook that auto-opens the session viewer in the browser when the agent pauses for human input, giving immediate visibility into governance decisions after each turn
- Updates the `Stop` hook to only generate HTML quietly (no browser open) since the Notification hook already handles that
- Updates `claude-init` to install/remove the Notification hook alongside existing hooks

## Test plan
- [x] `pnpm build` passes (CLI rebuilt with new handler)
- [x] 527 CLI tests pass (`pnpm test --filter=@red-codes/agentguard`)
- [x] `node apps/cli/dist/bin.js claude-hook notify` generates viewer and opens browser
- [x] `node apps/cli/dist/bin.js claude-hook stop` generates viewer HTML without opening browser
- [x] `claude-init --remove` + `claude-init` correctly installs/removes Notification hook
- [ ] Verify Notification hook fires in a live Claude Code session when the agent pauses

🤖 Generated with [Claude Code](https://claude.com/claude-code)