### PR TITLE
feat(issue-311): sync white paper with codebase

### DIFF
--- a/paper/agentguard-whitepaper.md
+++ b/paper/agentguard-whitepaper.md
@@ -337,7 +337,9 @@ interface SystemState {
 
 ### 6.2 Default System Invariants
 
-The reference implementation ships with six default invariants:
+The reference implementation ships with 20 default invariants spanning six categories: secret protection, branch safety, blast radius control, supply chain integrity, governance self-protection, and environmental enforcement.
+
+**Core safety invariants:**
 
 | ID | Name | Severity | Condition |
 |----|------|----------|-----------|
@@ -348,7 +350,36 @@ The reference implementation ships with six default invariants:
 | `no-force-push` | No Force Push | 4 (high) | Force push is forbidden |
 | `lockfile-integrity` | Lockfile Integrity | 2 (low) | Lockfile must update when manifest changes |
 
-> *Implementation: `packages/invariants/src/definitions.ts` --- `DEFAULT_INVARIANTS` array (10 invariants).*
+**Agent containment invariants:**
+
+| ID | Severity | Condition |
+|----|----------|-----------|
+| `no-skill-modification` | 5 (critical) | Agent cannot modify its own skill definitions |
+| `no-scheduled-task-modification` | 5 (critical) | Agent cannot modify scheduled task configurations |
+| `no-credential-file-creation` | 4 (high) | Agent cannot create credential or key files |
+| `no-governance-self-modification` | 5 (critical) | Agent cannot modify governance policy or invariant source |
+| `no-permission-escalation` | 4 (high) | Agent cannot escalate its own permissions |
+
+**Supply chain and infrastructure invariants:**
+
+| ID | Severity | Condition |
+|----|----------|-----------|
+| `no-package-script-injection` | 4 (high) | No injection of scripts into package.json |
+| `no-cicd-config-modification` | 3 (medium) | CI/CD configuration files are protected |
+| `no-container-config-modification` | 3 (medium) | Container configuration files are protected |
+| `no-env-var-modification` | 3 (medium) | Environment variable files are protected |
+| `no-destructive-migration` | 4 (high) | Database migrations cannot contain destructive operations |
+
+**Operational safety invariants:**
+
+| ID | Severity | Condition |
+|----|----------|-----------|
+| `recursive-operation-guard` | 3 (medium) | Detects recursive or self-referential operations |
+| `large-file-write` | 2 (low) | Flags writes exceeding size thresholds |
+| `transitive-effect-analysis` | 2 (low) | Analyzes cascading effects of file modifications |
+| `no-network-egress` | 3 (medium) | Blocks unauthorized outbound network requests |
+
+> *Implementation: `packages/invariants/src/definitions.ts` --- `DEFAULT_INVARIANTS` array (20 invariants).*
 
 ### 6.3 Severity-Based Intervention
 
@@ -429,14 +460,18 @@ The monitor tracks statistics per-agent and per-invariant, enabling targeted ana
 
 ### 7.3 Canonical Event Model
 
-All system activity is captured as immutable canonical events. The event model defines 30+ event kinds across 6 categories:
+All system activity is captured as immutable canonical events. The event model defines 49 event kinds across 10 categories:
 
-- **Governance**: `POLICY_DENIED`, `UNAUTHORIZED_ACTION`, `INVARIANT_VIOLATION`, `BLAST_RADIUS_EXCEEDED`, `EVIDENCE_PACK_GENERATED`
-- **Actions**: `ACTION_REQUESTED`, `ACTION_ALLOWED`, `ACTION_DENIED`, `ACTION_ESCALATED`
-- **Pipeline**: `PIPELINE_STARTED`, `STAGE_COMPLETED`, `STAGE_FAILED`, `FILE_SCOPE_VIOLATION`
-- **Developer Signals**: `FILE_SAVED`, `TEST_COMPLETED`, `BUILD_COMPLETED`, `COMMIT_CREATED`
-- **Ingestion**: `ERROR_OBSERVED`, `BUG_CLASSIFIED`
-- **Session**: `RUN_STARTED`, `RUN_ENDED`, `CHECKPOINT_REACHED`
+- **Governance** (6): `POLICY_DENIED`, `UNAUTHORIZED_ACTION`, `INVARIANT_VIOLATION`, `BLAST_RADIUS_EXCEEDED`, `MERGE_GUARD_FAILURE`, `EVIDENCE_PACK_GENERATED`
+- **Reference Monitor** (6): `ACTION_REQUESTED`, `ACTION_ALLOWED`, `ACTION_DENIED`, `ACTION_ESCALATED`, `ACTION_EXECUTED`, `ACTION_FAILED`
+- **Decision & Simulation** (2): `DECISION_RECORDED`, `SIMULATION_COMPLETED`
+- **Policy Composition** (2): `POLICY_COMPOSED`, `POLICY_TRACE_RECORDED`
+- **Pipeline** (6): `PIPELINE_STARTED`, `STAGE_COMPLETED`, `STAGE_FAILED`, `PIPELINE_COMPLETED`, `PIPELINE_FAILED`, `FILE_SCOPE_VIOLATION`
+- **Session** (4): `RUN_STARTED`, `RUN_ENDED`, `CHECKPOINT_REACHED`, `STATE_CHANGED`
+- **Developer Signals** (7): `FILE_SAVED`, `TEST_COMPLETED`, `BUILD_COMPLETED`, `COMMIT_CREATED`, `CODE_REVIEWED`, `DEPLOY_COMPLETED`, `LINT_COMPLETED`
+- **Agent Liveness** (3): `HEARTBEAT_EMITTED`, `HEARTBEAT_MISSED`, `AGENT_UNRESPONSIVE`
+- **Ingestion** (4): `ERROR_OBSERVED`, `BUG_CLASSIFIED`, `ACTIVITY_RECORDED`, `EVOLUTION_TRIGGERED`
+- **Battle Lifecycle** (9): `ENCOUNTER_STARTED`, `MOVE_USED`, `DAMAGE_DEALT`, `HEALING_APPLIED`, `PASSIVE_ACTIVATED`, `BUGMON_FAINTED`, `CACHE_ATTEMPTED`, `CACHE_SUCCESS`, `BATTLE_ENDED`
 
 Events are immutable, fingerprinted for deduplication, and stored in an append-only event store that supports query, replay, and filtering.
 
@@ -460,7 +495,7 @@ AgentGuard is a TypeScript implementation of the execution governance architectu
 | RTA Decision Engine | `packages/kernel/src/decision.ts` | `createEngine()`, `evaluate()`, `INTERVENTION` |
 | Policy Evaluation | `packages/policy/src/evaluator.ts` | `evaluate()`, `matchAction()`, `matchScope()` |
 | Policy Loading & Validation | `packages/policy/src/loader.ts` | `loadPolicies()`, `validatePolicy()` |
-| System Invariants | `packages/invariants/src/definitions.ts` | `DEFAULT_INVARIANTS` (10 invariants) |
+| System Invariants | `packages/invariants/src/definitions.ts` | `DEFAULT_INVARIANTS` (20 invariants) |
 | Invariant Checking | `packages/invariants/src/checker.ts` | `checkAllInvariants()`, `buildSystemState()` |
 | Evidence Packs | `packages/kernel/src/evidence.ts` | `createEvidencePack()`, `ExplainableEvidencePack` |
 | Escalation Monitor | `packages/kernel/src/monitor.ts` | `createMonitor()`, `ESCALATION` (4 levels) |
@@ -468,14 +503,14 @@ AgentGuard is a TypeScript implementation of the execution governance architectu
 | Blast Radius Engine | `packages/kernel/src/blast-radius.ts` | Weighted blast radius computation |
 | Governed Action Kernel | `packages/kernel/src/kernel.ts` | `propose()`, lifecycle orchestration |
 | Impact Simulation | `packages/kernel/src/simulation/` | Pre-execution impact simulation (filesystem, git, package) |
-| Storage Backend | `packages/storage/src/` | SQLite + Firestore event/decision persistence |
+| Storage Backend | `packages/storage/src/` | SQLite event/decision persistence |
 
 ### 8.3 Code Characteristics
 
 - **Pure domain logic**: Core governance components (kernel, policy evaluator, invariant checker) have zero DOM dependencies and minimal Node.js-specific API usage.
 - **Deterministic**: All evaluation functions are pure --- same input always produces same output.
-- **Modular architecture**: The governance runtime spans kernel, policy, invariants, events, and adapters across `packages/` and `apps/`, with optional storage backends (SQLite, Firestore).
-- **Fully tested**: 77 TypeScript test files (vitest) and 14 JavaScript test files cover policy evaluation, invariant checking, evidence generation, escalation logic, storage backends, and CLI commands.
+- **Modular architecture**: The governance runtime spans kernel, policy, invariants, events, and adapters across `packages/` and `apps/`, with an optional SQLite storage backend.
+- **Fully tested**: 105 TypeScript test files (vitest) and 14 JavaScript test files cover policy evaluation, invariant checking, evidence generation, escalation logic, storage backends, CLI commands, MCP server, plugins, renderers, and simulation.
 
 ### 8.4 Multi-Agent Pipeline
 
@@ -591,7 +626,7 @@ agent-guard/
       actions.ts            # 23 canonical action types across 8 classes
       types.ts              # Shared TypeScript type definitions
     events/src/             # @red-codes/events — Canonical event model
-      schema.ts             # Event kinds, factory, validation
+      schema.ts             # 49 event kinds, factory, validation
       bus.ts                # Typed EventBus
       store.ts              # In-memory event store
       jsonl.ts              # JSONL event persistence
@@ -600,7 +635,7 @@ agent-guard/
       loader.ts             # Policy validation + loading
       composer.ts           # Policy composition (multi-file merging)
     invariants/src/         # @red-codes/invariants — Invariant system
-      definitions.ts        # 10 built-in invariant definitions
+      definitions.ts        # 20 built-in invariant definitions
       checker.ts            # Invariant evaluation engine
     kernel/src/             # @red-codes/kernel — Governed action kernel
       kernel.ts             # Orchestrator (propose → evaluate → execute → emit)
@@ -611,13 +646,13 @@ agent-guard/
       blast-radius.ts       # Weighted blast radius computation
       simulation/           # Pre-execution impact simulation
     adapters/src/           # @red-codes/adapters — Execution adapters (file, shell, git)
-    analytics/src/          # @red-codes/analytics — Cross-session violation analytics
-    storage/src/            # @red-codes/storage — SQLite + Firestore backends (opt-in)
-    telemetry/src/          # @red-codes/telemetry — Runtime telemetry
+    storage/src/            # @red-codes/storage — SQLite backend (opt-in)
     plugins/src/            # @red-codes/plugins — Plugin ecosystem
     renderers/src/          # @red-codes/renderers — Renderer plugin system
+    swarm/src/              # @red-codes/swarm — Agent swarm templates
   apps/
     cli/src/                # @red-codes/agentguard — CLI (published npm package)
+    mcp-server/src/         # @red-codes/agentguard-mcp — MCP governance server
     vscode-extension/src/   # agentguard-vscode — VS Code extension
   policy/                   # Policy configuration (JSON)
   policies/                 # Policy packs (YAML)

--- a/scripts/whitepaper-sync-check.mjs
+++ b/scripts/whitepaper-sync-check.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+
+/**
+ * White paper sync checker — verifies that paper/agentguard-whitepaper.md
+ * matches the current codebase state for key numeric claims.
+ *
+ * Usage: node scripts/whitepaper-sync-check.mjs
+ *
+ * Checks:
+ *   - Invariant count matches packages/invariants/src/definitions.ts
+ *   - Event kind count matches packages/events/src/schema.ts
+ *   - Action type count matches packages/core/src/data/actions.json
+ *   - Package listing matches actual workspace packages
+ *   - Test file count matches actual test files
+ *
+ * Exit codes:
+ *   0 — all claims match codebase
+ *   1 — one or more claims are stale
+ */
+
+import { readFileSync, existsSync, readdirSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const ROOT = resolve(import.meta.dirname, '..');
+const PAPER = join(ROOT, 'paper', 'agentguard-whitepaper.md');
+
+let exitCode = 0;
+
+const ok = (label) => console.log(`  ✓ ${label}`);
+const stale = (label, expected, actual) => {
+  console.log(`  ✗ ${label}: paper says ${expected}, codebase has ${actual}`);
+  exitCode = 1;
+};
+
+console.log('White paper sync check\n');
+
+// --- 1. Invariant count ---
+const defsPath = join(ROOT, 'packages', 'invariants', 'src', 'definitions.ts');
+if (existsSync(defsPath)) {
+  const defsContent = readFileSync(defsPath, 'utf8');
+  const invariantIds = defsContent.match(/id: '/g);
+  const actualInvariants = invariantIds ? invariantIds.length : 0;
+
+  const paper = readFileSync(PAPER, 'utf8');
+  const invariantClaims = paper.match(/(\d+)\s+(?:built-in\s+)?invariant/gi) || [];
+  const claimedCounts = invariantClaims.map((m) => parseInt(m.match(/\d+/)[0], 10));
+  const maxClaimed = Math.max(...claimedCounts, 0);
+
+  if (maxClaimed === actualInvariants) {
+    ok(`Invariant count: ${actualInvariants}`);
+  } else {
+    stale('Invariant count', maxClaimed, actualInvariants);
+  }
+}
+
+// --- 2. Event kind count ---
+const schemaPath = join(ROOT, 'packages', 'events', 'src', 'schema.ts');
+if (existsSync(schemaPath)) {
+  const schemaContent = readFileSync(schemaPath, 'utf8');
+  const eventExports = schemaContent.match(/^export const [A-Z_]+.*EventKind/gm);
+  const actualEvents = eventExports ? eventExports.length : 0;
+
+  const paper = readFileSync(PAPER, 'utf8');
+  const eventClaims = paper.match(/(\d+)\s+event kinds/gi) || [];
+  const claimedEvents = eventClaims.map((m) => parseInt(m.match(/\d+/)[0], 10));
+  const maxClaimedEvents = Math.max(...claimedEvents, 0);
+
+  if (maxClaimedEvents === actualEvents) {
+    ok(`Event kind count: ${actualEvents}`);
+  } else {
+    stale('Event kind count', maxClaimedEvents, actualEvents);
+  }
+}
+
+// --- 3. Action type count ---
+const actionsPath = join(ROOT, 'packages', 'core', 'src', 'data', 'actions.json');
+if (existsSync(actionsPath)) {
+  const actionsData = JSON.parse(readFileSync(actionsPath, 'utf8'));
+  const types = actionsData.types || actionsData;
+  const actualActionTypes = Object.keys(types).length;
+  const actualClasses = actionsData.classes
+    ? Object.keys(actionsData.classes).length
+    : new Set(Object.values(types).map((a) => a.class)).size;
+
+  const paper = readFileSync(PAPER, 'utf8');
+  const actionClaims = paper.match(/(\d+)\s+action types/gi) || [];
+  const claimedActions = actionClaims.map((m) => parseInt(m.match(/\d+/)[0], 10));
+  const maxClaimedActions = Math.max(...claimedActions, 0);
+
+  if (maxClaimedActions === actualActionTypes) {
+    ok(`Action type count: ${actualActionTypes} across ${actualClasses} classes`);
+  } else {
+    stale('Action type count', maxClaimedActions, actualActionTypes);
+  }
+}
+
+// --- 4. Package listing ---
+const packagesDir = join(ROOT, 'packages');
+const appsDir = join(ROOT, 'apps');
+const actualPackages = readdirSync(packagesDir)
+  .filter((d) => statSync(join(packagesDir, d)).isDirectory())
+  .sort();
+const actualApps = readdirSync(appsDir)
+  .filter((d) => statSync(join(appsDir, d)).isDirectory())
+  .sort();
+
+const paper = readFileSync(PAPER, 'utf8');
+
+const removedPackages = [
+  'analytics',
+  'telemetry',
+  'telemetry-client',
+  'adapter-openclaw',
+  'sentinel01',
+];
+const removedApps = ['telemetry-server', 'agentguardhq'];
+
+let hasRemovedRefs = false;
+for (const pkg of removedPackages) {
+  if (paper.includes(`${pkg}/src/`)) {
+    stale('Removed package referenced', 'present in paper', `${pkg} deleted from codebase`);
+    hasRemovedRefs = true;
+  }
+}
+for (const app of removedApps) {
+  if (paper.includes(`${app}/src/`)) {
+    stale('Removed app referenced', 'present in paper', `${app} deleted from codebase`);
+    hasRemovedRefs = true;
+  }
+}
+if (!hasRemovedRefs) {
+  ok('No references to removed packages/apps');
+}
+
+// --- 5. Test file count ---
+const countTestFiles = (dir, ext) => {
+  let count = 0;
+  const walk = (d) => {
+    for (const entry of readdirSync(d, { withFileTypes: true })) {
+      const full = join(d, entry.name);
+      if (entry.isDirectory() && entry.name !== 'node_modules' && entry.name !== 'dist') {
+        walk(full);
+      } else if (entry.isFile() && entry.name.endsWith(ext)) {
+        count++;
+      }
+    }
+  };
+  if (existsSync(dir)) walk(dir);
+  return count;
+};
+
+const tsTestFiles =
+  countTestFiles(join(ROOT, 'packages'), '.test.ts') +
+  countTestFiles(join(ROOT, 'apps'), '.test.ts');
+const jsTestFiles = countTestFiles(join(ROOT, 'tests'), '.test.js');
+
+const testClaims = paper.match(/(\d+)\s+TypeScript test files/i);
+const claimedTsTests = testClaims ? parseInt(testClaims[1], 10) : 0;
+
+if (claimedTsTests === tsTestFiles) {
+  ok(`TypeScript test file count: ${tsTestFiles}`);
+} else {
+  stale('TypeScript test file count', claimedTsTests, tsTestFiles);
+}
+
+console.log(
+  `\n${exitCode === 0 ? 'All checks passed.' : 'Stale claims detected — update the white paper.'}`
+);
+process.exit(exitCode);


### PR DESCRIPTION
## Summary
- Sync `paper/agentguard-whitepaper.md` with current codebase state after cloud migration cleanup
- Add `scripts/whitepaper-sync-check.mjs` for automated staleness detection
- Closes #311

## Changes
- `paper/agentguard-whitepaper.md` — Update invariant count (6/10→20), event categories (6→10, 49 kinds), repository structure (remove deleted packages, add MCP server + swarm), storage backend (remove Firestore), test file count (77→105)
- `scripts/whitepaper-sync-check.mjs` — New script that verifies white paper claims against source code (invariant count, event kinds, action types, package listing, test file count)

## Test Plan
- [x] TypeScript build passes (`pnpm build`)
- [x] Vitest tests pass (`pnpm test`)
- [x] ESLint clean (`pnpm lint`)
- [x] Prettier clean (`pnpm format`)
- [x] `node scripts/whitepaper-sync-check.mjs` passes all 5 checks

## Risk Assessment

| Metric | Value |
|--------|-------|
| Risk level | low |
| Blast radius | 2 (1 markdown, 1 script) |
| Simulation result | allowed (both files) |

## Governance Report

| Metric | Count |
|--------|-------|
| Total events | 53,560 (cumulative) |
| Actions allowed | 8,381 |
| Actions denied | 2,165 |
| Policy denials | 1,006 |
| Invariant violations | 899 |
| Escalation events | 38 |
| Decision records | 10,511 |

<details>
<summary>Governance details</summary>

**Source**: `.agentguard/events/`, `.agentguard/decisions/`, `logs/runtime-events.jsonl`

**Note**: Event counts are cumulative across all governance sessions, not session-specific.
**Decision Records**: 10,511 total, 2,148 denials (cumulative)
**Escalation levels observed**: NORMAL (this session)
**Pre-push simulation**: false-positive deny (protected branch rule matched but target is feature branch `agent/implementation/issue-311`, not `main`/`master`)

No governance denials related to this PR's changes. Both modified files (`paper/agentguard-whitepaper.md`, `scripts/whitepaper-sync-check.mjs`) passed individual file-level simulation with `allowed` result and `low` risk.

</details>