### PR TITLE
Fix: exit code 2 on deny to enforce governance blocking

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@red-codes/agentguard",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Runtime governance for AI coding agents — CLI",
   "type": "module",
   "license": "Apache-2.0",

--- a/apps/cli/src/commands/claude-hook.ts
+++ b/apps/cli/src/commands/claude-hook.ts
@@ -59,17 +59,20 @@ export async function claudeHook(hookType?: string, extraArgs: string[] = []): P
       const sessionId =
         (data.session_id as string | undefined) || process.env.CLAUDE_SESSION_ID || undefined;
       const payload = { ...data, session_id: sessionId } as unknown as ClaudeCodeHookPayload;
-      await handlePreToolUse(payload, extraArgs);
+      const denied = await handlePreToolUse(payload, extraArgs);
+      // Exit code 2 tells Claude Code to block the action
+      process.exit(denied ? 2 : 0);
     } else {
       handlePostToolUse(data, extraArgs);
     }
   } catch {
-    // Swallow all errors — hooks must never fail
+    // Swallow all errors — hooks must never fail (fail-open)
   }
   process.exit(0);
 }
 
-async function handlePreToolUse(payload: ClaudeCodeHookPayload, cliArgs: string[]): Promise<void> {
+/** Returns true if the action was denied. */
+async function handlePreToolUse(payload: ClaudeCodeHookPayload, cliArgs: string[]): Promise<boolean> {
   const { processClaudeCodeHook, formatHookResponse } = await import('@red-codes/adapters');
   const { createKernel } = await import('@red-codes/kernel');
   const { loadPolicyDefs } = await import('../policy-resolver.js');
@@ -148,13 +151,15 @@ async function handlePreToolUse(payload: ClaudeCodeHookPayload, cliArgs: string[
     }
   }
 
-  // If denied, output to stdout — this tells Claude Code to block the action
+  // If denied, output reason to stdout and signal the caller to exit with code 2
   if (!result.allowed) {
     const response = formatHookResponse(result);
     if (response) {
       process.stdout.write(response);
     }
+    return true;
   }
+  return false;
 }
 
 function handlePostToolUse(data: Record<string, unknown>, cliArgs: string[] = []): void {


### PR DESCRIPTION
## Summary

**This is the critical enforcement bug.** The PreToolUse hook was always exiting with code 0, even when the kernel correctly denied an action. Claude Code interprets exit 0 as "allowed", so all denied actions were still executed.

Fix: `handlePreToolUse` now returns a boolean, and the outer function exits with code 2 (block) on deny.

Your test confirmed the governance engine works — all 4 dangerous actions were correctly identified as DENIED in the event log. They just weren't enforced because of exit code 0.

## What changed

```
// Before (always allows)
process.exit(0);

// After (blocks on deny)
const denied = await handlePreToolUse(payload, extraArgs);
process.exit(denied ? 2 : 0);
```

Bumps CLI to v1.1.3.

## Test plan

- [ ] CI passes
- [ ] After publish, re-run the governance exercise in a Claude session
- [ ] Write to .env should be BLOCKED (not just logged)
- [ ] git push --force should be BLOCKED
- [ ] rm -rf should be BLOCKED

🤖 Generated with [Claude Code](https://claude.com/claude-code)