### PR TITLE
docs: sync documentation with codebase state

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -50,7 +50,6 @@ packages/
 ├── invariant-data-protection/ @red-codes/invariant-data-protection — Data protection invariant plugin
 ├── kernel/        @red-codes/kernel — Governed action kernel (orchestrate, normalize, decide, escalate)
 ├── adapters/      @red-codes/adapters — Execution adapters (file, shell, git, claude-code, copilot-cli)
-├── analytics/     @red-codes/analytics — Cross-session violation analytics
 ├── storage/       @red-codes/storage — SQLite storage backend (opt-in)
 ├── telemetry/     @red-codes/telemetry — Runtime telemetry and logging
 ├── plugins/       @red-codes/plugins — Plugin ecosystem (discovery, registry, validation, sandboxing)
@@ -61,8 +60,7 @@ packages/
 apps/
 ├── cli/           @red-codes/agentguard — CLI entry point and commands (published npm package)
 ├── mcp-server/    @red-codes/mcp-server — MCP governance server (14 governance tools)
-├── vscode-extension/  agentguard-vscode — VS Code extension (sidebar panels, notifications, diagnostics)
-└── telemetry-server/  @red-codes/telemetry-server — Telemetry ingestion server (enrollment, batch ingest)
+└── vscode-extension/  agentguard-vscode — VS Code extension (sidebar panels, notifications, diagnostics)
 
 policies/          Policy packs (YAML: ci-safe, engineering-standards, enterprise, hipaa, open-source, soc2, strict)
 ```
@@ -78,8 +76,7 @@ Package boundaries enforce these dependency rules via `package.json` workspace d
 - **@red-codes/adapters** may import from core, kernel only
 - **@red-codes/plugins** may import from core only
 - **@red-codes/renderers** may import from core, kernel, plugins only
-- **@red-codes/analytics** may import from core only
-- **@red-codes/storage** may import from core, events, kernel, analytics, telemetry only
+- **@red-codes/storage** may import from core, events, kernel, telemetry only
 - **@red-codes/agentguard** (cli) may import from all workspace packages
 - **@red-codes/telemetry** may import from core only
 - **@red-codes/core** has no project imports (leaf layer)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ The system has one architectural spine: the **canonical event model**. All syste
 - Each package compiles independently via `tsc`; CLI bundle via `esbuild` in `apps/cli`
 - Scoped npm packages: `@red-codes/*` for workspace modules, `@red-codes/agentguard` for published CLI
 - CLI has runtime dependencies (`chokidar`, `commander`, `pino`); optional `better-sqlite3` for SQLite storage backend
-- Analytics, telemetry, and Firestore packages have been removed from this repo (out of scope for the OSS kernel)
+- Firestore package has been removed from this repo (out of scope for the OSS kernel)
 - Build tooling: Turbo + tsc + esbuild + vitest (dev dependencies only)
 
 ## Quick Start
@@ -144,7 +144,7 @@ apps/
 │   ├── session-store.ts        # Session management
 │   ├── file-event-store.ts     # File-based event persistence
 │   ├── evidence-summary.ts     # Evidence summary generator for PR reports
-│   └── commands/               # guard, inspect, replay, export, import, simulate, ci-check, plugin, policy, policy-verify, claude-hook, claude-init, init, diff, evidence-pr, traces, session-viewer, status, analytics, auto-setup, config, audit-verify, demo, adoption, learn, migrate, trust
+│   └── commands/               # guard, inspect, replay, export, import, simulate, ci-check, plugin, policy, policy-verify, claude-hook, claude-init, copilot-hook, copilot-init, cloud, init, diff, evidence-pr, traces, session-viewer, status, analytics, auto-setup, config, audit-verify, demo, adoption, learn, migrate, trust
 ├── mcp-server/src/             # @red-codes/mcp-server — MCP governance server
 │   ├── index.ts                # Entry point
 │   ├── server.ts               # MCP server implementation
@@ -158,7 +158,7 @@ apps/
 
 tests/
 └── *.test.js               # 14 JS test files (custom zero-dependency harness)
-# 132 TS test files (vitest) distributed across packages/ and apps/ directories
+# 138 TS test files (vitest) distributed across packages/ and apps/ directories
 policy/                     # Policy configuration (JSON: action_rules, capabilities)
 policies/                   # Policy packs (YAML: ci-safe, engineering-standards, enterprise, hipaa, open-source, soc2, strict)
 docs/                       # System documentation (architecture, event model, specs)
@@ -259,6 +259,9 @@ Each workspace package maps to a single architectural concept:
 - `agentguard learn` — Interactive tutorials and learning paths
 - `agentguard migrate` — Migrate configuration between versions
 - `agentguard trust` — Manage policy and hook trust verification
+- `agentguard cloud connect|status|events|runs|summary|disconnect` — Cloud governance analytics
+- `agentguard copilot-hook` — Handle GitHub Copilot PreToolUse/PostToolUse hook events
+- `agentguard copilot-init` — Set up GitHub Copilot hook integration
 
 ### Event Model
 The canonical event model is the architectural spine. Event kinds defined in `packages/events/src/schema.ts`:
@@ -276,6 +279,7 @@ The canonical event model is the architectural spine. Event kinds defined in `pa
 - **Integrity & Trust**: `HookIntegrityVerified`, `HookIntegrityFailed`, `PolicyTrustVerified`, `PolicyTrustDenied`
 - **Adoption Analytics**: `AdoptionAnalyzed`, `AdoptionAnalysisFailed`
 - **Denial Learning**: `DenialPatternDetected`
+- **Intent Drift**: `IntentDriftDetected`
 - **Environmental Enforcement**: `IdeSocketAccessBlocked`
 
 ### Action Classes & Types
@@ -330,7 +334,7 @@ pnpm test --filter=@red-codes/kernel  # Test a single package
 **Test structure:**
 - **Vitest workspace** (`vitest.workspace.ts`): orchestrates tests across all packages
 - **JS tests** (`tests/*.test.js`): 14 files using a custom zero-dependency harness (`tests/run.js` with `node:assert`)
-- **TypeScript tests** (distributed across `packages/*/tests/` and `apps/*/tests/`): 132 files using vitest
+- **TypeScript tests** (distributed across `packages/*/tests/` and `apps/*/tests/`): 138 files using vitest
 - **Coverage areas**: adapters, kernel (AAB, engine, monitor, blast radius, heartbeat, integration, e2e pipeline, conformance), CLI commands (args, guard, inspect, init, simulate, ci-check, claude-hook, claude-init, export/import, policy-validate, policy-verify, diff, evidence-pr, traces, plugin, auto-setup, config), decision records, domain models, events, evidence packs, evidence summary, execution log, export-import roundtrip, impact forecast, invariants, notification formatter, plugins (discovery, registry, sandbox, validation), policy evaluation (including composer, pack loader, policy packs, evaluation trace, forecast conditions), renderers, replay (engine, comparator, processor), simulation, SQLite storage (migrations, session, sink, store, factory), swarm (scaffolder), TUI renderer, violation mapper, VS Code event reader, YAML loading
 
 ## CI/CD & Automation

--- a/README.md
+++ b/README.md
@@ -450,7 +450,6 @@ packages/
 ├── invariant-data-protection/src/ # @red-codes/invariant-data-protection — Data protection invariant plugin
 ├── kernel/src/             # @red-codes/kernel — Governed action kernel (orchestrator, AAB, decisions, simulation)
 ├── adapters/src/           # @red-codes/adapters — Execution adapters (file, shell, git, claude-code)
-├── analytics/src/          # @red-codes/analytics — Cross-session violation analytics
 ├── storage/src/            # @red-codes/storage — SQLite storage backend (opt-in)
 ├── telemetry/src/          # @red-codes/telemetry — Runtime telemetry and logging
 ├── plugins/src/            # @red-codes/plugins — Plugin ecosystem (discovery, registry, sandboxing)
@@ -468,7 +467,6 @@ apps/
 │   ├── extension.ts        # Sidebar panels, file watcher, notifications
 │   ├── providers/          # Tree data providers (run status, run history, recent events)
 │   └── services/           # Event reader, notification formatter, diagnostics, violation mapper
-└── telemetry-server/src/   # @red-codes/telemetry-server — Telemetry ingestion server (enrollment, batch ingest, rate limiting)
 
 crates/
 └── kernel-core/            # Rust kernel (in development)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -60,7 +60,7 @@ A comprehensive codebase audit assessed the current system against the strategic
 | Action Authorization Boundary (AAB) | Implemented (2 bypass vectors) | `packages/kernel/src/aab.ts` |
 | Policy Evaluator (two-phase deny/allow) | Implemented | `packages/policy/src/evaluator.ts` |
 | 21 Built-in Invariants | Fully Implemented | `packages/invariants/src/definitions.ts`, `packages/invariants/src/checker.ts` |
-| Event Model (45 event kinds) | Comprehensive | `packages/events/src/schema.ts` |
+| Event Model (46 event kinds) | Comprehensive | `packages/events/src/schema.ts` |
 | SQLite Persistence | Implemented | `packages/storage/src/sqlite-store.ts` |
 | Simulation Engine (3 simulators + impact forecast) | Fully Implemented | `packages/kernel/src/simulation/` |
 | Blast Radius Computation | Implemented | `packages/kernel/src/blast-radius.ts` |
@@ -104,7 +104,7 @@ A comprehensive codebase audit assessed the current system against the strategic
 | AAB Reference Monitor | Implemented | 1 bypass vector to close (missing-adapter fixed) |
 | Policy Evaluator | Implemented | Production |
 | 21 Built-in Invariants | Fully Implemented | Production |
-| Event Model (45 kinds) | Comprehensive | Production |
+| Event Model (46 kinds) | Comprehensive | Production |
 | Simulation & Forecasting | Fully Implemented | Production |
 | Escalation State Machine | Implemented | Functional (events persisted as StateChanged) |
 | Plugin Sandbox | Implemented | Application-level only |


### PR DESCRIPTION
## Summary

Automated documentation sync detected drift between codebase and docs.

### Drift found and fixed:

**CLAUDE.md:**
- Fixed misleading claim "Analytics, telemetry, and Firestore packages have been removed" — telemetry packages exist; corrected to only mention Firestore
- Updated TypeScript test file count: 132 → 138
- Added missing CLI commands: `cloud`, `copilot-hook`, `copilot-init`
- Added missing `IntentDriftDetected` event kind to Event Model section

**README.md:**
- Removed stale `analytics/src/` listing (directory exists but has no source code or package.json)
- Removed stale `telemetry-server/src/` listing (directory exists but has no source code or package.json)

**ARCHITECTURE.md:**
- Removed stale `analytics/` package from package layout (no source)
- Removed stale `telemetry-server/` app from apps layout (no source)
- Removed stale `@red-codes/analytics` from layer rules (package doesn't exist in workspace)

**ROADMAP.md:**
- Updated event kind count: 45 → 46 (2 instances in Architectural Audit and Maturity Matrix)

### Strategic document staleness check:
- `docs/current-priorities.md` — does not exist (no action needed)
- `docs/strategic-roadmap.md` — does not exist (no action needed)
- No contradictions found between ROADMAP.md and actual source structure

## Changes

- `CLAUDE.md` — corrected removed-package claim, test count, CLI commands, event model
- `README.md` — removed 2 stale package listings from repository structure
- `ARCHITECTURE.md` — removed 2 stale package listings and 1 stale layer rule
- `ROADMAP.md` — updated event kind count (45 → 46)

## Source

Auto-generated by the **Scheduled Docs Sync** skill.

---
*Run: 2026-03-18*