### PR TITLE
feat(issue-247): explainable evidence packs with reasoning mode separation

### DIFF
--- a/packages/kernel/src/contract.ts
+++ b/packages/kernel/src/contract.ts
@@ -27,6 +27,8 @@ export type {
   ExplainableEvidencePack,
   EvaluationStep,
   ProvenanceEntry,
+  ReasoningMode,
+  ExplanationChain,
 } from './evidence.js';
 export type {
   SimulatorRegistry,

--- a/packages/kernel/src/evidence.ts
+++ b/packages/kernel/src/evidence.ts
@@ -10,7 +10,7 @@ import type { InvariantCheck } from '@red-codes/invariants';
 // ---------------------------------------------------------------------------
 // Schema version for the explainable evidence pack format
 // ---------------------------------------------------------------------------
-export const EVIDENCE_PACK_SCHEMA_VERSION = '1.0.0';
+export const EVIDENCE_PACK_SCHEMA_VERSION = '1.1.0';
 
 // ---------------------------------------------------------------------------
 // Core Evidence Pack (unchanged for backward compatibility)
@@ -46,6 +46,13 @@ export interface EvaluationStep {
   durationMs?: number;
 }
 
+/**
+ * Classification of reasoning used to produce a piece of evidence.
+ * - `deterministic`: Binary outcome derived from rules or checks (policy match, invariant hold/fail)
+ * - `probabilistic`: Predicted outcome with inherent uncertainty (simulation, AI-based assessment)
+ */
+export type ReasoningMode = 'deterministic' | 'probabilistic';
+
 /** Links a piece of evidence to its authoritative source */
 export interface ProvenanceEntry {
   sourceType: 'policy-rule' | 'invariant' | 'simulation' | 'default';
@@ -53,6 +60,28 @@ export interface ProvenanceEntry {
   sourceName: string;
   contribution: 'allow' | 'deny' | 'neutral';
   evidence: string;
+  /** Whether this evidence was produced by deterministic rules or probabilistic prediction */
+  reasoningMode: ReasoningMode;
+  /** Confidence score (0.0–1.0). Always 1.0 for deterministic; variable for probabilistic. */
+  confidenceScore: number;
+}
+
+/**
+ * Structured explanation that formally separates deterministic adjudication
+ * from probabilistic advice. This is the primary interface for formal
+ * verification tools (e.g., SMT solvers) to reason about governance decisions.
+ */
+export interface ExplanationChain {
+  /** Evidence from deterministic sources (policy rules, invariants, defaults) */
+  deterministicInputs: ProvenanceEntry[];
+  /** Evidence from probabilistic sources (simulations, AI predictions) */
+  probabilisticInputs: ProvenanceEntry[];
+  /** The final allow/deny verdict */
+  verdict: 'allow' | 'deny';
+  /** How the verdict was derived — currently always deterministic */
+  verdictBasis: 'deterministic';
+  /** Human-readable derivation explaining how inputs combined to reach the verdict */
+  derivation: string;
 }
 
 /** Explainable evidence pack — extends EvidencePack with decision explanation */
@@ -62,6 +91,8 @@ export interface ExplainableEvidencePack extends EvidencePack {
   provenance: ProvenanceEntry[];
   verdictType: 'deterministic';
   confidence: number;
+  /** Formal separation of probabilistic advice from deterministic adjudication */
+  explanationChain: ExplanationChain;
 }
 
 /** Serialized form suitable for JSON export and long-term archival */
@@ -86,6 +117,7 @@ export interface SerializedEvidencePack {
   };
   evaluationPath: EvaluationStep[];
   provenance: ProvenanceEntry[];
+  explanationChain: ExplanationChain;
   violations: Array<{
     invariantId: string;
     name: string;
@@ -278,6 +310,20 @@ function buildEvaluationPath(
   return steps;
 }
 
+/** Map simulation risk level to a confidence score for probabilistic entries */
+function simulationConfidence(riskLevel: string): number {
+  switch (riskLevel) {
+    case 'high':
+      return 0.9;
+    case 'medium':
+      return 0.7;
+    case 'low':
+      return 0.5;
+    default:
+      return 0.5;
+  }
+}
+
 function buildProvenance(
   decision: EvalResult,
   violations: InvariantCheck[],
@@ -285,7 +331,7 @@ function buildProvenance(
 ): ProvenanceEntry[] {
   const entries: ProvenanceEntry[] = [];
 
-  // Provenance from matched policy rule
+  // Provenance from matched policy rule (deterministic)
   if (decision.matchedPolicy && decision.matchedRule) {
     entries.push({
       sourceType: 'policy-rule',
@@ -293,10 +339,12 @@ function buildProvenance(
       sourceName: decision.matchedPolicy.name,
       contribution: decision.decision === 'deny' ? 'deny' : 'allow',
       evidence: decision.reason,
+      reasoningMode: 'deterministic',
+      confidenceScore: 1.0,
     });
   }
 
-  // Provenance from default (no rule matched)
+  // Provenance from default (no rule matched — deterministic)
   if (!decision.matchedPolicy && !decision.matchedRule) {
     entries.push({
       sourceType: 'default',
@@ -304,10 +352,12 @@ function buildProvenance(
       sourceName: 'Default policy (no matching rule)',
       contribution: 'allow',
       evidence: decision.reason,
+      reasoningMode: 'deterministic',
+      confidenceScore: 1.0,
     });
   }
 
-  // Provenance from invariant violations
+  // Provenance from invariant violations (deterministic)
   for (const v of violations) {
     entries.push({
       sourceType: 'invariant',
@@ -315,10 +365,12 @@ function buildProvenance(
       sourceName: v.invariant.name,
       contribution: 'deny',
       evidence: `Expected: ${v.result.expected}. Actual: ${v.result.actual}`,
+      reasoningMode: 'deterministic',
+      confidenceScore: 1.0,
     });
   }
 
-  // Provenance from simulation
+  // Provenance from simulation (probabilistic — predictions carry uncertainty)
   if (simulation) {
     entries.push({
       sourceType: 'simulation',
@@ -328,10 +380,55 @@ function buildProvenance(
       evidence:
         `Risk: ${simulation.riskLevel}, blast radius: ${simulation.blastRadius}, ` +
         `predicted changes: ${simulation.predictedChanges.length}`,
+      reasoningMode: 'probabilistic',
+      confidenceScore: simulationConfidence(simulation.riskLevel),
     });
   }
 
   return entries;
+}
+
+function buildExplanationChain(
+  decision: EvalResult,
+  provenance: ProvenanceEntry[]
+): ExplanationChain {
+  const deterministicInputs = provenance.filter((p) => p.reasoningMode === 'deterministic');
+  const probabilisticInputs = provenance.filter((p) => p.reasoningMode === 'probabilistic');
+
+  const verdict: 'allow' | 'deny' = decision.decision === 'deny' ? 'deny' : 'allow';
+
+  // Build human-readable derivation
+  const parts: string[] = [];
+
+  if (deterministicInputs.length > 0) {
+    const denyingSources = deterministicInputs.filter((p) => p.contribution === 'deny');
+    const allowingSources = deterministicInputs.filter((p) => p.contribution === 'allow');
+
+    if (denyingSources.length > 0) {
+      parts.push(`Deterministic deny from: ${denyingSources.map((s) => s.sourceName).join(', ')}`);
+    } else if (allowingSources.length > 0) {
+      parts.push(
+        `Deterministic allow from: ${allowingSources.map((s) => s.sourceName).join(', ')}`
+      );
+    }
+  }
+
+  if (probabilisticInputs.length > 0) {
+    const advisories = probabilisticInputs.map(
+      (p) => `${p.sourceName} (confidence: ${p.confidenceScore.toFixed(1)}, ${p.contribution})`
+    );
+    parts.push(`Probabilistic advisory: ${advisories.join('; ')}`);
+  }
+
+  parts.push(`Verdict: ${verdict.toUpperCase()} (basis: deterministic)`);
+
+  return {
+    deterministicInputs,
+    probabilisticInputs,
+    verdict,
+    verdictBasis: 'deterministic',
+    derivation: parts.join('. '),
+  };
 }
 
 export function createExplainableEvidencePack(params: {
@@ -352,6 +449,7 @@ export function createExplainableEvidencePack(params: {
     simulation
   );
   const provenance = buildProvenance(params.decision, violations, simulation);
+  const explanationChain = buildExplanationChain(params.decision, provenance);
 
   const pack: ExplainableEvidencePack = {
     ...basePack,
@@ -360,6 +458,7 @@ export function createExplainableEvidencePack(params: {
     provenance,
     verdictType: 'deterministic',
     confidence: 1.0,
+    explanationChain,
   };
 
   return { pack, event };
@@ -391,6 +490,7 @@ export function serializeEvidencePack(pack: ExplainableEvidencePack): Serialized
     },
     evaluationPath: pack.evaluationPath,
     provenance: pack.provenance,
+    explanationChain: pack.explanationChain,
     violations: pack.violations,
     relatedEventIds: pack.events,
     summary: pack.summary,

--- a/packages/kernel/tests/evidence-explanation-chain.test.ts
+++ b/packages/kernel/tests/evidence-explanation-chain.test.ts
@@ -1,0 +1,365 @@
+// Tests for explanation chain — formal probabilistic/deterministic separation
+import { describe, it, expect } from 'vitest';
+import {
+  createExplainableEvidencePack,
+  serializeEvidencePack,
+  EVIDENCE_PACK_SCHEMA_VERSION,
+} from '@red-codes/kernel';
+import type { ExplanationChain, ReasoningMode } from '@red-codes/kernel';
+import type { NormalizedIntent, EvalResult, LoadedPolicy } from '@red-codes/policy';
+import type { InvariantCheck } from '@red-codes/invariants';
+import type { SimulationSummary } from '@red-codes/core';
+
+function makeIntent(overrides: Partial<NormalizedIntent> = {}): NormalizedIntent {
+  return {
+    action: 'file.write',
+    target: 'src/index.ts',
+    agent: 'test-agent',
+    destructive: false,
+    ...overrides,
+  };
+}
+
+function makeAllowResult(overrides: Partial<EvalResult> = {}): EvalResult {
+  return {
+    allowed: true,
+    decision: 'allow',
+    matchedRule: null,
+    matchedPolicy: null,
+    reason: 'No matching deny rule',
+    severity: 0,
+    ...overrides,
+  };
+}
+
+function makeDenyResult(overrides: Partial<EvalResult> = {}): EvalResult {
+  return {
+    allowed: false,
+    decision: 'deny',
+    matchedRule: null,
+    matchedPolicy: null,
+    reason: 'Policy denied',
+    severity: 3,
+    ...overrides,
+  };
+}
+
+function makePolicy(): LoadedPolicy {
+  return {
+    id: 'policy-1',
+    name: 'Test Policy',
+    rules: [{ action: 'git.push', effect: 'deny', reason: 'Protected branch' }],
+    severity: 3,
+  };
+}
+
+function makeViolation(overrides: Partial<InvariantCheck> = {}): InvariantCheck {
+  return {
+    holds: false,
+    invariant: {
+      id: 'no-secret-exposure',
+      name: 'No Secret Exposure',
+      description: 'No secrets',
+      severity: 5,
+      check: () => ({ holds: false, expected: 'safe', actual: 'unsafe' }),
+    },
+    result: { holds: false, expected: 'safe', actual: 'unsafe' },
+    ...overrides,
+  };
+}
+
+function makeSimulation(overrides: Partial<SimulationSummary> = {}): SimulationSummary {
+  return {
+    predictedChanges: ['src/index.ts'],
+    blastRadius: 5,
+    riskLevel: 'low',
+    simulatorId: 'test-sim',
+    durationMs: 10,
+    ...overrides,
+  };
+}
+
+describe('explanation chain', () => {
+  describe('schema version', () => {
+    it('uses schema version 1.1.0', () => {
+      expect(EVIDENCE_PACK_SCHEMA_VERSION).toBe('1.1.0');
+    });
+  });
+
+  describe('reasoning mode classification', () => {
+    it('classifies policy-rule provenance as deterministic', () => {
+      const policy = makePolicy();
+      const { pack } = createExplainableEvidencePack({
+        intent: makeIntent(),
+        decision: makeDenyResult({
+          matchedPolicy: policy,
+          matchedRule: policy.rules[0],
+        }),
+      });
+
+      const policyProv = pack.provenance.find((p) => p.sourceType === 'policy-rule');
+      expect(policyProv?.reasoningMode).toBe('deterministic');
+      expect(policyProv?.confidenceScore).toBe(1.0);
+    });
+
+    it('classifies default provenance as deterministic', () => {
+      const { pack } = createExplainableEvidencePack({
+        intent: makeIntent(),
+        decision: makeAllowResult(),
+      });
+
+      const defaultProv = pack.provenance.find((p) => p.sourceType === 'default');
+      expect(defaultProv?.reasoningMode).toBe('deterministic');
+      expect(defaultProv?.confidenceScore).toBe(1.0);
+    });
+
+    it('classifies invariant provenance as deterministic', () => {
+      const { pack } = createExplainableEvidencePack({
+        intent: makeIntent(),
+        decision: makeDenyResult(),
+        violations: [makeViolation()],
+      });
+
+      const invProv = pack.provenance.find((p) => p.sourceType === 'invariant');
+      expect(invProv?.reasoningMode).toBe('deterministic');
+      expect(invProv?.confidenceScore).toBe(1.0);
+    });
+
+    it('classifies simulation provenance as probabilistic', () => {
+      const { pack } = createExplainableEvidencePack({
+        intent: makeIntent(),
+        decision: makeAllowResult(),
+        simulation: makeSimulation(),
+      });
+
+      const simProv = pack.provenance.find((p) => p.sourceType === 'simulation');
+      expect(simProv?.reasoningMode).toBe('probabilistic');
+      expect(simProv?.confidenceScore).toBeLessThan(1.0);
+    });
+
+    it('assigns higher confidence to high-risk simulations', () => {
+      const { pack: lowPack } = createExplainableEvidencePack({
+        intent: makeIntent(),
+        decision: makeAllowResult(),
+        simulation: makeSimulation({ riskLevel: 'low' }),
+      });
+
+      const { pack: highPack } = createExplainableEvidencePack({
+        intent: makeIntent(),
+        decision: makeDenyResult(),
+        simulation: makeSimulation({ riskLevel: 'high' }),
+      });
+
+      const lowSim = lowPack.provenance.find((p) => p.sourceType === 'simulation');
+      const highSim = highPack.provenance.find((p) => p.sourceType === 'simulation');
+
+      expect(highSim!.confidenceScore).toBeGreaterThan(lowSim!.confidenceScore);
+    });
+
+    it('assigns medium confidence for medium-risk simulations', () => {
+      const { pack } = createExplainableEvidencePack({
+        intent: makeIntent(),
+        decision: makeAllowResult(),
+        simulation: makeSimulation({ riskLevel: 'medium' }),
+      });
+
+      const simProv = pack.provenance.find((p) => p.sourceType === 'simulation');
+      expect(simProv?.confidenceScore).toBe(0.7);
+    });
+  });
+
+  describe('explanation chain structure', () => {
+    it('includes explanation chain in evidence pack', () => {
+      const { pack } = createExplainableEvidencePack({
+        intent: makeIntent(),
+        decision: makeAllowResult(),
+      });
+
+      expect(pack.explanationChain).toBeDefined();
+      expect(pack.explanationChain.verdictBasis).toBe('deterministic');
+    });
+
+    it('separates deterministic and probabilistic inputs', () => {
+      const policy = makePolicy();
+      const { pack } = createExplainableEvidencePack({
+        intent: makeIntent(),
+        decision: makeDenyResult({
+          matchedPolicy: policy,
+          matchedRule: policy.rules[0],
+        }),
+        violations: [makeViolation()],
+        simulation: makeSimulation({ riskLevel: 'high' }),
+      });
+
+      const chain = pack.explanationChain;
+
+      // Policy rule + invariant = 2 deterministic
+      expect(chain.deterministicInputs).toHaveLength(2);
+      expect(chain.deterministicInputs.every((p) => p.reasoningMode === 'deterministic')).toBe(
+        true
+      );
+
+      // Simulation = 1 probabilistic
+      expect(chain.probabilisticInputs).toHaveLength(1);
+      expect(chain.probabilisticInputs.every((p) => p.reasoningMode === 'probabilistic')).toBe(
+        true
+      );
+    });
+
+    it('verdict matches decision outcome for deny', () => {
+      const { pack } = createExplainableEvidencePack({
+        intent: makeIntent(),
+        decision: makeDenyResult(),
+      });
+
+      expect(pack.explanationChain.verdict).toBe('deny');
+    });
+
+    it('verdict matches decision outcome for allow', () => {
+      const { pack } = createExplainableEvidencePack({
+        intent: makeIntent(),
+        decision: makeAllowResult(),
+      });
+
+      expect(pack.explanationChain.verdict).toBe('allow');
+    });
+
+    it('verdictBasis is always deterministic', () => {
+      const { pack } = createExplainableEvidencePack({
+        intent: makeIntent(),
+        decision: makeAllowResult(),
+        simulation: makeSimulation({ riskLevel: 'high' }),
+      });
+
+      expect(pack.explanationChain.verdictBasis).toBe('deterministic');
+    });
+
+    it('has no probabilistic inputs when no simulation provided', () => {
+      const { pack } = createExplainableEvidencePack({
+        intent: makeIntent(),
+        decision: makeAllowResult(),
+      });
+
+      expect(pack.explanationChain.probabilisticInputs).toHaveLength(0);
+      expect(pack.explanationChain.deterministicInputs.length).toBeGreaterThan(0);
+    });
+
+    it('derivation includes deterministic source names for deny', () => {
+      const policy = makePolicy();
+      const { pack } = createExplainableEvidencePack({
+        intent: makeIntent(),
+        decision: makeDenyResult({
+          matchedPolicy: policy,
+          matchedRule: policy.rules[0],
+        }),
+      });
+
+      expect(pack.explanationChain.derivation).toContain('Deterministic deny');
+      expect(pack.explanationChain.derivation).toContain('Test Policy');
+      expect(pack.explanationChain.derivation).toContain('DENY');
+    });
+
+    it('derivation includes deterministic source names for allow', () => {
+      const { pack } = createExplainableEvidencePack({
+        intent: makeIntent(),
+        decision: makeAllowResult(),
+      });
+
+      expect(pack.explanationChain.derivation).toContain('Deterministic allow');
+      expect(pack.explanationChain.derivation).toContain('ALLOW');
+    });
+
+    it('derivation includes probabilistic advisory when simulation present', () => {
+      const { pack } = createExplainableEvidencePack({
+        intent: makeIntent(),
+        decision: makeAllowResult(),
+        simulation: makeSimulation({ riskLevel: 'medium' }),
+      });
+
+      expect(pack.explanationChain.derivation).toContain('Probabilistic advisory');
+      expect(pack.explanationChain.derivation).toContain('confidence: 0.7');
+    });
+
+    it('deterministic + probabilistic inputs sum to total provenance', () => {
+      const policy = makePolicy();
+      const { pack } = createExplainableEvidencePack({
+        intent: makeIntent(),
+        decision: makeDenyResult({
+          matchedPolicy: policy,
+          matchedRule: policy.rules[0],
+        }),
+        violations: [makeViolation()],
+        simulation: makeSimulation(),
+      });
+
+      const chain = pack.explanationChain;
+      expect(chain.deterministicInputs.length + chain.probabilisticInputs.length).toBe(
+        pack.provenance.length
+      );
+    });
+  });
+
+  describe('serialization', () => {
+    it('includes explanation chain in serialized output', () => {
+      const { pack } = createExplainableEvidencePack({
+        intent: makeIntent(),
+        decision: makeDenyResult(),
+        simulation: makeSimulation(),
+      });
+
+      const serialized = serializeEvidencePack(pack);
+
+      expect(serialized.explanationChain).toBeDefined();
+      expect(serialized.explanationChain.verdict).toBe('deny');
+      expect(serialized.explanationChain.verdictBasis).toBe('deterministic');
+      expect(serialized.explanationChain.deterministicInputs.length).toBeGreaterThan(0);
+    });
+
+    it('round-trips explanation chain through JSON', () => {
+      const policy = makePolicy();
+      const { pack } = createExplainableEvidencePack({
+        intent: makeIntent(),
+        decision: makeDenyResult({
+          matchedPolicy: policy,
+          matchedRule: policy.rules[0],
+        }),
+        violations: [makeViolation()],
+        simulation: makeSimulation({ riskLevel: 'high' }),
+      });
+
+      const serialized = serializeEvidencePack(pack);
+      const json = JSON.stringify(serialized);
+      const restored = JSON.parse(json);
+
+      expect(restored.explanationChain.deterministicInputs).toHaveLength(2);
+      expect(restored.explanationChain.probabilisticInputs).toHaveLength(1);
+      expect(restored.explanationChain.verdict).toBe('deny');
+      expect(restored.explanationChain.verdictBasis).toBe('deterministic');
+      expect(restored.explanationChain.derivation).toBeTruthy();
+    });
+
+    it('preserves reasoning mode and confidence in serialized provenance', () => {
+      const { pack } = createExplainableEvidencePack({
+        intent: makeIntent(),
+        decision: makeAllowResult(),
+        simulation: makeSimulation({ riskLevel: 'high' }),
+      });
+
+      const serialized = serializeEvidencePack(pack);
+      const json = JSON.stringify(serialized);
+      const restored = JSON.parse(json);
+
+      const simProv = restored.provenance.find(
+        (p: { sourceType: string }) => p.sourceType === 'simulation'
+      );
+      expect(simProv.reasoningMode).toBe('probabilistic');
+      expect(simProv.confidenceScore).toBe(0.9);
+
+      const defaultProv = restored.provenance.find(
+        (p: { sourceType: string }) => p.sourceType === 'default'
+      );
+      expect(defaultProv.reasoningMode).toBe('deterministic');
+      expect(defaultProv.confidenceScore).toBe(1.0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add formal separation between deterministic adjudication and probabilistic advice in evidence packs
- Introduce `ExplanationChain` type, `ReasoningMode` classification, and confidence scores for provenance entries
- Closes #247

## Changes
- `packages/kernel/src/evidence.ts` — Add `ReasoningMode` type, extend `ProvenanceEntry` with `reasoningMode`/`confidenceScore`, add `ExplanationChain` interface, implement `buildExplanationChain()`, wire into `createExplainableEvidencePack()` and `serializeEvidencePack()`, bump schema version to 1.1.0
- `packages/kernel/src/contract.ts` — Export new `ReasoningMode` and `ExplanationChain` types from kernel contract
- `packages/kernel/tests/evidence-explanation-chain.test.ts` — 18 new tests covering reasoning mode classification, explanation chain structure, derivation text, serialization round-trips

## Test Plan
- [x] TypeScript build passes (`pnpm build`)
- [x] Type-check passes (`pnpm ts:check`)
- [x] Vitest tests pass (`pnpm test` — 629 kernel tests, all green)
- [x] ESLint clean (`pnpm lint`)
- [x] Prettier clean (`pnpm format`)

## Risk Assessment

| Metric | Value |
|--------|-------|
| Risk level | low |
| Risk score | 0/100 |
| Blast radius | 0 (weighted) |
| Simulation result | low risk (remoteTrackingError — feature branch) |

## Governance Report

| Metric | Count |
|--------|-------|
| Total events | 4 |
| Actions allowed | 1 |
| Actions denied | 0 |
| Policy denials | 0 |
| Invariant violations | 0 |
| Escalation events | 0 |
| Decision records | 0 |

<details>
<summary>Governance details</summary>

**Source**: `~/.agentguard/agentguard.db` (SQLite)

**Decision Records**: 0 total, 0 denials
**Escalation levels observed**: NORMAL only
**Pre-push simulation**: risk=low, blast-radius=0

All actions passed governance checks. No denials or violations observed.

</details>