### PR TITLE
Fix CLI: inject version at build time, fix bundled path resolution

### DIFF
--- a/apps/cli/esbuild.config.ts
+++ b/apps/cli/esbuild.config.ts
@@ -18,6 +18,9 @@ const shared: esbuild.BuildOptions = {
   sourcemap: true,
   outdir: 'dist',
   external: externalDeps,
+  define: {
+    'AGENTGUARD_VERSION': JSON.stringify(pkg.version),
+  },
 };
 
 // CLI bundle — single self-contained entry point

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@red-codes/agentguard",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Runtime governance for AI coding agents — CLI",
   "type": "module",
   "license": "Apache-2.0",

--- a/apps/cli/src/bin.ts
+++ b/apps/cli/src/bin.ts
@@ -2,6 +2,9 @@
 
 // AgentGuard CLI — Runtime governance for AI coding agents
 
+// Injected by esbuild at build time via define
+declare const AGENTGUARD_VERSION: string;
+
 import { formatHelp } from './args.js';
 import { resolveStorageConfig } from '@red-codes/storage';
 
@@ -837,14 +840,7 @@ async function main() {
 
     case '--version':
     case '-v': {
-      const { readFileSync } = await import('node:fs');
-      const { fileURLToPath } = await import('node:url');
-      const { dirname, join } = await import('node:path');
-      const __dir = dirname(fileURLToPath(import.meta.url));
-      const pkg = JSON.parse(readFileSync(join(__dir, '..', '..', 'package.json'), 'utf8')) as {
-        version: string;
-      };
-      console.log(`agentguard v${pkg.version}`);
+      console.log(`agentguard v${AGENTGUARD_VERSION}`);
       break;
     }
 


### PR DESCRIPTION
## Summary

`agentguard --version` crashed with `ENOENT` when installed from npm because the bundled `dist/bin.js` tried to read `../../package.json` which doesn't exist outside the monorepo.

Fix: inject `AGENTGUARD_VERSION` via esbuild `define` at build time. No runtime file reads needed.

## Verified locally

- [x] `agentguard --version` → `agentguard v1.1.2`
- [x] `agentguard status` → detects hooks, policy, RTK
- [x] `agentguard claude-hook pre` → exits 0 (allow)
- [x] `agentguard policy validate agentguard.yaml` → VALID, 14 rules
- [x] Templates and hooks bundled in `dist/`

## Test plan

- [ ] CI passes
- [ ] Publish v1.1.2, `npm install -g @red-codes/agentguard`, verify `agentguard --version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)