### PR TITLE
fix(ci): update Rust test assertion and fix copilot-init formatting

### DIFF
--- a/apps/cli/src/commands/copilot-init.ts
+++ b/apps/cli/src/commands/copilot-init.ts
@@ -122,9 +122,7 @@ export async function copilotInit(args: string[] = []): Promise<void> {
     `  ${FG.green}\u2713${RESET}  Hooks installed in ${FG.cyan}${hooksLabel}${RESET}\n`
   );
   process.stderr.write(`  ${DIM}preToolUse:    governance enforcement (all tools)${RESET}\n`);
-  process.stderr.write(
-    `  ${DIM}postToolUse:   error monitoring (bash/powershell)${RESET}\n`
-  );
+  process.stderr.write(`  ${DIM}postToolUse:   error monitoring (bash/powershell)${RESET}\n`);
   if (storeBackend) {
     process.stderr.write(`  ${DIM}Storage:       ${storeBackend}${RESET}\n`);
   }
@@ -301,7 +299,9 @@ function showProtectionSummary(policyGenerated: boolean): void {
   process.stderr.write(
     `  ${FG.green}\u25A0${RESET} ${DIM}Allow${RESET} file reads, file writes (non-sensitive)\n`
   );
-  process.stderr.write(`  ${FG.blue}\u25A0${RESET} ${DIM}Track${RESET} all actions with audit trail\n`);
+  process.stderr.write(
+    `  ${FG.blue}\u25A0${RESET} ${DIM}Track${RESET} all actions with audit trail\n`
+  );
   process.stderr.write('\n');
 
   process.stderr.write(`  ${BOLD}Next steps:${RESET}\n`);
@@ -323,16 +323,11 @@ function showProtectionSummary(policyGenerated: boolean): void {
       `  ${DIM}2. Run ${FG.cyan}agentguard inspect --last${RESET}${DIM} to review decisions${RESET}\n`
     );
   }
-  process.stderr.write(
-    `\n  ${DIM}Remove: ${FG.cyan}agentguard copilot-init --remove${RESET}\n\n`
-  );
+  process.stderr.write(`\n  ${DIM}Remove: ${FG.cyan}agentguard copilot-init --remove${RESET}\n\n`);
 }
 
 function hasAgentGuardHook(config: HooksConfig): boolean {
-  const allEntries = [
-    ...(config.hooks?.preToolUse || []),
-    ...(config.hooks?.postToolUse || []),
-  ];
+  const allEntries = [...(config.hooks?.preToolUse || []), ...(config.hooks?.postToolUse || [])];
   return allEntries.some((entry) => {
     const cmd = entry.bash || '';
     return cmd.includes(HOOK_MARKER);

--- a/crates/kernel-core/src/data.rs
+++ b/crates/kernel-core/src/data.rs
@@ -148,7 +148,7 @@ mod tests {
         assert_eq!(TOOL_ACTION_MAP.get("Bash").unwrap(), "shell.exec");
         assert_eq!(TOOL_ACTION_MAP.get("Write").unwrap(), "file.write");
         assert_eq!(TOOL_ACTION_MAP.get("WebFetch").unwrap(), "http.request");
-        assert_eq!(TOOL_ACTION_MAP.len(), 12);
+        assert_eq!(TOOL_ACTION_MAP.len(), 21);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Update `crates/kernel-core/src/data.rs` Rust test assertion from 12 to 21 entries — `tool-action-map.json` grew with generic agent mappings but the test was not updated, breaking CI on all branches
- Fix Prettier formatting in `apps/cli/src/commands/copilot-init.ts` (merged unformatted in PR #586)

## Root cause

PR #586 added 9 generic agent tool mappings to `packages/core/src/data/tool-action-map.json` (lines 15-23: `create`, `edit`, `view`, `bash`, `powershell`, `glob`, `grep`, `web_fetch`, `task`) but did not update the Rust kernel test that asserts the map length.

## CI runs affected

- https://github.com/AgentGuardHQ/agent-guard/actions/runs/23218428778
- https://github.com/AgentGuardHQ/agent-guard/actions/runs/23216816652

## Related issues

- #589 — claude-hook-errors.test.ts format mismatch (separate fix needed)
- #590 — cli-simulate.test.ts flaky timeout

## Test plan

- [ ] Rust kernel tests pass (`cargo test --manifest-path crates/kernel-core/Cargo.toml`)
- [ ] `pnpm format` passes (no Prettier warnings)
- [ ] CI green on this PR


🤖 Generated with [Claude Code](https://claude.com/claude-code)