### PR TITLE
Fix: use Claude Code hookSpecificOutput format for hard deny

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@red-codes/agentguard",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Runtime governance for AI coding agents — CLI",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/adapters/src/claude-code.ts
+++ b/packages/adapters/src/claude-code.ts
@@ -226,11 +226,19 @@ export function formatHookResponse(result: KernelResult): string {
   if (!result.allowed) {
     const reason = result.decision?.decision?.reason ?? 'Action denied';
     const violations = result.decision?.violations ?? [];
-    const parts = [`DENIED: ${reason}`];
+    const parts = [reason];
     if (violations.length > 0) {
-      parts.push(`Violations: ${violations.map((v) => v.name).join(', ')}`);
+      parts.push(`Violations: ${violations.map((v: { name: string }) => v.name).join(', ')}`);
     }
-    return JSON.stringify({ error: parts.join(' | ') });
+    // Claude Code PreToolUse hook format: permissionDecision "deny" with exit code 2
+    // ensures the tool call is hard-blocked (non-retryable)
+    return JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason: parts.join(' | '),
+      },
+    });
   }
   return '';
 }


### PR DESCRIPTION
## Summary

Claude Code PreToolUse hooks must return `permissionDecision: "deny"` in the `hookSpecificOutput` structure for a non-retryable block. Our old format (`{"error":"DENIED: ..."}`) was treated as a generic error that the model could retry around.

In testing, the .env Write got "Error writing file" (partial block) but the model retried and succeeded. With the correct format, Claude Code will hard-block the tool call.

## Test plan

- [ ] CI passes
- [ ] Publish v1.1.5 and re-test enforcement in a real Claude session
- [ ] Write .env should be HARD BLOCKED (no retry)
- [ ] git push --force should be HARD BLOCKED

🤖 Generated with [Claude Code](https://claude.com/claude-code)