### PR TITLE
fix(ci): update stale Rust assertion and apply Prettier to copilot-init.ts

### DIFF
--- a/apps/cli/src/commands/copilot-init.ts
+++ b/apps/cli/src/commands/copilot-init.ts
@@ -122,9 +122,7 @@ export async function copilotInit(args: string[] = []): Promise<void> {
     `  ${FG.green}\u2713${RESET}  Hooks installed in ${FG.cyan}${hooksLabel}${RESET}\n`
   );
   process.stderr.write(`  ${DIM}preToolUse:    governance enforcement (all tools)${RESET}\n`);
-  process.stderr.write(
-    `  ${DIM}postToolUse:   error monitoring (bash/powershell)${RESET}\n`
-  );
+  process.stderr.write(`  ${DIM}postToolUse:   error monitoring (bash/powershell)${RESET}\n`);
   if (storeBackend) {
     process.stderr.write(`  ${DIM}Storage:       ${storeBackend}${RESET}\n`);
   }
@@ -301,7 +299,9 @@ function showProtectionSummary(policyGenerated: boolean): void {
   process.stderr.write(
     `  ${FG.green}\u25A0${RESET} ${DIM}Allow${RESET} file reads, file writes (non-sensitive)\n`
   );
-  process.stderr.write(`  ${FG.blue}\u25A0${RESET} ${DIM}Track${RESET} all actions with audit trail\n`);
+  process.stderr.write(
+    `  ${FG.blue}\u25A0${RESET} ${DIM}Track${RESET} all actions with audit trail\n`
+  );
   process.stderr.write('\n');
 
   process.stderr.write(`  ${BOLD}Next steps:${RESET}\n`);
@@ -323,16 +323,11 @@ function showProtectionSummary(policyGenerated: boolean): void {
       `  ${DIM}2. Run ${FG.cyan}agentguard inspect --last${RESET}${DIM} to review decisions${RESET}\n`
     );
   }
-  process.stderr.write(
-    `\n  ${DIM}Remove: ${FG.cyan}agentguard copilot-init --remove${RESET}\n\n`
-  );
+  process.stderr.write(`\n  ${DIM}Remove: ${FG.cyan}agentguard copilot-init --remove${RESET}\n\n`);
 }
 
 function hasAgentGuardHook(config: HooksConfig): boolean {
-  const allEntries = [
-    ...(config.hooks?.preToolUse || []),
-    ...(config.hooks?.postToolUse || []),
-  ];
+  const allEntries = [...(config.hooks?.preToolUse || []), ...(config.hooks?.postToolUse || [])];
   return allEntries.some((entry) => {
     const cmd = entry.bash || '';
     return cmd.includes(HOOK_MARKER);


### PR DESCRIPTION
## Summary

Two CI blockers introduced by PR #586 (Copilot CLI adapter) that affect all open PRs targeting `main`:

1. **`crates/kernel-core/src/data.rs`** — `test_tool_action_map_loads` hardcoded `12` entries; PR #586 added 9 Copilot tool entries bringing the total to `21`. Any PR whose CI merge commit includes #586 will fail this test.

2. **`apps/cli/src/commands/copilot-init.ts`** — merged with minor Prettier line-length violations. Blocks `pnpm format` CI check on any PR targeting `main`.

No logic changes in either file.

## Test plan

- [ ] CI `rust-kernel` passes (`test_tool_action_map_loads` assertion)
- [ ] CI `lint` passes (`pnpm format` check)
- [ ] No functional changes — both diffs are count update + whitespace only

🤖 Generated with [Claude Code](https://claude.com/claude-code)