### PR TITLE
fix(issue-544): fix Windows-specific test failures

### DIFF
--- a/apps/mcp-server/src/backends/local.ts
+++ b/apps/mcp-server/src/backends/local.ts
@@ -8,6 +8,7 @@ import type { StorageBundle } from '@red-codes/storage';
 export function createLocalDataSource(config: McpConfig): DataSource {
   // Lazy-load storage to avoid requiring better-sqlite3 at import time
   let storagePromise: Promise<StorageBundle> | null = null;
+  let resolvedStorage: StorageBundle | null = null;
 
   async function getStorage(): Promise<StorageBundle> {
     if (!storagePromise) {
@@ -20,6 +21,7 @@ export function createLocalDataSource(config: McpConfig): DataSource {
         if (!storage.db) {
           throw new Error('SQLite storage backend did not initialize database.');
         }
+        resolvedStorage = storage;
         return storage;
       })();
     }
@@ -27,6 +29,14 @@ export function createLocalDataSource(config: McpConfig): DataSource {
   }
 
   return {
+    close(): void {
+      if (resolvedStorage) {
+        resolvedStorage.close();
+        resolvedStorage = null;
+      }
+      storagePromise = null;
+    },
+
     async listRuns(limit?: number): Promise<string[]> {
       const storage = await getStorage();
       const { listRunIds } = await import('@red-codes/storage');

--- a/apps/mcp-server/src/backends/types.ts
+++ b/apps/mcp-server/src/backends/types.ts
@@ -7,4 +7,6 @@ export interface DataSource {
   loadEvents(runId: string): Promise<DomainEvent[]>;
   loadDecisions(runId: string): Promise<GovernanceDecisionRecord[]>;
   queryEvents(opts: { runId?: string; kind?: string; limit?: number }): Promise<DomainEvent[]>;
+  /** Release underlying resources (e.g. close SQLite connection). No-op if unsupported. */
+  close?(): void;
 }

--- a/apps/mcp-server/tests/server.test.ts
+++ b/apps/mcp-server/tests/server.test.ts
@@ -28,8 +28,13 @@ describe('MCP server config', () => {
 
 describe('Local data source', () => {
   let tmpDir: string | undefined;
+  let activeDs: ReturnType<typeof createLocalDataSource> | undefined;
 
   afterEach(() => {
+    if (activeDs) {
+      activeDs.close?.();
+      activeDs = undefined;
+    }
     if (tmpDir) {
       rmSync(tmpDir, { recursive: true, force: true });
       tmpDir = undefined;
@@ -54,6 +59,7 @@ describe('Local data source', () => {
       baseDir: tmpDir,
     };
     const ds = createLocalDataSource(config);
+    activeDs = ds;
     const runs = await ds.listRuns();
     expect(runs).toEqual([]);
   });

--- a/packages/core/tests/repo-root.test.ts
+++ b/packages/core/tests/repo-root.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { isAbsolute } from 'node:path';
 import { resolveMainRepoRoot, isWorktree, _resetRepoRootCache } from '../src/repo-root.js';
 
 beforeEach(() => {
@@ -20,7 +21,7 @@ describe('resolveMainRepoRoot', () => {
 
   it('returns an absolute path', () => {
     const result = resolveMainRepoRoot();
-    expect(result.startsWith('/')).toBe(true);
+    expect(isAbsolute(result)).toBe(true);
   });
 
   it('cache can be reset', () => {


### PR DESCRIPTION
## Summary
- Fix 2 Windows-specific test failures: repo-root path assertion and MCP SQLite file locking
- Closes #544

## Changes
- `packages/core/tests/repo-root.test.ts` — replace `startsWith('/')` with `path.isAbsolute()` for cross-platform path detection
- `apps/mcp-server/src/backends/types.ts` — add optional `close()` method to `DataSource` interface for resource cleanup
- `apps/mcp-server/src/backends/local.ts` — implement `close()` to synchronously release the SQLite connection before temp directory cleanup
- `apps/mcp-server/tests/server.test.ts` — call `ds.close?.()` in `afterEach` before `rmSync` to prevent EBUSY errors on Windows

## Test Plan
- [x] TypeScript build passes (`pnpm build`)
- [x] Vitest tests pass (`pnpm test`) — 30/30 task groups, all passing
- [x] ESLint clean (`pnpm lint`)
- [x] Prettier clean (`pnpm format`)

## Risk Assessment

| Metric | Value |
|--------|-------|
| Risk level | low |
| Blast radius | 2 (test files + 2 source files in MCP backend) |
| Simulation result | not available |

## Governance Report

| Metric | Count |
|--------|-------|
| Total events | session active |
| Actions allowed | all |
| Actions denied | 0 |
| Policy denials | 0 |
| Invariant violations | 0 |
| Escalation events | 0 |

<details>
<summary>Governance details</summary>

**Source**: `.agentguard/events/`, `.agentguard/decisions/`, SQLite store
**Decision Records**: 0 denials
**Escalation levels observed**: NORMAL only
**Pre-push simulation**: not available

No notable denials or violations during this session.

</details>