### PR TITLE
fix: make governance hooks work in git worktree environments

### DIFF
--- a/apps/cli/src/commands/auto-setup.ts
+++ b/apps/cli/src/commands/auto-setup.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { RESET, BOLD, DIM, FG } from '../colors.js';
 import { claudeInit } from './claude-init.js';
+import { resolveMainRepoRoot } from '@red-codes/core';
 
 const HOOK_MARKER = 'claude-hook';
 
@@ -104,7 +105,7 @@ export function detectExistingHooks(cwd: string = process.cwd()): boolean {
 export async function autoSetup(args: string[] = []): Promise<AutoSetupResult> {
   const quiet = args.includes('--quiet') || args.includes('-q');
   const dryRun = args.includes('--dry-run');
-  const cwd = process.cwd();
+  const cwd = resolveMainRepoRoot();
 
   const result: AutoSetupResult = {
     detected: false,

--- a/apps/cli/src/commands/claude-hook.ts
+++ b/apps/cli/src/commands/claude-hook.ts
@@ -12,10 +12,12 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { ClaudeCodeHookPayload } from '@red-codes/adapters';
+import { resolveMainRepoRoot } from '@red-codes/core';
 
 /** Resolve the CLI command — use local bin.js if in the agentguard dev repo, else bare `agentguard`. */
 function resolveCliCommand(): string {
-  const localBin = join(process.cwd(), 'apps', 'cli', 'dist', 'bin.js');
+  const mainRoot = resolveMainRepoRoot();
+  const localBin = join(mainRoot, 'apps', 'cli', 'dist', 'bin.js');
   if (existsSync(localBin)) return `node ${localBin}`;
   return 'agentguard';
 }

--- a/apps/cli/src/commands/claude-init.ts
+++ b/apps/cli/src/commands/claude-init.ts
@@ -5,6 +5,7 @@ import { execSync } from 'node:child_process';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { RESET, BOLD, DIM, FG } from '../colors.js';
+import { resolveMainRepoRoot } from '@red-codes/core';
 
 const HOOK_MARKER = 'claude-hook';
 const BUILD_MARKER = 'apps/cli/dist/bin.js';
@@ -12,8 +13,9 @@ const LOCAL_BIN = 'node apps/cli/dist/bin.js';
 
 /** Detect if we're in the agentguard development repo (local dev) vs. globally installed. */
 function resolveCliPrefix(): { cli: string; isLocal: boolean } {
-  // If apps/cli/src/bin.ts exists, we're in the agentguard source repo
-  const localMarker = join(process.cwd(), 'apps', 'cli', 'src', 'bin.ts');
+  // If apps/cli/src/bin.ts exists, we're in the agentguard source repo (works in worktrees too)
+  const mainRoot = resolveMainRepoRoot();
+  const localMarker = join(mainRoot, 'apps', 'cli', 'src', 'bin.ts');
   if (existsSync(localMarker)) {
     return { cli: LOCAL_BIN, isLocal: true };
   }
@@ -223,10 +225,11 @@ export async function claudeInit(args: string[] = []): Promise<void> {
     }
   }
 
-  // Ensure telemetry directories exist
+  // Ensure telemetry directories exist (use main repo root so worktrees share them)
+  const repoRoot = resolveMainRepoRoot();
   const dirs = ['.agentguard/events', '.agentguard/decisions', 'logs'];
   for (const dir of dirs) {
-    const dirPath = join(process.cwd(), dir);
+    const dirPath = join(repoRoot, dir);
     if (!existsSync(dirPath)) {
       mkdirSync(dirPath, { recursive: true });
     }
@@ -427,14 +430,15 @@ const POLICY_CANDIDATES = [
 ];
 
 function generateStarterPolicy(): boolean {
-  // Check if any policy file already exists
+  // Check if any policy file already exists (check main repo root for worktree support)
+  const repoRoot = resolveMainRepoRoot();
   for (const candidate of POLICY_CANDIDATES) {
-    if (existsSync(join(process.cwd(), candidate))) {
+    if (existsSync(join(repoRoot, candidate))) {
       return false;
     }
   }
 
-  const policyPath = join(process.cwd(), 'agentguard.yaml');
+  const policyPath = join(repoRoot, 'agentguard.yaml');
   writeFileSync(policyPath, STARTER_POLICY, 'utf8');
   process.stderr.write(
     `  ${FG.green}✓${RESET}  Policy created: ${FG.cyan}agentguard.yaml${RESET}\n`

--- a/apps/cli/src/policy-resolver.ts
+++ b/apps/cli/src/policy-resolver.ts
@@ -9,6 +9,7 @@ import { resolveExtends, mergePolicies } from '@red-codes/policy';
 import type { LoadedPolicy } from '@red-codes/policy';
 import type { CompositionSource, CompositionResult } from '@red-codes/policy';
 import { composePolicies, describeComposition } from '@red-codes/policy';
+import { resolveMainRepoRoot } from '@red-codes/core';
 
 const DEFAULT_POLICY_CANDIDATES = [
   'agentguard.yaml',
@@ -24,9 +25,21 @@ const USER_POLICY_CANDIDATES = [
 ];
 
 export function findDefaultPolicy(): string | null {
+  // Check cwd first (worktree-local policies take precedence)
   for (const name of DEFAULT_POLICY_CANDIDATES) {
     if (existsSync(name)) return name;
   }
+
+  // Fall back to main repo root (shared policy, if we're in a worktree)
+  const mainRoot = resolveMainRepoRoot();
+  const cwd = process.cwd();
+  if (mainRoot !== cwd) {
+    for (const name of DEFAULT_POLICY_CANDIDATES) {
+      const mainRootPath = join(mainRoot, name);
+      if (existsSync(mainRootPath)) return mainRootPath;
+    }
+  }
+
   return null;
 }
 

--- a/hooks/post-commit
+++ b/hooks/post-commit
@@ -3,7 +3,9 @@
 # Tracks git commits for developer activity events
 # Install: cp hooks/post-commit .git/hooks/post-commit && chmod +x .git/hooks/post-commit
 
-EVENTS_FILE="$(git rev-parse --show-toplevel)/.events.json"
+# Use main repo root (not worktree root) so all worktrees share the same events file
+MAIN_ROOT="$(git worktree list --porcelain | head -1 | sed 's/^worktree //')"
+EVENTS_FILE="$MAIN_ROOT/.events.json"
 
 # Initialize events file if it doesn't exist
 if [ ! -f "$EVENTS_FILE" ]; then

--- a/hooks/post-merge
+++ b/hooks/post-merge
@@ -3,7 +3,9 @@
 # Tracks merges for developer activity events
 # Install: cp hooks/post-merge .git/hooks/post-merge && chmod +x .git/hooks/post-merge
 
-EVENTS_FILE="$(git rev-parse --show-toplevel)/.events.json"
+# Use main repo root (not worktree root) so all worktrees share the same events file
+MAIN_ROOT="$(git worktree list --porcelain | head -1 | sed 's/^worktree //')"
+EVENTS_FILE="$MAIN_ROOT/.events.json"
 
 if [ ! -f "$EVENTS_FILE" ]; then
   echo '{"commits":0,"prs_merged":0,"bugs_fixed":0,"tests_passing":0,"refactors":0,"code_reviews":0,"conflicts_resolved":0,"ci_passes":0,"deploys":0,"docs_written":0}' > "$EVENTS_FILE"

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -3,7 +3,8 @@
 # Auto-stages telemetry files so governance data rides with every commit.
 # Without this, telemetry JSONL files accumulate as untracked forever.
 
-REPO_ROOT="$(git rev-parse --show-toplevel)"
+# Use main repo root (not worktree root) so governance files are centralized
+REPO_ROOT="$(git worktree list --porcelain | head -1 | sed 's/^worktree //')"
 
 # Stage consolidated telemetry log
 if [ -f "$REPO_ROOT/logs/runtime-events.jsonl" ]; then

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,3 +9,4 @@ export * from './governance-data.js';
 export * from './persona.js';
 export * from './rtk.js';
 export * from './trust-store.js';
+export * from './repo-root.js';

--- a/packages/core/src/repo-root.ts
+++ b/packages/core/src/repo-root.ts
@@ -1,0 +1,59 @@
+// Worktree-aware repository root resolution.
+// In a git worktree, process.cwd() returns the worktree path, not the main repo root.
+// This utility resolves the main repo root so governance paths (policy, storage, hooks)
+// are consistent across all worktrees.
+
+import { execSync } from 'node:child_process';
+
+let _cachedMainRoot: string | null | undefined; // undefined = not yet computed
+
+/**
+ * Returns the main git repository root, resolving through worktrees.
+ * In a worktree, this returns the main repo root (not the worktree root).
+ * Falls back to process.cwd() if not in a git repo or git is unavailable.
+ * Result is cached per-process.
+ */
+export function resolveMainRepoRoot(): string {
+  if (_cachedMainRoot !== undefined) return _cachedMainRoot ?? process.cwd();
+
+  try {
+    // `git worktree list --porcelain` always lists the main worktree first
+    const output = execSync('git worktree list --porcelain', {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 3000,
+    });
+    const firstLine = output.split('\n')[0];
+    if (firstLine?.startsWith('worktree ')) {
+      _cachedMainRoot = firstLine.slice('worktree '.length).trim();
+      return _cachedMainRoot;
+    }
+  } catch {
+    // Not in a git repo, or git not available
+  }
+
+  _cachedMainRoot = null;
+  return process.cwd();
+}
+
+/**
+ * Returns true if the current working directory is a git worktree
+ * (not the main repository checkout).
+ */
+export function isWorktree(): boolean {
+  try {
+    const toplevel = execSync('git rev-parse --show-toplevel', {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 3000,
+    }).trim();
+    return toplevel !== resolveMainRepoRoot();
+  } catch {
+    return false;
+  }
+}
+
+/** Reset the cached root (for testing). */
+export function _resetRepoRootCache(): void {
+  _cachedMainRoot = undefined;
+}

--- a/packages/core/tests/repo-root.test.ts
+++ b/packages/core/tests/repo-root.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { resolveMainRepoRoot, isWorktree, _resetRepoRootCache } from '../src/repo-root.js';
+
+beforeEach(() => {
+  _resetRepoRootCache();
+});
+
+describe('resolveMainRepoRoot', () => {
+  it('returns a non-empty string', () => {
+    const result = resolveMainRepoRoot();
+    expect(typeof result).toBe('string');
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it('returns the same value on subsequent calls (caching)', () => {
+    const first = resolveMainRepoRoot();
+    const second = resolveMainRepoRoot();
+    expect(first).toBe(second);
+  });
+
+  it('returns an absolute path', () => {
+    const result = resolveMainRepoRoot();
+    expect(result.startsWith('/')).toBe(true);
+  });
+
+  it('cache can be reset', () => {
+    const first = resolveMainRepoRoot();
+    _resetRepoRootCache();
+    const second = resolveMainRepoRoot();
+    // Should still be the same value (same repo), but cache was cleared
+    expect(first).toBe(second);
+  });
+});
+
+describe('isWorktree', () => {
+  it('returns a boolean', () => {
+    const result = isWorktree();
+    expect(typeof result).toBe('boolean');
+  });
+
+  it('returns false in the main repo checkout', () => {
+    // This test runs in the main repo, so it should return false
+    expect(isWorktree()).toBe(false);
+  });
+});

--- a/packages/storage/src/factory.ts
+++ b/packages/storage/src/factory.ts
@@ -8,6 +8,7 @@ import type { DecisionSink } from '@red-codes/core';
 import type { StorageConfig } from './types.js';
 import { DEFAULT_BASE_DIR, DEFAULT_DB_FILENAME, DEFAULT_SQLITE_DB_PATH } from './types.js';
 import { join } from 'node:path';
+import { resolveMainRepoRoot } from '@red-codes/core';
 
 /** Bundled storage objects returned by the factory */
 export interface StorageBundle {
@@ -88,8 +89,9 @@ export function resolveSqlitePath(config: StorageConfig): string {
   // Explicit baseDir means user chose a custom location
   if (config.baseDir) return join(config.baseDir, DEFAULT_DB_FILENAME);
 
-  // Check for repo-local DB (backward compat) — use it if it exists, but hint migration
-  const repoLocal = join(DEFAULT_BASE_DIR, DEFAULT_DB_FILENAME);
+  // Check for repo-local DB (backward compat) — use main repo root so worktrees share one DB
+  const mainRoot = resolveMainRepoRoot();
+  const repoLocal = join(mainRoot, DEFAULT_BASE_DIR, DEFAULT_DB_FILENAME);
   if (existsSync(repoLocal)) {
     process.stderr.write(
       `[agentguard] Using repo-local SQLite database at ${repoLocal}\n` +

--- a/packages/storage/tests/storage-factory.test.ts
+++ b/packages/storage/tests/storage-factory.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import { createStorageBundle, resolveStorageConfig, resolveSqlitePath } from '@red-codes/storage';
 import { DEFAULT_DB_FILENAME, DEFAULT_SQLITE_DB_PATH } from '@red-codes/storage';
 import type { DomainEvent } from '@red-codes/core';
+import { _resetRepoRootCache } from '@red-codes/core';
 
 function makeEvent(id: string): DomainEvent {
   return {
@@ -100,6 +101,7 @@ describe('resolveSqlitePath', () => {
     const origCwd = process.cwd();
     const tmpDir = mkdtempSync(join(tmpdir(), 'ag-resolve-'));
     process.chdir(tmpDir);
+    _resetRepoRootCache();
 
     // Create a repo-local .agentguard/agentguard.db
     mkdirSync(join(tmpDir, '.agentguard'), { recursive: true });
@@ -109,7 +111,8 @@ describe('resolveSqlitePath', () => {
 
     try {
       const result = resolveSqlitePath({ backend: 'sqlite' });
-      expect(result).toBe(join('.agentguard', DEFAULT_DB_FILENAME));
+      // resolveMainRepoRoot() falls back to cwd when not in a git repo
+      expect(result).toBe(join(tmpDir, '.agentguard', DEFAULT_DB_FILENAME));
 
       // Should have emitted a migration hint
       const output = stderrSpy.mock.calls.map((c) => String(c[0])).join('');
@@ -118,6 +121,7 @@ describe('resolveSqlitePath', () => {
     } finally {
       stderrSpy.mockRestore();
       process.chdir(origCwd);
+      _resetRepoRootCache();
       rmSync(tmpDir, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
Add resolveMainRepoRoot() utility to @red-codes/core that resolves
the main repository root through git worktrees. Previously, governance
hooks used process.cwd() which returns the worktree path, causing CLI
command resolution, policy discovery, storage paths, and git hooks to
fail silently — producing empty governance reports.

Changes:
- New packages/core/src/repo-root.ts with cached worktree-aware resolution
- CLI commands (claude-hook, claude-init, auto-setup) use main repo root
  for dev-repo detection and directory creation
- Policy resolver falls back to main repo root for shared policies
- Storage factory resolves repo-local DB against main repo root
- Git hooks (pre-commit, post-commit, post-merge) use git worktree list

https://claude.ai/code/session_01Y2LYpr3NFeRsPg1uQPPh4u