### PR TITLE
feat(kernel): adaptive governance depth — tiered evaluation pipeline

### DIFF
--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -21,3 +21,4 @@ export * from './simulation/dependency-graph-simulator.js';
 export * from './contract.js';
 export * from './enforcement-audit.js';
 export * from './intent.js';
+export * from './tier-router.js';

--- a/packages/kernel/src/kernel.ts
+++ b/packages/kernel/src/kernel.ts
@@ -13,8 +13,11 @@ import type {
   EventSink,
 } from '@red-codes/core';
 import { createMonitor } from './monitor.js';
-import type { MonitorConfig, MonitorDecision } from './monitor.js';
+import type { MonitorConfig, MonitorDecision, MonitorState } from './monitor.js';
 import type { RawAgentAction } from './aab.js';
+import { normalizeIntent } from './aab.js';
+import { createTierRouter } from './tier-router.js';
+import type { EvaluationTier, TierRouterConfig, TierRouter, TierMetrics } from './tier-router.js';
 import {
   createAction,
   getActionClass,
@@ -76,6 +79,8 @@ export interface KernelResult {
   modified?: boolean;
   /** Intent drift results (advisory — present when an IntentSpec is configured) */
   intentDrift?: IntentDriftResult;
+  /** Evaluation tier used for this action (fast/standard/deep) */
+  tier?: EvaluationTier;
 }
 
 /**
@@ -150,6 +155,9 @@ export interface KernelConfig extends MonitorConfig {
    * Advisory mode only — does not block execution.
    */
   intentSpec?: IntentSpec;
+  /** Tier router configuration for adaptive governance depth.
+   *  When provided, enables tiered evaluation (fast/standard/deep). */
+  tierRouterConfig?: TierRouterConfig;
 }
 
 export interface Kernel {
@@ -162,6 +170,8 @@ export interface Kernel {
   getSeed(): number;
   getActionLog(): KernelResult[];
   getEventCount(): number;
+  /** Returns tier evaluation metrics (counts and timings per tier) */
+  getTierMetrics(): TierMetrics | null;
   shutdown(): void;
 }
 
@@ -186,6 +196,9 @@ export function createKernel(config: KernelConfig = {}): Kernel {
   const modifyTimeoutMs = config.modifyTimeoutMs ?? 30_000;
   const tracer = config.tracer ?? null;
   const intentSpec = config.intentSpec ?? null;
+  const tierRouter: TierRouter | null = config.tierRouterConfig
+    ? createTierRouter(config.tierRouterConfig)
+    : null;
   const actionLog: KernelResult[] = [];
   let eventCount = 0;
   let filesModifiedCount = 0;
@@ -222,6 +235,24 @@ export function createKernel(config: KernelConfig = {}): Kernel {
     propose: async (rawAction, systemContext = {}) => {
       const span =
         tracer?.startSpan('kernel.propose', `propose:${rawAction.tool || 'unknown'}`) ?? null;
+
+      // Tier classification — performed before proposalBody so it's available for the wrapper
+      let outerTier: EvaluationTier = 'standard';
+      const outerTierStart = performance.now();
+      if (tierRouter) {
+        const preIntent = normalizeIntent(rawAction);
+        const escalation = monitor.getEscalationLevel();
+        const classification = tierRouter.classify(
+          preIntent.action,
+          preIntent.target,
+          escalation,
+          preIntent.destructive
+        );
+        outerTier = classification.tier;
+        span?.setAttribute('tier', outerTier);
+        span?.setAttribute('tierReason', classification.reason);
+      }
+
       const proposalBody = async (): Promise<KernelResult> => {
         const allEvents: DomainEvent[] = [];
         let wasModified = false;
@@ -236,6 +267,164 @@ export function createKernel(config: KernelConfig = {}): Kernel {
           metadata: { runId, command: rawAction.command, persona: rawAction.persona },
         });
         allEvents.push(requestedEvent);
+
+        // 1b. Tier routing — use outer tier classification for fast-path cache
+        const currentTier = outerTier;
+
+        if (tierRouter && currentTier === 'fast') {
+          const intent = normalizeIntent(rawAction);
+
+          // Fast-path: check cache for previously allowed action signatures
+          {
+            const cached = tierRouter.getCached(intent.action, intent.target);
+            if (cached) {
+              tierRouter.recordTiming('fast', performance.now() - outerTierStart);
+
+              // Construct minimal allow result without full policy evaluation
+              const allowedEvent = createEvent(ACTION_ALLOWED, {
+                actionType: intent.action,
+                target: intent.target,
+                capability: 'fast-path-cache',
+                actionId: undefined,
+                reason: cached.reason,
+                metadata: { runId, tier: 'fast', cacheHitCount: cached.hitCount },
+              });
+              allEvents.push(allowedEvent);
+
+              // Build canonical action for execution
+              let fastAction: CanonicalAction | null = null;
+              try {
+                if (intent.action !== 'unknown') {
+                  fastAction = createAction(intent.action, intent.target, 'kernel-proposed', {
+                    command: rawAction.command,
+                    agent: rawAction.agent,
+                    runId,
+                  });
+                }
+              } catch {
+                // Action creation may fail for unknown types
+              }
+
+              // Execute via adapter if not dry-run
+              let execution: ExecutionResult | null = null;
+              let executionDurationMs: number | null = null;
+              if (!dryRun && fastAction) {
+                const actionClass = getActionClass(fastAction.type);
+                if (actionClass && adapters.has(actionClass)) {
+                  const adapterDecisionRecord: DecisionRecord = {
+                    actionId: fastAction.id,
+                    decision: 'allow',
+                    reason: 'Fast-path cached allow',
+                    timestamp: Date.now(),
+                    policyHash: 'fast-path-cache',
+                  };
+                  const startTime = Date.now();
+                  try {
+                    execution = await adapters.execute(fastAction, adapterDecisionRecord);
+                    executionDurationMs = Date.now() - startTime;
+                    if (execution.success) {
+                      allEvents.push(
+                        createEvent(ACTION_EXECUTED, {
+                          actionType: fastAction.type,
+                          target: fastAction.target,
+                          result: 'success',
+                          actionId: fastAction.id,
+                          duration: executionDurationMs,
+                          metadata: { runId, tier: 'fast' },
+                        })
+                      );
+                    } else {
+                      allEvents.push(
+                        createEvent(ACTION_FAILED, {
+                          actionType: fastAction.type,
+                          target: fastAction.target,
+                          error: execution.error || 'Unknown execution error',
+                          actionId: fastAction.id,
+                          duration: executionDurationMs,
+                          metadata: { runId, tier: 'fast' },
+                        })
+                      );
+                    }
+                  } catch (err) {
+                    executionDurationMs = Date.now() - startTime;
+                    execution = { success: false, error: (err as Error).message };
+                    allEvents.push(
+                      createEvent(ACTION_FAILED, {
+                        actionType: fastAction.type,
+                        target: fastAction.target,
+                        error: (err as Error).message,
+                        actionId: fastAction.id,
+                        duration: executionDurationMs,
+                        metadata: { runId, tier: 'fast' },
+                      })
+                    );
+                  }
+                }
+              }
+
+              sinkEvents(allEvents);
+
+              const fastMonitorState: MonitorState = {
+                escalationLevel: monitor.getEscalationLevel(),
+                totalEvaluations: 0,
+                totalDenials: 0,
+                totalViolations: 0,
+                windowedDenials: 0,
+                windowedViolations: 0,
+              };
+
+              const fastDecision: MonitorDecision = {
+                allowed: true,
+                intent,
+                decision: {
+                  allowed: true,
+                  decision: 'allow',
+                  matchedRule: null,
+                  matchedPolicy: null,
+                  reason: 'Fast-path cached allow',
+                  severity: 0,
+                },
+                violations: [],
+                events: [],
+                evidencePack: null,
+                intervention: null,
+                monitor: fastMonitorState,
+              };
+
+              const decisionRecord = buildDecisionRecord({
+                runId,
+                decision: fastDecision,
+                execution,
+                executionDurationMs,
+                simulation: null,
+              });
+              sinkDecision(decisionRecord);
+
+              const decisionEvent = createEvent(DECISION_RECORDED, {
+                recordId: decisionRecord.recordId,
+                outcome: decisionRecord.outcome,
+                actionType: decisionRecord.action.type,
+                target: decisionRecord.action.target,
+                reason: decisionRecord.reason,
+              });
+              sinkEvent(decisionEvent);
+
+              const result: KernelResult = {
+                allowed: true,
+                executed: execution !== null,
+                decision: fastDecision,
+                execution,
+                action: fastAction,
+                events: allEvents,
+                runId,
+                decisionRecord,
+                tier: 'fast',
+              };
+              actionLog.push(result);
+              return result;
+            }
+          }
+        }
 
         // 2. Evaluate via monitor (AAB → policy → invariants → evidence)
         // `let` because the PAUSE-approved path reassigns: decision = { ...decision, allowed: true }
@@ -744,7 +933,9 @@ export function createKernel(config: KernelConfig = {}): Kernel {
             sinkEvent(simEvent);
 
             // Re-check invariants if simulation reveals elevated risk
+            // Deep tier forces re-check for all simulated actions regardless of threshold
             if (
+              currentTier === 'deep' ||
               simulationResult.blastRadius > blastRadiusThreshold ||
               simulationResult.riskLevel === 'high'
             ) {
@@ -1084,6 +1275,11 @@ export function createKernel(config: KernelConfig = {}): Kernel {
         });
         sinkEvent(decisionEvent);
 
+        // Cache allow for fast-path eligible actions
+        if (tierRouter && currentTier === 'fast' && decision.allowed) {
+          tierRouter.setCached(decision.intent.action, decision.intent.target);
+        }
+
         const result: KernelResult = {
           allowed: true,
           executed: execution !== null,
@@ -1118,6 +1314,13 @@ export function createKernel(config: KernelConfig = {}): Kernel {
             clearTimeout(timer!);
           }
         }
+        // Record tier timing and attach tier to result
+        if (tierRouter) {
+          tierRouter.recordTiming(outerTier, performance.now() - outerTierStart);
+          if (!result.tier) {
+            result = { ...result, tier: outerTier };
+          }
+        }
         span?.setAttribute('outcome', result.allowed ? 'allow' : 'deny');
         span?.end();
         return result;
@@ -1141,6 +1344,10 @@ export function createKernel(config: KernelConfig = {}): Kernel {
 
     getEventCount() {
       return eventCount;
+    },
+
+    getTierMetrics() {
+      return tierRouter ? tierRouter.getMetrics() : null;
     },
 
     shutdown() {

--- a/packages/kernel/src/monitor.ts
+++ b/packages/kernel/src/monitor.ts
@@ -25,7 +25,7 @@ const ESCALATION_NAMES: Record<EscalationLevel, string> = {
   [ESCALATION.LOCKDOWN]: 'LOCKDOWN',
 };
 
-interface MonitorState {
+export interface MonitorState {
   escalationLevel: EscalationLevel;
   totalEvaluations: number;
   totalDenials: number;
@@ -66,6 +66,7 @@ export interface Monitor {
     systemContext?: Record<string, unknown>
   ): MonitorDecision;
   getStatus(): Record<string, unknown>;
+  getEscalationLevel(): EscalationLevel;
   resetEscalation(): void;
 }
 
@@ -235,6 +236,10 @@ export function createMonitor(config: MonitorConfig = {}): Monitor {
           windowedViolations: recentViolations.length,
         },
       };
+    },
+
+    getEscalationLevel() {
+      return escalationLevel;
     },
 
     getStatus() {

--- a/packages/kernel/src/tier-router.ts
+++ b/packages/kernel/src/tier-router.ts
@@ -1,0 +1,267 @@
+// Tiered evaluation pipeline — adaptive governance depth.
+// Classifies actions into fast/standard/deep tiers based on risk profile.
+// Provides a fast-path cache for known-safe action signatures.
+// Pure domain logic. No I/O, no Node.js-specific APIs.
+
+import { BLAST_RADIUS_SENSITIVE_PATTERNS, BLAST_RADIUS_CONFIG_PATTERNS } from '@red-codes/core';
+import type { EscalationLevel } from './monitor.js';
+import { ESCALATION } from './monitor.js';
+
+/** Evaluation depth tier */
+export type EvaluationTier = 'fast' | 'standard' | 'deep';
+
+/** Result of tier classification */
+export interface TierClassification {
+  tier: EvaluationTier;
+  reason: string;
+}
+
+/** Cached allow decision for fast-path tier */
+export interface CachedDecision {
+  allowed: true;
+  reason: string;
+  cachedAt: number;
+  hitCount: number;
+}
+
+/** Per-tier timing metrics */
+export interface TierMetrics {
+  fast: TierTimings;
+  standard: TierTimings;
+  deep: TierTimings;
+}
+
+export interface TierTimings {
+  count: number;
+  totalMs: number;
+  minMs: number;
+  maxMs: number;
+}
+
+/** Configuration for the tier router */
+export interface TierRouterConfig {
+  /** Action types that always use the fast path (default: ['file.read']) */
+  fastPathActions?: string[];
+  /** Action types that always use deep analysis */
+  deepPathActions?: string[];
+  /** Path patterns that force deep analysis (appended to built-in sensitive patterns) */
+  deepPathPatterns?: string[];
+  /** Maximum cache size (default: 1000) */
+  maxCacheSize?: number;
+  /** Cache TTL in milliseconds (default: 300000 = 5 minutes) */
+  cacheTtlMs?: number;
+  /** Injectable clock for testing (default: Date.now) */
+  now?: () => number;
+}
+
+const DEFAULT_FAST_PATH_ACTIONS = ['file.read'];
+const DEFAULT_DEEP_PATH_ACTIONS = [
+  'git.push',
+  'git.reset',
+  'git.merge',
+  'git.branch.delete',
+  'infra.apply',
+  'infra.destroy',
+  'deploy.trigger',
+  'npm.publish',
+];
+
+const DEFAULT_MAX_CACHE_SIZE = 1000;
+const DEFAULT_CACHE_TTL_MS = 300_000; // 5 minutes
+
+/** Normalize a target path into a cacheable pattern (strip numeric/hash suffixes) */
+function normalizeTargetPattern(target: string): string {
+  if (!target) return '';
+  // Replace specific filenames with directory patterns for broader cache hits
+  // e.g., "src/utils/foo.ts" → "src/utils/*.ts"
+  const lastSlash = target.lastIndexOf('/');
+  if (lastSlash >= 0) {
+    const dir = target.slice(0, lastSlash + 1);
+    const ext = target.includes('.') ? target.slice(target.lastIndexOf('.')) : '';
+    return `${dir}*${ext}`;
+  }
+  return target;
+}
+
+/** Build cache key from action type and target pattern */
+function cacheKey(actionType: string, target: string): string {
+  return `${actionType}:${normalizeTargetPattern(target)}`;
+}
+
+/** Check if a target path matches sensitive or config patterns */
+function isSensitivePath(target: string): boolean {
+  if (!target) return false;
+  const lower = target.toLowerCase();
+  return (
+    BLAST_RADIUS_SENSITIVE_PATTERNS.some((p: string) => lower.includes(p)) ||
+    BLAST_RADIUS_CONFIG_PATTERNS.some((p: string) => lower.includes(p))
+  );
+}
+
+export interface TierRouter {
+  /** Classify an action into an evaluation tier */
+  classify(
+    actionType: string,
+    target: string,
+    escalationLevel: EscalationLevel,
+    destructive: boolean
+  ): TierClassification;
+
+  /** Get a cached allow decision for an action (fast-path only) */
+  getCached(actionType: string, target: string): CachedDecision | null;
+
+  /** Cache an allow decision for an action (only 'allow' results are cached) */
+  setCached(actionType: string, target: string): void;
+
+  /** Invalidate the entire cache (e.g., policy or invariant change) */
+  invalidateCache(): void;
+
+  /** Record an evaluation timing for a tier */
+  recordTiming(tier: EvaluationTier, durationMs: number): void;
+
+  /** Get current metrics */
+  getMetrics(): TierMetrics;
+
+  /** Get cache stats */
+  getCacheStats(): { size: number; hits: number; misses: number };
+}
+
+export function createTierRouter(config: TierRouterConfig = {}): TierRouter {
+  const fastPathActions = new Set(config.fastPathActions ?? DEFAULT_FAST_PATH_ACTIONS);
+  const deepPathActions = new Set(config.deepPathActions ?? DEFAULT_DEEP_PATH_ACTIONS);
+  const deepPathPatterns = config.deepPathPatterns ?? [];
+  const maxCacheSize = config.maxCacheSize ?? DEFAULT_MAX_CACHE_SIZE;
+  const cacheTtlMs = config.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
+  const clock = config.now ?? Date.now;
+
+  // LRU-ish cache: Map maintains insertion order, we evict oldest on overflow
+  const cache = new Map<string, CachedDecision>();
+  let cacheHits = 0;
+  let cacheMisses = 0;
+
+  const metrics: TierMetrics = {
+    fast: { count: 0, totalMs: 0, minMs: Infinity, maxMs: 0 },
+    standard: { count: 0, totalMs: 0, minMs: Infinity, maxMs: 0 },
+    deep: { count: 0, totalMs: 0, minMs: Infinity, maxMs: 0 },
+  };
+
+  function matchesDeepPattern(target: string): boolean {
+    if (!target) return false;
+    const lower = target.toLowerCase();
+    return deepPathPatterns.some((p) => lower.includes(p.toLowerCase()));
+  }
+
+  return {
+    classify(actionType, target, escalationLevel, destructive) {
+      // Rule 1: LOCKDOWN → everything is denied by the monitor anyway, deep analysis
+      if (escalationLevel === ESCALATION.LOCKDOWN) {
+        return { tier: 'deep', reason: 'Governance LOCKDOWN — deep analysis required' };
+      }
+
+      // Rule 2: HIGH escalation → force deep for all actions
+      if (escalationLevel === ESCALATION.HIGH) {
+        return { tier: 'deep', reason: 'HIGH escalation — deep analysis required' };
+      }
+
+      // Rule 3: Destructive actions always get deep analysis
+      if (destructive) {
+        return { tier: 'deep', reason: 'Destructive action detected' };
+      }
+
+      // Rule 4: Explicitly configured deep-path actions
+      if (deepPathActions.has(actionType)) {
+        return { tier: 'deep', reason: `Action type '${actionType}' requires deep analysis` };
+      }
+
+      // Rule 5: Sensitive or config paths → deep
+      if (isSensitivePath(target)) {
+        return { tier: 'deep', reason: 'Sensitive or config path detected' };
+      }
+
+      // Rule 6: Custom deep path patterns
+      if (matchesDeepPattern(target)) {
+        return { tier: 'deep', reason: 'Path matches deep analysis pattern' };
+      }
+
+      // Rule 7: ELEVATED escalation → standard (no fast-path)
+      if (escalationLevel === ESCALATION.ELEVATED) {
+        return { tier: 'standard', reason: 'ELEVATED escalation — standard analysis' };
+      }
+
+      // Rule 8: Fast-path eligible actions at NORMAL escalation
+      if (fastPathActions.has(actionType)) {
+        return { tier: 'fast', reason: `Action type '${actionType}' eligible for fast-path` };
+      }
+
+      // Default: standard evaluation
+      return { tier: 'standard', reason: 'Standard evaluation' };
+    },
+
+    getCached(actionType, target) {
+      const key = cacheKey(actionType, target);
+      const entry = cache.get(key);
+
+      if (!entry) {
+        cacheMisses++;
+        return null;
+      }
+
+      // Check TTL
+      if (clock() - entry.cachedAt > cacheTtlMs) {
+        cache.delete(key);
+        cacheMisses++;
+        return null;
+      }
+
+      // Move to end for LRU behavior
+      cache.delete(key);
+      entry.hitCount++;
+      cache.set(key, entry);
+      cacheHits++;
+      return entry;
+    },
+
+    setCached(actionType, target) {
+      const key = cacheKey(actionType, target);
+
+      // Evict oldest if at capacity
+      if (cache.size >= maxCacheSize && !cache.has(key)) {
+        const oldest = cache.keys().next().value;
+        if (oldest !== undefined) {
+          cache.delete(oldest);
+        }
+      }
+
+      cache.set(key, {
+        allowed: true,
+        reason: 'Cached fast-path allow',
+        cachedAt: clock(),
+        hitCount: 0,
+      });
+    },
+
+    invalidateCache() {
+      cache.clear();
+    },
+
+    recordTiming(tier, durationMs) {
+      const t = metrics[tier];
+      t.count++;
+      t.totalMs += durationMs;
+      if (durationMs < t.minMs) t.minMs = durationMs;
+      if (durationMs > t.maxMs) t.maxMs = durationMs;
+    },
+
+    getMetrics() {
+      return {
+        fast: { ...metrics.fast },
+        standard: { ...metrics.standard },
+        deep: { ...metrics.deep },
+      };
+    },
+
+    getCacheStats() {
+      return { size: cache.size, hits: cacheHits, misses: cacheMisses };
+    },
+  };
+}

--- a/packages/kernel/tests/kernel-tiers.test.ts
+++ b/packages/kernel/tests/kernel-tiers.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import { createKernel } from '@red-codes/kernel';
+import type { KernelConfig } from '@red-codes/kernel';
+
+function makeConfig(overrides: Partial<KernelConfig> = {}): KernelConfig {
+  return {
+    dryRun: true,
+    policyDefs: [
+      {
+        id: 'test-policy',
+        name: 'Test Policy',
+        severity: 3,
+        rules: [{ action: '*', effect: 'allow' }],
+      },
+    ],
+    tierRouterConfig: {},
+    ...overrides,
+  };
+}
+
+describe('kernel tier routing integration', () => {
+  it('sets tier=fast for file.read actions with tier router enabled', async () => {
+    const kernel = createKernel(makeConfig());
+    const result = await kernel.propose({ tool: 'Read', file: 'src/index.ts', agent: 'test' });
+
+    expect(result.allowed).toBe(true);
+    expect(result.tier).toBe('fast');
+  });
+
+  it('sets tier=standard for file.write actions', async () => {
+    const kernel = createKernel(makeConfig());
+    const result = await kernel.propose({ tool: 'Write', file: 'src/index.ts', agent: 'test' });
+
+    expect(result.allowed).toBe(true);
+    expect(result.tier).toBe('standard');
+  });
+
+  it('sets tier=deep for git push actions', async () => {
+    const kernel = createKernel(makeConfig());
+    const result = await kernel.propose({
+      tool: 'Bash',
+      command: 'git push origin main',
+      agent: 'test',
+    });
+
+    expect(result.tier).toBe('deep');
+  });
+
+  it('returns fast-path cached result on second identical file.read', async () => {
+    const kernel = createKernel(makeConfig());
+
+    // First call — cache miss, full evaluation
+    const first = await kernel.propose({ tool: 'Read', file: 'src/index.ts', agent: 'test' });
+    expect(first.allowed).toBe(true);
+    expect(first.tier).toBe('fast');
+
+    // Second call — cache hit
+    const second = await kernel.propose({ tool: 'Read', file: 'src/index.ts', agent: 'test' });
+    expect(second.allowed).toBe(true);
+    expect(second.tier).toBe('fast');
+    // The cached result should have 'fast-path-cache' as capability
+    // Event data is spread directly on the DomainEvent object
+    const allowedEvent = second.events.find(
+      (e) =>
+        e.kind === 'ActionAllowed' &&
+        (e as Record<string, unknown>).capability === 'fast-path-cache'
+    );
+    expect(allowedEvent).toBeDefined();
+  });
+
+  it('does not set tier when tierRouterConfig is not provided', async () => {
+    const kernel = createKernel({
+      dryRun: true,
+      policyDefs: [
+        {
+          id: 'test-policy',
+          name: 'Test Policy',
+          severity: 3,
+          rules: [{ action: '*', effect: 'allow' }],
+        },
+      ],
+    });
+    const result = await kernel.propose({ tool: 'Read', file: 'src/index.ts', agent: 'test' });
+
+    expect(result.allowed).toBe(true);
+    expect(result.tier).toBeUndefined();
+  });
+
+  it('returns tier metrics when tier router is configured', async () => {
+    const kernel = createKernel(makeConfig());
+    await kernel.propose({ tool: 'Read', file: 'src/a.ts', agent: 'test' });
+    await kernel.propose({ tool: 'Write', file: 'src/b.ts', agent: 'test' });
+
+    const metrics = kernel.getTierMetrics();
+    expect(metrics).not.toBeNull();
+    expect(metrics!.fast.count).toBe(1);
+    expect(metrics!.standard.count).toBe(1);
+  });
+
+  it('returns null tier metrics when no tier router configured', () => {
+    const kernel = createKernel({ dryRun: true });
+    expect(kernel.getTierMetrics()).toBeNull();
+  });
+
+  it('assigns deep tier to sensitive paths even for file.read', async () => {
+    const kernel = createKernel(makeConfig());
+    const result = await kernel.propose({
+      tool: 'Read',
+      file: '.env.production',
+      agent: 'test',
+    });
+
+    expect(result.tier).toBe('deep');
+  });
+
+  it('sets tier on denied actions', async () => {
+    const kernel = createKernel(
+      makeConfig({
+        policyDefs: [
+          {
+            id: 'strict',
+            name: 'Strict',
+            severity: 5,
+            rules: [{ action: 'file.write', effect: 'deny', reason: 'no writes allowed' }],
+          },
+        ],
+      })
+    );
+    const result = await kernel.propose({ tool: 'Write', file: 'src/x.ts', agent: 'test' });
+
+    expect(result.allowed).toBe(false);
+    expect(result.tier).toBe('standard');
+  });
+});

--- a/packages/kernel/tests/tier-router.test.ts
+++ b/packages/kernel/tests/tier-router.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createTierRouter, ESCALATION } from '@red-codes/kernel';
+import type { TierRouter, EvaluationTier } from '@red-codes/kernel';
+
+describe('tier-router', () => {
+  let router: TierRouter;
+
+  beforeEach(() => {
+    router = createTierRouter();
+  });
+
+  describe('classify', () => {
+    it('classifies file.read as fast tier at NORMAL escalation', () => {
+      const result = router.classify('file.read', 'src/index.ts', ESCALATION.NORMAL, false);
+      expect(result.tier).toBe('fast');
+    });
+
+    it('classifies file.write as standard tier at NORMAL escalation', () => {
+      const result = router.classify('file.write', 'src/index.ts', ESCALATION.NORMAL, false);
+      expect(result.tier).toBe('standard');
+    });
+
+    it('classifies git.push as deep tier', () => {
+      const result = router.classify('git.push', 'main', ESCALATION.NORMAL, false);
+      expect(result.tier).toBe('deep');
+    });
+
+    it('classifies git.reset as deep tier', () => {
+      const result = router.classify('git.reset', '', ESCALATION.NORMAL, false);
+      expect(result.tier).toBe('deep');
+    });
+
+    it('classifies deploy.trigger as deep tier', () => {
+      const result = router.classify('deploy.trigger', 'prod', ESCALATION.NORMAL, false);
+      expect(result.tier).toBe('deep');
+    });
+
+    it('classifies npm.publish as deep tier', () => {
+      const result = router.classify('npm.publish', 'my-package', ESCALATION.NORMAL, false);
+      expect(result.tier).toBe('deep');
+    });
+
+    it('classifies destructive actions as deep tier', () => {
+      const result = router.classify('shell.exec', 'rm -rf /tmp', ESCALATION.NORMAL, true);
+      expect(result.tier).toBe('deep');
+      expect(result.reason).toContain('Destructive');
+    });
+
+    it('classifies sensitive paths as deep tier', () => {
+      const result = router.classify('file.write', '.env.production', ESCALATION.NORMAL, false);
+      expect(result.tier).toBe('deep');
+      expect(result.reason).toContain('Sensitive');
+    });
+
+    it('classifies config paths as deep tier', () => {
+      const result = router.classify('file.write', 'package.json', ESCALATION.NORMAL, false);
+      expect(result.tier).toBe('deep');
+      expect(result.reason).toContain('Sensitive');
+    });
+
+    // Escalation level tests
+    it('forces standard tier for fast-path actions at ELEVATED escalation', () => {
+      const result = router.classify('file.read', 'src/index.ts', ESCALATION.ELEVATED, false);
+      expect(result.tier).toBe('standard');
+    });
+
+    it('forces deep tier at HIGH escalation', () => {
+      const result = router.classify('file.write', 'src/index.ts', ESCALATION.HIGH, false);
+      expect(result.tier).toBe('deep');
+    });
+
+    it('forces deep tier at LOCKDOWN', () => {
+      const result = router.classify('file.read', 'src/index.ts', ESCALATION.LOCKDOWN, false);
+      expect(result.tier).toBe('deep');
+    });
+
+    // Custom configuration
+    it('respects custom fastPathActions', () => {
+      const custom = createTierRouter({ fastPathActions: ['shell.exec'] });
+      const result = custom.classify('shell.exec', 'echo hello', ESCALATION.NORMAL, false);
+      expect(result.tier).toBe('fast');
+    });
+
+    it('respects custom deepPathActions', () => {
+      const custom = createTierRouter({ deepPathActions: ['file.write'] });
+      const result = custom.classify('file.write', 'src/index.ts', ESCALATION.NORMAL, false);
+      expect(result.tier).toBe('deep');
+    });
+
+    it('respects custom deepPathPatterns', () => {
+      const custom = createTierRouter({ deepPathPatterns: ['migrations/'] });
+      const result = custom.classify(
+        'file.write',
+        'db/migrations/001.sql',
+        ESCALATION.NORMAL,
+        false
+      );
+      expect(result.tier).toBe('deep');
+    });
+  });
+
+  describe('fast-path cache', () => {
+    it('returns null for uncached actions', () => {
+      expect(router.getCached('file.read', 'src/index.ts')).toBeNull();
+    });
+
+    it('caches and retrieves allow decisions', () => {
+      router.setCached('file.read', 'src/index.ts');
+      const cached = router.getCached('file.read', 'src/index.ts');
+      expect(cached).not.toBeNull();
+      expect(cached!.allowed).toBe(true);
+    });
+
+    it('normalizes target patterns for broader cache hits', () => {
+      // Setting cache for one file in a directory should hit for another file
+      // with the same extension in the same directory
+      router.setCached('file.read', 'src/utils/foo.ts');
+      const cached = router.getCached('file.read', 'src/utils/bar.ts');
+      expect(cached).not.toBeNull();
+    });
+
+    it('increments hit count on cache hits', () => {
+      router.setCached('file.read', 'src/index.ts');
+      router.getCached('file.read', 'src/index.ts');
+      const second = router.getCached('file.read', 'src/index.ts');
+      expect(second!.hitCount).toBe(2);
+    });
+
+    it('invalidates entire cache', () => {
+      router.setCached('file.read', 'src/index.ts');
+      router.invalidateCache();
+      expect(router.getCached('file.read', 'src/index.ts')).toBeNull();
+    });
+
+    it('expires entries after TTL', () => {
+      let now = 1000;
+      const ttlRouter = createTierRouter({
+        cacheTtlMs: 5000,
+        now: () => now,
+      });
+
+      ttlRouter.setCached('file.read', 'src/index.ts');
+      expect(ttlRouter.getCached('file.read', 'src/index.ts')).not.toBeNull();
+
+      now = 7000; // 6 seconds later, past TTL
+      expect(ttlRouter.getCached('file.read', 'src/index.ts')).toBeNull();
+    });
+
+    it('evicts oldest entries when cache is full', () => {
+      const smallRouter = createTierRouter({ maxCacheSize: 2 });
+
+      // Use different directories so normalized patterns are distinct cache keys
+      smallRouter.setCached('file.read', 'src/utils/a.ts');
+      smallRouter.setCached('file.read', 'src/models/b.ts');
+      smallRouter.setCached('file.read', 'src/services/c.ts');
+
+      // First entry should be evicted, keeping only 2
+      const stats = smallRouter.getCacheStats();
+      expect(stats.size).toBe(2);
+    });
+
+    it('tracks cache hit and miss stats', () => {
+      router.getCached('file.read', 'src/missing.ts'); // miss
+      router.setCached('file.read', 'src/hit.ts');
+      router.getCached('file.read', 'src/hit.ts'); // hit
+
+      const stats = router.getCacheStats();
+      expect(stats.misses).toBe(1);
+      expect(stats.hits).toBe(1);
+    });
+  });
+
+  describe('metrics', () => {
+    it('starts with zero counts', () => {
+      const metrics = router.getMetrics();
+      expect(metrics.fast.count).toBe(0);
+      expect(metrics.standard.count).toBe(0);
+      expect(metrics.deep.count).toBe(0);
+    });
+
+    it('records timing for each tier', () => {
+      router.recordTiming('fast', 0.5);
+      router.recordTiming('standard', 1.2);
+      router.recordTiming('deep', 25.0);
+
+      const metrics = router.getMetrics();
+      expect(metrics.fast.count).toBe(1);
+      expect(metrics.fast.totalMs).toBe(0.5);
+      expect(metrics.fast.minMs).toBe(0.5);
+      expect(metrics.fast.maxMs).toBe(0.5);
+
+      expect(metrics.standard.count).toBe(1);
+      expect(metrics.standard.totalMs).toBe(1.2);
+
+      expect(metrics.deep.count).toBe(1);
+      expect(metrics.deep.totalMs).toBe(25.0);
+    });
+
+    it('tracks min/max across multiple recordings', () => {
+      router.recordTiming('standard', 1.0);
+      router.recordTiming('standard', 0.5);
+      router.recordTiming('standard', 2.0);
+
+      const metrics = router.getMetrics();
+      expect(metrics.standard.count).toBe(3);
+      expect(metrics.standard.totalMs).toBe(3.5);
+      expect(metrics.standard.minMs).toBe(0.5);
+      expect(metrics.standard.maxMs).toBe(2.0);
+    });
+  });
+
+  describe('tier priority', () => {
+    it('destructive overrides fast-path action type', () => {
+      const custom = createTierRouter({ fastPathActions: ['shell.exec'] });
+      const result = custom.classify('shell.exec', 'rm -rf /', ESCALATION.NORMAL, true);
+      expect(result.tier).toBe('deep');
+    });
+
+    it('HIGH escalation overrides fast-path action type', () => {
+      const result = router.classify('file.read', 'src/safe.ts', ESCALATION.HIGH, false);
+      expect(result.tier).toBe('deep');
+    });
+
+    it('LOCKDOWN overrides everything', () => {
+      const result = router.classify('file.read', 'src/safe.ts', ESCALATION.LOCKDOWN, false);
+      expect(result.tier).toBe('deep');
+    });
+
+    it('sensitive path overrides fast-path action type', () => {
+      const result = router.classify('file.read', '.env', ESCALATION.NORMAL, false);
+      expect(result.tier).toBe('deep');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implements a tiered evaluation pipeline (fast/standard/deep) that adapts governance analysis depth based on action risk profile
- Known-safe patterns (e.g., `file.read` on non-sensitive paths) use a cached fast-path for sub-ms evaluation; high-risk actions (destructive, sensitive paths, elevated escalation) get deep analysis with simulation re-checks
- Closes #560

## Changes
- `packages/kernel/src/tier-router.ts` — New module: tier classification logic, fast-path LRU cache with TTL, per-tier timing metrics
- `packages/kernel/src/kernel.ts` — Integrate tier router into `propose()` flow: fast-path cache hit returns early, deep tier forces simulation re-checks, tier metadata on all `KernelResult`s
- `packages/kernel/src/monitor.ts` — Export `MonitorState` interface, add `getEscalationLevel()` method for tier classification
- `packages/kernel/src/index.ts` — Re-export tier-router types
- `packages/kernel/tests/tier-router.test.ts` — 30 tests for tier classification, cache behavior, TTL, eviction, metrics
- `packages/kernel/tests/kernel-tiers.test.ts` — 9 integration tests for kernel tier routing

## Test Plan
- [x] TypeScript build passes (`pnpm build` — 15/15 packages)
- [x] Type-check passes (`pnpm ts:check` — 26/26 tasks)
- [x] All tests pass (`pnpm test` — 30/30 tasks, 692 kernel tests)
- [x] ESLint clean (`pnpm lint` — 14/14 tasks)
- [x] Prettier clean (verified on changed files)

## Risk Assessment

| Metric | Value |
|--------|-------|
| Risk level | low |
| Files changed | 6 (4 source, 2 test) |
| Simulation result | not available |

## Governance Report

| Metric | Count |
|--------|-------|
| Total events | N/A (fail-open, no policy file) |
| Actions allowed | all |
| Actions denied | 0 |
| Policy denials | 0 |
| Invariant violations | 0 |

## Design Notes

### Tier Classification Rules (in priority order)
1. LOCKDOWN → deep (everything denied by monitor anyway)
2. HIGH escalation → deep
3. Destructive actions → deep
4. Deep-path action types (git.push, deploy.trigger, infra.destroy, npm.publish, etc.) → deep
5. Sensitive/config paths (.env, package.json, etc.) → deep
6. Custom deep path patterns → deep
7. ELEVATED escalation → standard (no fast-path)
8. Fast-path action types (file.read) → fast
9. Default → standard

### Fast-Path Cache
- Key: `actionType:normalizedTargetPattern` (directory + extension wildcard)
- Only caches allow decisions (denials always re-evaluate)
- LRU eviction at configurable max size (default: 1000)
- TTL expiry (default: 5 minutes)
- Full invalidation on `invalidateCache()` (call when policy/invariants change)
- Disabled during ELEVATED+ escalation (tier router won't classify as fast)

🤖 Generated with [Claude Code](https://claude.com/claude-code)