### PR TITLE
feat(plugins): add reference invariant plugin for data protection

### DIFF
--- a/packages/invariant-data-protection/package.json
+++ b/packages/invariant-data-protection/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@red-codes/invariant-data-protection",
+  "version": "0.1.0",
+  "description": "Reference invariant plugin for data protection — PII detection, secret scanning, and batch limits",
+  "type": "module",
+  "license": "Apache-2.0",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc -b",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "lint": "eslint src/",
+    "ts:check": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@red-codes/core": "workspace:*",
+    "@red-codes/invariants": "workspace:*",
+    "@red-codes/plugins": "workspace:*"
+  },
+  "devDependencies": {
+    "vitest": "^4.1.0",
+    "typescript": "^5.9.3"
+  },
+  "agentguard": {
+    "type": "invariant"
+  },
+  "keywords": [
+    "agentguard-plugin",
+    "invariant",
+    "data-protection",
+    "pii",
+    "secrets"
+  ]
+}

--- a/packages/invariant-data-protection/src/index.ts
+++ b/packages/invariant-data-protection/src/index.ts
@@ -1,0 +1,39 @@
+// Reference invariant plugin: data protection.
+//
+// Exports a plugin manifest for the AgentGuard plugin discovery system
+// and the invariant definitions for registration with the invariant checker.
+
+import type { PluginManifest } from '@red-codes/plugins';
+import { DATA_PROTECTION_INVARIANTS } from './invariants.js';
+
+export { DATA_PROTECTION_INVARIANTS } from './invariants.js';
+export {
+  PII_PATTERNS,
+  SECRET_PATTERNS,
+  LOG_PATH_PATTERNS,
+  isLogPath,
+  EMAIL_PATTERN,
+  SSN_PATTERN,
+  CREDIT_CARD_PATTERN,
+  PHONE_PATTERN,
+  AWS_KEY_PATTERN,
+  GENERIC_API_KEY_PATTERN,
+  BEARER_TOKEN_PATTERN,
+  PRIVATE_KEY_PATTERN,
+  CONNECTION_STRING_PATTERN,
+} from './patterns.js';
+
+/** Plugin manifest for the data protection invariant pack */
+export const manifest: PluginManifest = {
+  id: 'invariant-data-protection',
+  name: 'Data Protection Invariants',
+  version: '0.1.0',
+  description:
+    'Reference invariant plugin providing PII detection, secret scanning, and batch file limits',
+  type: 'invariant',
+  apiVersion: '^1.0.0',
+  capabilities: ['filesystem:read'],
+};
+
+/** All invariants exported by this plugin */
+export const invariants = DATA_PROTECTION_INVARIANTS;

--- a/packages/invariant-data-protection/src/invariants.ts
+++ b/packages/invariant-data-protection/src/invariants.ts
@@ -1,0 +1,163 @@
+// Data protection invariant definitions.
+// Follows the same shape as built-in invariants in @red-codes/invariants.
+
+import type { AgentGuardInvariant, SystemState } from '@red-codes/invariants';
+import { PII_PATTERNS, SECRET_PATTERNS, isLogPath } from './patterns.js';
+
+/** Default maximum files per batch operation */
+const DEFAULT_MAX_FILE_COUNT = 50;
+
+/**
+ * Scan content for the first matching PII pattern.
+ * Returns the label of the first match, or null if none found.
+ */
+function detectPii(content: string): string | null {
+  for (const { pattern, label } of PII_PATTERNS) {
+    if (pattern.test(content)) {
+      return label;
+    }
+  }
+  return null;
+}
+
+/**
+ * Scan content for the first matching secret pattern.
+ * Returns the label of the first match, or null if none found.
+ */
+function detectSecret(content: string): string | null {
+  for (const { pattern, label } of SECRET_PATTERNS) {
+    if (pattern.test(content)) {
+      return label;
+    }
+  }
+  return null;
+}
+
+/**
+ * Data protection invariants — 3 invariants for PII, secrets, and batch limits.
+ */
+export const DATA_PROTECTION_INVARIANTS: AgentGuardInvariant[] = [
+  {
+    id: 'no-pii-in-logs',
+    name: 'No PII in Logs',
+    description:
+      'Log files and output files must not contain personally identifiable information (PII)',
+    severity: 4,
+    check(state: SystemState): { holds: boolean; expected: string; actual: string } {
+      const actionType = state.currentActionType || '';
+
+      // Only trigger on file.write actions
+      if (actionType !== 'file.write') {
+        return { holds: true, expected: 'N/A', actual: 'Not a file.write action' };
+      }
+
+      const target = state.currentTarget || '';
+
+      // Only check log-like paths
+      if (!isLogPath(target)) {
+        return { holds: true, expected: 'No PII in log files', actual: 'Target is not a log file' };
+      }
+
+      // Check content for PII patterns
+      const content = state.fileContentDiff || '';
+      if (!content) {
+        return {
+          holds: true,
+          expected: 'No PII in log files',
+          actual: 'No content to check',
+        };
+      }
+
+      const piiType = detectPii(content);
+      if (piiType) {
+        return {
+          holds: false,
+          expected: 'No PII in log files',
+          actual: `PII pattern detected: ${piiType}`,
+        };
+      }
+
+      return {
+        holds: true,
+        expected: 'No PII in log files',
+        actual: 'No PII detected in log content',
+      };
+    },
+  },
+
+  {
+    id: 'no-hardcoded-secrets',
+    name: 'No Hardcoded Secrets',
+    description:
+      'Written files must not contain hardcoded secrets such as API keys, tokens, or private keys',
+    severity: 5,
+    check(state: SystemState): { holds: boolean; expected: string; actual: string } {
+      const actionType = state.currentActionType || '';
+
+      // Only trigger on file.write actions
+      if (actionType !== 'file.write') {
+        return { holds: true, expected: 'N/A', actual: 'Not a file.write action' };
+      }
+
+      const content = state.fileContentDiff || '';
+      if (!content) {
+        return {
+          holds: true,
+          expected: 'No hardcoded secrets',
+          actual: 'No content to check',
+        };
+      }
+
+      const secretType = detectSecret(content);
+      if (secretType) {
+        return {
+          holds: false,
+          expected: 'No hardcoded secrets',
+          actual: `Hardcoded secret detected: ${secretType}`,
+        };
+      }
+
+      return {
+        holds: true,
+        expected: 'No hardcoded secrets',
+        actual: 'No hardcoded secrets detected',
+      };
+    },
+  },
+
+  {
+    id: 'max-file-count-per-action',
+    name: 'Max File Count Per Action',
+    description:
+      'Batch file operations must not exceed a configurable limit on the number of files affected',
+    severity: 2,
+    check(state: SystemState): { holds: boolean; expected: string; actual: string } {
+      const actionType = state.currentActionType || '';
+
+      // Only trigger on file mutation actions
+      const FILE_MUTATION_ACTIONS = ['file.write', 'file.delete', 'file.move'];
+      if (!FILE_MUTATION_ACTIONS.includes(actionType)) {
+        return { holds: true, expected: 'N/A', actual: 'Not a file mutation action' };
+      }
+
+      const limit =
+        (state as SystemState & { maxFileCountLimit?: number }).maxFileCountLimit ??
+        DEFAULT_MAX_FILE_COUNT;
+      const count = state.filesAffected ?? 0;
+
+      if (count > limit) {
+        return {
+          holds: false,
+          expected: `At most ${limit} files per batch operation`,
+          actual: `Batch operation exceeds ${limit} file limit (${count} files)`,
+        };
+      }
+
+      return {
+        holds: true,
+        expected: `At most ${limit} files per batch operation`,
+        actual: `${count} files in batch (within limit)`,
+      };
+    },
+  },
+];

--- a/packages/invariant-data-protection/src/patterns.ts
+++ b/packages/invariant-data-protection/src/patterns.ts
@@ -1,0 +1,76 @@
+// Regex patterns for data protection invariants.
+// Extracted for testability and reuse.
+
+// ---------------------------------------------------------------------------
+// PII Patterns
+// ---------------------------------------------------------------------------
+
+/** Email addresses: user@domain.tld */
+export const EMAIL_PATTERN = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/;
+
+/** US Social Security Numbers: 123-45-6789 */
+export const SSN_PATTERN = /\b\d{3}-\d{2}-\d{4}\b/;
+
+/** Credit card numbers: 1234 5678 9012 3456 or 1234-5678-9012-3456 or 1234567890123456 */
+export const CREDIT_CARD_PATTERN = /\b\d{4}[- ]?\d{4}[- ]?\d{4}[- ]?\d{4}\b/;
+
+/** US phone numbers: 123-456-7890 or 123.456.7890 or 1234567890 */
+export const PHONE_PATTERN = /\b\d{3}[-.]?\d{3}[-.]?\d{4}\b/;
+
+/** All PII patterns with labels for violation messages */
+export const PII_PATTERNS: readonly { pattern: RegExp; label: string }[] = [
+  { pattern: EMAIL_PATTERN, label: 'email address' },
+  { pattern: SSN_PATTERN, label: 'SSN' },
+  { pattern: CREDIT_CARD_PATTERN, label: 'credit card number' },
+  { pattern: PHONE_PATTERN, label: 'phone number' },
+];
+
+// ---------------------------------------------------------------------------
+// Log file path patterns
+// ---------------------------------------------------------------------------
+
+/** File extensions and path segments that indicate log/output files */
+export const LOG_PATH_PATTERNS: readonly RegExp[] = [
+  /\.log$/i,
+  /(?:^|\/)logs\//i,
+  /(?:^|\\)logs\\/i,
+  /(?:^|\/)output\//i,
+  /(?:^|\\)output\\/i,
+  /\bstdout\b/i,
+  /\bstderr\b/i,
+];
+
+/** Returns true if the given path looks like a log or output file */
+export function isLogPath(filePath: string): boolean {
+  if (!filePath) return false;
+  return LOG_PATH_PATTERNS.some((p) => p.test(filePath));
+}
+
+// ---------------------------------------------------------------------------
+// Secret Patterns
+// ---------------------------------------------------------------------------
+
+/** AWS access key IDs: AKIA followed by 16 alphanumeric characters */
+export const AWS_KEY_PATTERN = /AKIA[0-9A-Z]{16}/;
+
+/** Generic API key assignments: api_key = "..." or apikey: "..." etc. */
+export const GENERIC_API_KEY_PATTERN =
+  /(?:api[_-]?key|apikey|api[_-]?secret)\s*[:=]\s*['"]?[a-zA-Z0-9_\-]{20,}/i;
+
+/** Bearer tokens in authorization headers (requires 20+ chars to avoid false positives on prose) */
+export const BEARER_TOKEN_PATTERN = /Bearer\s+[a-zA-Z0-9\-._~+/]{20,}=*/;
+
+/** PEM-encoded private keys */
+export const PRIVATE_KEY_PATTERN = /-----BEGIN (?:RSA |EC |DSA )?PRIVATE KEY-----/;
+
+/** Database connection strings with embedded credentials */
+export const CONNECTION_STRING_PATTERN = /(?:postgres|mysql|mongodb|redis):\/\/[^\s'"]+/i;
+
+/** All secret patterns with labels for violation messages */
+export const SECRET_PATTERNS: readonly { pattern: RegExp; label: string }[] = [
+  { pattern: AWS_KEY_PATTERN, label: 'AWS access key' },
+  { pattern: GENERIC_API_KEY_PATTERN, label: 'generic API key' },
+  { pattern: BEARER_TOKEN_PATTERN, label: 'Bearer token' },
+  { pattern: PRIVATE_KEY_PATTERN, label: 'private key' },
+  { pattern: CONNECTION_STRING_PATTERN, label: 'connection string' },
+];

--- a/packages/invariant-data-protection/tests/invariants.test.ts
+++ b/packages/invariant-data-protection/tests/invariants.test.ts
@@ -1,0 +1,568 @@
+// Tests for data protection invariants — comprehensive coverage.
+import { describe, it, expect } from 'vitest';
+import {
+  DATA_PROTECTION_INVARIANTS,
+  manifest,
+  isLogPath,
+  PII_PATTERNS,
+  SECRET_PATTERNS,
+} from '@red-codes/invariant-data-protection';
+import type { SystemState } from '@red-codes/invariants';
+
+function findInvariant(id: string) {
+  const inv = DATA_PROTECTION_INVARIANTS.find((i) => i.id === id);
+  if (!inv) throw new Error(`Invariant ${id} not found`);
+  return inv;
+}
+
+// ---------------------------------------------------------------------------
+// Plugin manifest
+// ---------------------------------------------------------------------------
+
+describe('plugin manifest', () => {
+  it('has correct metadata', () => {
+    expect(manifest.id).toBe('invariant-data-protection');
+    expect(manifest.type).toBe('invariant');
+    expect(manifest.version).toBe('0.1.0');
+    expect(manifest.apiVersion).toBe('^1.0.0');
+  });
+
+  it('exports 3 invariants', () => {
+    expect(DATA_PROTECTION_INVARIANTS).toHaveLength(3);
+  });
+
+  it('all invariants have required fields', () => {
+    for (const inv of DATA_PROTECTION_INVARIANTS) {
+      expect(inv.id).toBeTruthy();
+      expect(inv.name).toBeTruthy();
+      expect(inv.description).toBeTruthy();
+      expect(typeof inv.severity).toBe('number');
+      expect(typeof inv.check).toBe('function');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pattern helpers
+// ---------------------------------------------------------------------------
+
+describe('isLogPath', () => {
+  it('detects .log extension', () => {
+    expect(isLogPath('app.log')).toBe(true);
+    expect(isLogPath('/var/log/app.log')).toBe(true);
+    expect(isLogPath('C:\\logs\\error.log')).toBe(true);
+  });
+
+  it('detects /logs/ directory', () => {
+    expect(isLogPath('/var/logs/app.txt')).toBe(true);
+    expect(isLogPath('project/logs/debug.txt')).toBe(true);
+  });
+
+  it('detects \\logs\\ directory (Windows)', () => {
+    expect(isLogPath('C:\\project\\logs\\debug.txt')).toBe(true);
+  });
+
+  it('detects /output/ directory', () => {
+    expect(isLogPath('/tmp/output/result.txt')).toBe(true);
+  });
+
+  it('detects \\output\\ directory (Windows)', () => {
+    expect(isLogPath('C:\\tmp\\output\\result.txt')).toBe(true);
+  });
+
+  it('detects stdout/stderr paths', () => {
+    expect(isLogPath('/dev/stdout')).toBe(true);
+    expect(isLogPath('/dev/stderr')).toBe(true);
+    expect(isLogPath('stdout.txt')).toBe(true);
+  });
+
+  it('returns false for non-log paths', () => {
+    expect(isLogPath('src/index.ts')).toBe(false);
+    expect(isLogPath('README.md')).toBe(false);
+    expect(isLogPath('package.json')).toBe(false);
+    expect(isLogPath('catalog.txt')).toBe(false);
+  });
+
+  it('returns false for empty/missing input', () => {
+    expect(isLogPath('')).toBe(false);
+  });
+});
+
+describe('PII_PATTERNS', () => {
+  it('has 4 patterns', () => {
+    expect(PII_PATTERNS).toHaveLength(4);
+  });
+});
+
+describe('SECRET_PATTERNS', () => {
+  it('has 5 patterns', () => {
+    expect(SECRET_PATTERNS).toHaveLength(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// no-pii-in-logs
+// ---------------------------------------------------------------------------
+
+describe('no-pii-in-logs', () => {
+  const inv = findInvariant('no-pii-in-logs');
+
+  it('skips non-file.write actions', () => {
+    const result = inv.check({ currentActionType: 'file.read' });
+    expect(result.holds).toBe(true);
+    expect(result.actual).toContain('Not a file.write');
+  });
+
+  it('skips when action type is missing', () => {
+    const result = inv.check({});
+    expect(result.holds).toBe(true);
+  });
+
+  it('skips non-log file targets', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      currentTarget: 'src/index.ts',
+      fileContentDiff: 'user@example.com',
+    });
+    expect(result.holds).toBe(true);
+    expect(result.actual).toContain('not a log file');
+  });
+
+  it('skips log files with no content', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      currentTarget: '/var/log/app.log',
+      fileContentDiff: '',
+    });
+    expect(result.holds).toBe(true);
+  });
+
+  it('skips log files when content is undefined', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      currentTarget: '/var/log/app.log',
+    });
+    expect(result.holds).toBe(true);
+  });
+
+  it('detects email addresses in log files', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      currentTarget: '/var/log/app.log',
+      fileContentDiff: 'User login: john.doe@example.com at 2024-01-01',
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('email address');
+  });
+
+  it('detects SSN in log files', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      currentTarget: 'logs/audit.log',
+      fileContentDiff: 'Customer SSN: 123-45-6789',
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('SSN');
+  });
+
+  it('detects credit card numbers in log files', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      currentTarget: 'output/transactions.txt',
+      fileContentDiff: 'Payment: 4111 1111 1111 1111',
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('credit card');
+  });
+
+  it('detects credit card numbers with dashes', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      currentTarget: '/var/log/payment.log',
+      fileContentDiff: 'Card: 4111-1111-1111-1111',
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('credit card');
+  });
+
+  it('detects phone numbers in log files', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      currentTarget: 'output/contacts.txt',
+      fileContentDiff: 'Contact phone: 555-123-4567',
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('phone number');
+  });
+
+  it('holds when log file has clean content', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      currentTarget: '/var/log/app.log',
+      fileContentDiff: '[INFO] Application started successfully at port 3000',
+    });
+    expect(result.holds).toBe(true);
+  });
+
+  it('detects PII in /output/ directory', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      currentTarget: '/tmp/output/report.csv',
+      fileContentDiff: 'name,email\nJohn,john@example.com',
+    });
+    expect(result.holds).toBe(false);
+  });
+
+  it('detects PII in stderr path', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      currentTarget: '/proc/self/fd/stderr',
+      fileContentDiff: 'Error for user 123-45-6789',
+    });
+    expect(result.holds).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// no-hardcoded-secrets
+// ---------------------------------------------------------------------------
+
+describe('no-hardcoded-secrets', () => {
+  const inv = findInvariant('no-hardcoded-secrets');
+
+  it('skips non-file.write actions', () => {
+    const result = inv.check({ currentActionType: 'git.push' });
+    expect(result.holds).toBe(true);
+    expect(result.actual).toContain('Not a file.write');
+  });
+
+  it('skips when action type is missing', () => {
+    const result = inv.check({});
+    expect(result.holds).toBe(true);
+  });
+
+  it('skips when content is empty', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      fileContentDiff: '',
+    });
+    expect(result.holds).toBe(true);
+  });
+
+  it('skips when content is undefined', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+    });
+    expect(result.holds).toBe(true);
+  });
+
+  it('detects AWS access keys', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      fileContentDiff: 'aws_access_key_id = AKIAIOSFODNN7EXAMPLE',
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('AWS access key');
+  });
+
+  it('detects generic API keys with equals', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      fileContentDiff: 'api_key = "sk_live_abcdefghijklmnopqrst"',
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('generic API key');
+  });
+
+  it('detects generic API keys with colon', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      fileContentDiff: 'apiKey: "abcdefghijklmnopqrstuvwxyz1234"',
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('generic API key');
+  });
+
+  it('detects api-secret pattern', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      fileContentDiff: 'api-secret = "xyzzy1234567890abcdefghijk"',
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('generic API key');
+  });
+
+  it('detects Bearer tokens', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      fileContentDiff: 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0=',
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('Bearer token');
+  });
+
+  it('detects RSA private keys', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      fileContentDiff: '-----BEGIN RSA PRIVATE KEY-----\nMIIBogIBAAJBAKj...',
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('private key');
+  });
+
+  it('detects EC private keys', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      fileContentDiff: '-----BEGIN EC PRIVATE KEY-----\nMHQCAQEE...',
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('private key');
+  });
+
+  it('detects generic private keys', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      fileContentDiff: '-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkq...',
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('private key');
+  });
+
+  it('detects PostgreSQL connection strings', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      fileContentDiff: 'DATABASE_URL=postgres://admin:password123@db.example.com:5432/mydb',
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('connection string');
+  });
+
+  it('detects MongoDB connection strings', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      fileContentDiff: 'const uri = "mongodb://user:pass@cluster0.example.net:27017/db";',
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('connection string');
+  });
+
+  it('detects Redis connection strings', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      fileContentDiff: 'REDIS_URL=redis://default:password@redis.example.com:6379',
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('connection string');
+  });
+
+  it('detects MySQL connection strings', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      fileContentDiff: 'mysql://root:secret@localhost:3306/app',
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('connection string');
+  });
+
+  it('holds for clean code content', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      fileContentDiff: `
+        const config = {
+          host: process.env.DB_HOST,
+          port: parseInt(process.env.DB_PORT || '5432'),
+          apiKey: process.env.API_KEY,
+        };
+      `,
+    });
+    expect(result.holds).toBe(true);
+  });
+
+  it('holds for code with short variable names', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      fileContentDiff: 'const api_key = getKey();',
+    });
+    expect(result.holds).toBe(true);
+  });
+
+  it('does not flag "Bearer" without a token value', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      fileContentDiff: 'The Bearer scheme requires a token.',
+    });
+    // "Bearer " is not followed by a valid token character sequence
+    expect(result.holds).toBe(true);
+  });
+
+  it('flags Bearer with an actual token value', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      fileContentDiff:
+        'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0=',
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('Bearer token');
+  });
+
+  it('does not flag protocol documentation without credentials', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      fileContentDiff: 'PostgreSQL uses the postgres:// protocol prefix.',
+    });
+    // "postgres://" followed by a space — [^\s'"]+ requires at least one non-space char
+    expect(result.holds).toBe(true);
+  });
+
+  it('does not flag bare protocol mention', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      fileContentDiff: 'Use postgres:// for connection strings.',
+    });
+    expect(result.holds).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// max-file-count-per-action
+// ---------------------------------------------------------------------------
+
+describe('max-file-count-per-action', () => {
+  const inv = findInvariant('max-file-count-per-action');
+
+  it('skips non-file-mutation actions', () => {
+    const result = inv.check({ currentActionType: 'git.push' });
+    expect(result.holds).toBe(true);
+    expect(result.actual).toContain('Not a file mutation');
+  });
+
+  it('skips when action type is missing', () => {
+    const result = inv.check({});
+    expect(result.holds).toBe(true);
+  });
+
+  it('holds when file count is within default limit (50)', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      filesAffected: 10,
+    });
+    expect(result.holds).toBe(true);
+    expect(result.actual).toContain('10 files');
+  });
+
+  it('holds at exactly the default limit', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      filesAffected: 50,
+    });
+    expect(result.holds).toBe(true);
+  });
+
+  it('fails when file count exceeds default limit', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      filesAffected: 51,
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('51 files');
+    expect(result.actual).toContain('50');
+  });
+
+  it('works with file.delete action', () => {
+    const result = inv.check({
+      currentActionType: 'file.delete',
+      filesAffected: 100,
+    });
+    expect(result.holds).toBe(false);
+  });
+
+  it('works with file.move action', () => {
+    const result = inv.check({
+      currentActionType: 'file.move',
+      filesAffected: 100,
+    });
+    expect(result.holds).toBe(false);
+  });
+
+  it('holds when filesAffected is 0', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      filesAffected: 0,
+    });
+    expect(result.holds).toBe(true);
+  });
+
+  it('holds when filesAffected is undefined (defaults to 0)', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+    });
+    expect(result.holds).toBe(true);
+  });
+
+  it('respects custom maxFileCountLimit', () => {
+    const state: SystemState & { maxFileCountLimit: number } = {
+      currentActionType: 'file.write',
+      filesAffected: 11,
+      maxFileCountLimit: 10,
+    };
+    const result = inv.check(state);
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('10 file limit');
+  });
+
+  it('holds with custom limit when under', () => {
+    const state: SystemState & { maxFileCountLimit: number } = {
+      currentActionType: 'file.write',
+      filesAffected: 5,
+      maxFileCountLimit: 10,
+    };
+    const result = inv.check(state);
+    expect(result.holds).toBe(true);
+  });
+
+  it('holds at exactly custom limit', () => {
+    const state: SystemState & { maxFileCountLimit: number } = {
+      currentActionType: 'file.delete',
+      filesAffected: 10,
+      maxFileCountLimit: 10,
+    };
+    const result = inv.check(state);
+    expect(result.holds).toBe(true);
+  });
+
+  it('skips file.read actions', () => {
+    const result = inv.check({
+      currentActionType: 'file.read',
+      filesAffected: 1000,
+    });
+    expect(result.holds).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: all invariants work with checkAllInvariants
+// ---------------------------------------------------------------------------
+
+describe('integration with invariant checker', () => {
+  it('all invariants produce valid results for empty state', () => {
+    for (const inv of DATA_PROTECTION_INVARIANTS) {
+      const result = inv.check({});
+      expect(typeof result.holds).toBe('boolean');
+      expect(typeof result.expected).toBe('string');
+      expect(typeof result.actual).toBe('string');
+    }
+  });
+
+  it('invariants have unique IDs', () => {
+    const ids = DATA_PROTECTION_INVARIANTS.map((inv) => inv.id);
+    const uniqueIds = new Set(ids);
+    expect(uniqueIds.size).toBe(ids.length);
+  });
+
+  it('all severities are between 1 and 5', () => {
+    for (const inv of DATA_PROTECTION_INVARIANTS) {
+      expect(inv.severity).toBeGreaterThanOrEqual(1);
+      expect(inv.severity).toBeLessThanOrEqual(5);
+    }
+  });
+});

--- a/packages/invariant-data-protection/tsconfig.json
+++ b/packages/invariant-data-protection/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "composite": true
+  },
+  "include": ["src/**/*.ts"],
+  "references": [{ "path": "../core" }, { "path": "../invariants" }, { "path": "../plugins" }]
+}

--- a/packages/invariant-data-protection/vitest.config.ts
+++ b/packages/invariant-data-protection/vitest.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@red-codes/invariant-data-protection': path.resolve(__dirname, 'src/index.ts'),
+      '@red-codes/invariants': path.resolve(__dirname, '../invariants/src/index.ts'),
+      '@red-codes/plugins': path.resolve(__dirname, '../plugins/src/index.ts'),
+      '@red-codes/core': path.resolve(__dirname, '../core/src/index.ts'),
+      '@red-codes/events': path.resolve(__dirname, '../events/src/index.ts'),
+    },
+  },
+  test: {
+    include: ['tests/**/*.test.ts'],
+    environment: 'node',
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.ts'],
+      reporter: ['text', 'json-summary', 'lcov'],
+      thresholds: {
+        lines: 50,
+        branches: 40,
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,25 @@ importers:
         specifier: workspace:*
         version: link:../core
 
+  packages/invariant-data-protection:
+    dependencies:
+      '@red-codes/core':
+        specifier: workspace:*
+        version: link:../core
+      '@red-codes/invariants':
+        specifier: workspace:*
+        version: link:../invariants
+      '@red-codes/plugins':
+        specifier: workspace:*
+        version: link:../plugins
+    devDependencies:
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+
   packages/invariants:
     dependencies:
       '@red-codes/core':

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     { "path": "packages/adapters" },
     { "path": "packages/storage" },
     { "path": "packages/plugins" },
+    { "path": "packages/invariant-data-protection" },
     { "path": "packages/renderers" },
     { "path": "packages/swarm" },
     { "path": "apps/cli" },


### PR DESCRIPTION
## Summary

First reference plugin validating the plugin framework end-to-end. Implements `@red-codes/invariant-data-protection` with 3 invariants:

- **`no-pii-in-logs`** (severity 4) — Scans file.write actions targeting log paths for email, SSN, credit card, and phone patterns
- **`no-hardcoded-secrets`** (severity 5) — Scans file.write content for AWS keys, API keys, Bearer tokens, private keys, and connection strings
- **`max-file-count-per-action`** (severity 2) — Flags batch operations exceeding configurable file count limit (default 50)

This proves the plugin discovery, registration, and validation pipeline works with a real, useful invariant pack. Enterprise users can copy this as a template for custom invariants.

## Files

- `packages/invariant-data-protection/src/patterns.ts` — Extracted regex patterns (4 PII + 5 secret + 7 log path)
- `packages/invariant-data-protection/src/invariants.ts` — 3 invariant definitions following `AgentGuardInvariant` shape
- `packages/invariant-data-protection/src/index.ts` — Plugin manifest and re-exports
- `packages/invariant-data-protection/tests/invariants.test.ts` — 64 tests

## Test plan

- [x] `pnpm build --filter=@red-codes/invariant-data-protection` — builds clean
- [x] `pnpm test --filter=@red-codes/invariant-data-protection` — 64/64 tests passing
- [x] `pnpm ts:check --filter=@red-codes/invariant-data-protection` — typecheck clean
- [ ] Install via plugin CLI: `agentguard plugin install ./packages/invariant-data-protection`

🤖 Generated with [Claude Code](https://claude.com/claude-code)