### PR TITLE
fix(evidence-pr): add SQLite storage backend support

### DIFF
--- a/.claude/skills/create-pr.md
+++ b/.claude/skills/create-pr.md
@@ -48,27 +48,16 @@ If push fails due to remote rejection, diagnose and report. Do NOT force push.
 
 ### 4. Collect Governance Telemetry
 
-Read governance event data from this session:
+Use the evidence-pr command in dry-run mode to collect and format governance telemetry:
 
 ```bash
-ls -la .agentguard/events/ 2>/dev/null
+node apps/cli/dist/bin.js evidence-pr --last --dry-run --store sqlite 2>/dev/null
 ```
 
-For each `.jsonl` file in `.agentguard/events/`, count event types:
+If the command fails or returns no output, fall back to JSONL mode:
 
 ```bash
-cat .agentguard/events/*.jsonl 2>/dev/null | wc -l
-cat .agentguard/events/*.jsonl 2>/dev/null | grep -c "ActionAllowed" || echo 0
-cat .agentguard/events/*.jsonl 2>/dev/null | grep -c "ActionDenied" || echo 0
-cat .agentguard/events/*.jsonl 2>/dev/null | grep -c "PolicyDenied" || echo 0
-cat .agentguard/events/*.jsonl 2>/dev/null | grep -c "InvariantViolation" || echo 0
-cat .agentguard/events/*.jsonl 2>/dev/null | grep -c "ActionEscalated" || echo 0
-```
-
-Also check the runtime telemetry log:
-
-```bash
-cat logs/runtime-events.jsonl 2>/dev/null | wc -l
+node apps/cli/dist/bin.js evidence-pr --last --dry-run 2>/dev/null
 ```
 
 If no telemetry files exist, note "No governance telemetry recorded" — still proceed with PR creation.

--- a/apps/cli/src/bin.ts
+++ b/apps/cli/src/bin.ts
@@ -299,12 +299,15 @@ const COMMANDS: Record<string, CommandHelp> = {
       { flag: '--run, -r <runId>', description: 'Use events from a specific run' },
       { flag: '--last', description: 'Use events from the most recent run only' },
       { flag: '--dry-run', description: 'Print markdown without posting to GitHub' },
+      { flag: '--store <backend>', description: 'Storage backend: jsonl or sqlite (default: jsonl)' },
+      { flag: '--db-path <path>', description: 'Path to SQLite database file' },
     ],
     examples: [
       'agentguard evidence-pr',
       'agentguard evidence-pr --pr 42',
       'agentguard evidence-pr --last --dry-run',
       'agentguard evidence-pr --run run_1234567890_abc',
+      'agentguard evidence-pr --last --store sqlite',
     ],
   },
   'audit-verify': {
@@ -538,7 +541,7 @@ async function main() {
         break;
       }
       const { evidencePr } = await import('./commands/evidence-pr.js');
-      const code = await evidencePr(args.slice(1));
+      const code = await evidencePr(args.slice(1), resolveStorageConfig(args.slice(1)));
       process.exit(code);
       break;
     }

--- a/apps/cli/src/commands/evidence-pr.ts
+++ b/apps/cli/src/commands/evidence-pr.ts
@@ -1,5 +1,5 @@
 // CLI command: agentguard evidence-pr — attach governance evidence to a pull request.
-// Reads JSONL event files, aggregates governance metrics, and posts a PR comment.
+// Reads governance events (JSONL or SQLite), aggregates metrics, and posts a PR comment.
 
 import { readFileSync, existsSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
@@ -7,11 +7,16 @@ import { execSync } from 'node:child_process';
 import { parseArgs } from '../args.js';
 import { aggregateEvents, formatEvidenceMarkdown } from '../evidence-summary.js';
 import type { DomainEvent } from '@red-codes/core';
+import type { StorageConfig } from '@red-codes/storage';
 
 const BASE_DIR = '.agentguard';
 const EVENTS_DIR = join(BASE_DIR, 'events');
 
-function listRuns(): string[] {
+// ---------------------------------------------------------------------------
+// JSONL helpers (fallback when SQLite is not configured)
+// ---------------------------------------------------------------------------
+
+function listRunsJsonl(): string[] {
   if (!existsSync(EVENTS_DIR)) return [];
   return readdirSync(EVENTS_DIR)
     .filter((f) => f.endsWith('.jsonl'))
@@ -20,7 +25,7 @@ function listRuns(): string[] {
     .reverse();
 }
 
-function loadRunEvents(runId: string): DomainEvent[] {
+function loadRunEventsJsonl(runId: string): DomainEvent[] {
   const filePath = join(EVENTS_DIR, `${runId}.jsonl`);
   if (!existsSync(filePath)) return [];
 
@@ -38,13 +43,27 @@ function loadRunEvents(runId: string): DomainEvent[] {
   return events;
 }
 
-function loadAllRunEvents(): DomainEvent[] {
-  const runIds = listRuns();
+function loadAllRunEventsJsonl(): DomainEvent[] {
+  const runIds = listRunsJsonl();
   const events: DomainEvent[] = [];
   for (const runId of runIds) {
-    events.push(...loadRunEvents(runId));
+    events.push(...loadRunEventsJsonl(runId));
   }
   return events;
+}
+
+// ---------------------------------------------------------------------------
+// SQLite helpers
+// ---------------------------------------------------------------------------
+
+async function openSqliteDb(storageConfig: StorageConfig) {
+  const { createStorageBundle } = await import('@red-codes/storage');
+  const storage = await createStorageBundle(storageConfig);
+  if (!storage.db) {
+    process.stderr.write('  Error: SQLite storage backend did not initialize database.\n');
+    return null;
+  }
+  return storage;
 }
 
 function detectPrNumber(): string | null {
@@ -101,39 +120,90 @@ function postPrComment(prNumber: string, markdown: string): boolean {
   }
 }
 
-export async function evidencePr(args: string[]): Promise<number> {
+export async function evidencePr(
+  args: string[],
+  storageConfig?: StorageConfig
+): Promise<number> {
   const parsed = parseArgs(args, {
     boolean: ['--dry-run', '--last', '--all'],
     string: ['--pr', '--run'],
     alias: { '-n': '--pr', '-r': '--run' },
   });
 
+  const useSqlite = storageConfig?.backend === 'sqlite';
+
   // Determine which events to aggregate
   let events: DomainEvent[];
 
   if (parsed.flags.run) {
     const runId = parsed.flags.run as string;
-    events = loadRunEvents(runId);
+
+    if (useSqlite) {
+      const storage = await openSqliteDb(storageConfig);
+      if (!storage) return 1;
+      const { loadRunEvents } = await import('@red-codes/storage');
+      const db = storage.db as import('better-sqlite3').Database;
+      events = loadRunEvents(db, runId);
+      storage.close();
+    } else {
+      events = loadRunEventsJsonl(runId);
+    }
+
     if (events.length === 0) {
       process.stderr.write(`\n  \x1b[31mError:\x1b[0m Run "${runId}" has no events.\n\n`);
       return 1;
     }
   } else if (parsed.flags.last) {
-    const runs = listRuns();
-    if (runs.length === 0) {
-      process.stderr.write('\n  \x1b[31mError:\x1b[0m No governance runs recorded.\n\n');
-      return 1;
-    }
-    events = loadRunEvents(runs[0]);
-    if (events.length === 0) {
-      process.stderr.write(
-        `\n  \x1b[31mError:\x1b[0m Most recent run "${runs[0]}" has no events.\n\n`
-      );
-      return 1;
+    if (useSqlite) {
+      const storage = await openSqliteDb(storageConfig);
+      if (!storage) return 1;
+      const { getLatestRunId, loadRunEvents } = await import('@red-codes/storage');
+      const db = storage.db as import('better-sqlite3').Database;
+      const latestRunId = getLatestRunId(db);
+      if (!latestRunId) {
+        storage.close();
+        process.stderr.write('\n  \x1b[31mError:\x1b[0m No governance runs recorded.\n\n');
+        return 1;
+      }
+      events = loadRunEvents(db, latestRunId);
+      storage.close();
+      if (events.length === 0) {
+        process.stderr.write(
+          `\n  \x1b[31mError:\x1b[0m Most recent run "${latestRunId}" has no events.\n\n`
+        );
+        return 1;
+      }
+    } else {
+      const runs = listRunsJsonl();
+      if (runs.length === 0) {
+        process.stderr.write('\n  \x1b[31mError:\x1b[0m No governance runs recorded.\n\n');
+        return 1;
+      }
+      events = loadRunEventsJsonl(runs[0]);
+      if (events.length === 0) {
+        process.stderr.write(
+          `\n  \x1b[31mError:\x1b[0m Most recent run "${runs[0]}" has no events.\n\n`
+        );
+        return 1;
+      }
     }
   } else {
     // Default: aggregate all events from all runs
-    events = loadAllRunEvents();
+    if (useSqlite) {
+      const storage = await openSqliteDb(storageConfig);
+      if (!storage) return 1;
+      const { listRunIds, loadRunEvents } = await import('@red-codes/storage');
+      const db = storage.db as import('better-sqlite3').Database;
+      const runIds = listRunIds(db);
+      events = [];
+      for (const rid of runIds) {
+        events.push(...loadRunEvents(db, rid));
+      }
+      storage.close();
+    } else {
+      events = loadAllRunEventsJsonl();
+    }
+
     if (events.length === 0) {
       process.stderr.write('\n  \x1b[31mError:\x1b[0m No governance events found.\n\n');
       return 1;

--- a/apps/cli/tests/cli-evidence-pr.test.ts
+++ b/apps/cli/tests/cli-evidence-pr.test.ts
@@ -20,11 +20,29 @@ vi.mock('../src/evidence-summary.js', () => ({
   formatEvidenceMarkdown: vi.fn(),
 }));
 
+vi.mock('@red-codes/storage', () => {
+  const db = {};
+  const close = vi.fn();
+  return {
+    createStorageBundle: vi.fn().mockResolvedValue({ db, close }),
+    listRunIds: vi.fn(),
+    getLatestRunId: vi.fn(),
+    loadRunEvents: vi.fn(),
+  };
+});
+
 import { evidencePr } from '../src/commands/evidence-pr.js';
 import { readFileSync, existsSync, readdirSync } from 'node:fs';
 import { execSync } from 'node:child_process';
 import { parseArgs } from '../src/args.js';
 import { aggregateEvents, formatEvidenceMarkdown } from '../src/evidence-summary.js';
+import {
+  createStorageBundle,
+  listRunIds,
+  getLatestRunId,
+  loadRunEvents as sqliteLoadRunEvents,
+} from '@red-codes/storage';
+import type { StorageConfig } from '@red-codes/storage';
 
 const mockSummary = {
   totalEvents: 5,
@@ -299,6 +317,86 @@ describe('evidencePr CLI', () => {
       expect(code).toBe(0);
       expect(stderrOutput.join('')).toContain('Evidence report posted to PR #55');
       expect(stderrOutput.join('')).toContain('Events analyzed');
+    });
+  });
+
+  describe('SQLite backend', () => {
+    const sqliteConfig: StorageConfig = { backend: 'sqlite' };
+    const mockEvent = { id: 'evt_1', kind: 'ActionAllowed', timestamp: 1700000000000 };
+
+    it('loads events from SQLite for --run flag', async () => {
+      mockParsed({ run: 'run_sqlite', 'dry-run': true });
+      vi.mocked(sqliteLoadRunEvents).mockReturnValue([mockEvent] as never);
+      mockEvidencePipeline('# SQLite Evidence');
+
+      const code = await evidencePr([], sqliteConfig);
+
+      expect(code).toBe(0);
+      expect(createStorageBundle).toHaveBeenCalledWith(sqliteConfig);
+      expect(sqliteLoadRunEvents).toHaveBeenCalledWith(expect.anything(), 'run_sqlite');
+      expect(readFileSync).not.toHaveBeenCalled();
+      expect(stdoutOutput.join('')).toContain('# SQLite Evidence');
+    });
+
+    it('returns 1 when --run finds no events in SQLite', async () => {
+      mockParsed({ run: 'run_empty_sq' });
+      vi.mocked(sqliteLoadRunEvents).mockReturnValue([]);
+
+      const code = await evidencePr([], sqliteConfig);
+
+      expect(code).toBe(1);
+      expect(stderrOutput.join('')).toContain('run_empty_sq');
+      expect(stderrOutput.join('')).toContain('no events');
+    });
+
+    it('loads latest run from SQLite for --last flag', async () => {
+      mockParsed({ last: true, 'dry-run': true });
+      vi.mocked(getLatestRunId).mockReturnValue('run_latest_sq');
+      vi.mocked(sqliteLoadRunEvents).mockReturnValue([mockEvent] as never);
+      mockEvidencePipeline();
+
+      const code = await evidencePr([], sqliteConfig);
+
+      expect(code).toBe(0);
+      expect(getLatestRunId).toHaveBeenCalledWith(expect.anything());
+      expect(sqliteLoadRunEvents).toHaveBeenCalledWith(expect.anything(), 'run_latest_sq');
+      expect(readdirSync).not.toHaveBeenCalled();
+    });
+
+    it('returns 1 when --last finds no runs in SQLite', async () => {
+      mockParsed({ last: true });
+      vi.mocked(getLatestRunId).mockReturnValue(null);
+
+      const code = await evidencePr([], sqliteConfig);
+
+      expect(code).toBe(1);
+      expect(stderrOutput.join('')).toContain('No governance runs');
+    });
+
+    it('aggregates all runs from SQLite in default mode', async () => {
+      mockParsed({ 'dry-run': true });
+      vi.mocked(listRunIds).mockReturnValue(['run_a', 'run_b']);
+      vi.mocked(sqliteLoadRunEvents)
+        .mockReturnValueOnce([mockEvent] as never)
+        .mockReturnValueOnce([{ ...mockEvent, id: 'evt_2' }] as never);
+      mockEvidencePipeline();
+
+      const code = await evidencePr([], sqliteConfig);
+
+      expect(code).toBe(0);
+      expect(listRunIds).toHaveBeenCalledWith(expect.anything());
+      expect(sqliteLoadRunEvents).toHaveBeenCalledTimes(2);
+      expect(aggregateEvents).toHaveBeenCalledWith(expect.arrayContaining([mockEvent]));
+    });
+
+    it('returns 1 when no events found across all SQLite runs', async () => {
+      mockParsed({});
+      vi.mocked(listRunIds).mockReturnValue([]);
+
+      const code = await evidencePr([], sqliteConfig);
+
+      expect(code).toBe(1);
+      expect(stderrOutput.join('')).toContain('No governance events found');
     });
   });
 });

--- a/packages/swarm/templates/skills/create-pr.md
+++ b/packages/swarm/templates/skills/create-pr.md
@@ -48,27 +48,16 @@ If push fails due to remote rejection, diagnose and report. Do NOT force push.
 
 ### 4. Collect Governance Telemetry
 
-Read governance event data from this session:
+Use the evidence-pr command in dry-run mode to collect and format governance telemetry:
 
 ```bash
-ls -la .agentguard/events/ 2>/dev/null
+<%= paths.cli %> evidence-pr --last --dry-run --store sqlite 2>/dev/null
 ```
 
-For each `.jsonl` file in `.agentguard/events/`, count event types:
+If the command fails or returns no output, fall back to JSONL mode:
 
 ```bash
-cat .agentguard/events/*.jsonl 2>/dev/null | wc -l
-cat .agentguard/events/*.jsonl 2>/dev/null | grep -c "ActionAllowed" || echo 0
-cat .agentguard/events/*.jsonl 2>/dev/null | grep -c "ActionDenied" || echo 0
-cat .agentguard/events/*.jsonl 2>/dev/null | grep -c "PolicyDenied" || echo 0
-cat .agentguard/events/*.jsonl 2>/dev/null | grep -c "InvariantViolation" || echo 0
-cat .agentguard/events/*.jsonl 2>/dev/null | grep -c "ActionEscalated" || echo 0
-```
-
-Also check the runtime telemetry log:
-
-```bash
-cat <%= paths.logs %> 2>/dev/null | wc -l
+<%= paths.cli %> evidence-pr --last --dry-run 2>/dev/null
 ```
 
 If no telemetry files exist, note "No governance telemetry recorded" — still proceed with PR creation.


### PR DESCRIPTION
The evidence-pr command only read from .agentguard/events/*.jsonl files,
which don't exist when using --store sqlite. This caused governance
reports to show all zeros.

Add the dual-backend pattern (matching inspect, traces, ci-check):
- Accept optional StorageConfig parameter
- When backend is sqlite, use createStorageBundle/loadRunEvents/etc
- Keep JSONL loading as fallback
- Wire up resolveStorageConfig in bin.ts
- Update create-pr skills to use evidence-pr CLI instead of raw bash

https://claude.ai/code/session_01QPuCb9X7ojHRPDtJPZqURV