### PR TITLE
Fix CLI publish: add repository field for provenance

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -15,6 +15,11 @@
     "LICENSE",
     "README.md"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AgentGuardHQ/agentguard",
+    "directory": "apps/cli"
+  },
   "exports": {
     ".": {
       "import": "./dist/index.js",


### PR DESCRIPTION
## Summary

npm provenance verification (via `--provenance`) requires `repository.url` in package.json to match the GitHub Actions source repo. The CLI was missing this field, causing E422 on publish.

## Test plan

- [ ] CI passes
- [ ] Re-create v1.1.1 release after merge → CLI publishes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)