### PR TITLE
docs: sync documentation with codebase state

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -44,13 +44,13 @@ This is a **pnpm monorepo** orchestrated by **Turbo**. Each workspace package ma
 ```
 packages/
 ├── core/          @red-codes/core — Shared utilities (types, actions, hash, execution-log)
-├── events/        @red-codes/events — Canonical event model (schema, bus, store, JSONL persistence)
+├── events/        @red-codes/events — Canonical event model (schema, bus, store)
 ├── policy/        @red-codes/policy — Policy system (composer, evaluator, loaders, pack loader)
-├── invariants/    @red-codes/invariants — Invariant system (17 built-in definitions, checker)
+├── invariants/    @red-codes/invariants — Invariant system (20 built-in definitions, checker)
 ├── kernel/        @red-codes/kernel — Governed action kernel (orchestrate, normalize, decide, escalate)
 ├── adapters/      @red-codes/adapters — Execution adapters (file, shell, git, claude-code)
 ├── analytics/     @red-codes/analytics — Cross-session violation analytics
-├── storage/       @red-codes/storage — SQLite and Firestore backends (opt-in)
+├── storage/       @red-codes/storage — SQLite storage backend (opt-in)
 ├── telemetry/     @red-codes/telemetry — Runtime telemetry and logging
 ├── plugins/       @red-codes/plugins — Plugin ecosystem (discovery, registry, validation, sandboxing)
 ├── renderers/     @red-codes/renderers — Renderer plugin system (registry, TUI renderer)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,16 +4,16 @@
 
 **AgentGuard** is a **governed action runtime for AI coding agents**. It intercepts agent tool calls, enforces policies and invariants, executes authorized actions via adapters, and emits lifecycle events. The Action is the primary unit of computation.
 
-The system has one architectural spine: the **canonical event model**. All system activity becomes events. The kernel produces governance events. Subscribers (TUI renderer, JSONL sink, CLI inspect) consume them.
+The system has one architectural spine: the **canonical event model**. All system activity becomes events. The kernel produces governance events. Subscribers (TUI renderer, SQLite sink, CLI inspect) consume them.
 
 **Key characteristics:**
 - Governed action kernel: propose → normalize → evaluate → execute → emit
-- 17 built-in invariants (secret exposure, protected branches, blast radius, test-before-push, no force push, no skill modification, no scheduled task modification, credential file creation, package script injection, lockfile integrity, recursive operation guard, large file write, CI/CD config modification, permission escalation, governance self-modification, container config modification, environment variable modification)
+- 20 built-in invariants (secret exposure, protected branches, blast radius, test-before-push, no force push, no skill modification, no scheduled task modification, credential file creation, package script injection, lockfile integrity, recursive operation guard, large file write, CI/CD config modification, permission escalation, governance self-modification, container config modification, environment variable modification, network egress, destructive migration, transitive effect analysis)
 - YAML/JSON policy format with pattern matching, scopes, and branch conditions
 - Escalation tracking: NORMAL → ELEVATED → HIGH → LOCKDOWN
-- JSONL event persistence for audit trail and replay
+- SQLite event persistence for audit trail and replay (JSONL export still supported)
 - Claude Code adapter for PreToolUse/PostToolUse hooks
-- **pnpm monorepo** with Turbo orchestration: 11 packages under `packages/`, 3 apps under `apps/`
+- **pnpm monorepo** with Turbo orchestration: 13 packages under `packages/`, 3 apps under `apps/`
 - Each package compiles independently via `tsc`; CLI bundle via `esbuild` in `apps/cli`
 - Scoped npm packages: `@red-codes/*` for workspace modules, `@red-codes/agentguard` for published CLI
 - CLI has runtime dependencies (`chokidar`, `commander`, `pino`); optional `better-sqlite3` for SQLite storage backend
@@ -47,6 +47,7 @@ packages/
 │   ├── governance-data.ts      # Governance data loader (typed access to shared JSON data)
 │   ├── data/                   # JSON governance data (actions, blast-radius, destructive-patterns, escalation, git-action-patterns, invariant-patterns, tool-action-map)
 │   ├── hash.ts                 # Content hashing utilities
+│   ├── rtk.ts                  # RTK token optimization integration
 │   ├── adapters.ts             # Adapter registry interface
 │   ├── rng.ts                  # Seeded random number generator
 │   └── execution-log/          # Execution audit log
@@ -58,9 +59,7 @@ packages/
 ├── events/src/                 # @red-codes/events — Canonical event model
 │   ├── schema.ts               # Event kinds, factory, validation
 │   ├── bus.ts                  # Generic typed EventBus
-│   ├── store.ts                # In-memory event store
-│   ├── jsonl.ts                # JSONL event persistence (audit trail)
-│   └── decision-jsonl.ts       # Decision record persistence
+│   └── store.ts                # In-memory event store
 ├── policy/src/                 # @red-codes/policy — Policy system
 │   ├── composer.ts             # Policy composition (multi-file merging)
 │   ├── evaluator.ts            # Rule matching engine
@@ -68,7 +67,7 @@ packages/
 │   ├── pack-loader.ts          # Policy pack loader (community policy sets)
 │   └── yaml-loader.ts          # YAML policy parser
 ├── invariants/src/             # @red-codes/invariants — Invariant system
-│   ├── definitions.ts          # 17 built-in invariant definitions
+│   ├── definitions.ts          # 20 built-in invariant definitions
 │   └── checker.ts              # Invariant evaluation engine
 ├── kernel/src/                 # @red-codes/kernel — Governed action kernel
 │   ├── kernel.ts               # Orchestrator (propose → evaluate → execute → emit)
@@ -118,6 +117,8 @@ packages/
 │   ├── sqlite-store.ts         # SQLite event store implementation
 │   └── types.ts                # Storage type definitions
 ├── runtime/src/                # @red-codes/runtime — Agent runtime (placeholder)
+├── telemetry/src/              # @red-codes/telemetry — Runtime telemetry and logging
+├── telemetry-client/src/       # @red-codes/telemetry-client — Telemetry client (identity, signing, queue, sender)
 └── swarm/src/                  # @red-codes/swarm — Shareable agent swarm templates
     ├── config.ts               # Swarm configuration
     ├── manifest.ts             # Swarm manifest parsing
@@ -137,7 +138,7 @@ apps/
 │   ├── session-store.ts        # Session management
 │   ├── file-event-store.ts     # File-based event persistence
 │   ├── evidence-summary.ts     # Evidence summary generator for PR reports
-│   └── commands/               # guard, inspect, replay, export, import, simulate, ci-check, plugin, policy, policy-verify, claude-hook, claude-init, init, diff, evidence-pr, traces, session-viewer, status
+│   └── commands/               # guard, inspect, replay, export, import, simulate, ci-check, plugin, policy, policy-verify, claude-hook, claude-init, init, diff, evidence-pr, traces, session-viewer, status, analytics, auto-setup, config, audit-verify, demo
 ├── mcp-server/src/             # @red-codes/mcp-server — MCP governance server
 │   ├── index.ts                # Entry point
 │   ├── server.ts               # MCP server implementation
@@ -151,7 +152,7 @@ apps/
 
 tests/
 └── *.test.js               # 14 JS test files (custom zero-dependency harness)
-# 105 TS test files (vitest) distributed across packages/ and apps/ directories
+# 118 TS test files (vitest) distributed across packages/ and apps/ directories
 policy/                     # Policy configuration (JSON: action_rules, capabilities)
 policies/                   # Policy packs (YAML: ci-safe, enterprise, open-source, strict)
 docs/                       # System documentation (architecture, event model, specs)
@@ -195,10 +196,10 @@ The kernel loop is the core of AgentGuard. Every agent action passes through it:
 1. Agent proposes action (Claude Code tool call → `RawAgentAction`)
 2. AAB normalizes intent (tool → action type, detect git/destructive commands)
 3. Policy evaluator matches rules (deny/allow with scopes, branches, limits)
-4. Invariant checker verifies system state (17 defaults)
+4. Invariant checker verifies system state (20 defaults)
 5. If allowed: execute via adapter (file/shell/git handlers)
 6. Emit lifecycle events: `ACTION_REQUESTED` → `ACTION_ALLOWED/DENIED` → `ACTION_EXECUTED/FAILED`
-7. Sink all events to JSONL for audit trail
+7. Sink all events to SQLite for audit trail
 
 Key files: `packages/kernel/src/kernel.ts`, `packages/kernel/src/aab.ts`, `packages/kernel/src/decision.ts`, `packages/kernel/src/monitor.ts`
 See `docs/unified-architecture.md` for the full model.
@@ -213,7 +214,9 @@ Each workspace package maps to a single architectural concept:
 - **packages/plugins/** — Plugin ecosystem (discovery, registry, validation, sandboxing)
 - **packages/renderers/** — Renderer plugin system (registry, TUI renderer)
 - **packages/core/** — Shared utilities (types, actions, hash, execution-log)
-- **packages/storage/** — Storage backend: SQLite (opt-in alternative to JSONL, indexed queries)
+- **packages/storage/** — Storage backend: SQLite (indexed queries, the only storage backend)
+- **packages/telemetry/** — Runtime telemetry and logging
+- **packages/telemetry-client/** — Telemetry client (identity, signing, queue, sender)
 - **packages/swarm/** — Shareable agent swarm templates (config, manifest, scaffolder)
 - **apps/cli/** — CLI entry point and commands (published as `@red-codes/agentguard`)
 - **apps/mcp-server/** — MCP governance server (15 governance tools)
@@ -240,6 +243,11 @@ Each workspace package maps to a single architectural concept:
 - `agentguard init <type>` — Scaffold governance extensions (invariant, policy-pack, adapter, renderer, replay-processor)
 - `agentguard status` — Show current governance session status
 - `agentguard policy-verify <file>` — Verify policy file structure and rules
+- `agentguard analytics` — Analyze violation patterns across sessions
+- `agentguard auto-setup` — Auto-detect AgentGuard and configure Claude Code hooks
+- `agentguard config show|get|set` — Manage AgentGuard configuration
+- `agentguard audit-verify` — Verify tamper-resistant audit chain integrity
+- `agentguard demo` — Interactive governance showcase
 
 ### Event Model
 The canonical event model is the architectural spine. Event kinds defined in `packages/events/src/schema.ts`:
@@ -252,6 +260,7 @@ The canonical event model is the architectural spine. Event kinds defined in `pa
 - **Policy Traces**: `PolicyTraceRecorded`
 - **Pipeline**: `PipelineStarted`, `StageCompleted`, `StageFailed`, `PipelineCompleted`, `PipelineFailed`, `FileScopeViolation`
 - **Dev activity**: `FileSaved`, `TestCompleted`, `BuildCompleted`, `CommitCreated`, `CodeReviewed`, `DeployCompleted`, `LintCompleted`
+- **Token Optimization**: `TokenOptimizationApplied`
 - **Heartbeat**: `HeartbeatEmitted`, `HeartbeatMissed`, `AgentUnresponsive`
 - **Battle lifecycle**: `ENCOUNTER_STARTED`, `MOVE_USED`, `DAMAGE_DEALT`, `HEALING_APPLIED`, `PASSIVE_ACTIVATED`, `BUGMON_FAINTED`, `CACHE_ATTEMPTED`, `CACHE_SUCCESS`, `BATTLE_ENDED`
 - **Ingestion**: `ErrorObserved`, `BugClassified`, `ActivityRecorded`, `EvolutionTriggered`
@@ -308,8 +317,8 @@ pnpm test --filter=@red-codes/kernel  # Test a single package
 **Test structure:**
 - **Vitest workspace** (`vitest.workspace.ts`): orchestrates tests across all packages
 - **JS tests** (`tests/*.test.js`): 14 files using a custom zero-dependency harness (`tests/run.js` with `node:assert`)
-- **TypeScript tests** (distributed across `packages/*/tests/` and `apps/*/tests/`): 105 files using vitest
-- **Coverage areas**: adapters, kernel (AAB, engine, monitor, blast radius, heartbeat, integration, e2e pipeline, conformance), CLI commands (args, guard, inspect, init, simulate, ci-check, claude-hook, claude-init, export/import, policy-validate, policy-verify, diff, evidence-pr, traces, plugin), decision records, domain models, events, evidence packs, evidence summary, execution log, export-import roundtrip, impact forecast, invariants, JSONL persistence, notification formatter, plugins (discovery, registry, sandbox, validation), policy evaluation (including composer, pack loader, policy packs, evaluation trace), renderers, replay (engine, comparator, processor), simulation, SQLite storage (migrations, session, sink, store, factory), swarm (scaffolder), TUI renderer, violation mapper, VS Code event reader, YAML loading
+- **TypeScript tests** (distributed across `packages/*/tests/` and `apps/*/tests/`): 118 files using vitest
+- **Coverage areas**: adapters, kernel (AAB, engine, monitor, blast radius, heartbeat, integration, e2e pipeline, conformance), CLI commands (args, guard, inspect, init, simulate, ci-check, claude-hook, claude-init, export/import, policy-validate, policy-verify, diff, evidence-pr, traces, plugin, auto-setup, config), decision records, domain models, events, evidence packs, evidence summary, execution log, export-import roundtrip, impact forecast, invariants, notification formatter, plugins (discovery, registry, sandbox, validation), policy evaluation (including composer, pack loader, policy packs, evaluation trace, forecast conditions), renderers, replay (engine, comparator, processor), simulation, SQLite storage (migrations, session, sink, store, factory), swarm (scaffolder), TUI renderer, violation mapper, VS Code event reader, YAML loading
 
 ## CI/CD & Automation
 

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ AI coding agents execute file writes, shell commands, and git operations autonom
 AgentGuard adds a **deterministic decision point** between proposal and execution:
 
 - **Safety policies** — declare what agents can and cannot do in YAML
-- **Invariant enforcement** — 17 built-in checks (secrets, protected branches, blast radius, skill/task protection, package script injection, lockfile integrity, CI/CD config, permission escalation, governance self-modification, container config, environment variables, recursive operations, large file writes) run on every action
-- **Audit trail** — every decision is recorded as structured JSONL, inspectable after the fact
+- **Invariant enforcement** — 20 built-in checks (secrets, protected branches, blast radius, skill/task protection, package script injection, lockfile integrity, CI/CD config, permission escalation, governance self-modification, container config, environment variables, recursive operations, large file writes, network egress, destructive migrations, transitive effect analysis) run on every action
+- **Audit trail** — every decision is recorded in structured SQLite, inspectable after the fact
 - **Session debugging** — replay any agent session to see exactly what happened and why
 
 ## How It Works
@@ -61,15 +61,15 @@ AgentGuard evaluates every agent action through a **governed action kernel**:
 
 1. **Normalize** — Claude Code tool calls (Bash, Write, Edit, Read) are mapped to canonical action types (shell.exec, file.write, file.read)
 2. **Evaluate** — policies match against the action (deny git.push to main, deny destructive commands, enforce scope limits)
-3. **Check invariants** — 17 built-in safety checks run on every action
+3. **Check invariants** — 20 built-in safety checks run on every action
 4. **Execute** — if allowed, the action runs via adapters (file, shell, git handlers)
-5. **Emit events** — full lifecycle events sunk to JSONL for audit trail
+5. **Emit events** — full lifecycle events sunk to SQLite for audit trail
 
 ### Example Output
 
 ```
   AgentGuard Runtime Active
-  policy: agentguard.yaml | invariants: 17 active
+  policy: agentguard.yaml | invariants: 20 active
 
   ✓ file.write src/auth/service.ts
   ✓ shell.exec npm test
@@ -109,7 +109,7 @@ Drop an `agentguard.yaml` in your repo root — the CLI picks it up automaticall
 
 ## Built-in Invariants
 
-17 safety invariants run on every action evaluation:
+20 safety invariants run on every action evaluation:
 
 | Invariant | Severity | Description |
 |-----------|----------|-------------|
@@ -128,6 +128,9 @@ Drop an `agentguard.yaml` in your repo root — the CLI picks it up automaticall
 | **large-file-write** | 3 (medium) | Enforces per-file size limit to prevent data dumps |
 | **no-container-config-modification** | 3 (medium) | Protects Dockerfile, docker-compose.yml, .dockerignore |
 | **no-env-var-modification** | 3 (medium) | Detects attempts to modify environment variables or shell profile files |
+| **no-destructive-migration** | 3 (medium) | Flags writes to migration directories containing destructive DDL |
+| **no-network-egress** | 4 (high) | Denies HTTP requests to non-allowlisted domains |
+| **transitive-effect-analysis** | 4 (high) | Analyzes written files for downstream effects that would violate policy |
 | **recursive-operation-guard** | 2 (low) | Flags find -exec, xargs combined with write/delete operations |
 | **lockfile-integrity** | 2 (low) | Ensures package.json changes sync with lockfiles |
 
@@ -302,13 +305,13 @@ This is a **pnpm monorepo** orchestrated by **Turbo**. Workspace packages live i
 ```
 packages/
 ├── core/src/               # @red-codes/core — Shared types, actions, hash, rng, execution-log
-├── events/src/             # @red-codes/events — Canonical event model (schema, bus, store, JSONL)
+├── events/src/             # @red-codes/events — Canonical event model (schema, bus, store)
 ├── policy/src/             # @red-codes/policy — Policy evaluation, YAML/JSON loaders, composition
-├── invariants/src/         # @red-codes/invariants — 17 built-in invariant definitions + checker
+├── invariants/src/         # @red-codes/invariants — 20 built-in invariant definitions + checker
 ├── kernel/src/             # @red-codes/kernel — Governed action kernel (orchestrator, AAB, decisions, simulation)
 ├── adapters/src/           # @red-codes/adapters — Execution adapters (file, shell, git, claude-code)
 ├── analytics/src/          # @red-codes/analytics — Cross-session violation analytics
-├── storage/src/            # @red-codes/storage — SQLite + Firestore backends (opt-in)
+├── storage/src/            # @red-codes/storage — SQLite storage backend (opt-in)
 ├── telemetry/src/          # @red-codes/telemetry — Runtime telemetry and logging
 ├── plugins/src/            # @red-codes/plugins — Plugin ecosystem (discovery, registry, sandboxing)
 ├── renderers/src/          # @red-codes/renderers — Renderer plugin system (TUI renderer)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -59,9 +59,9 @@ A comprehensive codebase audit assessed the current system against the strategic
 | Canonical Action Representation (23 types, 8 classes) | Implemented | `packages/core/src/actions.ts` |
 | Action Authorization Boundary (AAB) | Implemented (2 bypass vectors) | `packages/kernel/src/aab.ts` |
 | Policy Evaluator (two-phase deny/allow) | Implemented | `packages/policy/src/evaluator.ts` |
-| 17 Built-in Invariants | Fully Implemented | `packages/invariants/src/definitions.ts`, `packages/invariants/src/checker.ts` |
-| Event Model (49 event kinds) | Comprehensive | `packages/events/src/schema.ts` |
-| JSONL Persistence | Implemented | `packages/events/src/jsonl.ts` |
+| 20 Built-in Invariants | Fully Implemented | `packages/invariants/src/definitions.ts`, `packages/invariants/src/checker.ts` |
+| Event Model (50 event kinds) | Comprehensive | `packages/events/src/schema.ts` |
+| SQLite Persistence | Implemented | `packages/storage/src/sqlite-store.ts` |
 | Simulation Engine (3 simulators + impact forecast) | Fully Implemented | `packages/kernel/src/simulation/` |
 | Blast Radius Computation | Implemented | `packages/kernel/src/blast-radius.ts` |
 | Escalation State Machine (NORMAL → LOCKDOWN) | Implemented | `packages/kernel/src/monitor.ts` |
@@ -269,9 +269,9 @@ This is the architectural hinge. These changes transform the AAB from advisory i
 - [x] Governance self-modification invariant — agents must not modify `agentguard.yaml`, `.agentguard/`, or `policies/` (`no-governance-self-modification` invariant, severity 5)
 - [ ] Performance benchmark suite — formal latency measurement (p50/p95/p99) per action type for policy evaluation, invariant checking, and simulation overhead. Publish results as a marketing asset and regression gate in CI
 
-### Phase 6.5 — Invariant Expansion `IN PROGRESS`
+### Phase 6.5 — Invariant Expansion `STABLE`
 
-> **Theme:** Close invariant coverage gaps. Expanded from 10 to 17 built-in invariants; remaining items cover network egress, database migration safety, and transitive effect analysis.
+> **Theme:** Close invariant coverage gaps. Expanded from 10 to 20 built-in invariants.
 
 The `SystemState` interface in `packages/invariants/src/definitions.ts` is the bottleneck for invariant expansion — it needs to become a richer context object with action-specific fields.
 
@@ -321,7 +321,7 @@ Prior art: Kubernetes Capability Primitives (KCP), OS capability-based security 
 - [ ] Framework-specific adapters (LangGraph, CrewAI, AutoGen, OpenAI Agents SDK)
 - [ ] Agent SDK for programmatic governance integration
 - [ ] Generic MCP adapter
-- [ ] Session-aware context tracking (modified files, test results, deployment state)
+- [x] Session-aware context tracking (modified files, test results, deployment state) (#197)
 - [ ] Deep Claude Code integration (auto-install, configuration management)
 - [ ] Cursor integration
 
@@ -341,7 +341,7 @@ The JSONL persistence layer was the right starting point — append-only, human-
 - [x] ~~Aggregation queries for analytics~~ — Migrated to agentguard-cloud
 - [x] JSONL export compatibility — `agentguard export` still produces portable JSONL
 - [x] Storage location: `~/.agentguard/agentguard.db` (home directory, out of repo tree)
-- [x] Retain JSONL as optional fallback/streaming sink for real-time tailing
+- ~~Retain JSONL as optional fallback/streaming sink for real-time tailing~~ — JSONL storage backend removed (#503); SQLite is now the only backend
 - [x] ~~Firestore NoSQL storage backend for cross-session governance data sharing~~ — Migrated to agentguard-cloud
 - [x] ~~`agentguard init firestore` scaffold command~~ — Migrated to agentguard-cloud
 - [x] Wire up `sessions` table — insert on `RunStarted`, update on `RunEnded` (`packages/storage/src/sqlite-session.ts`)
@@ -414,7 +414,7 @@ The JSONL persistence layer was the right starting point — append-only, human-
 > **Theme:** Govern outcomes before execution
 
 - [x] Structured impact forecasts (predicted files changed, dependencies affected, test risk, blast radius score)
-- [ ] Predictive policy rules (`deny if predicted_test_failures > 0`)
+- [x] Predictive policy rules with forecast conditions (`deny if predicted_test_failures > 0`) (#501)
 - [ ] Plan-level simulation — simulate a sequence of actions as a batch, including plan-level threat assessment that analyzes the full action sequence for threat vectors (data exfiltration paths, privilege escalation chains, blast radius amplification) before any action executes
 - [ ] Simulator plugin interface — community-contributed simulators
 - [ ] Dependency graph simulation (transitive impact of package changes)


### PR DESCRIPTION
## Summary

Automated documentation sync detected significant drift between codebase and docs:

- **Invariant count**: 17 → 20 across all docs (README, CLAUDE.md, ARCHITECTURE.md, ROADMAP.md)
  - Added: `no-destructive-migration`, `no-network-egress`, `transitive-effect-analysis`
- **Event kind count**: 49 → 50 in ROADMAP.md (`TokenOptimizationApplied` added in #509)
- **Storage backend**: Removed stale JSONL references — SQLite is now the only backend (#503)
- **Firestore references**: Removed from ARCHITECTURE.md and README.md (migrated to agentguard-cloud)
- **Test file count**: 105 → 118 TS test files in CLAUDE.md
- **Package count**: 11 → 13 packages in CLAUDE.md (telemetry, telemetry-client)
- **New module**: Added `core/src/rtk.ts` to CLAUDE.md structure tree (#509)
- **Missing CLI commands**: Added analytics, auto-setup, config, audit-verify, demo to CLAUDE.md
- **ROADMAP phase updates**:
  - Phase 6.5 (Invariant Expansion): `IN PROGRESS` → `STABLE` (all items complete)
  - Phase 16: Checked predictive policy rules (#501)
  - Phase 9: Checked session-aware context tracking (#197)
  - Phase 10: Struck through JSONL fallback item (removed in #503)

## Strategic Document Check

- `docs/current-priorities.md` — does not exist (no staleness)
- `docs/strategic-roadmap.md` — does not exist (no staleness)
- No contradictions found between ROADMAP.md and source structure

## Changes

- `README.md` — invariant count, invariant table (+3 rows), JSONL→SQLite references, repo structure
- `CLAUDE.md` — invariant count, package count, test count, structure tree, CLI commands, event model, storage references
- `ARCHITECTURE.md` — invariant count, storage backend, JSONL reference
- `ROADMAP.md` — event/invariant counts, JSONL→SQLite in kernel table, phase status updates

## Source

Auto-generated by the **Scheduled Docs Sync** skill.

---
*Run: 2026-03-16*