### PR TITLE
Prepare core/events for npm publish, fix CLI bundling

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,17 +27,46 @@ jobs:
 
       - run: pnpm turbo test
 
-      - name: Verify package version matches tag
+      - name: Verify CLI version matches tag
         working-directory: apps/cli
         run: |
           TAG="${GITHUB_REF_NAME#v}"
           PKG=$(node -p "require('./package.json').version")
           if [ "$TAG" != "$PKG" ]; then
-            echo "::error::Tag version ($TAG) does not match package.json version ($PKG)"
+            echo "::error::Tag version ($TAG) does not match CLI package.json version ($PKG)"
             exit 1
           fi
 
-      - name: Publish CLI package to npm
+      # Publish in dependency order: core → events → cli
+      # Each step skips if the version is already on npm
+
+      - name: Publish @red-codes/core
+        working-directory: packages/core
+        run: |
+          PKG_NAME=$(node -p "require('./package.json').name")
+          PKG_VER=$(node -p "require('./package.json').version")
+          if npm view "${PKG_NAME}@${PKG_VER}" version 2>/dev/null; then
+            echo "${PKG_NAME}@${PKG_VER} already published, skipping"
+          else
+            pnpm publish --provenance --access public --no-git-checks
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish @red-codes/events
+        working-directory: packages/events
+        run: |
+          PKG_NAME=$(node -p "require('./package.json').name")
+          PKG_VER=$(node -p "require('./package.json').version")
+          if npm view "${PKG_NAME}@${PKG_VER}" version 2>/dev/null; then
+            echo "${PKG_NAME}@${PKG_VER} already published, skipping"
+          else
+            pnpm publish --provenance --access public --no-git-checks
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish @red-codes/agentguard (CLI)
         working-directory: apps/cli
         run: pnpm publish --provenance --access public --no-git-checks
         env:

--- a/apps/cli/esbuild.config.ts
+++ b/apps/cli/esbuild.config.ts
@@ -1,4 +1,14 @@
 import * as esbuild from 'esbuild';
+import { readFileSync } from 'fs';
+
+const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
+
+// Bundle @red-codes/* packages inline (they're not published individually).
+// Externalize only true npm runtime deps that users install.
+const externalDeps = [
+  ...Object.keys(pkg.dependencies || {}).filter((d: string) => !d.startsWith('@red-codes/')),
+  ...Object.keys(pkg.optionalDependencies || {}),
+];
 
 const shared: esbuild.BuildOptions = {
   bundle: true,
@@ -7,7 +17,7 @@ const shared: esbuild.BuildOptions = {
   format: 'esm',
   sourcemap: true,
   outdir: 'dist',
-  packages: 'external',
+  external: externalDeps,
 };
 
 // CLI bundle — single self-contained entry point

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@red-codes/agentguard",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Runtime governance for AI coding agents — CLI",
   "type": "module",
   "license": "Apache-2.0",
@@ -33,6 +33,14 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "commander": "^14.0.3",
+    "pino": "^10.3.1",
+    "chokidar": "^5.0.0"
+  },
+  "optionalDependencies": {
+    "better-sqlite3": "^12.8.0"
+  },
+  "devDependencies": {
     "@red-codes/core": "workspace:*",
     "@red-codes/events": "workspace:*",
     "@red-codes/policy": "workspace:*",
@@ -45,14 +53,6 @@
     "@red-codes/swarm": "workspace:*",
     "@red-codes/telemetry": "workspace:*",
     "@red-codes/telemetry-client": "workspace:*",
-    "commander": "^14.0.3",
-    "pino": "^10.3.1",
-    "chokidar": "^5.0.0"
-  },
-  "optionalDependencies": {
-    "better-sqlite3": "^12.8.0"
-  },
-  "devDependencies": {
     "@types/better-sqlite3": "^7.6.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,9 +1,10 @@
 {
   "name": "@red-codes/core",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Core types, actions, and utilities for the AgentGuard platform",
   "type": "module",
   "license": "Apache-2.0",
+  "private": false,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
@@ -11,6 +12,16 @@
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     }
+  },
+  "files": [
+    "dist/",
+    "LICENSE",
+    "README.md"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AgentGuardHQ/agentguard",
+    "directory": "packages/core"
   },
   "scripts": {
     "build": "tsc -b",

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -1,9 +1,10 @@
 {
   "name": "@red-codes/events",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Canonical event model for AgentGuard",
   "type": "module",
   "license": "Apache-2.0",
+  "private": false,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
@@ -11,6 +12,16 @@
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     }
+  },
+  "files": [
+    "dist/",
+    "LICENSE",
+    "README.md"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AgentGuardHQ/agentguard",
+    "directory": "packages/events"
   },
   "scripts": {
     "build": "tsc -b",


### PR DESCRIPTION
## Summary

- **Publish `@red-codes/core` and `@red-codes/events` to npm** — adds `files`, `repository`, `private: false`, bumps to v1.0.0. These are consumed by `agentguard-cloud` and will replace the git subtree approach.
- **Fix CLI bundling** — `packages: 'external'` was externalizing all `@red-codes/*` packages, making `npm install -g @red-codes/agentguard` broken for anyone outside the monorepo. Now bundles internal packages inline and only externalizes true npm deps (commander, pino, chokidar, better-sqlite3).
- **Update publish workflow** — publishes core → events → cli in dependency order with idempotent version checks (skips already-published versions on future releases).
- **Bump CLI to v1.1.0**

## After merge

1. Create GitHub release with tag `v1.1.0` to trigger publish
2. Verify packages on npm: `npm view @red-codes/core`, `npm view @red-codes/events`, `npm view @red-codes/agentguard`
3. In `agentguard-cloud`: remove `oss/agent-guard/` subtree, switch to `@red-codes/core@^1.0.0` and `@red-codes/events@^1.0.0` from npm

## Test plan

- [x] `pnpm build` passes clean (all 15 packages)
- [ ] `pnpm test` passes (2 pre-existing flakes: Windows file-lock in mcp-server, Unix path assertion in core)
- [ ] `npm install -g @red-codes/agentguard@1.1.0` installs cleanly after publish
- [ ] `agentguard status` works from global install

🤖 Generated with [Claude Code](https://claude.com/claude-code)