### PR TITLE
fix: default RTK on via AGENTGUARD_RTK_ENABLED env var

### DIFF
--- a/packages/adapters/src/shell.ts
+++ b/packages/adapters/src/shell.ts
@@ -144,9 +144,11 @@ export function createShellAdapter(
   const credentialOptions = isNewOptions
     ? ((optionsOrCredentials as ShellAdapterOptions).credentials ?? {})
     : ((optionsOrCredentials as CredentialStrippingOptions) ?? {});
+  // RTK defaults to ON via AGENTGUARD_RTK_ENABLED env var (set 'false' to disable)
+  const envRtk = process.env.AGENTGUARD_RTK_ENABLED !== 'false';
   const rtkEnabled = isNewOptions
-    ? ((optionsOrCredentials as ShellAdapterOptions).rtkEnabled ?? false)
-    : false;
+    ? ((optionsOrCredentials as ShellAdapterOptions).rtkEnabled ?? envRtk)
+    : envRtk;
 
   return async (action: CanonicalAction): Promise<ShellResult> => {
     let command = (action as Record<string, unknown>).command as string | undefined;
@@ -203,7 +205,8 @@ export function createShellAdapter(
 }
 
 /**
- * Default shell adapter with credential stripping enabled.
+ * Default shell adapter with credential stripping and RTK token optimization enabled.
+ * RTK is on by default (set AGENTGUARD_RTK_ENABLED=false to disable).
  * Strips all DEFAULT_STRIPPED_CREDENTIALS from the child process environment.
  */
 export const shellAdapter = createShellAdapter();


### PR DESCRIPTION
## Summary

- **Port env-based RTK default from cloud fork to OSS shell adapter.** The `createShellAdapter` function in `@red-codes/adapters` now reads `AGENTGUARD_RTK_ENABLED` from the environment. RTK token optimization defaults to ON unless the env var is explicitly set to `'false'`.
- **Programmatic override preserved.** If `rtkEnabled` is passed in `ShellAdapterOptions`, it takes precedence over the env var.
- **Matches cloud fork behavior.** This aligns the OSS repo with `agentguard-cloud/oss/agent-guard/packages/adapters/src/shell.ts`, ensuring swarm agents spawned in worktrees get RTK without needing explicit programmatic configuration.

## Changes

`packages/adapters/src/shell.ts`:
- Added `const envRtk = process.env.AGENTGUARD_RTK_ENABLED !== 'false'` before the RTK resolution line
- Changed fallback from `false` to `envRtk` in both the new-options and legacy-options branches
- Updated JSDoc on the default `shellAdapter` export to document RTK-on-by-default behavior

## Test plan

- [x] `pnpm build --filter=@red-codes/adapters` compiles cleanly
- [x] `pnpm test --filter=@red-codes/adapters` — all 81 tests pass
- [ ] Manual: verify `AGENTGUARD_RTK_ENABLED=false` disables RTK
- [ ] Manual: verify unset env var enables RTK by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)