### PR TITLE
Fix site URLs + add RTK to Quick Start

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -10,8 +10,8 @@
   <meta property="og:title" content="AgentGuard — Governed Action Runtime for AI Coding Agents">
   <meta property="og:description" content="Deterministic governance layer between AI agent proposals and execution. Policy enforcement, 20 safety invariants, 87 destructive patterns, full audit trail.">
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://jpleva91.github.io/agent-guard/">
-  <meta property="og:image" content="https://jpleva91.github.io/agent-guard/og-image.png">
+  <meta property="og:url" content="https://agentguardhq.github.io/agentguard/">
+  <meta property="og:image" content="https://agentguardhq.github.io/agentguard/og-image.png">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
@@ -257,7 +257,7 @@
         <a href="#cli" class="text-muted hover:text-text transition-colors text-sm font-medium cursor-pointer">CLI</a>
         <a href="#swarm" class="text-muted hover:text-text transition-colors text-sm font-medium cursor-pointer">Swarm</a>
         <a href="posts.html" class="text-muted hover:text-text transition-colors text-sm font-medium cursor-pointer">Newsletter</a>
-        <a href="https://github.com/AgentGuardHQ/agent-guard" target="_blank" rel="noopener noreferrer" class="text-muted hover:text-text transition-colors text-sm font-medium cursor-pointer">GitHub</a>
+        <a href="https://github.com/AgentGuardHQ/agentguard" target="_blank" rel="noopener noreferrer" class="text-muted hover:text-text transition-colors text-sm font-medium cursor-pointer">GitHub</a>
         <a href="#quickstart" class="bg-cta hover:bg-cta-dark text-bg font-semibold text-sm px-4 py-2 rounded-lg transition-colors cursor-pointer">Get Started</a>
       </div>
 
@@ -278,7 +278,7 @@
         <a href="#cli" class="text-muted hover:text-text transition-colors text-sm font-medium cursor-pointer">CLI</a>
         <a href="#swarm" class="text-muted hover:text-text transition-colors text-sm font-medium cursor-pointer">Swarm</a>
         <a href="posts.html" class="text-muted hover:text-text transition-colors text-sm font-medium cursor-pointer">Newsletter</a>
-        <a href="https://github.com/AgentGuardHQ/agent-guard" target="_blank" rel="noopener noreferrer" class="text-muted hover:text-text transition-colors text-sm font-medium cursor-pointer">GitHub</a>
+        <a href="https://github.com/AgentGuardHQ/agentguard" target="_blank" rel="noopener noreferrer" class="text-muted hover:text-text transition-colors text-sm font-medium cursor-pointer">GitHub</a>
         <a href="#quickstart" class="bg-cta hover:bg-cta-dark text-bg font-semibold text-sm px-4 py-2 rounded-lg transition-colors text-center cursor-pointer">Get Started</a>
       </div>
     </div>
@@ -301,8 +301,8 @@
             <span class="text-surface-light">&middot;</span>
             <span class="font-mono text-muted text-sm">Apache 2.0</span>
             <span class="text-surface-light">&middot;</span>
-            <a href="https://github.com/AgentGuardHQ/agent-guard" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1.5 hover:opacity-80 transition-opacity cursor-pointer">
-              <img src="https://img.shields.io/github/stars/AgentGuardHQ/agent-guard?style=flat&logo=github&color=22C55E&labelColor=1E293B" alt="GitHub stars" height="20">
+            <a href="https://github.com/AgentGuardHQ/agentguard" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1.5 hover:opacity-80 transition-opacity cursor-pointer">
+              <img src="https://img.shields.io/github/stars/AgentGuardHQ/agentguard?style=flat&logo=github&color=22C55E&labelColor=1E293B" alt="GitHub stars" height="20">
             </a>
             <a href="https://www.npmjs.com/package/@red-codes/agentguard" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1.5 hover:opacity-80 transition-opacity cursor-pointer">
               <img src="https://img.shields.io/npm/dm/@red-codes/agentguard?style=flat&logo=npm&color=22C55E&labelColor=1E293B" alt="npm downloads" height="20">
@@ -319,7 +319,7 @@
               <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polygon points="5 3 19 12 5 21 5 3"/></svg>
               Get Started
             </a>
-            <a href="https://github.com/AgentGuardHQ/agent-guard" target="_blank" rel="noopener noreferrer" class="border border-surface-light hover:border-muted text-text font-semibold px-6 py-3 rounded-lg transition-colors text-sm inline-flex items-center gap-2 cursor-pointer">
+            <a href="https://github.com/AgentGuardHQ/agentguard" target="_blank" rel="noopener noreferrer" class="border border-surface-light hover:border-muted text-text font-semibold px-6 py-3 rounded-lg transition-colors text-sm inline-flex items-center gap-2 cursor-pointer">
               <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
               View on GitHub
             </a>
@@ -859,10 +859,26 @@
             </div>
           </div>
 
-          <!-- Try it -->
+          <!-- RTK (optional) -->
           <div class="reveal" style="transition-delay: 100ms">
             <div class="flex items-center gap-2 mb-3">
               <span class="font-mono text-cta text-sm font-semibold">02</span>
+              <span class="text-text font-semibold text-sm">Install RTK for token savings <span class="text-muted font-normal">(optional)</span></span>
+            </div>
+            <div class="relative group">
+              <pre class="bg-surface border border-surface-light rounded-xl p-5 font-mono text-sm overflow-x-auto"><code><span class="text-muted">#</span> <span class="text-muted">Homebrew (macOS/Linux) &mdash; 60-90% token savings</span>
+<span class="text-muted">$</span> <span class="text-text">brew install rtk</span>
+<span class="text-muted">#</span> <span class="text-muted">Windows: github.com/rtk-ai/rtk/releases</span></code></pre>
+              <button class="copy-btn absolute top-3 right-3 text-muted hover:text-text p-2 rounded-lg hover:bg-surface-light transition-colors opacity-0 group-hover:opacity-100 cursor-pointer" data-code="brew install rtk" aria-label="Copy to clipboard">
+                <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
+              </button>
+            </div>
+          </div>
+
+          <!-- Hook into Claude Code -->
+          <div class="reveal" style="transition-delay: 200ms">
+            <div class="flex items-center gap-2 mb-3">
+              <span class="font-mono text-cta text-sm font-semibold">03</span>
               <span class="text-text font-semibold text-sm">Hook into Claude Code</span>
             </div>
             <div class="relative group">
@@ -874,9 +890,9 @@
           </div>
 
           <!-- Status -->
-          <div class="reveal" style="transition-delay: 200ms">
+          <div class="reveal" style="transition-delay: 300ms">
             <div class="flex items-center gap-2 mb-3">
-              <span class="font-mono text-cta text-sm font-semibold">03</span>
+              <span class="font-mono text-cta text-sm font-semibold">04</span>
               <span class="text-text font-semibold text-sm">Check governance status</span>
             </div>
             <div class="relative group">
@@ -1520,7 +1536,7 @@ rules:
         </div>
 
         <div class="text-center mt-10 reveal">
-          <a href="https://github.com/AgentGuardHQ/agent-guard/blob/main/ROADMAP.md" target="_blank" rel="noopener noreferrer" class="text-cta hover:text-cta-dark transition-colors text-sm font-mono font-semibold inline-flex items-center gap-2 cursor-pointer">
+          <a href="https://github.com/AgentGuardHQ/agentguard/blob/main/ROADMAP.md" target="_blank" rel="noopener noreferrer" class="text-cta hover:text-cta-dark transition-colors text-sm font-mono font-semibold inline-flex items-center gap-2 cursor-pointer">
             Full roadmap (18 phases)
             <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><line x1="7" y1="17" x2="17" y2="7"/><polyline points="7 7 17 7 17 17"/></svg>
           </a>
@@ -1542,7 +1558,7 @@ rules:
             <h2 id="contribute-heading" class="font-mono font-bold text-3xl sm:text-4xl mb-4">Apache 2.0 Licensed</h2>
             <p class="text-muted text-lg mb-8 max-w-lg mx-auto">AgentGuard is built in the open. Write invariants, create policy packs, build adapters, or contribute a renderer.</p>
             <div class="flex flex-wrap justify-center gap-4">
-              <a href="https://github.com/AgentGuardHQ/agent-guard/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer" class="bg-cta hover:bg-cta-dark text-bg font-semibold px-6 py-3 rounded-lg transition-colors text-sm inline-flex items-center gap-2 cursor-pointer">
+              <a href="https://github.com/AgentGuardHQ/agentguard/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer" class="bg-cta hover:bg-cta-dark text-bg font-semibold px-6 py-3 rounded-lg transition-colors text-sm inline-flex items-center gap-2 cursor-pointer">
                 <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
                 Contributing Guide
               </a>
@@ -1550,7 +1566,7 @@ rules:
                 <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
                 Report Issues
               </a>
-              <a href="https://github.com/AgentGuardHQ/agent-guard" target="_blank" rel="noopener noreferrer" class="border border-surface-light hover:border-muted text-text font-semibold px-6 py-3 rounded-lg transition-colors text-sm inline-flex items-center gap-2 cursor-pointer">
+              <a href="https://github.com/AgentGuardHQ/agentguard" target="_blank" rel="noopener noreferrer" class="border border-surface-light hover:border-muted text-text font-semibold px-6 py-3 rounded-lg transition-colors text-sm inline-flex items-center gap-2 cursor-pointer">
                 <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
                 Star on GitHub
               </a>
@@ -1600,11 +1616,11 @@ rules:
         <div>
           <h3 class="font-mono font-semibold text-text text-sm mb-4">Resources</h3>
           <ul class="space-y-2">
-            <li><a href="https://github.com/AgentGuardHQ/agent-guard/blob/main/docs/unified-architecture.md" target="_blank" rel="noopener noreferrer" class="text-muted hover:text-text transition-colors text-sm cursor-pointer">Architecture Docs</a></li>
-            <li><a href="https://github.com/AgentGuardHQ/agent-guard/blob/main/docs/event-model.md" target="_blank" rel="noopener noreferrer" class="text-muted hover:text-text transition-colors text-sm cursor-pointer">Event Model</a></li>
-            <li><a href="https://github.com/AgentGuardHQ/agent-guard/blob/main/docs/plugin-api.md" target="_blank" rel="noopener noreferrer" class="text-muted hover:text-text transition-colors text-sm cursor-pointer">Plugin API</a></li>
-            <li><a href="https://github.com/AgentGuardHQ/agent-guard/blob/main/ROADMAP.md" target="_blank" rel="noopener noreferrer" class="text-muted hover:text-text transition-colors text-sm cursor-pointer">Roadmap</a></li>
-            <li><a href="https://github.com/AgentGuardHQ/agent-guard/blob/main/CHANGELOG.md" target="_blank" rel="noopener noreferrer" class="text-muted hover:text-text transition-colors text-sm cursor-pointer">Changelog</a></li>
+            <li><a href="https://github.com/AgentGuardHQ/agentguard/blob/main/docs/unified-architecture.md" target="_blank" rel="noopener noreferrer" class="text-muted hover:text-text transition-colors text-sm cursor-pointer">Architecture Docs</a></li>
+            <li><a href="https://github.com/AgentGuardHQ/agentguard/blob/main/docs/event-model.md" target="_blank" rel="noopener noreferrer" class="text-muted hover:text-text transition-colors text-sm cursor-pointer">Event Model</a></li>
+            <li><a href="https://github.com/AgentGuardHQ/agentguard/blob/main/docs/plugin-api.md" target="_blank" rel="noopener noreferrer" class="text-muted hover:text-text transition-colors text-sm cursor-pointer">Plugin API</a></li>
+            <li><a href="https://github.com/AgentGuardHQ/agentguard/blob/main/ROADMAP.md" target="_blank" rel="noopener noreferrer" class="text-muted hover:text-text transition-colors text-sm cursor-pointer">Roadmap</a></li>
+            <li><a href="https://github.com/AgentGuardHQ/agentguard/blob/main/CHANGELOG.md" target="_blank" rel="noopener noreferrer" class="text-muted hover:text-text transition-colors text-sm cursor-pointer">Changelog</a></li>
           </ul>
         </div>
 
@@ -1612,10 +1628,10 @@ rules:
         <div>
           <h3 class="font-mono font-semibold text-text text-sm mb-4">Community</h3>
           <ul class="space-y-2">
-            <li><a href="https://github.com/AgentGuardHQ/agent-guard" target="_blank" rel="noopener noreferrer" class="text-muted hover:text-text transition-colors text-sm cursor-pointer">GitHub</a></li>
-            <li><a href="https://github.com/AgentGuardHQ/agent-guard/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer" class="text-muted hover:text-text transition-colors text-sm cursor-pointer">Contributing</a></li>
-            <li><a href="https://github.com/AgentGuardHQ/agent-guard/issues" target="_blank" rel="noopener noreferrer" class="text-muted hover:text-text transition-colors text-sm cursor-pointer">Issues</a></li>
-            <li><a href="https://github.com/AgentGuardHQ/agent-guard/discussions" target="_blank" rel="noopener noreferrer" class="text-muted hover:text-text transition-colors text-sm cursor-pointer">Discussions</a></li>
+            <li><a href="https://github.com/AgentGuardHQ/agentguard" target="_blank" rel="noopener noreferrer" class="text-muted hover:text-text transition-colors text-sm cursor-pointer">GitHub</a></li>
+            <li><a href="https://github.com/AgentGuardHQ/agentguard/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer" class="text-muted hover:text-text transition-colors text-sm cursor-pointer">Contributing</a></li>
+            <li><a href="https://github.com/AgentGuardHQ/agentguard/issues" target="_blank" rel="noopener noreferrer" class="text-muted hover:text-text transition-colors text-sm cursor-pointer">Issues</a></li>
+            <li><a href="https://github.com/AgentGuardHQ/agentguard/discussions" target="_blank" rel="noopener noreferrer" class="text-muted hover:text-text transition-colors text-sm cursor-pointer">Discussions</a></li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Fix all OG meta URLs (`jpleva91.github.io/agent-guard` → `agentguardhq.github.io/agentguard`)
- Fix all GitHub links (`agent-guard` → `agentguard`)
- Add RTK install as step 02 in Quick Start with `brew install rtk` + Windows download link
- Renumber Quick Start to 4 steps: Install → RTK → Claude Init → Status

🤖 Generated with [Claude Code](https://claude.com/claude-code)