### PR TITLE
Fix: update lockfile after CLI dep restructure

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,20 @@ importers:
 
   apps/cli:
     dependencies:
+      chokidar:
+        specifier: ^5.0.0
+        version: 5.0.0
+      commander:
+        specifier: ^14.0.3
+        version: 14.0.3
+      pino:
+        specifier: ^10.3.1
+        version: 10.3.1
+    optionalDependencies:
+      better-sqlite3:
+        specifier: ^12.8.0
+        version: 12.8.0
+    devDependencies:
       '@red-codes/adapters':
         specifier: workspace:*
         version: link:../../packages/adapters
@@ -80,20 +94,6 @@ importers:
       '@red-codes/telemetry-client':
         specifier: workspace:*
         version: link:../../packages/telemetry-client
-      chokidar:
-        specifier: ^5.0.0
-        version: 5.0.0
-      commander:
-        specifier: ^14.0.3
-        version: 14.0.3
-      pino:
-        specifier: ^10.3.1
-        version: 10.3.1
-    optionalDependencies:
-      better-sqlite3:
-        specifier: ^12.8.0
-        version: 12.8.0
-    devDependencies:
       '@types/better-sqlite3':
         specifier: ^7.6.0
         version: 7.6.13


### PR DESCRIPTION
## Summary

- Regenerates `pnpm-lock.yaml` after #536 moved `@red-codes/*` from dependencies to devDependencies in the CLI package.json
- CI was failing with `ERR_PNPM_OUTDATED_LOCKFILE`

## Test plan

- [ ] `pnpm install --frozen-lockfile` passes in CI
- [ ] `pnpm build` passes
- [ ] `pnpm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)