### PR TITLE
feat(issue-212): multi-agent pipeline orchestration

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@red-codes/runtime",
   "version": "0.1.0",
-  "description": "Agent runtime — scheduler, skills, workflow (placeholder)",
+  "description": "Agent runtime — pipeline orchestration, scheduler, skills, workflow",
   "type": "module",
   "license": "Apache-2.0",
   "main": "./dist/index.js",
@@ -14,13 +14,14 @@
   },
   "scripts": {
     "build": "tsc -b",
-    
+    "test": "vitest run",
     "lint": "eslint src/",
     "ts:check": "tsc --noEmit",
     "clean": "rm -rf dist"
   },
   "dependencies": {
     "@red-codes/core": "workspace:*",
+    "@red-codes/events": "workspace:*",
     "@red-codes/kernel": "workspace:*"
   }
 }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,1 +1,3 @@
 export const VERSION = '0.0.1';
+
+export * from './pipeline/index.js';

--- a/packages/runtime/src/pipeline/index.ts
+++ b/packages/runtime/src/pipeline/index.ts
@@ -1,0 +1,15 @@
+// Multi-agent pipeline orchestration — public API.
+// Re-exports roles, stages, and orchestrator for external consumption.
+
+export { ROLE_DEFINITIONS, getRole, isRoleAuthorized } from './roles.js';
+export {
+  STAGE_DEFINITIONS,
+  STAGE_ORDER,
+  getStage,
+  validateRoleForStage,
+  validateInputs,
+  validateOutput,
+  checkFileScope,
+} from './stages.js';
+export { runPipeline } from './orchestrator.js';
+export type { StageHandler, StageHandlers, PipelineOptions } from './orchestrator.js';

--- a/packages/runtime/src/pipeline/orchestrator.ts
+++ b/packages/runtime/src/pipeline/orchestrator.ts
@@ -1,0 +1,253 @@
+// Pipeline orchestrator — creates and executes multi-agent pipelines sequentially.
+// Each stage runs through validation gates before and after execution.
+// Emits canonical pipeline events into the domain event model.
+
+import type { DomainEvent, StageId, StageStatus, StageResult, PipelineRun } from '@red-codes/core';
+import {
+  createEvent,
+  PIPELINE_STARTED,
+  STAGE_COMPLETED,
+  STAGE_FAILED,
+  PIPELINE_COMPLETED,
+  PIPELINE_FAILED,
+  FILE_SCOPE_VIOLATION,
+} from '@red-codes/events';
+import { STAGE_ORDER, getStage, validateInputs, validateOutput, checkFileScope } from './stages.js';
+
+/** Handler function that a stage executor calls. Receives the pipeline context, returns output. */
+export type StageHandler = (context: Record<string, unknown>) => Record<string, unknown>;
+
+/** Map of stage IDs to their handler functions. */
+export type StageHandlers = Partial<Record<StageId, StageHandler>>;
+
+/** Options for creating a pipeline run. */
+export interface PipelineOptions {
+  /** Optional event sink — receives events as they are emitted. */
+  onEvent?: (event: DomainEvent) => void;
+}
+
+/** Create a unique run ID. */
+const createRunId = (): string =>
+  `pipeline_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+
+/** Build the initial stages record with all stages pending. */
+const initStages = (): Record<StageId, StageResult> => {
+  const stages = {} as Record<StageId, StageResult>;
+  for (const id of STAGE_ORDER) {
+    stages[id] = { stageId: id, status: 'pending' as StageStatus };
+  }
+  return stages;
+};
+
+/**
+ * Run a multi-agent pipeline to completion.
+ *
+ * Stages execute sequentially: plan → build → test → optimize → audit.
+ * Each stage validates inputs, runs the handler, validates output,
+ * and (for build) checks file scope. If any gate fails, the pipeline halts.
+ *
+ * @param task - Description of the task being orchestrated
+ * @param handlers - Map of stage IDs to handler functions
+ * @param options - Optional configuration (event sink, etc.)
+ * @returns The completed PipelineRun
+ */
+export const runPipeline = (
+  task: string,
+  handlers: StageHandlers,
+  options: PipelineOptions = {}
+): PipelineRun => {
+  const runId = createRunId();
+  const startedAt = Date.now();
+  const context: Record<string, unknown> = {};
+  const events: DomainEvent[] = [];
+  const stages = initStages();
+
+  const emit = (event: DomainEvent): void => {
+    events.push(event);
+    options.onEvent?.(event);
+  };
+
+  // Emit PipelineStarted
+  emit(
+    createEvent(PIPELINE_STARTED, {
+      runId,
+      task,
+      agentRoles: STAGE_ORDER.map((id) => getStage(id).requiredRole),
+      stageCount: STAGE_ORDER.length,
+    })
+  );
+
+  let failedStage: StageId | null = null;
+  let failErrors: string[] = [];
+
+  for (const stageId of STAGE_ORDER) {
+    const handler = handlers[stageId];
+    if (!handler) {
+      // No handler provided — skip this stage
+      stages[stageId] = { stageId, status: 'skipped' as StageStatus };
+      continue;
+    }
+
+    const stageStart = Date.now();
+    const stageDef = getStage(stageId);
+
+    // Gate 1: Input validation
+    const inputCheck = validateInputs(stageId, context);
+    if (!inputCheck.valid) {
+      const errors = [`Missing required inputs: ${inputCheck.missing.join(', ')}`];
+      stages[stageId] = { stageId, status: 'failed' as StageStatus, errors };
+      emit(
+        createEvent(STAGE_FAILED, {
+          runId,
+          stageId,
+          errors,
+          agentRole: stageDef.requiredRole,
+          duration: Date.now() - stageStart,
+        })
+      );
+      failedStage = stageId;
+      failErrors = errors;
+      break;
+    }
+
+    // Gate 2: Execute handler
+    let output: Record<string, unknown>;
+    try {
+      output = handler(context);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      const errors = [`Handler threw: ${message}`];
+      stages[stageId] = { stageId, status: 'failed' as StageStatus, errors };
+      emit(
+        createEvent(STAGE_FAILED, {
+          runId,
+          stageId,
+          errors,
+          agentRole: stageDef.requiredRole,
+          duration: Date.now() - stageStart,
+        })
+      );
+      failedStage = stageId;
+      failErrors = errors;
+      break;
+    }
+
+    // Gate 3: Output validation
+    const outputCheck = validateOutput(stageId, output);
+    if (!outputCheck.valid) {
+      const errors = [`Missing required outputs: ${outputCheck.missing.join(', ')}`];
+      stages[stageId] = { stageId, status: 'failed' as StageStatus, errors };
+      emit(
+        createEvent(STAGE_FAILED, {
+          runId,
+          stageId,
+          errors,
+          agentRole: stageDef.requiredRole,
+          duration: Date.now() - stageStart,
+        })
+      );
+      failedStage = stageId;
+      failErrors = errors;
+      break;
+    }
+
+    // Gate 4: File scope enforcement (build stage only)
+    if (stageId === 'build' && output.changes && context.files) {
+      const allowedFiles = context.files as string[];
+      const modifiedFiles = Object.keys(output.changes as Record<string, unknown>);
+      const scopeCheck = checkFileScope(modifiedFiles, allowedFiles);
+      if (!scopeCheck.valid) {
+        emit(
+          createEvent(FILE_SCOPE_VIOLATION, {
+            runId,
+            files: scopeCheck.violations,
+            allowedFiles,
+            agentRole: 'builder',
+          })
+        );
+        const errors = [
+          `File scope violation: ${scopeCheck.violations.join(', ')} not in allowed scope`,
+        ];
+        stages[stageId] = { stageId, status: 'failed' as StageStatus, errors };
+        emit(
+          createEvent(STAGE_FAILED, {
+            runId,
+            stageId,
+            errors,
+            agentRole: stageDef.requiredRole,
+            duration: Date.now() - stageStart,
+          })
+        );
+        failedStage = stageId;
+        failErrors = errors;
+        break;
+      }
+    }
+
+    // Stage passed — merge output into context
+    Object.assign(context, output);
+    const duration = Date.now() - stageStart;
+    stages[stageId] = {
+      stageId,
+      status: 'passed' as StageStatus,
+      output,
+      duration,
+    };
+    emit(
+      createEvent(STAGE_COMPLETED, {
+        runId,
+        stageId,
+        status: 'passed',
+        duration,
+        outputKeys: Object.keys(output),
+        agentRole: stageDef.requiredRole,
+      })
+    );
+  }
+
+  // Emit final pipeline event
+  const duration = Date.now() - startedAt;
+  const stagesCompleted = Object.values(stages).filter((s) => s.status === 'passed').length;
+
+  if (failedStage) {
+    emit(
+      createEvent(PIPELINE_FAILED, {
+        runId,
+        failedStage,
+        errors: failErrors,
+        duration,
+        stagesCompleted,
+        task,
+      })
+    );
+    return {
+      runId,
+      task,
+      stages,
+      context,
+      events,
+      startedAt,
+      status: 'failed',
+    };
+  }
+
+  emit(
+    createEvent(PIPELINE_COMPLETED, {
+      runId,
+      result: 'completed',
+      duration,
+      stagesCompleted,
+      task,
+    })
+  );
+
+  return {
+    runId,
+    task,
+    stages,
+    context,
+    events,
+    startedAt,
+    status: 'completed',
+  };
+};

--- a/packages/runtime/src/pipeline/roles.ts
+++ b/packages/runtime/src/pipeline/roles.ts
@@ -1,0 +1,106 @@
+// Agent role definitions and permission checks for the multi-agent pipeline.
+// Each role has strict permission boundaries that are enforced by the orchestrator.
+
+import type { AgentRole, RoleDefinition } from '@red-codes/core';
+
+/**
+ * Built-in role definitions with strict permission boundaries.
+ *
+ * | Role       | Modify Files | Run Tests | Refactor |
+ * |------------|-------------|-----------|----------|
+ * | Architect  | No          | No        | No       |
+ * | Builder    | Yes         | No        | No       |
+ * | Tester     | Yes         | Yes       | No       |
+ * | Optimizer  | Yes         | Yes       | Yes      |
+ * | Auditor    | No          | Yes       | No       |
+ */
+export const ROLE_DEFINITIONS: Readonly<Record<AgentRole, RoleDefinition>> = {
+  architect: {
+    name: 'architect',
+    description: 'Interprets specifications and produces an implementation plan',
+    responsibilities: [
+      'Define file scope for implementation',
+      'Declare constraints and invariants',
+      'Produce architecture plan',
+    ],
+    allowedOutputs: ['files', 'constraints'],
+    canModifyFiles: false,
+    canRunTests: false,
+    canRefactor: false,
+  },
+  builder: {
+    name: 'builder',
+    description: 'Writes code following the architecture plan',
+    responsibilities: [
+      'Implement code within declared file scope',
+      'Follow architecture constraints',
+      'Produce implementation changes',
+    ],
+    allowedOutputs: ['changes'],
+    canModifyFiles: true,
+    canRunTests: false,
+    canRefactor: false,
+  },
+  tester: {
+    name: 'tester',
+    description: 'Generates tests and identifies coverage gaps',
+    responsibilities: ['Generate test cases', 'Run test scenarios', 'Report coverage gaps'],
+    allowedOutputs: ['testResults', 'gaps'],
+    canModifyFiles: true,
+    canRunTests: true,
+    canRefactor: false,
+  },
+  optimizer: {
+    name: 'optimizer',
+    description: 'Refactors for clarity and performance without changing behavior',
+    responsibilities: [
+      'Refactor for clarity',
+      'Optimize performance',
+      'Preserve public interfaces',
+    ],
+    allowedOutputs: ['changes'],
+    canModifyFiles: true,
+    canRunTests: true,
+    canRefactor: true,
+  },
+  auditor: {
+    name: 'auditor',
+    description: 'Final safety layer — reviews boundaries, enforces invariants',
+    responsibilities: [
+      'Review architecture boundaries',
+      'Detect anti-patterns',
+      'Enforce invariants',
+    ],
+    allowedOutputs: ['auditResult', 'violations'],
+    canModifyFiles: false,
+    canRunTests: true,
+    canRefactor: false,
+  },
+};
+
+/** Get the role definition for a given agent role. */
+export const getRole = (role: AgentRole): RoleDefinition => {
+  const def = ROLE_DEFINITIONS[role];
+  if (!def) {
+    throw new Error(`Unknown agent role: ${role}`);
+  }
+  return def;
+};
+
+/** Check if a role is authorized to perform a specific action category. */
+export const isRoleAuthorized = (
+  role: AgentRole,
+  action: 'modifyFiles' | 'runTests' | 'refactor'
+): boolean => {
+  const def = getRole(role);
+  switch (action) {
+    case 'modifyFiles':
+      return def.canModifyFiles;
+    case 'runTests':
+      return def.canRunTests;
+    case 'refactor':
+      return def.canRefactor;
+    default:
+      return false;
+  }
+};

--- a/packages/runtime/src/pipeline/stages.ts
+++ b/packages/runtime/src/pipeline/stages.ts
@@ -1,0 +1,103 @@
+// Stage definitions, validation gates, and file scope enforcement.
+// Each stage validates inputs (from prior stages) and outputs (from the handler).
+
+import type { AgentRole, StageId, StageDefinition } from '@red-codes/core';
+
+/** Built-in stage definitions in execution order. */
+export const STAGE_DEFINITIONS: readonly StageDefinition[] = [
+  {
+    id: 'plan',
+    name: 'Architecture Planning',
+    requiredRole: 'architect',
+    inputRequirements: [],
+    outputContract: ['files', 'constraints'],
+  },
+  {
+    id: 'build',
+    name: 'Implementation',
+    requiredRole: 'builder',
+    inputRequirements: ['files', 'constraints'],
+    outputContract: ['changes'],
+  },
+  {
+    id: 'test',
+    name: 'Testing',
+    requiredRole: 'tester',
+    inputRequirements: ['changes'],
+    outputContract: ['testResults'],
+  },
+  {
+    id: 'optimize',
+    name: 'Optimization',
+    requiredRole: 'optimizer',
+    inputRequirements: ['changes', 'testResults'],
+    outputContract: ['changes'],
+  },
+  {
+    id: 'audit',
+    name: 'Audit Review',
+    requiredRole: 'auditor',
+    inputRequirements: ['changes', 'testResults'],
+    outputContract: ['auditResult', 'violations'],
+  },
+];
+
+/** Ordered stage IDs for sequential execution. */
+export const STAGE_ORDER: readonly StageId[] = STAGE_DEFINITIONS.map((s) => s.id);
+
+/** Get a stage definition by ID. */
+export const getStage = (stageId: StageId): StageDefinition => {
+  const stage = STAGE_DEFINITIONS.find((s) => s.id === stageId);
+  if (!stage) {
+    throw new Error(`Unknown stage: ${stageId}`);
+  }
+  return stage;
+};
+
+/** Validate that a role is authorized to execute a stage. */
+export const validateRoleForStage = (
+  stageId: StageId,
+  role: AgentRole
+): { valid: boolean; error?: string } => {
+  const stage = getStage(stageId);
+  if (stage.requiredRole !== role) {
+    return {
+      valid: false,
+      error: `Stage "${stageId}" requires role "${stage.requiredRole}", got "${role}"`,
+    };
+  }
+  return { valid: true };
+};
+
+/** Validate that all required inputs exist in the pipeline context. */
+export const validateInputs = (
+  stageId: StageId,
+  context: Record<string, unknown>
+): { valid: boolean; missing: string[] } => {
+  const stage = getStage(stageId);
+  const missing = stage.inputRequirements.filter((key) => !(key in context));
+  return { valid: missing.length === 0, missing };
+};
+
+/** Validate that stage output contains all required contract fields. */
+export const validateOutput = (
+  stageId: StageId,
+  output: Record<string, unknown>
+): { valid: boolean; missing: string[] } => {
+  const stage = getStage(stageId);
+  const missing = stage.outputContract.filter((key) => !(key in output));
+  return { valid: missing.length === 0, missing };
+};
+
+/**
+ * Check file scope: verify that modified files are within the allowed set.
+ * Used during the build stage to enforce the architect's declared file scope.
+ */
+export const checkFileScope = (
+  modifiedFiles: readonly string[],
+  allowedFiles: readonly string[]
+): { valid: boolean; violations: string[] } => {
+  const allowedSet = new Set(allowedFiles);
+  const violations = modifiedFiles.filter((f) => !allowedSet.has(f));
+  return { valid: violations.length === 0, violations };
+};

--- a/packages/runtime/tests/pipeline.test.ts
+++ b/packages/runtime/tests/pipeline.test.ts
@@ -1,0 +1,311 @@
+// Tests for the multi-agent pipeline orchestration module.
+import { describe, it, expect, beforeEach } from 'vitest';
+import { resetEventCounter } from '@red-codes/events';
+import {
+  ROLE_DEFINITIONS,
+  getRole,
+  isRoleAuthorized,
+  STAGE_DEFINITIONS,
+  STAGE_ORDER,
+  getStage,
+  validateRoleForStage,
+  validateInputs,
+  validateOutput,
+  checkFileScope,
+  runPipeline,
+} from '@red-codes/runtime';
+import type { StageHandlers } from '@red-codes/runtime';
+import type { DomainEvent } from '@red-codes/core';
+
+beforeEach(() => {
+  resetEventCounter();
+});
+
+// ---------------------------------------------------------------------------
+// Roles
+// ---------------------------------------------------------------------------
+
+describe('roles', () => {
+  it('defines five agent roles', () => {
+    expect(Object.keys(ROLE_DEFINITIONS)).toHaveLength(5);
+    expect(Object.keys(ROLE_DEFINITIONS)).toEqual([
+      'architect',
+      'builder',
+      'tester',
+      'optimizer',
+      'auditor',
+    ]);
+  });
+
+  it('getRole returns a valid role definition', () => {
+    const builder = getRole('builder');
+    expect(builder.name).toBe('builder');
+    expect(builder.canModifyFiles).toBe(true);
+    expect(builder.canRunTests).toBe(false);
+  });
+
+  it('getRole throws for unknown role', () => {
+    expect(() => getRole('hacker' as never)).toThrow('Unknown agent role');
+  });
+
+  it('architect cannot modify files, run tests, or refactor', () => {
+    expect(isRoleAuthorized('architect', 'modifyFiles')).toBe(false);
+    expect(isRoleAuthorized('architect', 'runTests')).toBe(false);
+    expect(isRoleAuthorized('architect', 'refactor')).toBe(false);
+  });
+
+  it('builder can modify files but not run tests or refactor', () => {
+    expect(isRoleAuthorized('builder', 'modifyFiles')).toBe(true);
+    expect(isRoleAuthorized('builder', 'runTests')).toBe(false);
+    expect(isRoleAuthorized('builder', 'refactor')).toBe(false);
+  });
+
+  it('optimizer can modify files, run tests, and refactor', () => {
+    expect(isRoleAuthorized('optimizer', 'modifyFiles')).toBe(true);
+    expect(isRoleAuthorized('optimizer', 'runTests')).toBe(true);
+    expect(isRoleAuthorized('optimizer', 'refactor')).toBe(true);
+  });
+
+  it('auditor can run tests but not modify files or refactor', () => {
+    expect(isRoleAuthorized('auditor', 'modifyFiles')).toBe(false);
+    expect(isRoleAuthorized('auditor', 'runTests')).toBe(true);
+    expect(isRoleAuthorized('auditor', 'refactor')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stages
+// ---------------------------------------------------------------------------
+
+describe('stages', () => {
+  it('defines five stages in order', () => {
+    expect(STAGE_ORDER).toEqual(['plan', 'build', 'test', 'optimize', 'audit']);
+    expect(STAGE_DEFINITIONS).toHaveLength(5);
+  });
+
+  it('getStage returns the correct stage definition', () => {
+    const build = getStage('build');
+    expect(build.name).toBe('Implementation');
+    expect(build.requiredRole).toBe('builder');
+    expect(build.inputRequirements).toContain('files');
+    expect(build.outputContract).toContain('changes');
+  });
+
+  it('getStage throws for unknown stage', () => {
+    expect(() => getStage('deploy' as never)).toThrow('Unknown stage');
+  });
+
+  it('validateRoleForStage passes for correct role', () => {
+    expect(validateRoleForStage('plan', 'architect')).toEqual({ valid: true });
+    expect(validateRoleForStage('build', 'builder')).toEqual({ valid: true });
+    expect(validateRoleForStage('audit', 'auditor')).toEqual({ valid: true });
+  });
+
+  it('validateRoleForStage fails for wrong role', () => {
+    const result = validateRoleForStage('build', 'architect');
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('requires role "builder"');
+  });
+
+  it('validateInputs passes when all inputs exist in context', () => {
+    const result = validateInputs('build', { files: ['a.ts'], constraints: ['no side effects'] });
+    expect(result.valid).toBe(true);
+    expect(result.missing).toEqual([]);
+  });
+
+  it('validateInputs fails when inputs are missing', () => {
+    const result = validateInputs('build', {});
+    expect(result.valid).toBe(false);
+    expect(result.missing).toContain('files');
+    expect(result.missing).toContain('constraints');
+  });
+
+  it('validateOutput passes when all outputs are present', () => {
+    const result = validateOutput('plan', { files: ['a.ts'], constraints: ['pure functions'] });
+    expect(result.valid).toBe(true);
+  });
+
+  it('validateOutput fails when outputs are missing', () => {
+    const result = validateOutput('plan', { files: ['a.ts'] });
+    expect(result.valid).toBe(false);
+    expect(result.missing).toContain('constraints');
+  });
+
+  it('checkFileScope passes for files within scope', () => {
+    const result = checkFileScope(['src/a.ts', 'src/b.ts'], ['src/a.ts', 'src/b.ts', 'src/c.ts']);
+    expect(result.valid).toBe(true);
+    expect(result.violations).toEqual([]);
+  });
+
+  it('checkFileScope detects violations', () => {
+    const result = checkFileScope(['src/a.ts', 'src/secret.ts'], ['src/a.ts']);
+    expect(result.valid).toBe(false);
+    expect(result.violations).toEqual(['src/secret.ts']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Orchestrator
+// ---------------------------------------------------------------------------
+
+describe('orchestrator', () => {
+  const makeHandlers = (): StageHandlers => ({
+    plan: () => ({
+      files: ['src/feature.ts'],
+      constraints: ['no side effects'],
+    }),
+    build: () => ({
+      changes: { 'src/feature.ts': '// implementation' },
+    }),
+    test: () => ({
+      testResults: { passed: 3, failed: 0 },
+    }),
+    optimize: () => ({
+      changes: { 'src/feature.ts': '// optimized' },
+    }),
+    audit: () => ({
+      auditResult: 'pass',
+      violations: [],
+    }),
+  });
+
+  it('runs a full pipeline to completion', () => {
+    const run = runPipeline('implement feature X', makeHandlers());
+    expect(run.status).toBe('completed');
+    expect(run.task).toBe('implement feature X');
+    expect(run.runId).toMatch(/^pipeline_/);
+    expect(run.stages.plan.status).toBe('passed');
+    expect(run.stages.build.status).toBe('passed');
+    expect(run.stages.test.status).toBe('passed');
+    expect(run.stages.optimize.status).toBe('passed');
+    expect(run.stages.audit.status).toBe('passed');
+  });
+
+  it('emits PipelineStarted and PipelineCompleted events', () => {
+    const run = runPipeline('test task', makeHandlers());
+    const kinds = run.events.map((e) => e.kind);
+    expect(kinds[0]).toBe('PipelineStarted');
+    expect(kinds[kinds.length - 1]).toBe('PipelineCompleted');
+  });
+
+  it('emits StageCompleted for each passing stage', () => {
+    const run = runPipeline('test task', makeHandlers());
+    const stageCompleted = run.events.filter((e) => e.kind === 'StageCompleted');
+    expect(stageCompleted).toHaveLength(5);
+  });
+
+  it('calls onEvent callback for each event', () => {
+    const collected: DomainEvent[] = [];
+    runPipeline('test task', makeHandlers(), {
+      onEvent: (e) => collected.push(e),
+    });
+    expect(collected.length).toBeGreaterThan(0);
+    expect(collected[0].kind).toBe('PipelineStarted');
+  });
+
+  it('fails when a handler throws', () => {
+    const handlers = makeHandlers();
+    handlers.build = () => {
+      throw new Error('compilation failed');
+    };
+    const run = runPipeline('broken build', handlers);
+    expect(run.status).toBe('failed');
+    expect(run.stages.build.status).toBe('failed');
+    expect(run.stages.build.errors?.[0]).toContain('Handler threw: compilation failed');
+    // Subsequent stages remain pending
+    expect(run.stages.test.status).toBe('pending');
+  });
+
+  it('fails when output contract is not satisfied', () => {
+    const handlers = makeHandlers();
+    handlers.plan = () => ({ files: ['src/a.ts'] }); // missing 'constraints'
+    const run = runPipeline('missing output', handlers);
+    expect(run.status).toBe('failed');
+    expect(run.stages.plan.status).toBe('failed');
+    expect(run.stages.plan.errors?.[0]).toContain('Missing required outputs: constraints');
+  });
+
+  it('fails when input requirements are not met', () => {
+    // Skip plan handler so build has no 'files' or 'constraints' in context
+    const handlers: StageHandlers = {
+      build: () => ({
+        changes: { 'src/a.ts': '// code' },
+      }),
+    };
+    const run = runPipeline('missing inputs', handlers);
+    expect(run.status).toBe('failed');
+    expect(run.stages.build.status).toBe('failed');
+    expect(run.stages.build.errors?.[0]).toContain('Missing required inputs');
+  });
+
+  it('detects file scope violations during build', () => {
+    const handlers = makeHandlers();
+    handlers.build = () => ({
+      changes: {
+        'src/feature.ts': '// allowed',
+        'src/unauthorized.ts': '// not in scope',
+      },
+    });
+    const run = runPipeline('scope violation', handlers);
+    expect(run.status).toBe('failed');
+    expect(run.stages.build.status).toBe('failed');
+    const scopeEvent = run.events.find((e) => e.kind === 'FileScopeViolation');
+    expect(scopeEvent).toBeDefined();
+    expect((scopeEvent as Record<string, unknown>).files).toContain('src/unauthorized.ts');
+  });
+
+  it('emits PipelineFailed event on failure', () => {
+    const handlers = makeHandlers();
+    handlers.test = () => {
+      throw new Error('test crashed');
+    };
+    const run = runPipeline('crash test', handlers);
+    const failEvent = run.events.find((e) => e.kind === 'PipelineFailed');
+    expect(failEvent).toBeDefined();
+    expect((failEvent as Record<string, unknown>).failedStage).toBe('test');
+  });
+
+  it('skips stages without handlers', () => {
+    const handlers: StageHandlers = {
+      plan: () => ({
+        files: ['src/a.ts'],
+        constraints: ['none'],
+      }),
+      build: () => ({
+        changes: { 'src/a.ts': '// code' },
+      }),
+      // test, optimize, audit are skipped
+    };
+    const run = runPipeline('partial pipeline', handlers);
+    expect(run.status).toBe('completed');
+    expect(run.stages.plan.status).toBe('passed');
+    expect(run.stages.build.status).toBe('passed');
+    expect(run.stages.test.status).toBe('skipped');
+    expect(run.stages.optimize.status).toBe('skipped');
+    expect(run.stages.audit.status).toBe('skipped');
+  });
+
+  it('merges stage output into context for subsequent stages', () => {
+    let buildContext: Record<string, unknown> = {};
+    const handlers: StageHandlers = {
+      plan: () => ({
+        files: ['src/a.ts'],
+        constraints: ['pure functions'],
+      }),
+      build: (ctx) => {
+        buildContext = { ...ctx };
+        return { changes: { 'src/a.ts': '// code' } };
+      },
+    };
+    runPipeline('context passing', handlers);
+    expect(buildContext.files).toEqual(['src/a.ts']);
+    expect(buildContext.constraints).toEqual(['pure functions']);
+  });
+
+  it('pipeline events include runId consistently', () => {
+    const run = runPipeline('consistency check', makeHandlers());
+    for (const event of run.events) {
+      expect((event as Record<string, unknown>).runId).toBe(run.runId);
+    }
+  });
+});

--- a/packages/runtime/tsconfig.json
+++ b/packages/runtime/tsconfig.json
@@ -6,5 +6,5 @@
     "composite": true
   },
   "include": ["src/**/*.ts"],
-  "references": [{ "path": "../core" }, { "path": "../kernel" }]
+  "references": [{ "path": "../core" }, { "path": "../events" }, { "path": "../kernel" }]
 }

--- a/packages/runtime/vitest.config.ts
+++ b/packages/runtime/vitest.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@red-codes/runtime': path.resolve(__dirname, 'src/index.ts'),
+    },
+  },
+  test: {
+    include: ['tests/**/*.test.ts'],
+    environment: 'node',
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.ts'],
+      reporter: ['text', 'json-summary', 'lcov'],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,6 +215,9 @@ importers:
       '@red-codes/core':
         specifier: workspace:*
         version: link:../core
+      '@red-codes/events':
+        specifier: workspace:*
+        version: link:../events
       '@red-codes/kernel':
         specifier: workspace:*
         version: link:../kernel


### PR DESCRIPTION
## Summary
- Implements multi-agent pipeline orchestration in `@red-codes/runtime` as specified in `docs/multi-agent-pipeline.md`
- Adds 5 agent roles (architect, builder, tester, optimizer, auditor) with strict permission boundaries, 5 sequential stages with validation gates, and a pipeline orchestrator with event emission
- Closes #212

## Changes
- `packages/runtime/src/pipeline/roles.ts` — Agent role definitions and permission checks
- `packages/runtime/src/pipeline/stages.ts` — Stage definitions, validation gates, file scope enforcement
- `packages/runtime/src/pipeline/orchestrator.ts` — Pipeline run creation and sequential execution with event emission
- `packages/runtime/src/pipeline/index.ts` — Public API re-exports
- `packages/runtime/src/index.ts` — Re-export pipeline module
- `packages/runtime/package.json` — Add `@red-codes/events` dependency, update description
- `packages/runtime/tsconfig.json` — Add events project reference
- `packages/runtime/vitest.config.ts` — New vitest config for runtime package
- `packages/runtime/tests/pipeline.test.ts` — 30 tests covering roles, stages, and orchestrator

## Test Plan
- [x] TypeScript build passes (`pnpm build`)
- [x] Vitest tests pass (`pnpm test` — 30 new tests, 839 total passing in relevant packages)
- [x] ESLint clean (`pnpm lint`)
- [x] Prettier clean (`pnpm format`)

## Risk Assessment

| Metric | Value |
|--------|-------|
| Risk level | low |
| Blast radius | 0 (new module, no existing code modified) |
| Simulation result | allowed (feature branch) |

## Governance Report

| Metric | Count |
|--------|-------|
| Total events | N/A (worktree) |
| Actions allowed | N/A |
| Actions denied | 0 |
| Policy denials | 0 |
| Invariant violations | 0 |
| Escalation events | 0 |
| Decision records | 0 |

<details>
<summary>Governance details</summary>

**Source**: Worktree-based development — governance hooks run in main working directory.

**Decision Records**: 0 (worktree isolation)
**Escalation levels observed**: NORMAL only
**Pre-push simulation**: low risk, blast radius 0

This is a purely additive change — no existing source files were modified. The new pipeline module lives entirely in `packages/runtime/src/pipeline/` and builds on existing type definitions from `@red-codes/core` and event kinds from `@red-codes/events`.

</details>