### PR TITLE
docs: sync documentation with codebase state

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -46,7 +46,8 @@ packages/
 ├── core/          @red-codes/core — Shared utilities (types, actions, hash, execution-log)
 ├── events/        @red-codes/events — Canonical event model (schema, bus, store)
 ├── policy/        @red-codes/policy — Policy system (composer, evaluator, loaders, pack loader)
-├── invariants/    @red-codes/invariants — Invariant system (20 built-in definitions, checker)
+├── invariants/    @red-codes/invariants — Invariant system (21 built-in definitions, checker)
+├── invariant-data-protection/ @red-codes/invariant-data-protection — Data protection invariant plugin
 ├── kernel/        @red-codes/kernel — Governed action kernel (orchestrate, normalize, decide, escalate)
 ├── adapters/      @red-codes/adapters — Execution adapters (file, shell, git, claude-code)
 ├── analytics/     @red-codes/analytics — Cross-session violation analytics
@@ -59,10 +60,11 @@ packages/
 
 apps/
 ├── cli/           @red-codes/agentguard — CLI entry point and commands (published npm package)
+├── mcp-server/    @red-codes/mcp-server — MCP governance server (14 governance tools)
 ├── vscode-extension/  agentguard-vscode — VS Code extension (sidebar panels, notifications, diagnostics)
 └── telemetry-server/  @red-codes/telemetry-server — Telemetry ingestion server (enrollment, batch ingest)
 
-policies/          Policy packs (YAML: ci-safe, enterprise, open-source, strict)
+policies/          Policy packs (YAML: ci-safe, engineering-standards, enterprise, hipaa, open-source, soc2, strict)
 ```
 
 ## Layer Rules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@ The system has one architectural spine: the **canonical event model**. All syste
 
 **Key characteristics:**
 - Governed action kernel: propose → normalize → evaluate → execute → emit
-- 20 built-in invariants (secret exposure, protected branches, blast radius, test-before-push, no force push, no skill modification, no scheduled task modification, credential file creation, package script injection, lockfile integrity, recursive operation guard, large file write, CI/CD config modification, permission escalation, governance self-modification, container config modification, environment variable modification, network egress, destructive migration, transitive effect analysis)
+- 21 built-in invariants (secret exposure, protected branches, blast radius, test-before-push, no force push, no skill modification, no scheduled task modification, credential file creation, package script injection, lockfile integrity, recursive operation guard, large file write, CI/CD config modification, permission escalation, governance self-modification, container config modification, environment variable modification, network egress, destructive migration, transitive effect analysis, IDE socket access)
 - YAML/JSON policy format with pattern matching, scopes, and branch conditions
 - Escalation tracking: NORMAL → ELEVATED → HIGH → LOCKDOWN
 - SQLite event persistence for audit trail and replay (JSONL export still supported)
 - Claude Code adapter for PreToolUse/PostToolUse hooks
-- **pnpm monorepo** with Turbo orchestration: 10 packages under `packages/`, 3 apps under `apps/`
+- **pnpm monorepo** with Turbo orchestration: 13 packages under `packages/`, 3 apps under `apps/`
 - Each package compiles independently via `tsc`; CLI bundle via `esbuild` in `apps/cli`
 - Scoped npm packages: `@red-codes/*` for workspace modules, `@red-codes/agentguard` for published CLI
 - CLI has runtime dependencies (`chokidar`, `commander`, `pino`); optional `better-sqlite3` for SQLite storage backend
@@ -67,7 +67,7 @@ packages/
 │   ├── pack-loader.ts          # Policy pack loader (community policy sets)
 │   └── yaml-loader.ts          # YAML policy parser
 ├── invariants/src/             # @red-codes/invariants — Invariant system
-│   ├── definitions.ts          # 20 built-in invariant definitions
+│   ├── definitions.ts          # 21 built-in invariant definitions
 │   └── checker.ts              # Invariant evaluation engine
 ├── kernel/src/                 # @red-codes/kernel — Governed action kernel
 │   ├── kernel.ts               # Orchestrator (propose → evaluate → execute → emit)
@@ -99,6 +99,7 @@ packages/
 │   ├── discovery.ts            # Plugin discovery mechanism
 │   ├── registry.ts             # Plugin registry
 │   ├── sandbox.ts              # Plugin sandboxing
+│   ├── simulator-loader.ts     # Simulator plugin loader
 │   ├── validator.ts            # Plugin validation
 │   ├── types.ts                # Plugin type definitions
 │   └── index.ts                # Module re-exports
@@ -109,6 +110,8 @@ packages/
 │   ├── types.ts                # Renderer type definitions
 │   └── index.ts                # Module re-exports
 ├── storage/src/                # @red-codes/storage — Storage backends (SQLite, opt-in)
+│   ├── adoption-analytics.ts   # Adoption analytics engine
+│   ├── denial-learner.ts       # Denial pattern learning
 │   ├── factory.ts              # Storage bundle factory
 │   ├── index.ts                # Module re-exports
 │   ├── migrations.ts           # Schema migrations (version-based)
@@ -118,12 +121,16 @@ packages/
 │   └── types.ts                # Storage type definitions
 ├── telemetry/src/              # @red-codes/telemetry — Runtime telemetry and logging
 ├── telemetry-client/src/       # @red-codes/telemetry-client — Telemetry client (identity, signing, queue, sender)
-└── swarm/src/                  # @red-codes/swarm — Shareable agent swarm templates
-    ├── config.ts               # Swarm configuration
-    ├── manifest.ts             # Swarm manifest parsing
-    ├── scaffolder.ts           # Swarm scaffolding
-    ├── types.ts                # Swarm type definitions
-    └── index.ts                # Module re-exports
+├── swarm/src/                  # @red-codes/swarm — Shareable agent swarm templates
+│   ├── config.ts               # Swarm configuration
+│   ├── manifest.ts             # Swarm manifest parsing
+│   ├── scaffolder.ts           # Swarm scaffolding
+│   ├── types.ts                # Swarm type definitions
+│   └── index.ts                # Module re-exports
+└── invariant-data-protection/src/ # @red-codes/invariant-data-protection — Data protection invariant plugin
+    ├── index.ts                # Module re-exports
+    ├── invariants.ts           # Data protection invariant definitions
+    └── patterns.ts             # Data protection patterns
 
 apps/
 ├── cli/src/                    # @red-codes/agentguard — CLI (published npm package)
@@ -137,13 +144,13 @@ apps/
 │   ├── session-store.ts        # Session management
 │   ├── file-event-store.ts     # File-based event persistence
 │   ├── evidence-summary.ts     # Evidence summary generator for PR reports
-│   └── commands/               # guard, inspect, replay, export, import, simulate, ci-check, plugin, policy, policy-verify, claude-hook, claude-init, init, diff, evidence-pr, traces, session-viewer, status, analytics, auto-setup, config, audit-verify, demo
+│   └── commands/               # guard, inspect, replay, export, import, simulate, ci-check, plugin, policy, policy-verify, claude-hook, claude-init, init, diff, evidence-pr, traces, session-viewer, status, analytics, auto-setup, config, audit-verify, demo, adoption, learn, migrate, trust
 ├── mcp-server/src/             # @red-codes/mcp-server — MCP governance server
 │   ├── index.ts                # Entry point
 │   ├── server.ts               # MCP server implementation
 │   ├── config.ts               # Server configuration
 │   ├── backends/               # Storage backends
-│   └── tools/                  # 15 governance MCP tools
+│   └── tools/                  # 14 governance MCP tools
 └── vscode-extension/src/       # agentguard-vscode — VS Code extension
     ├── extension.ts            # Extension entry point (sidebar panels, file watcher)
     ├── providers/              # Tree data providers (run status, run history, recent events)
@@ -151,9 +158,9 @@ apps/
 
 tests/
 └── *.test.js               # 14 JS test files (custom zero-dependency harness)
-# 118 TS test files (vitest) distributed across packages/ and apps/ directories
+# 132 TS test files (vitest) distributed across packages/ and apps/ directories
 policy/                     # Policy configuration (JSON: action_rules, capabilities)
-policies/                   # Policy packs (YAML: ci-safe, enterprise, open-source, strict)
+policies/                   # Policy packs (YAML: ci-safe, engineering-standards, enterprise, hipaa, open-source, soc2, strict)
 docs/                       # System documentation (architecture, event model, specs)
 hooks/                      # Git hooks (post-commit, post-merge)
 examples/                   # Example governance scenarios and error demos
@@ -195,7 +202,7 @@ The kernel loop is the core of AgentGuard. Every agent action passes through it:
 1. Agent proposes action (Claude Code tool call → `RawAgentAction`)
 2. AAB normalizes intent (tool → action type, detect git/destructive commands)
 3. Policy evaluator matches rules (deny/allow with scopes, branches, limits)
-4. Invariant checker verifies system state (20 defaults)
+4. Invariant checker verifies system state (21 defaults)
 5. If allowed: execute via adapter (file/shell/git handlers)
 6. Emit lifecycle events: `ACTION_REQUESTED` → `ACTION_ALLOWED/DENIED` → `ACTION_EXECUTED/FAILED`
 7. Sink all events to SQLite for audit trail
@@ -218,7 +225,8 @@ Each workspace package maps to a single architectural concept:
 - **packages/telemetry-client/** — Telemetry client (identity, signing, queue, sender)
 - **packages/swarm/** — Shareable agent swarm templates (config, manifest, scaffolder)
 - **apps/cli/** — CLI entry point and commands (published as `@red-codes/agentguard`)
-- **apps/mcp-server/** — MCP governance server (15 governance tools)
+- **packages/invariant-data-protection/** — Data protection invariant plugin
+- **apps/mcp-server/** — MCP governance server (14 governance tools)
 
 ### CLI Commands
 - `agentguard guard` — Start the governed action runtime (policy + invariant enforcement)
@@ -247,6 +255,10 @@ Each workspace package maps to a single architectural concept:
 - `agentguard config show|get|set` — Manage AgentGuard configuration
 - `agentguard audit-verify` — Verify tamper-resistant audit chain integrity
 - `agentguard demo` — Interactive governance showcase
+- `agentguard adoption` — Adoption metrics and onboarding status
+- `agentguard learn` — Interactive tutorials and learning paths
+- `agentguard migrate` — Migrate configuration between versions
+- `agentguard trust` — Manage policy and hook trust verification
 
 ### Event Model
 The canonical event model is the architectural spine. Event kinds defined in `packages/events/src/schema.ts`:
@@ -261,6 +273,10 @@ The canonical event model is the architectural spine. Event kinds defined in `pa
 - **Dev activity**: `FileSaved`, `TestCompleted`, `BuildCompleted`, `CommitCreated`, `CodeReviewed`, `DeployCompleted`, `LintCompleted`
 - **Token Optimization**: `TokenOptimizationApplied`
 - **Heartbeat**: `HeartbeatEmitted`, `HeartbeatMissed`, `AgentUnresponsive`
+- **Integrity & Trust**: `HookIntegrityVerified`, `HookIntegrityFailed`, `PolicyTrustVerified`, `PolicyTrustDenied`
+- **Adoption Analytics**: `AdoptionAnalyzed`, `AdoptionAnalysisFailed`
+- **Denial Learning**: `DenialPatternDetected`
+- **Environmental Enforcement**: `IdeSocketAccessBlocked`
 
 ### Action Classes & Types
 23 canonical action types across 8 classes, defined in `packages/core/src/actions.ts`:
@@ -314,7 +330,7 @@ pnpm test --filter=@red-codes/kernel  # Test a single package
 **Test structure:**
 - **Vitest workspace** (`vitest.workspace.ts`): orchestrates tests across all packages
 - **JS tests** (`tests/*.test.js`): 14 files using a custom zero-dependency harness (`tests/run.js` with `node:assert`)
-- **TypeScript tests** (distributed across `packages/*/tests/` and `apps/*/tests/`): 118 files using vitest
+- **TypeScript tests** (distributed across `packages/*/tests/` and `apps/*/tests/`): 132 files using vitest
 - **Coverage areas**: adapters, kernel (AAB, engine, monitor, blast radius, heartbeat, integration, e2e pipeline, conformance), CLI commands (args, guard, inspect, init, simulate, ci-check, claude-hook, claude-init, export/import, policy-validate, policy-verify, diff, evidence-pr, traces, plugin, auto-setup, config), decision records, domain models, events, evidence packs, evidence summary, execution log, export-import roundtrip, impact forecast, invariants, notification formatter, plugins (discovery, registry, sandbox, validation), policy evaluation (including composer, pack loader, policy packs, evaluation trace, forecast conditions), renderers, replay (engine, comparator, processor), simulation, SQLite storage (migrations, session, sink, store, factory), swarm (scaffolder), TUI renderer, violation mapper, VS Code event reader, YAML loading
 
 ## CI/CD & Automation
@@ -328,3 +344,4 @@ pnpm test --filter=@red-codes/kernel  # Test a single package
 | `agentguard-governance.yml` | Reusable workflow (called from other repos) | CI governance verification for sessions |
 | `codeql.yml` | PR to `main`/`master` + weekly schedule | CodeQL security analysis |
 | `deploy-pages.yml` | Push to `main` (paths: `site/**`) | Deploys site directory to GitHub Pages |
+| `bench-regression-gate.yml` | PR / scheduled | Performance benchmark regression gate |

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ AI coding agents execute file writes, shell commands, and git operations autonom
 AgentGuard adds a **deterministic decision point** between proposal and execution:
 
 - **Safety policies** — declare what agents can and cannot do in YAML
-- **Invariant enforcement** — 20 built-in checks (secrets, protected branches, blast radius, skill/task protection, package script injection, lockfile integrity, CI/CD config, permission escalation, governance self-modification, container config, environment variables, recursive operations, large file writes, network egress, destructive migrations, transitive effect analysis) run on every action
+- **Invariant enforcement** — 21 built-in checks (secrets, protected branches, blast radius, skill/task protection, package script injection, lockfile integrity, CI/CD config, permission escalation, governance self-modification, container config, environment variables, recursive operations, large file writes, network egress, destructive migrations, transitive effect analysis, IDE socket access) run on every action
 - **Audit trail** — every decision is recorded in structured SQLite, inspectable after the fact
 - **Session debugging** — replay any agent session to see exactly what happened and why
 
@@ -75,7 +75,7 @@ AgentGuard evaluates every agent action through a **governed action kernel**:
 
 1. **Normalize** — Claude Code tool calls (Bash, Write, Edit, Read) are mapped to canonical action types (shell.exec, file.write, file.read)
 2. **Evaluate** — policies match against the action (deny git.push to main, deny destructive commands, enforce scope limits)
-3. **Check invariants** — 20 built-in safety checks run on every action
+3. **Check invariants** — 21 built-in safety checks run on every action
 4. **Execute** — if allowed, the action runs via adapters (file, shell, git handlers)
 5. **Emit events** — full lifecycle events sunk to SQLite for audit trail
 
@@ -83,7 +83,7 @@ AgentGuard evaluates every agent action through a **governed action kernel**:
 
 ```
   AgentGuard Runtime Active
-  policy: agentguard.yaml | invariants: 20 active
+  policy: agentguard.yaml | invariants: 21 active
 
   ✓ file.write src/auth/service.ts
   ✓ shell.exec npm test
@@ -123,7 +123,7 @@ Drop an `agentguard.yaml` in your repo root — the CLI picks it up automaticall
 
 ## Built-in Invariants
 
-20 safety invariants run on every action evaluation:
+21 safety invariants run on every action evaluation:
 
 | Invariant | Severity | Description |
 |-----------|----------|-------------|
@@ -147,6 +147,7 @@ Drop an `agentguard.yaml` in your repo root — the CLI picks it up automaticall
 | **transitive-effect-analysis** | 4 (high) | Analyzes written files for downstream effects that would violate policy |
 | **recursive-operation-guard** | 2 (low) | Flags find -exec, xargs combined with write/delete operations |
 | **lockfile-integrity** | 2 (low) | Ensures package.json changes sync with lockfiles |
+| **no-ide-socket-access** | 4 (high) | Blocks access to IDE socket files (vscode-ipc-*.sock) |
 
 ## RTK Token Optimization
 
@@ -232,7 +233,8 @@ agentguard plugin install <path>          # Install a plugin from a local path
 agentguard plugin remove <id>            # Remove a plugin by ID
 agentguard plugin search [query]          # Search for plugins on npm
 
-# === Telemetry ===
+# === Trust & Telemetry ===
+agentguard trust                          # Manage policy and hook trust verification
 agentguard telemetry                      # Manage telemetry enrollment and settings
 agentguard help                           # Show all commands
 ```
@@ -340,7 +342,8 @@ packages/
 ├── core/src/               # @red-codes/core — Shared types, actions, hash, rng, execution-log
 ├── events/src/             # @red-codes/events — Canonical event model (schema, bus, store)
 ├── policy/src/             # @red-codes/policy — Policy evaluation, YAML/JSON loaders, composition
-├── invariants/src/         # @red-codes/invariants — 20 built-in invariant definitions + checker
+├── invariants/src/         # @red-codes/invariants — 21 built-in invariant definitions + checker
+├── invariant-data-protection/src/ # @red-codes/invariant-data-protection — Data protection invariant plugin
 ├── kernel/src/             # @red-codes/kernel — Governed action kernel (orchestrator, AAB, decisions, simulation)
 ├── adapters/src/           # @red-codes/adapters — Execution adapters (file, shell, git, claude-code)
 ├── analytics/src/          # @red-codes/analytics — Cross-session violation analytics
@@ -356,6 +359,7 @@ apps/
 │   ├── bin.ts              # CLI entry point
 │   ├── evidence-summary.ts # Evidence summary generator for PR reports
 │   └── commands/           # analytics, guard, inspect, replay, export, import, simulate, ci-check, etc.
+├── mcp-server/src/         # @red-codes/mcp-server — MCP governance server (14 governance tools)
 ├── vscode-extension/src/   # agentguard-vscode — VS Code extension
 │   ├── extension.ts        # Sidebar panels, file watcher, notifications
 │   ├── providers/          # Tree data providers (run status, run history, recent events)
@@ -365,7 +369,7 @@ apps/
 crates/
 └── kernel-core/            # Rust kernel (in development)
 
-policies/                   # Policy packs (YAML: ci-safe, enterprise, open-source, strict)
+policies/                   # Policy packs (YAML: ci-safe, engineering-standards, enterprise, hipaa, open-source, soc2, strict)
 ```
 
 ## npm Packages

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -59,8 +59,8 @@ A comprehensive codebase audit assessed the current system against the strategic
 | Canonical Action Representation (23 types, 8 classes) | Implemented | `packages/core/src/actions.ts` |
 | Action Authorization Boundary (AAB) | Implemented (2 bypass vectors) | `packages/kernel/src/aab.ts` |
 | Policy Evaluator (two-phase deny/allow) | Implemented | `packages/policy/src/evaluator.ts` |
-| 20 Built-in Invariants | Fully Implemented | `packages/invariants/src/definitions.ts`, `packages/invariants/src/checker.ts` |
-| Event Model (50 event kinds) | Comprehensive | `packages/events/src/schema.ts` |
+| 21 Built-in Invariants | Fully Implemented | `packages/invariants/src/definitions.ts`, `packages/invariants/src/checker.ts` |
+| Event Model (45 event kinds) | Comprehensive | `packages/events/src/schema.ts` |
 | SQLite Persistence | Implemented | `packages/storage/src/sqlite-store.ts` |
 | Simulation Engine (3 simulators + impact forecast) | Fully Implemented | `packages/kernel/src/simulation/` |
 | Blast Radius Computation | Implemented | `packages/kernel/src/blast-radius.ts` |
@@ -75,7 +75,7 @@ A comprehensive codebase audit assessed the current system against the strategic
 |-----------|--------|-----------|
 | Plugin Ecosystem (discovery, registry, validation) | Implemented | `packages/plugins/src/` |
 | Renderer Plugin System | Implemented | `packages/renderers/src/` |
-| CLI (guard, inspect, events, replay, export, import, simulate, ci-check, plugin, policy, policy-verify, claude-hook, claude-init, init, diff, evidence-pr, traces, session-viewer, status) | Implemented | `apps/cli/src/` |
+| CLI (guard, inspect, events, replay, export, import, simulate, ci-check, plugin, policy, policy-verify, claude-hook, claude-init, init, diff, evidence-pr, traces, session-viewer, status, adoption, learn, migrate, trust) | Implemented | `apps/cli/src/` |
 | Claude Code Hook Integration | Implemented | `packages/adapters/src/claude-code.ts` |
 | VS Code Extension (sidebar panels, event reader, inline diagnostics) | Implemented | `apps/vscode-extension/` |
 | Policy Pack Loader | Implemented | `packages/policy/src/pack-loader.ts` |
@@ -103,8 +103,8 @@ A comprehensive codebase audit assessed the current system against the strategic
 | Canonical Action Representation | Implemented | Production |
 | AAB Reference Monitor | Implemented | 1 bypass vector to close (missing-adapter fixed) |
 | Policy Evaluator | Implemented | Production |
-| 17 Built-in Invariants | Fully Implemented | Production |
-| Event Model (49 kinds) | Comprehensive | Production |
+| 21 Built-in Invariants | Fully Implemented | Production |
+| Event Model (45 kinds) | Comprehensive | Production |
 | Simulation & Forecasting | Fully Implemented | Production |
 | Escalation State Machine | Implemented | Functional (events persisted as StateChanged) |
 | Plugin Sandbox | Implemented | Application-level only |
@@ -251,7 +251,7 @@ This is the architectural hinge. These changes transform the AAB from advisory i
 
 ### Phase 6.5 — Invariant Expansion `STABLE`
 
-> **Theme:** Close invariant coverage gaps. Expanded from 10 to 20 built-in invariants.
+> **Theme:** Close invariant coverage gaps. Expanded from 10 to 21 built-in invariants.
 
 The `SystemState` interface in `packages/invariants/src/definitions.ts` is the bottleneck for invariant expansion — it needs to become a richer context object with action-specific fields.
 
@@ -291,7 +291,7 @@ Prior art: Kubernetes Capability Primitives (KCP), OS capability-based security 
 - [x] Policy templates for common scenarios (`policies/strict`, `policies/ci-safe`, `policies/enterprise`, `policies/open-source`)
 - [x] Policy composition (multiple policy files merged with precedence) (`packages/policy/src/composer.ts`, `guard --policy a --policy b`)
 - [x] Policy validation CLI (`agentguard policy validate <file>`)
-- [ ] Community policy packs (SOC2, HIPAA, internal engineering standards)
+- [x] Community policy packs (SOC2, HIPAA, engineering standards) (`policies/soc2/`, `policies/hipaa/`, `policies/engineering-standards/`)
 - [ ] Policy pack versioning and compatibility
 
 ### Phase 9 — Agent Integrations `PLANNED`
@@ -457,7 +457,7 @@ The agent governance space is emerging. Several projects address overlapping pro
 
 AgentGuard is built for contributors. Here are the best places to start:
 
-- **Write an invariant pack** — Define domain-specific invariants in `packages/invariants/src/community/`. See `packages/invariants/src/definitions.ts` for the 17 built-in invariants as a reference.
+- **Write an invariant pack** — Define domain-specific invariants in `packages/invariants/src/community/`. See `packages/invariants/src/definitions.ts` for the 21 built-in invariants as a reference.
 - **Create a policy pack** — Ship a reusable policy YAML in `policies/`. See `agentguard.yaml` for the format and `packages/policy/src/pack-loader.ts` for the pack loading contract.
 - **Build an adapter** — Add support for a new agent framework in `packages/adapters/src/`. Follow the pattern in `packages/adapters/src/claude-code.ts`.
 - **Add a renderer** — Create a custom governance output renderer implementing the `GovernanceRenderer` interface in `packages/renderers/src/types.ts`.


### PR DESCRIPTION
## Summary

Scheduled docs-sync agent detected documentation drift across all 4 primary documentation files. Recent feature PRs (#568, #574, #535, #562) landed code changes without updating documentation counts and listings.

### Fixes applied

| Discrepancy | Before | After | Files affected |
|---|---|---|---|
| Invariant count | 20 | 21 (`no-ide-socket-access` added in #535) | CLAUDE.md, README.md, ARCHITECTURE.md, ROADMAP.md |
| Policy packs | 4 (ci-safe, enterprise, open-source, strict) | 7 (+engineering-standards, hipaa, soc2 from #568) | CLAUDE.md, README.md, ARCHITECTURE.md, ROADMAP.md |
| CLI commands | 24 | 27 (+adoption, learn, migrate, trust) | CLAUDE.md, ROADMAP.md |
| Event kinds (ROADMAP) | 50/49 | 45 (verified from schema.ts) | ROADMAP.md |
| MCP tools | 15 | 14 (verified from source) | CLAUDE.md |
| TS test files | 118 | 132 | CLAUDE.md |
| Package count | 10 | 13 (+invariant-data-protection) | CLAUDE.md, README.md, ARCHITECTURE.md |
| GitHub workflows | 5 | 6 (+bench-regression-gate.yml) | CLAUDE.md |
| Missing event categories | — | +8 event kinds across 4 categories | CLAUDE.md |
| Phase 8 policy packs | unchecked | checked (SOC2, HIPAA, eng-standards shipped) | ROADMAP.md |

### Strategic document staleness check

`docs/current-priorities.md` and `docs/strategic-roadmap.md` do not exist — ROADMAP.md is the single source of truth. No contradictions found between ROADMAP.md and ARCHITECTURE.md.

### No contradictions found between documents

All 4 files now agree on invariant count (21), policy pack list (7), and package structure.

## Test plan

- [ ] Verify all invariant count references show 21
- [ ] Verify all policy pack listings include 7 packs
- [ ] Verify CLI command list matches `apps/cli/src/commands/` directory
- [ ] Verify event kind count matches `packages/events/src/schema.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)