### PR TITLE
fix(ci): add permissions block to bench-regression-gate

### DIFF
--- a/.github/workflows/bench-regression-gate.yml
+++ b/.github/workflows/bench-regression-gate.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   bench:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4


### PR DESCRIPTION
## Summary
- Add explicit `permissions: contents: read` to the bench job in `bench-regression-gate.yml` to prevent write-all GITHUB_TOKEN exposure on pull_request-triggered runs
- Closes #492

## Changes
- `.github/workflows/bench-regression-gate.yml` — Added `permissions: contents: read` block at the job level for the `bench` job

## Test Plan
- [x] TypeScript build passes (`pnpm build`)
- [x] Vitest tests pass (`pnpm test`) — 519+ tests passing
- [x] Type-check passes (`pnpm ts:check`) — 26 tasks clean
- [x] ESLint clean (`pnpm lint`) — 0 errors
- [x] Prettier clean (`pnpm format`)

## Risk Assessment

| Metric | Value |
|--------|-------|
| Risk level | low |
| Blast radius | 1 (single workflow file) |
| Simulation result | policy: allow, invariant: CI/CD config modification (expected — issue authorizes this change) |

## Governance Report

| Metric | Value |
|--------|-------|
| Governance storage | SQLite (~/.agentguard/agentguard.db) |
| Policy file | agentguard.yaml |
| Escalation level | NORMAL |
| Pre-push simulation | allowed (policy: allow) |

<details>
<summary>Governance details</summary>

**Source**: SQLite governance database, `.agentguard/events/`, `logs/runtime-events.jsonl`

**Pre-push simulation**: Risk level medium (CI/CD config modification is expected for this issue). Policy decision: allow. Invariant violation: "No CI/CD Config Modification" — acknowledged as explicitly authorized by CI/CD hardening audit (#490).

**Escalation levels observed**: NORMAL only

</details>