### PR TITLE
fix(security): path-aware policy resolution for global hook bypass

### DIFF
--- a/apps/cli/src/commands/claude-hook.ts
+++ b/apps/cli/src/commands/claude-hook.ts
@@ -71,6 +71,33 @@ export async function claudeHook(hookType?: string, extraArgs: string[] = []): P
   process.exit(0);
 }
 
+/**
+ * Extract the target file path from a hook payload for path-aware policy resolution.
+ * Used to find the nearest agentguard.yaml when cwd differs from the project root.
+ */
+function extractTargetPath(payload: ClaudeCodeHookPayload): string | undefined {
+  const input = payload.tool_input || {};
+
+  // File tools have an explicit file_path
+  if (input.file_path && typeof input.file_path === 'string') {
+    return input.file_path;
+  }
+
+  // Glob/Grep have a path parameter
+  if (input.path && typeof input.path === 'string') {
+    return input.path;
+  }
+
+  // Bash: look for absolute paths in the command
+  if (payload.tool_name === 'Bash' && typeof input.command === 'string') {
+    // Match Unix or Windows absolute paths (avoid matching flags like --force)
+    const match = input.command.match(/(?:^|\s)(\/(?!dev\/null)[^\s"']+|[A-Z]:\\[^\s"']+)/);
+    if (match) return match[1];
+  }
+
+  return undefined;
+}
+
 /** Returns true if the action was denied. */
 async function handlePreToolUse(
   payload: ClaudeCodeHookPayload,
@@ -78,7 +105,7 @@ async function handlePreToolUse(
 ): Promise<boolean> {
   const { processClaudeCodeHook, formatHookResponse } = await import('@red-codes/adapters');
   const { createKernel } = await import('@red-codes/kernel');
-  const { loadPolicyDefs } = await import('../policy-resolver.js');
+  const { loadPolicyDefs, findPolicyForPath } = await import('../policy-resolver.js');
   const { resolveStorageConfig, createStorageBundle } = await import('@red-codes/storage');
 
   // Ensure hook field is set
@@ -87,10 +114,23 @@ async function handlePreToolUse(
     hook: 'PreToolUse',
   };
 
+  // Extract target path for path-aware policy resolution.
+  // This fixes the governance bypass when Claude Code runs from a parent directory.
+  const targetPath = extractTargetPath(normalizedPayload);
+  let projectRoot: string | undefined;
+
+  // If we have a target path, try to find the project root and policy together (one walk-up)
+  if (targetPath) {
+    const policyResult = findPolicyForPath(targetPath);
+    if (policyResult) {
+      projectRoot = policyResult.projectRoot;
+    }
+  }
+
   // Load policy (fail-open: empty policy if none found)
   let policyDefs: unknown[] = [];
   try {
-    policyDefs = loadPolicyDefs();
+    policyDefs = loadPolicyDefs(undefined, targetPath);
   } catch (policyErr) {
     // Policy loading failure is non-fatal — continue with no policy (allow all)
     process.stderr.write(
@@ -142,7 +182,7 @@ async function handlePreToolUse(
   const envPersona = readPersonaFromEnv();
   const resolvedPersona = envPersona ? resolvePersona(undefined, envPersona) : undefined;
 
-  const result = await processClaudeCodeHook(kernel, normalizedPayload, {}, resolvedPersona);
+  const result = await processClaudeCodeHook(kernel, normalizedPayload, {}, resolvedPersona, projectRoot);
   kernel.shutdown();
 
   // Close storage (important for SQLite to flush WAL)

--- a/apps/cli/src/commands/claude-init.ts
+++ b/apps/cli/src/commands/claude-init.ts
@@ -257,7 +257,7 @@ export async function claudeInit(args: string[] = []): Promise<void> {
   }
 
   // Show what protections are active
-  showProtectionSummary(policyGenerated, rtkStatus);
+  showProtectionSummary(policyGenerated, rtkStatus, isGlobal);
 }
 
 function removeHook(settingsPath: string, settingsLabel: string): void {
@@ -448,7 +448,8 @@ function generateStarterPolicy(): boolean {
 
 function showProtectionSummary(
   policyGenerated: boolean,
-  rtkStatus?: { available: boolean; version?: string }
+  rtkStatus?: { available: boolean; version?: string },
+  isGlobal?: boolean
 ): void {
   process.stderr.write('\n');
   process.stderr.write(`  ${FG.green}${BOLD}AgentGuard is active.${RESET}\n\n`);
@@ -498,6 +499,16 @@ function showProtectionSummary(
       `  ${DIM}2. Run ${FG.cyan}agentguard inspect --last${RESET}${DIM} to review decisions${RESET}\n`
     );
   }
+  // Suggest global installation if this was a local install
+  if (!isGlobal) {
+    process.stderr.write(
+      `\n  ${FG.yellow}Tip:${RESET} Run ${FG.cyan}agentguard claude-init --global${RESET} to install hooks globally.\n`
+    );
+    process.stderr.write(
+      `  ${DIM}Global hooks protect governed repos even when Claude Code starts from a parent directory.${RESET}\n`
+    );
+  }
+
   process.stderr.write(
     `\n  ${DIM}Try it: ${FG.cyan}agentguard demo${RESET}${DIM} — see governance in action${RESET}\n`
   );

--- a/apps/cli/src/policy-resolver.ts
+++ b/apps/cli/src/policy-resolver.ts
@@ -2,7 +2,7 @@
 // Supports policy composition: multiple --policy flags + hierarchical discovery.
 
 import { readFileSync, existsSync } from 'node:fs';
-import { resolve, dirname, join } from 'node:path';
+import { resolve, dirname, join, normalize } from 'node:path';
 import { homedir } from 'node:os';
 import { loadYamlPolicy, parseYamlPolicy } from '@red-codes/policy';
 import { resolveExtends, mergePolicies } from '@red-codes/policy';
@@ -24,7 +24,43 @@ const USER_POLICY_CANDIDATES = [
   join('.agentguard', 'policy.yml'),
 ];
 
-export function findDefaultPolicy(): string | null {
+/**
+ * Walk up from a target file path looking for the nearest policy file.
+ * Returns both the policy path and the project root directory.
+ * This enables governance enforcement even when cwd differs from the project root
+ * (e.g., when Claude Code runs from a parent directory).
+ */
+export function findPolicyForPath(
+  targetPath: string
+): { policyPath: string; projectRoot: string } | null {
+  const absPath = normalize(resolve(targetPath));
+  // Start from the file's directory (dirname handles both files and trailing-slash dirs)
+  let dir = dirname(absPath);
+
+  const seen = new Set<string>();
+  while (!seen.has(dir)) {
+    seen.add(dir);
+    for (const name of DEFAULT_POLICY_CANDIDATES) {
+      const candidate = join(dir, name);
+      if (existsSync(candidate)) {
+        return { policyPath: candidate, projectRoot: dir };
+      }
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break; // Filesystem root
+    dir = parent;
+  }
+  return null;
+}
+
+export function findDefaultPolicy(targetPath?: string): string | null {
+  // Path-aware resolution: walk up from the target file to find the nearest policy.
+  // This fixes the governance bypass when cwd is a parent directory of the project.
+  if (targetPath) {
+    const result = findPolicyForPath(targetPath);
+    if (result) return result.policyPath;
+  }
+
   // Check cwd first (worktree-local policies take precedence)
   for (const name of DEFAULT_POLICY_CANDIDATES) {
     if (existsSync(name)) return name;
@@ -114,9 +150,11 @@ function loadPolicyFileTyped(policyPath: string): LoadedPolicy[] {
 
 /**
  * Load policy definitions from a single path (backwards compatible).
+ * When targetPath is provided, walks up from that file to find the nearest policy —
+ * fixing the governance bypass when cwd differs from the project root.
  */
-export function loadPolicyDefs(policyPath?: string): unknown[] {
-  const resolved = policyPath || findDefaultPolicy();
+export function loadPolicyDefs(policyPath?: string, targetPath?: string): unknown[] {
+  const resolved = policyPath || findDefaultPolicy(targetPath);
   return resolved ? loadPolicyFile(resolved) : [];
 }
 

--- a/apps/cli/tests/policy-resolver.test.ts
+++ b/apps/cli/tests/policy-resolver.test.ts
@@ -37,6 +37,7 @@ import {
 
 import {
   findDefaultPolicy,
+  findPolicyForPath,
   findUserPolicy,
   loadPolicyFile,
   loadPolicyDefs,
@@ -65,6 +66,80 @@ describe('findDefaultPolicy', () => {
   it('returns agentguard.yml if agentguard.yaml does not exist but .yml does', () => {
     vi.mocked(existsSync).mockImplementation((p) => p === 'agentguard.yml');
     expect(findDefaultPolicy()).toBe('agentguard.yml');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findPolicyForPath — path-aware policy resolution (global hook bypass fix)
+// ---------------------------------------------------------------------------
+
+describe('findPolicyForPath', () => {
+  // Use resolve() so paths include the drive letter on Windows (e.g., C:\home\...)
+  const projectDir = resolve('/home/user/project');
+  const policyPath = join(projectDir, 'agentguard.yaml');
+
+  it('finds policy in the same directory as the target file', () => {
+    vi.mocked(existsSync).mockImplementation((p) => p === policyPath);
+
+    const result = findPolicyForPath(join(projectDir, '.env'));
+
+    expect(result).toEqual({ policyPath, projectRoot: projectDir });
+  });
+
+  it('walks up directories to find policy', () => {
+    vi.mocked(existsSync).mockImplementation((p) => p === policyPath);
+
+    const result = findPolicyForPath(join(projectDir, 'src', 'deep', 'file.ts'));
+
+    expect(result).toEqual({ policyPath, projectRoot: projectDir });
+  });
+
+  it('returns null when no policy found anywhere up the tree', () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    const result = findPolicyForPath(join(projectDir, 'file.ts'));
+
+    expect(result).toBeNull();
+  });
+
+  it('finds .agentguard.yaml variant', () => {
+    const dotPolicyPath = join(projectDir, '.agentguard.yaml');
+    vi.mocked(existsSync).mockImplementation((p) => p === dotPolicyPath);
+
+    const result = findPolicyForPath(join(projectDir, 'src', 'index.ts'));
+
+    expect(result).toEqual({ policyPath: dotPolicyPath, projectRoot: projectDir });
+  });
+
+  it('prefers agentguard.yaml over agentguard.yml in same directory', () => {
+    const ymlPath = join(projectDir, 'agentguard.yml');
+    vi.mocked(existsSync).mockImplementation((p) => p === policyPath || p === ymlPath);
+
+    const result = findPolicyForPath(join(projectDir, '.env'));
+
+    // agentguard.yaml is checked first in DEFAULT_POLICY_CANDIDATES
+    expect(result?.policyPath).toBe(policyPath);
+  });
+});
+
+describe('findDefaultPolicy with targetPath', () => {
+  const projectDir = resolve('/home/user/project');
+  const policyPath = join(projectDir, 'agentguard.yaml');
+
+  it('uses path-aware resolution when targetPath is provided', () => {
+    vi.mocked(existsSync).mockImplementation((p) => p === policyPath);
+
+    const result = findDefaultPolicy(join(projectDir, 'src', 'auth.ts'));
+
+    expect(result).toBe(policyPath);
+  });
+
+  it('falls back to cwd when targetPath yields no policy', () => {
+    vi.mocked(existsSync).mockImplementation((p) => p === 'agentguard.yaml');
+
+    const result = findDefaultPolicy(resolve('/some/random/file.ts'));
+
+    expect(result).toBe('agentguard.yaml');
   });
 });
 
@@ -220,6 +295,25 @@ describe('loadPolicyDefs', () => {
     const result = loadPolicyDefs();
 
     expect(result).toEqual([]);
+  });
+
+  it('uses targetPath for path-aware resolution when no explicit path given', () => {
+    const projectDir = resolve('/home/user/project');
+    const projectPolicyPath = join(projectDir, 'agentguard.yaml');
+    const yamlContent = 'id: project\nname: Project\nrules: []';
+    const mockPolicy = { id: 'project', name: 'Project', rules: [], severity: 3 };
+
+    vi.mocked(existsSync).mockImplementation(
+      (p) => p === projectPolicyPath || p === resolve(projectPolicyPath)
+    );
+    vi.mocked(readFileSync).mockReturnValue(yamlContent);
+    vi.mocked(loadYamlPolicy).mockReturnValue(mockPolicy as never);
+    vi.mocked(parseYamlPolicy).mockReturnValue({ extends: [] } as never);
+
+    const result = loadPolicyDefs(undefined, join(projectDir, '.env'));
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ id: 'project', name: 'Project', rules: [], severity: 3 });
   });
 });
 

--- a/packages/adapters/src/claude-code.ts
+++ b/packages/adapters/src/claude-code.ts
@@ -37,9 +37,12 @@ export function resolveAgentIdentity(sessionId?: string): string {
  * Normalize file paths for policy matching.
  * Claude Code sends absolute paths (e.g. C:\Users\...\project\.env).
  * Policy rules use relative paths (e.g. .env, .github/workflows/).
- * Convert absolute paths to relative (from cwd) so rules match correctly.
+ * Convert absolute paths to relative (from projectRoot or cwd) so rules match correctly.
+ *
+ * When projectRoot is provided (from path-aware policy resolution), it's used instead of
+ * process.cwd(). This fixes the governance bypass when cwd differs from the project root.
  */
-function normalizeFilePath(filePath: string | undefined): string | undefined {
+function normalizeFilePath(filePath: string | undefined, projectRoot?: string): string | undefined {
   if (!filePath) return filePath;
 
   // Normalize Windows backslashes to forward slashes
@@ -48,10 +51,10 @@ function normalizeFilePath(filePath: string | undefined): string | undefined {
   const isAbsolute = normalized.startsWith('/') || /^[a-zA-Z]:\//.test(normalized);
   if (!isAbsolute) return normalized;
 
-  // Convert to relative path from cwd
-  const cwd = process.cwd().replace(/\\/g, '/');
-  if (normalized.startsWith(cwd + '/')) {
-    return normalized.slice(cwd.length + 1);
+  // Convert to relative path from project root (preferred) or cwd (fallback)
+  const root = (projectRoot || process.cwd()).replace(/\\/g, '/');
+  if (normalized.startsWith(root + '/')) {
+    return normalized.slice(root.length + 1);
   }
 
   // Fallback: use basename so .env still matches regardless of full path
@@ -61,7 +64,8 @@ function normalizeFilePath(filePath: string | undefined): string | undefined {
 
 export function normalizeClaudeCodeAction(
   payload: ClaudeCodeHookPayload,
-  persona?: AgentPersona
+  persona?: AgentPersona,
+  projectRoot?: string
 ): RawAgentAction {
   const input = payload.tool_input || {};
   const agent = resolveAgentIdentity(payload.session_id);
@@ -74,7 +78,7 @@ export function normalizeClaudeCodeAction(
     case 'Write':
       baseAction = {
         tool: 'Write',
-        file: normalizeFilePath(input.file_path as string | undefined),
+        file: normalizeFilePath(input.file_path as string | undefined, projectRoot),
         content: input.content as string | undefined,
         agent,
         metadata: { hook: payload.hook, sessionId: payload.session_id },
@@ -84,7 +88,7 @@ export function normalizeClaudeCodeAction(
     case 'Edit':
       baseAction = {
         tool: 'Edit',
-        file: normalizeFilePath(input.file_path as string | undefined),
+        file: normalizeFilePath(input.file_path as string | undefined, projectRoot),
         content: input.new_string as string | undefined,
         agent,
         metadata: {
@@ -98,7 +102,7 @@ export function normalizeClaudeCodeAction(
     case 'Read':
       baseAction = {
         tool: 'Read',
-        file: normalizeFilePath(input.file_path as string | undefined),
+        file: normalizeFilePath(input.file_path as string | undefined, projectRoot),
         agent,
         metadata: { hook: payload.hook, sessionId: payload.session_id },
       };
@@ -216,9 +220,10 @@ export async function processClaudeCodeHook(
   kernel: Kernel,
   payload: ClaudeCodeHookPayload,
   systemContext: Record<string, unknown> = {},
-  persona?: AgentPersona
+  persona?: AgentPersona,
+  projectRoot?: string
 ): Promise<KernelResult> {
-  const rawAction = normalizeClaudeCodeAction(payload, persona);
+  const rawAction = normalizeClaudeCodeAction(payload, persona, projectRoot);
   return kernel.propose(rawAction, systemContext);
 }
 


### PR DESCRIPTION
When Claude Code runs from a parent directory, process.cwd() doesn't match the governed project root, causing policy discovery to fail silently (fail-open). This allows agents to bypass all governance checks including secret protection and protected branch rules.

Fix: Extract the target file path from hook payloads and walk up the directory tree to find the nearest agentguard.yaml. The discovered project root is also used for file path normalization so policy rules match correctly regardless of working directory.

Changes:
- policy-resolver: add findPolicyForPath() with directory walk-up
- claude-hook: extract target path from payload, pass to policy loader
- claude-code adapter: thread projectRoot through path normalization
- claude-init: suggest --global installation for defense-in-depth