### PR TITLE
fix: copy hooks/templates into dist, bump CLI to v1.1.1

### DIFF
--- a/apps/cli/esbuild.config.ts
+++ b/apps/cli/esbuild.config.ts
@@ -1,5 +1,5 @@
 import * as esbuild from 'esbuild';
-import { readFileSync } from 'fs';
+import { cpSync, readFileSync } from 'fs';
 
 const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
 
@@ -25,5 +25,10 @@ await esbuild.build({
   ...shared,
   entryPoints: ['src/bin.ts'],
 });
+
+// Copy hooks/ and templates/ into dist so they ship with the npm package
+// (npm rejects path traversals like ../../hooks/ in the files array)
+cpSync('../../hooks', 'dist/hooks', { recursive: true });
+cpSync('../../templates', 'dist/templates', { recursive: true });
 
 console.log('CLI build complete.');

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@red-codes/agentguard",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Runtime governance for AI coding agents — CLI",
   "type": "module",
   "license": "Apache-2.0",
@@ -12,8 +12,6 @@
   },
   "files": [
     "dist/",
-    "../../hooks/",
-    "../../templates/",
     "LICENSE",
     "README.md"
   ],


### PR DESCRIPTION
npm rejects path traversals (../../hooks/) in the files array. Copy hooks/ and templates/ into dist/ at build time instead. Bump to 1.1.1 since 1.1.0 was partially published.