### PR TITLE
Fix: update adapter test for hookSpecificOutput format

### DIFF
--- a/packages/adapters/tests/claude-code-adapter.test.ts
+++ b/packages/adapters/tests/claude-code-adapter.test.ts
@@ -344,7 +344,9 @@ describe('formatHookResponse', () => {
       agent: 'test',
     });
     const response = formatHookResponse(result);
-    expect(response).toContain('DENIED');
-    expect(JSON.parse(response)).toHaveProperty('error');
+    const parsed = JSON.parse(response);
+    expect(parsed).toHaveProperty('hookSpecificOutput');
+    expect(parsed.hookSpecificOutput.permissionDecision).toBe('deny');
+    expect(parsed.hookSpecificOutput.permissionDecisionReason).toContain('Destructive command');
   });
 });


### PR DESCRIPTION
Test assertion updated for the new Claude Code deny format. Merge and re-tag v1.1.5.