### PR TITLE
Ensure AgentGuard bootstraps in fresh worktrees/checkouts

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -26,6 +26,12 @@
         "hooks": [
           {
             "type": "command",
+            "command": "test -d node_modules || pnpm install --frozen-lockfile",
+            "timeout": 120000,
+            "blocking": true
+          },
+          {
+            "type": "command",
             "command": "test -f apps/cli/dist/bin.js || pnpm build",
             "timeout": 120000,
             "blocking": true


### PR DESCRIPTION
Add a pnpm install step to the SessionStart hook so that dependencies
are installed before attempting to build. This fixes sessions in fresh
worktree checkouts where node_modules/ is missing (gitignored).

https://claude.ai/code/session_01Qyi3FWeez7or7GcUwfo45i