### PR TITLE
fix(swarm): worktree env propagation + RTK setup

### DIFF
--- a/.claude/skills/sync-main.md
+++ b/.claude/skills/sync-main.md
@@ -12,7 +12,23 @@ git fetch origin main && git merge origin/main --ff-only
 
 The `--ff-only` flag ensures a clean fast-forward. If the merge fails (e.g., local commits on main that diverge from origin), report the error and STOP — do not proceed with stale or conflicted state.
 
-### 2. Confirm Sync
+### 2. Copy Environment Files
+
+Worktrees don't inherit `.env` files (they're gitignored). Copy from the main working tree if missing:
+
+```bash
+MAIN_ROOT=$(git worktree list --porcelain | head -1 | sed 's/worktree //')
+if [ -f "$MAIN_ROOT/.env" ] && [ ! -f ".env" ]; then
+  cp "$MAIN_ROOT/.env" .env
+  echo "Copied .env from main working tree"
+fi
+if [ -f "$MAIN_ROOT/.env.local" ] && [ ! -f ".env.local" ]; then
+  cp "$MAIN_ROOT/.env.local" .env.local
+  echo "Copied .env.local from main working tree"
+fi
+```
+
+### 3. Confirm Sync
 
 Report the current HEAD:
 

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# AgentGuard OSS Environment
+
+# RTK Token Optimization (rtk-ai/rtk)
+# Enabled by default — set to 'false' to disable.
+# Requires rtk CLI installed globally: npm install -g rtk-ai
+AGENTGUARD_RTK_ENABLED=true
+
+# Telemetry (opt-in cloud telemetry)
+# AGENTGUARD_TELEMETRY_URL=https://agentguard-cloud.vercel.app
+# AGENTGUARD_TELEMETRY_MODE=anonymous


### PR DESCRIPTION
## Summary
- sync-main skill now copies `.env` and `.env.local` from main working tree into worktrees on startup
- Add `.env.example` with `AGENTGUARD_RTK_ENABLED=true` and telemetry config

## Why
Worktrees are created via `git worktree add` which doesn't copy gitignored files. Agents running in worktrees were missing `.env` config, so RTK detection and telemetry settings weren't available.

## Test plan
- [ ] Create a worktree, verify `.env` is missing
- [ ] Run sync-main skill, verify `.env` is copied from main tree
- [ ] Verify `AGENTGUARD_RTK_ENABLED` is documented in `.env.example`

🤖 Generated with [Claude Code](https://claude.com/claude-code)