### PR TITLE
feat(issue-344): add replay --ui timeline viewer

### DIFF
--- a/apps/cli/src/bin.ts
+++ b/apps/cli/src/bin.ts
@@ -109,6 +109,11 @@ const COMMANDS: Record<string, CommandHelp> = {
       { flag: '--last, -l', description: 'Replay the most recent session' },
       { flag: '--step, -s', description: 'Step through events one at a time' },
       { flag: '--stats', description: 'Show session statistics only' },
+      { flag: '--ui', description: 'Open interactive HTML timeline viewer in browser' },
+      { flag: '--denied-only', description: 'Show only denied actions (with --ui)' },
+      { flag: '--output, -o <file>', description: 'Output HTML file path (with --ui)' },
+      { flag: '--no-open', description: 'Do not open browser automatically (with --ui)' },
+      { flag: '--run <runId>', description: 'Replay a specific governance run (with --ui)' },
       { flag: '--filter <kind>', description: 'Filter events by kind' },
       { flag: '--store <backend>', description: 'Storage backend (sqlite)' },
       {
@@ -116,7 +121,13 @@ const COMMANDS: Record<string, CommandHelp> = {
         description: 'SQLite database path (default: ~/.agentguard/agentguard.db)',
       },
     ],
-    examples: ['agentguard replay', 'agentguard replay --last', 'agentguard replay --last --step'],
+    examples: [
+      'agentguard replay',
+      'agentguard replay --last',
+      'agentguard replay --last --step',
+      'agentguard replay --last --ui',
+      'agentguard replay --last --ui --denied-only',
+    ],
   },
   export: {
     name: 'agentguard export',
@@ -786,6 +797,7 @@ function printHelp(): void {
     agentguard replay                         List recorded sessions
     agentguard replay --last                  Replay most recent session
     agentguard replay --last --step           Step through events interactively
+    agentguard replay --last --ui             Open interactive timeline viewer in browser
 
   \x1b[1mPolicy:\x1b[0m
     agentguard policy validate <file>        Validate a policy file (YAML/JSON)

--- a/apps/cli/src/replay-timeline-html.ts
+++ b/apps/cli/src/replay-timeline-html.ts
@@ -1,0 +1,455 @@
+/**
+ * Generates a self-contained HTML timeline viewer for governance sessions.
+ *
+ * The timeline renders governance events chronologically with:
+ * - Color-coded event kinds (governance, lifecycle, safety, reference monitor)
+ * - Action lifecycle grouping (propose → evaluate → execute → emit)
+ * - Filtering by event kind via checkboxes
+ * - Expandable event details
+ * - Session summary header
+ * - Escalation state indicators
+ */
+
+import type { ReplaySession, ReplayAction } from '@red-codes/kernel';
+import type { DomainEvent } from '@red-codes/core';
+
+export interface TimelineOptions {
+  /** Filter to only denied actions */
+  deniedOnly?: boolean;
+  /** Filter events by kind */
+  filterKind?: string;
+}
+
+/** Map event kinds to visual categories for color-coding. */
+const EVENT_CATEGORIES: Record<string, string> = {
+  PolicyDenied: 'governance',
+  UnauthorizedAction: 'governance',
+  InvariantViolation: 'governance',
+  RunStarted: 'lifecycle',
+  RunEnded: 'lifecycle',
+  CheckpointReached: 'lifecycle',
+  StateChanged: 'lifecycle',
+  BlastRadiusExceeded: 'safety',
+  MergeGuardFailure: 'safety',
+  EvidencePackGenerated: 'safety',
+  ActionRequested: 'reference',
+  ActionAllowed: 'reference',
+  ActionDenied: 'reference',
+  ActionEscalated: 'reference',
+  ActionExecuted: 'reference',
+  ActionFailed: 'reference',
+  DecisionRecorded: 'decision',
+  SimulationCompleted: 'decision',
+  TokenOptimizationApplied: 'lifecycle',
+  HeartbeatEmitted: 'lifecycle',
+  HeartbeatMissed: 'safety',
+  AgentUnresponsive: 'safety',
+};
+
+function categorize(kind: string): string {
+  return EVENT_CATEGORIES[kind] ?? 'other';
+}
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function formatTimestamp(ts: number, baseTs: number): string {
+  const delta = ts - baseTs;
+  if (delta < 0) return '00:00.000';
+  const totalMs = Math.floor(delta);
+  const ms = totalMs % 1000;
+  const totalSec = Math.floor(totalMs / 1000);
+  const sec = totalSec % 60;
+  const min = Math.floor(totalSec / 60);
+  return `${String(min).padStart(2, '0')}:${String(sec).padStart(2, '0')}.${String(ms).padStart(3, '0')}`;
+}
+
+function buildActionHtml(action: ReplayAction, baseTs: number, index: number): string {
+  const statusClass = action.allowed ? (action.succeeded ? 'allowed' : 'failed') : 'denied';
+  const statusLabel = action.allowed
+    ? action.succeeded
+      ? 'ALLOWED'
+      : action.executed
+        ? 'FAILED'
+        : 'DRY-RUN'
+    : 'DENIED';
+
+  const time = formatTimestamp(action.requestedEvent.timestamp, baseTs);
+  const target = escapeHtml(action.target || '(none)');
+  const actionType = escapeHtml(action.actionType);
+
+  const governanceHtml = action.governanceEvents
+    .map((g) => {
+      const reason = (g.reason as string) || (g.invariant as string) || (g.policy as string) || '';
+      return `<div class="violation">${escapeHtml(g.kind)}${reason ? ` — ${escapeHtml(String(reason))}` : ''}</div>`;
+    })
+    .join('');
+
+  const decisionReason = action.decisionEvent ? (action.decisionEvent.reason as string) || '' : '';
+
+  const simHtml = action.simulationEvent
+    ? `<div class="sim-badge">risk=${escapeHtml(String((action.simulationEvent.riskLevel as string) || '?'))} blast=${(action.simulationEvent.blastRadius as number) ?? '?'}</div>`
+    : '';
+
+  // Build lifecycle steps
+  const steps: string[] = [];
+  steps.push(`<span class="step step-requested" title="Requested at ${time}">PROPOSE</span>`);
+  if (action.decisionEvent) {
+    const cat = categorize(action.decisionEvent.kind);
+    steps.push(
+      `<span class="step step-${cat}" title="${escapeHtml(action.decisionEvent.kind)}">EVALUATE</span>`
+    );
+  }
+  if (action.executionEvent) {
+    const cat = action.succeeded ? 'allowed' : 'failed';
+    steps.push(`<span class="step step-${cat}">EXECUTE</span>`);
+  }
+  steps.push(`<span class="step step-emit">EMIT</span>`);
+
+  return `<div class="action action-${statusClass}" data-index="${index}" data-kind="${actionType}" data-status="${statusClass}">
+  <div class="action-header" onclick="toggleDetail(${index})">
+    <span class="action-time">${time}</span>
+    <span class="action-badge badge-${statusClass}">${statusLabel}</span>
+    <span class="action-type">${actionType}</span>
+    <span class="action-target">${target}</span>
+    <span class="action-expand" id="expand-${index}">&#9654;</span>
+  </div>
+  <div class="action-lifecycle">${steps.join('<span class="arrow">→</span>')}</div>
+  <div class="action-detail" id="detail-${index}" style="display:none;">
+    ${decisionReason ? `<div class="detail-row"><strong>Reason:</strong> ${escapeHtml(decisionReason)}</div>` : ''}
+    ${simHtml}
+    ${governanceHtml}
+    <div class="detail-row dim">Events in group: ${action.governanceEvents.length + (action.decisionEvent ? 1 : 0) + (action.executionEvent ? 1 : 0) + (action.simulationEvent ? 1 : 0) + 1}</div>
+  </div>
+</div>`;
+}
+
+export function generateTimelineHtml(
+  session: ReplaySession,
+  events: readonly DomainEvent[],
+  options: TimelineOptions = {}
+): string {
+  const s = session.summary;
+  const baseTs = events.length > 0 ? events[0].timestamp : 0;
+
+  let actions = [...session.actions];
+  if (options.deniedOnly) {
+    actions = actions.filter((a) => !a.allowed);
+  }
+
+  // Collect unique action types for filter
+  const actionTypeSet = new Set<string>();
+  for (const a of actions) {
+    actionTypeSet.add(a.actionType);
+  }
+  const actionTypes = [...actionTypeSet].sort();
+
+  // Build filter checkboxes HTML
+  const filterHtml = actionTypes
+    .map(
+      (t) =>
+        `<label class="filter-label"><input type="checkbox" checked onchange="applyFilters()" data-action-type="${escapeHtml(t)}"> ${escapeHtml(t)}</label>`
+    )
+    .join('\n');
+
+  const statusFilterHtml = ['allowed', 'denied', 'failed']
+    .map(
+      (s) =>
+        `<label class="filter-label"><input type="checkbox" checked onchange="applyFilters()" data-status="${s}"> ${s.toUpperCase()}</label>`
+    )
+    .join('\n');
+
+  // Build action timeline HTML
+  const actionsHtml = actions.map((a, i) => buildActionHtml(a, baseTs, i)).join('\n');
+
+  // Duration formatting
+  const durationSec = Math.floor(s.durationMs / 1000);
+  const durationMin = Math.floor(durationSec / 60);
+  const durationStr = durationMin > 0 ? `${durationMin}m ${durationSec % 60}s` : `${durationSec}s`;
+
+  // Event kind distribution for the summary chart
+  const kindCounts: Record<string, number> = {};
+  for (const e of events) {
+    kindCounts[e.kind] = (kindCounts[e.kind] || 0) + 1;
+  }
+  const topKinds = Object.entries(kindCounts)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 10);
+  const maxKindCount = topKinds.length > 0 ? topKinds[0][1] : 1;
+
+  const kindBarsHtml = topKinds
+    .map(([kind, count]) => {
+      const pct = Math.round((count / maxKindCount) * 100);
+      const cat = categorize(kind);
+      return `<div class="bar-row"><span class="bar-label">${escapeHtml(kind)}</span><div class="bar-track"><div class="bar-fill bar-${cat}" style="width:${pct}%"></div></div><span class="bar-count">${count}</span></div>`;
+    })
+    .join('\n');
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>AgentGuard Timeline — ${escapeHtml(session.runId)}</title>
+<style>
+  :root {
+    --bg: #0d1117;
+    --surface: #161b22;
+    --border: #30363d;
+    --text: #e6edf3;
+    --dim: #8b949e;
+    --green: #3fb950;
+    --red: #f85149;
+    --yellow: #d29922;
+    --blue: #58a6ff;
+    --purple: #bc8cff;
+    --orange: #f0883e;
+    --cyan: #39d2c0;
+  }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    font-family: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+    background: var(--bg);
+    color: var(--text);
+    font-size: 13px;
+    line-height: 1.5;
+  }
+  .container { max-width: 1100px; margin: 0 auto; padding: 24px 16px; }
+  h1 { font-size: 20px; font-weight: 600; margin-bottom: 4px; }
+  .run-id { color: var(--dim); font-size: 12px; margin-bottom: 20px; }
+
+  /* Summary cards */
+  .summary { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); gap: 12px; margin-bottom: 24px; }
+  .card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 12px;
+    text-align: center;
+  }
+  .card-value { font-size: 24px; font-weight: 700; }
+  .card-label { color: var(--dim); font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+  .card-green .card-value { color: var(--green); }
+  .card-red .card-value { color: var(--red); }
+  .card-yellow .card-value { color: var(--yellow); }
+  .card-blue .card-value { color: var(--blue); }
+
+  /* Event distribution */
+  .distribution { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 16px; margin-bottom: 24px; }
+  .distribution h2 { font-size: 14px; margin-bottom: 12px; color: var(--dim); }
+  .bar-row { display: flex; align-items: center; gap: 8px; margin-bottom: 4px; }
+  .bar-label { width: 180px; text-align: right; font-size: 11px; color: var(--dim); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .bar-track { flex: 1; height: 14px; background: var(--bg); border-radius: 3px; overflow: hidden; }
+  .bar-fill { height: 100%; border-radius: 3px; transition: width 0.3s ease; }
+  .bar-count { width: 40px; text-align: right; font-size: 11px; color: var(--dim); }
+  .bar-governance { background: var(--red); }
+  .bar-lifecycle { background: var(--blue); }
+  .bar-safety { background: var(--orange); }
+  .bar-reference { background: var(--purple); }
+  .bar-decision { background: var(--cyan); }
+  .bar-other { background: var(--dim); }
+
+  /* Filters */
+  .filters { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 12px 16px; margin-bottom: 20px; }
+  .filters h3 { font-size: 12px; color: var(--dim); margin-bottom: 8px; text-transform: uppercase; letter-spacing: 0.5px; }
+  .filter-group { display: flex; flex-wrap: wrap; gap: 6px 12px; margin-bottom: 8px; }
+  .filter-label { display: flex; align-items: center; gap: 4px; font-size: 12px; color: var(--text); cursor: pointer; }
+  .filter-label input { cursor: pointer; }
+
+  /* Timeline */
+  .timeline { position: relative; padding-left: 2px; }
+  .action {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    margin-bottom: 8px;
+    overflow: hidden;
+    transition: border-color 0.2s;
+  }
+  .action:hover { border-color: var(--blue); }
+  .action-denied { border-left: 3px solid var(--red); }
+  .action-allowed { border-left: 3px solid var(--green); }
+  .action-failed { border-left: 3px solid var(--yellow); }
+  .action-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 14px;
+    cursor: pointer;
+    user-select: none;
+  }
+  .action-header:hover { background: rgba(255,255,255,0.02); }
+  .action-time { font-size: 11px; color: var(--dim); min-width: 80px; }
+  .action-badge {
+    font-size: 10px;
+    font-weight: 700;
+    padding: 2px 8px;
+    border-radius: 4px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+  .badge-allowed { background: rgba(63,185,80,0.15); color: var(--green); }
+  .badge-denied { background: rgba(248,81,73,0.15); color: var(--red); }
+  .badge-failed { background: rgba(210,153,34,0.15); color: var(--yellow); }
+  .action-type { font-weight: 600; }
+  .action-target { color: var(--dim); flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .action-expand { color: var(--dim); font-size: 10px; transition: transform 0.2s; }
+  .action-expand.open { transform: rotate(90deg); }
+
+  .action-lifecycle {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 0 14px 8px;
+    font-size: 10px;
+  }
+  .step {
+    padding: 1px 6px;
+    border-radius: 3px;
+    font-weight: 600;
+    letter-spacing: 0.3px;
+  }
+  .step-requested { background: rgba(88,166,255,0.15); color: var(--blue); }
+  .step-reference { background: rgba(188,140,255,0.15); color: var(--purple); }
+  .step-allowed { background: rgba(63,185,80,0.15); color: var(--green); }
+  .step-failed { background: rgba(210,153,34,0.15); color: var(--yellow); }
+  .step-emit { background: rgba(57,210,192,0.15); color: var(--cyan); }
+  .arrow { color: var(--dim); font-size: 10px; }
+
+  .action-detail { padding: 8px 14px 12px; border-top: 1px solid var(--border); }
+  .detail-row { margin-bottom: 4px; font-size: 12px; }
+  .dim { color: var(--dim); }
+  .violation {
+    background: rgba(248,81,73,0.1);
+    border-left: 2px solid var(--red);
+    padding: 4px 8px;
+    margin: 4px 0;
+    font-size: 12px;
+    color: var(--red);
+  }
+  .sim-badge {
+    font-size: 11px;
+    color: var(--orange);
+    margin: 4px 0;
+  }
+
+  /* Scrubber */
+  .scrubber { margin-bottom: 16px; }
+  .scrubber input[type="range"] {
+    width: 100%;
+    accent-color: var(--blue);
+  }
+  .scrubber-label { display: flex; justify-content: space-between; font-size: 11px; color: var(--dim); }
+
+  /* Footer */
+  .footer { text-align: center; color: var(--dim); font-size: 11px; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--border); }
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>AgentGuard Timeline Viewer</h1>
+  <div class="run-id">Run: ${escapeHtml(session.runId)} &middot; ${s.totalActions} actions &middot; ${events.length} events &middot; ${durationStr}</div>
+
+  <div class="summary">
+    <div class="card card-blue">
+      <div class="card-value">${s.totalActions}</div>
+      <div class="card-label">Actions</div>
+    </div>
+    <div class="card card-green">
+      <div class="card-value">${s.allowed}</div>
+      <div class="card-label">Allowed</div>
+    </div>
+    <div class="card card-red">
+      <div class="card-value">${s.denied}</div>
+      <div class="card-label">Denied</div>
+    </div>
+    <div class="card card-yellow">
+      <div class="card-value">${s.violations}</div>
+      <div class="card-label">Violations</div>
+    </div>
+    <div class="card">
+      <div class="card-value">${s.escalations}</div>
+      <div class="card-label">Escalations</div>
+    </div>
+    <div class="card">
+      <div class="card-value">${s.simulationsRun}</div>
+      <div class="card-label">Simulations</div>
+    </div>
+  </div>
+
+  <div class="distribution">
+    <h2>Event Distribution</h2>
+    ${kindBarsHtml}
+  </div>
+
+  <div class="scrubber">
+    <input type="range" min="0" max="${Math.max(actions.length - 1, 0)}" value="${Math.max(actions.length - 1, 0)}" id="scrubber" oninput="scrubTo(this.value)">
+    <div class="scrubber-label">
+      <span>Start</span>
+      <span id="scrubber-pos">${actions.length} / ${actions.length} actions</span>
+      <span>End</span>
+    </div>
+  </div>
+
+  <div class="filters">
+    <h3>Filter by Action Type</h3>
+    <div class="filter-group" id="type-filters">
+      ${filterHtml}
+    </div>
+    <h3>Filter by Status</h3>
+    <div class="filter-group" id="status-filters">
+      ${statusFilterHtml}
+    </div>
+  </div>
+
+  <div class="timeline" id="timeline">
+    ${actionsHtml}
+  </div>
+
+  <div class="footer">
+    Generated by AgentGuard &middot; ${new Date().toISOString().slice(0, 19)}Z
+  </div>
+</div>
+
+<script>
+function toggleDetail(index) {
+  const detail = document.getElementById('detail-' + index);
+  const expand = document.getElementById('expand-' + index);
+  if (!detail) return;
+  const visible = detail.style.display !== 'none';
+  detail.style.display = visible ? 'none' : 'block';
+  if (expand) expand.classList.toggle('open', !visible);
+}
+
+function applyFilters() {
+  const typeChecks = document.querySelectorAll('#type-filters input[type=checkbox]');
+  const statusChecks = document.querySelectorAll('#status-filters input[type=checkbox]');
+  const allowedTypes = new Set();
+  const allowedStatuses = new Set();
+  typeChecks.forEach(function(cb) { if (cb.checked) allowedTypes.add(cb.dataset.actionType); });
+  statusChecks.forEach(function(cb) { if (cb.checked) allowedStatuses.add(cb.dataset.status); });
+  const actions = document.querySelectorAll('.action');
+  actions.forEach(function(el) {
+    const kind = el.dataset.kind;
+    const status = el.dataset.status;
+    el.style.display = (allowedTypes.has(kind) && allowedStatuses.has(status)) ? '' : 'none';
+  });
+}
+
+function scrubTo(value) {
+  const actions = document.querySelectorAll('.action');
+  const n = parseInt(value, 10) + 1;
+  document.getElementById('scrubber-pos').textContent = n + ' / ' + actions.length + ' actions';
+  actions.forEach(function(el, i) {
+    el.style.opacity = i <= parseInt(value, 10) ? '1' : '0.2';
+  });
+}
+</script>
+</body>
+</html>`;
+}

--- a/apps/cli/src/replay.ts
+++ b/apps/cli/src/replay.ts
@@ -4,8 +4,14 @@
 // DONE(roadmap): Phase 4 — Replay comparator: see src/kernel/replay-comparator.ts
 // DONE(roadmap): Phase 4 — Replay processor plugin interface: see src/kernel/replay-processor.ts
 
+import { existsSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { execFileSync } from 'node:child_process';
 import { loadSession, listSessions } from './session-store.js';
 import { color, bold, dim } from './colors.js';
+import { buildReplaySession } from '@red-codes/kernel';
+import { generateTimelineHtml } from './replay-timeline-html.js';
 
 interface EventDisplay {
   icon: string;
@@ -72,16 +78,45 @@ export async function replay(args: string[]): Promise<void> {
   const wantsStep = args.includes('--step') || args.includes('-s');
   const wantsStats = args.includes('--stats');
   const wantsLast = args.includes('--last') || args.includes('-l');
+  const wantsUi = args.includes('--ui');
+  const noOpen = args.includes('--no-open');
+  const deniedOnly = args.includes('--denied-only');
 
   const filterIdx = args.indexOf('--filter');
   const filterKind = filterIdx !== -1 ? args[filterIdx + 1] : null;
 
+  // Parse --output / -o flag
+  let outputPath: string | undefined;
+  for (let i = 0; i < args.length; i++) {
+    if ((args[i] === '--output' || args[i] === '-o') && args[i + 1]) {
+      outputPath = args[i + 1];
+      break;
+    }
+  }
+
+  // Parse --run <runId> flag for explicit governance run ID
+  const runIdx = args.indexOf('--run');
+  const explicitRunId = runIdx !== -1 ? args[runIdx + 1] : undefined;
+
   let sessionId: string | null = null;
   for (const arg of args) {
-    if (!arg.startsWith('-') && arg !== filterKind) {
+    if (!arg.startsWith('-') && arg !== filterKind && arg !== outputPath && arg !== explicitRunId) {
       sessionId = arg;
       break;
     }
+  }
+
+  // --- UI mode: interactive HTML timeline viewer ---
+  if (wantsUi) {
+    await replayUi({
+      last: wantsLast,
+      runId: explicitRunId,
+      noOpen,
+      outputPath,
+      deniedOnly,
+      filterKind,
+    });
+    return;
   }
 
   if (wantsLast && !sessionId) {
@@ -119,6 +154,86 @@ export async function replay(args: string[]): Promise<void> {
   }
 
   replayTimeline(session, filterKind);
+}
+
+// ---------------------------------------------------------------------------
+// UI mode — generate interactive HTML timeline viewer
+// ---------------------------------------------------------------------------
+
+interface ReplayUiOptions {
+  last?: boolean;
+  runId?: string;
+  noOpen?: boolean;
+  outputPath?: string;
+  deniedOnly?: boolean;
+  filterKind?: string | null;
+}
+
+async function replayUi(options: ReplayUiOptions): Promise<void> {
+  const { createStorageBundle } = await import('@red-codes/storage');
+  const { getLatestRunId, loadRunEvents } = await import('@red-codes/storage');
+
+  const config = { backend: 'sqlite' as const };
+  const storage = await createStorageBundle(config);
+  if (!storage.db) {
+    process.stderr.write('  Error: SQLite storage backend did not initialize database.\n');
+    return;
+  }
+  const db = storage.db as import('better-sqlite3').Database;
+
+  const targetRunId = options.runId || (options.last ? getLatestRunId(db) : getLatestRunId(db));
+  if (!targetRunId) {
+    storage.close();
+    process.stderr.write(
+      '\n  No governance runs found.\n  Run "agentguard guard" first to generate events.\n\n'
+    );
+    return;
+  }
+
+  const events = loadRunEvents(db, targetRunId);
+  storage.close();
+
+  if (events.length === 0) {
+    process.stderr.write(`\n  Run "${targetRunId}" has no events.\n\n`);
+    return;
+  }
+
+  const session = buildReplaySession(targetRunId, events);
+  const html = generateTimelineHtml(session, events, {
+    deniedOnly: options.deniedOnly,
+    filterKind: options.filterKind ?? undefined,
+  });
+
+  const viewsDir = join(homedir(), '.agentguard', 'views');
+  const outFile = options.outputPath || join(viewsDir, `timeline_${targetRunId}.html`);
+  const outDir = options.outputPath ? join(outFile, '..') : viewsDir;
+  if (!existsSync(outDir)) {
+    mkdirSync(outDir, { recursive: true });
+  }
+  writeFileSync(outFile, html, 'utf8');
+
+  process.stderr.write(`\n  \x1b[32m+\x1b[0m Timeline viewer written to: ${outFile}\n`);
+
+  if (!options.noOpen) {
+    process.stderr.write('  Opening in browser...\n\n');
+    openInBrowser(outFile);
+  } else {
+    process.stderr.write('\n');
+  }
+}
+
+function openInBrowser(target: string): void {
+  try {
+    if (process.platform === 'win32') {
+      execFileSync('cmd.exe', ['/c', 'start', '', target], { stdio: 'ignore' });
+    } else if (process.platform === 'darwin') {
+      execFileSync('open', [target], { stdio: 'ignore' });
+    } else {
+      execFileSync('xdg-open', [target], { stdio: 'ignore' });
+    }
+  } catch {
+    process.stderr.write(`  Could not open browser. Open manually: ${target}\n`);
+  }
 }
 
 function renderSessionList(): void {

--- a/apps/cli/tests/replay-timeline-html.test.ts
+++ b/apps/cli/tests/replay-timeline-html.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect } from 'vitest';
+import { generateTimelineHtml } from '../src/replay-timeline-html.js';
+import type { ReplaySession, ReplayAction } from '@red-codes/kernel';
+import type { DomainEvent } from '@red-codes/core';
+
+// ---------------------------------------------------------------------------
+// Test data factories
+// ---------------------------------------------------------------------------
+
+function makeEvent(kind: string, overrides: Record<string, unknown> = {}): DomainEvent {
+  return {
+    id: `evt_${Math.random().toString(36).slice(2, 8)}`,
+    kind,
+    timestamp: 1700000000000,
+    fingerprint: 'test',
+    ...overrides,
+  } as DomainEvent;
+}
+
+function makeAction(overrides: Partial<ReplayAction> = {}): ReplayAction {
+  const requestedEvent = makeEvent('ActionRequested', { timestamp: 1700000000000 });
+  return {
+    index: 0,
+    requestedEvent,
+    decisionEvent: makeEvent('ActionAllowed', { timestamp: 1700000000100 }),
+    executionEvent: makeEvent('ActionExecuted', { timestamp: 1700000000200 }),
+    simulationEvent: null,
+    decisionRecordEvent: null,
+    escalationEvent: null,
+    governanceEvents: [],
+    allowed: true,
+    executed: true,
+    succeeded: true,
+    actionType: 'file.write',
+    target: 'src/test.ts',
+    ...overrides,
+  } as ReplayAction;
+}
+
+function makeSession(overrides: Partial<ReplaySession> = {}): ReplaySession {
+  const actions = overrides.actions ?? [makeAction()];
+  return {
+    runId: 'test_run_001',
+    events: [
+      makeEvent('ActionRequested', { timestamp: 1700000000000 }),
+      makeEvent('ActionAllowed', { timestamp: 1700000000100 }),
+      makeEvent('ActionExecuted', { timestamp: 1700000000200 }),
+    ],
+    actions,
+    summary: {
+      totalActions: actions.length,
+      allowed: actions.filter((a) => a.allowed).length,
+      denied: actions.filter((a) => !a.allowed).length,
+      executed: actions.filter((a) => a.executed).length,
+      failed: actions.filter((a) => a.executed && !a.succeeded).length,
+      violations: 0,
+      escalations: 0,
+      simulationsRun: 0,
+      durationMs: 5000,
+      actionTypes: { 'file.write': 1 },
+      denialReasons: [],
+      ...overrides.summary,
+    },
+    startEvent: null,
+    endEvent: null,
+    ...overrides,
+  } as ReplaySession;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('generateTimelineHtml', () => {
+  it('generates valid HTML with required structure', () => {
+    const session = makeSession();
+    const html = generateTimelineHtml(session, session.events);
+
+    expect(html).toContain('<!DOCTYPE html>');
+    expect(html).toContain('<html lang="en">');
+    expect(html).toContain('AgentGuard Timeline Viewer');
+    expect(html).toContain('test_run_001');
+  });
+
+  it('includes summary cards with correct counts', () => {
+    const session = makeSession({
+      summary: {
+        totalActions: 5,
+        allowed: 3,
+        denied: 2,
+        executed: 3,
+        failed: 0,
+        violations: 1,
+        escalations: 0,
+        simulationsRun: 1,
+        durationMs: 12000,
+        actionTypes: { 'file.write': 3, 'git.push': 2 },
+        denialReasons: ['policy: no-push'],
+      },
+    } as Partial<ReplaySession>);
+    const html = generateTimelineHtml(session, session.events);
+
+    expect(html).toContain('>5<'); // totalActions
+    expect(html).toContain('>3<'); // allowed
+    expect(html).toContain('>2<'); // denied
+  });
+
+  it('renders action entries in the timeline', () => {
+    const action = makeAction({
+      actionType: 'git.push',
+      target: 'origin/main',
+    });
+    const session = makeSession({ actions: [action] });
+    const html = generateTimelineHtml(session, session.events);
+
+    expect(html).toContain('git.push');
+    expect(html).toContain('origin/main');
+    expect(html).toContain('ALLOWED');
+  });
+
+  it('renders denied actions with correct badge', () => {
+    const action = makeAction({
+      allowed: false,
+      executed: false,
+      succeeded: false,
+      actionType: 'git.push',
+      target: 'origin/main',
+      decisionEvent: makeEvent('ActionDenied', {
+        timestamp: 1700000000100,
+        reason: 'Protected branch',
+      }),
+      executionEvent: null,
+    });
+    const session = makeSession({
+      actions: [action],
+      summary: { denied: 1, allowed: 0 },
+    } as Partial<ReplaySession>);
+    const html = generateTimelineHtml(session, session.events);
+
+    expect(html).toContain('DENIED');
+    expect(html).toContain('action-denied');
+    expect(html).toContain('Protected branch');
+  });
+
+  it('renders governance violation events', () => {
+    const govEvent = makeEvent('InvariantViolation', {
+      timestamp: 1700000000150,
+      invariant: 'no-force-push',
+    });
+    const action = makeAction({
+      governanceEvents: [govEvent],
+      actionType: 'git.push',
+    });
+    const session = makeSession({ actions: [action] });
+    const html = generateTimelineHtml(session, session.events);
+
+    expect(html).toContain('InvariantViolation');
+    expect(html).toContain('no-force-push');
+    expect(html).toContain('violation');
+  });
+
+  it('renders simulation badge when present', () => {
+    const simEvent = makeEvent('SimulationCompleted', {
+      timestamp: 1700000000150,
+      riskLevel: 'high',
+      blastRadius: 42,
+    });
+    const action = makeAction({ simulationEvent: simEvent });
+    const session = makeSession({ actions: [action] });
+    const html = generateTimelineHtml(session, session.events);
+
+    expect(html).toContain('risk=high');
+    expect(html).toContain('blast=42');
+  });
+
+  it('includes filter checkboxes for action types', () => {
+    const actions = [
+      makeAction({ index: 0, actionType: 'file.write', target: 'a.ts' }),
+      makeAction({ index: 1, actionType: 'git.push', target: 'origin/main' }),
+    ];
+    const session = makeSession({ actions });
+    const html = generateTimelineHtml(session, session.events);
+
+    expect(html).toContain('data-action-type="file.write"');
+    expect(html).toContain('data-action-type="git.push"');
+  });
+
+  it('includes scrubber with correct range', () => {
+    const actions = [makeAction({ index: 0 }), makeAction({ index: 1 }), makeAction({ index: 2 })];
+    const session = makeSession({ actions });
+    const html = generateTimelineHtml(session, session.events);
+
+    expect(html).toContain('max="2"');
+    expect(html).toContain('3 / 3 actions');
+  });
+
+  it('includes JavaScript for toggle, filter, and scrub', () => {
+    const session = makeSession();
+    const html = generateTimelineHtml(session, session.events);
+
+    expect(html).toContain('function toggleDetail');
+    expect(html).toContain('function applyFilters');
+    expect(html).toContain('function scrubTo');
+  });
+
+  it('respects deniedOnly option', () => {
+    const allowed = makeAction({ index: 0, allowed: true, actionType: 'file.read' });
+    const denied = makeAction({
+      index: 1,
+      allowed: false,
+      executed: false,
+      succeeded: false,
+      actionType: 'git.push',
+      decisionEvent: makeEvent('ActionDenied'),
+      executionEvent: null,
+    });
+    const session = makeSession({ actions: [allowed, denied] });
+    const html = generateTimelineHtml(session, session.events, { deniedOnly: true });
+
+    expect(html).toContain('git.push');
+    expect(html).not.toContain('data-kind="file.read"');
+  });
+
+  it('escapes HTML in target paths', () => {
+    const action = makeAction({
+      target: '<script>alert("xss")</script>',
+    });
+    const session = makeSession({ actions: [action] });
+    const html = generateTimelineHtml(session, session.events);
+
+    expect(html).not.toContain('<script>alert');
+    expect(html).toContain('&lt;script&gt;');
+  });
+
+  it('handles empty session gracefully', () => {
+    const session = makeSession({
+      actions: [],
+      events: [],
+      summary: {
+        totalActions: 0,
+        allowed: 0,
+        denied: 0,
+        executed: 0,
+        failed: 0,
+        violations: 0,
+        escalations: 0,
+        simulationsRun: 0,
+        durationMs: 0,
+        actionTypes: {},
+        denialReasons: [],
+      },
+    } as Partial<ReplaySession>);
+    const html = generateTimelineHtml(session, []);
+
+    expect(html).toContain('<!DOCTYPE html>');
+    expect(html).toContain('>0<'); // zero actions
+  });
+
+  it('renders lifecycle steps for each action', () => {
+    const session = makeSession();
+    const html = generateTimelineHtml(session, session.events);
+
+    expect(html).toContain('PROPOSE');
+    expect(html).toContain('EVALUATE');
+    expect(html).toContain('EXECUTE');
+    expect(html).toContain('EMIT');
+    expect(html).toContain('→');
+  });
+
+  it('renders event distribution bars', () => {
+    const events = [
+      makeEvent('ActionRequested', { timestamp: 1700000000000 }),
+      makeEvent('ActionAllowed', { timestamp: 1700000000100 }),
+      makeEvent('ActionExecuted', { timestamp: 1700000000200 }),
+      makeEvent('ActionRequested', { timestamp: 1700000000300 }),
+      makeEvent('ActionDenied', { timestamp: 1700000000400 }),
+    ];
+    const session = makeSession({ events });
+    const html = generateTimelineHtml(session, events);
+
+    expect(html).toContain('Event Distribution');
+    expect(html).toContain('ActionRequested');
+    expect(html).toContain('bar-fill');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `--ui` flag to `agentguard replay` command that generates an interactive HTML timeline viewer
- Timeline renders governance events chronologically with action lifecycle visualization (propose → evaluate → execute → emit)
- Closes #344

## Changes
- `apps/cli/src/replay-timeline-html.ts` — New file: self-contained HTML timeline generator with dark theme, summary cards, event distribution chart, action type/status filters, and timeline scrubber
- `apps/cli/src/replay.ts` — Added `--ui` flag handling: loads governance data from SQLite, generates HTML, opens in browser. Also supports `--denied-only`, `--output`, `--no-open`, and `--run` flags in UI mode
- `apps/cli/src/bin.ts` — Updated help text and command flags to document the `--ui` option
- `apps/cli/tests/replay-timeline-html.test.ts` — 14 tests covering HTML generation, filtering, XSS prevention, lifecycle rendering, and edge cases

## Test Plan
- [x] TypeScript build passes (`pnpm build`)
- [x] Vitest tests pass (`pnpm test --filter=@red-codes/agentguard` — 572 pass)
- [x] ESLint clean (`pnpm lint` — 0 errors in modified files)
- [x] Prettier clean (`pnpm format` — all modified files formatted)

## Risk Assessment

| Metric | Value |
|--------|-------|
| Risk level | low |
| Risk score | 5/100 |
| Blast radius | 4 files (all in apps/cli/) |
| Simulation result | not applicable (feature branch) |

## Governance Report

| Metric | Count |
|--------|-------|
| Total events | 4 |
| Actions allowed | 1 |
| Actions denied | 0 |
| Policy denials | 0 |
| Invariant violations | 0 |
| Escalation events | 0 |

<details>
<summary>Governance details</summary>

**Source**: SQLite governance database (`~/.agentguard/agentguard.db`)

**Escalation levels observed**: NORMAL only
**Pre-push simulation**: low risk, blast radius 0

All actions passed governance checks. No denials or violations during implementation.

</details>