### PR TITLE
fix: auto-open session viewer after guard command

### DIFF
--- a/apps/cli/src/commands/guard.ts
+++ b/apps/cli/src/commands/guard.ts
@@ -189,7 +189,21 @@ export async function guard(_args: string[], options: GuardOptions = {}): Promis
     process.stderr.write(`  ${'\x1b[2m'}Press Ctrl+C to stop.${'\x1b[0m'}\n\n`);
   }
 
-  return processStdin(kernel, renderers, storage, telemetryClient);
+  return processStdin(kernel, renderers, storage, telemetryClient, storeConfig);
+}
+
+/** Auto-open session viewer in browser after run completes */
+async function openSessionViewer(storeConfig: StorageConfig): Promise<void> {
+  try {
+    const { sessionViewer } = await import('./session-viewer.js');
+    const storeArgs: string[] = [];
+    if (storeConfig.backend === 'sqlite') {
+      storeArgs.push('--store', 'sqlite');
+    }
+    await sessionViewer(['--last', ...storeArgs], storeConfig);
+  } catch {
+    // Non-fatal — viewer generation is best-effort
+  }
 }
 
 /** Detect execution environment */
@@ -203,7 +217,8 @@ async function processStdin(
   kernel: ReturnType<typeof createKernel>,
   renderers: RendererRegistry,
   storage: StorageBundle,
-  telemetryClient: TelemetryClient | null
+  telemetryClient: TelemetryClient | null,
+  storeConfig: StorageConfig
 ): Promise<number> {
   const startTime = Date.now();
   let totalActions = 0;
@@ -318,14 +333,16 @@ async function processStdin(
       storage.close();
     };
 
-    process.stdin.on('end', () => {
+    process.stdin.on('end', async () => {
       shutdown();
+      await openSessionViewer(storeConfig);
       resolvePromise(0);
     });
 
-    process.on('SIGINT', () => {
+    process.on('SIGINT', async () => {
       shutdown();
       process.stderr.write('\n  \x1b[33mAgentGuard stopped.\x1b[0m\n\n');
+      await openSessionViewer(storeConfig);
       resolvePromise(0);
     });
   });

--- a/apps/cli/src/commands/session-viewer.ts
+++ b/apps/cli/src/commands/session-viewer.ts
@@ -148,10 +148,14 @@ function uploadToServer(
 // ---------------------------------------------------------------------------
 
 function openInBrowser(filePath: string): void {
-  const cmd =
-    process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'start' : 'xdg-open';
   try {
-    execSync(`${cmd} "${filePath}"`, { stdio: 'ignore' });
+    if (process.platform === 'win32') {
+      // Windows `start` treats the first quoted arg as a window title — pass empty title first
+      execSync(`start "" "${filePath}"`, { stdio: 'ignore' });
+    } else {
+      const cmd = process.platform === 'darwin' ? 'open' : 'xdg-open';
+      execSync(`${cmd} "${filePath}"`, { stdio: 'ignore' });
+    }
   } catch {
     // Silently fail — file path is printed to stderr regardless
   }


### PR DESCRIPTION
## Summary
- **guard.ts**: Add `openSessionViewer()` helper called on both stdin-end and SIGINT shutdown paths, so `agentguard guard` auto-opens the session viewer HTML in the browser after a run completes (matching the existing `claude-hook` behavior)
- **session-viewer.ts**: Fix Windows `start` command — pass empty title (`start "" "path"`) so the quoted path is treated as the file to open, not a window title (was opening a terminal instead of the browser)

## Test plan
- [x] Verified `echo '...' | node apps/cli/dist/bin.js guard` generates HTML and opens browser on Windows
- [x] Confirmed the `start ""` fix opens the default browser instead of a cmd terminal
- [ ] Verify macOS/Linux `open`/`xdg-open` paths are unaffected (no change to those branches)
- [ ] Verify `--dry-run` mode still auto-opens the viewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)