### PR TITLE
feat(adapters): add shell privilege profiles

### DIFF
--- a/packages/adapters/src/shell.ts
+++ b/packages/adapters/src/shell.ts
@@ -1,6 +1,7 @@
 // Shell execution adapter — executes shell.exec actions.
 // Node.js adapter. Uses child_process.
-// Includes credential stripping to prevent ambient credential leakage.
+// Includes credential stripping to prevent ambient credential leakage
+// and privilege profiles for command-level access control.
 
 import { exec } from 'node:child_process';
 import type { CanonicalAction } from '@red-codes/core';
@@ -8,6 +9,239 @@ import { INVARIANT_IDE_CONTEXT_ENV_VARS } from '@red-codes/core';
 
 const DEFAULT_TIMEOUT = 30_000;
 const MAX_BUFFER = 1024 * 1024; // 1MB
+
+// ---------------------------------------------------------------------------
+// Privilege Profiles — command-level access control
+// ---------------------------------------------------------------------------
+
+/** Named privilege profile for shell command restrictions. */
+export interface ShellPrivilegeProfile {
+  /** Profile name (e.g., 'readonly', 'developer', 'ci', 'admin'). */
+  readonly name: string;
+  /** Command patterns allowed by this profile. If empty, all commands are allowed. */
+  readonly allow: readonly string[];
+  /** Command patterns denied by this profile. Deny takes precedence over allow. */
+  readonly deny: readonly string[];
+  /** Additional environment variables to strip (beyond credential defaults). */
+  readonly envRestrictions?: readonly string[];
+}
+
+/**
+ * Check whether a command matches a shell privilege pattern.
+ *
+ * Patterns use a simple glob syntax:
+ * - `*` matches any sequence of characters
+ * - A pattern without `*` matches the command prefix at a word boundary
+ *   (e.g., `ls` matches `ls -la` but not `lsof`)
+ */
+export function commandMatchesPattern(command: string, pattern: string): boolean {
+  const cmd = command.trim();
+  const pat = pattern.trim();
+
+  if (pat === '*') return true;
+  if (!cmd || !pat) return false;
+
+  // Escape regex special chars then replace glob * with .*
+  const escaped = pat.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
+
+  // If pattern ends with *, match prefix freely; otherwise require word boundary
+  const suffix = pat.endsWith('*') ? '' : '(?:\\s|$)';
+  const regex = new RegExp(`^${escaped}${suffix}`, 'i');
+
+  return regex.test(cmd);
+}
+
+/**
+ * Error thrown when a command is blocked by a privilege profile.
+ * The kernel will catch this and emit the appropriate governance event.
+ */
+export class ShellProfileViolationError extends Error {
+  readonly profileName: string;
+  readonly command: string;
+
+  constructor(profileName: string, command: string) {
+    super(`Shell privilege profile '${profileName}' denied command: ${command}`);
+    this.name = 'ShellProfileViolationError';
+    this.profileName = profileName;
+    this.command = command;
+  }
+}
+
+/**
+ * Check a command against a privilege profile.
+ * Returns null if the command is allowed, or a reason string if denied.
+ */
+export function checkProfile(command: string, profile: ShellPrivilegeProfile): string | null {
+  // Deny patterns take precedence
+  for (const pattern of profile.deny) {
+    if (commandMatchesPattern(command, pattern)) {
+      return `denied by pattern '${pattern}' in profile '${profile.name}'`;
+    }
+  }
+
+  // If allow list is empty, all non-denied commands are allowed
+  if (profile.allow.length === 0) {
+    return null;
+  }
+
+  // Check if command matches any allow pattern
+  for (const pattern of profile.allow) {
+    if (commandMatchesPattern(command, pattern)) {
+      return null;
+    }
+  }
+
+  return `not in allowlist for profile '${profile.name}'`;
+}
+
+// ---------------------------------------------------------------------------
+// Built-in privilege profiles
+// ---------------------------------------------------------------------------
+
+/** Read-only profile: allows only observation commands, no mutations. */
+export const READONLY_PROFILE: ShellPrivilegeProfile = {
+  name: 'readonly',
+  allow: [
+    // File inspection
+    'ls',
+    'cat',
+    'head',
+    'tail',
+    'wc',
+    'file',
+    'stat',
+    'du',
+    'df',
+    // Output / info
+    'echo',
+    'printf',
+    'pwd',
+    'which',
+    'whoami',
+    'hostname',
+    'date',
+    'uname',
+    // Environment inspection
+    'env',
+    'printenv',
+    // Search
+    'grep',
+    'rg',
+    'find',
+    'tree',
+    'less',
+    'more',
+    // Git read-only
+    'git status*',
+    'git log*',
+    'git diff*',
+    'git show*',
+    'git branch*',
+    'git tag*',
+    'git remote*',
+    'git rev-parse*',
+    'git worktree list*',
+    // Runtime version checks
+    'node --version',
+    'node -v',
+    'npm --version',
+    'npm -v',
+    'pnpm --version',
+    'pnpm -v',
+  ],
+  deny: [],
+};
+
+/** Developer profile: allows build/test/dev work, denies destructive system operations. */
+export const DEVELOPER_PROFILE: ShellPrivilegeProfile = {
+  name: 'developer',
+  allow: [], // empty = allow all except denied
+  deny: [
+    // Destructive git operations
+    'git push --force*',
+    'git push -f*',
+    'git reset --hard*',
+    'git clean -f*',
+    // Dangerous system commands
+    'rm -rf /',
+    'rm -rf ~',
+    'mkfs*',
+    'dd if=*',
+    'shutdown*',
+    'reboot*',
+    'halt*',
+    'poweroff*',
+    'chmod 777*',
+    'fdisk*',
+    'parted*',
+    'format*',
+  ],
+};
+
+/** CI profile: allows build and test commands, denies pushes and installs. */
+export const CI_PROFILE: ShellPrivilegeProfile = {
+  name: 'ci',
+  allow: [
+    // Build tooling
+    'pnpm build*',
+    'pnpm test*',
+    'pnpm lint*',
+    'pnpm format*',
+    'pnpm ts:check*',
+    'npm run*',
+    'npm test*',
+    'npx *',
+    'node *',
+    'tsc*',
+    'esbuild*',
+    'vitest*',
+    'eslint*',
+    'prettier*',
+    // Git read operations
+    'git status*',
+    'git log*',
+    'git diff*',
+    'git show*',
+    'git branch*',
+    'git rev-parse*',
+    // File inspection
+    'ls',
+    'cat',
+    'head',
+    'tail',
+    'echo',
+    'pwd',
+    'grep',
+    'rg',
+    'find',
+  ],
+  deny: [
+    // No pushing in CI profile (CI pushes are handled by the CI system itself)
+    'git push*',
+    // No package installation (frozen lockfile only)
+    'pnpm install*',
+    'npm install*',
+    'yarn install*',
+    'yarn add*',
+    'pnpm add*',
+    'npm i *',
+  ],
+};
+
+/** Admin profile: unrestricted access with no command filtering. */
+export const ADMIN_PROFILE: ShellPrivilegeProfile = {
+  name: 'admin',
+  allow: [],
+  deny: [],
+};
+
+/** Map of built-in profile names to their definitions. */
+export const SHELL_PROFILES: Readonly<Record<string, ShellPrivilegeProfile>> = {
+  readonly: READONLY_PROFILE,
+  developer: DEVELOPER_PROFILE,
+  ci: CI_PROFILE,
+  admin: ADMIN_PROFILE,
+};
 
 /**
  * Default environment variables stripped before spawning child processes.
@@ -75,6 +309,8 @@ export interface ShellAdapterOptions {
   credentials?: CredentialStrippingOptions;
   /** When true, route commands through rtk for token-optimized output. */
   rtkEnabled?: boolean;
+  /** Privilege profile for command-level access control. String selects a built-in profile by name. */
+  profile?: ShellPrivilegeProfile | string;
 }
 
 /** Configuration for credential stripping behavior. */
@@ -97,6 +333,28 @@ export interface ShellResult {
   strippedIdeSockets?: string[];
   /** The original command before rtk rewrite (present only when rtk rewrote the command). */
   originalCommand?: string;
+  /** Active privilege profile name, if one was applied. */
+  profileName?: string;
+}
+
+/**
+ * Resolve a profile option to a ShellPrivilegeProfile.
+ * Accepts a profile object directly or a built-in profile name string.
+ */
+function resolveProfile(
+  profile: ShellPrivilegeProfile | string | undefined
+): ShellPrivilegeProfile | undefined {
+  if (!profile) return undefined;
+  if (typeof profile === 'string') {
+    const resolved = SHELL_PROFILES[profile];
+    if (!resolved) {
+      throw new Error(
+        `Unknown shell privilege profile '${profile}'. Available: ${Object.keys(SHELL_PROFILES).join(', ')}`
+      );
+    }
+    return resolved;
+  }
+  return profile;
 }
 
 /**
@@ -159,7 +417,9 @@ export function createShellAdapter(
   // Support both old (CredentialStrippingOptions) and new (ShellAdapterOptions) signatures
   const isNewOptions =
     optionsOrCredentials &&
-    ('credentials' in optionsOrCredentials || 'rtkEnabled' in optionsOrCredentials);
+    ('credentials' in optionsOrCredentials ||
+      'rtkEnabled' in optionsOrCredentials ||
+      'profile' in optionsOrCredentials);
   const credentialOptions = isNewOptions
     ? ((optionsOrCredentials as ShellAdapterOptions).credentials ?? {})
     : ((optionsOrCredentials as CredentialStrippingOptions) ?? {});
@@ -168,11 +428,23 @@ export function createShellAdapter(
   const rtkEnabled = isNewOptions
     ? ((optionsOrCredentials as ShellAdapterOptions).rtkEnabled ?? envRtk)
     : envRtk;
+  // Resolve privilege profile (string name or object)
+  const resolvedProfile = isNewOptions
+    ? resolveProfile((optionsOrCredentials as ShellAdapterOptions).profile)
+    : undefined;
 
   return async (action: CanonicalAction): Promise<ShellResult> => {
     let command = (action as Record<string, unknown>).command as string | undefined;
     if (!command) {
       throw new Error('shell.exec requires a command');
+    }
+
+    // Enforce privilege profile before any execution
+    if (resolvedProfile) {
+      const violation = checkProfile(command, resolvedProfile);
+      if (violation) {
+        throw new ShellProfileViolationError(resolvedProfile.name, command);
+      }
     }
 
     const timeout =
@@ -195,11 +467,22 @@ export function createShellAdapter(
       }
     }
 
+    // Merge profile env restrictions into credential stripping options
+    const effectiveCredentialOptions = resolvedProfile?.envRestrictions
+      ? {
+          ...credentialOptions,
+          additional: [...(credentialOptions.additional ?? []), ...resolvedProfile.envRestrictions],
+        }
+      : credentialOptions;
+
     const {
       env: sanitizedEnv,
       stripped,
       strippedIdeSockets,
-    } = sanitizeEnvironment(process.env as Record<string, string | undefined>, credentialOptions);
+    } = sanitizeEnvironment(
+      process.env as Record<string, string | undefined>,
+      effectiveCredentialOptions
+    );
 
     return new Promise((resolve, reject) => {
       exec(
@@ -218,6 +501,7 @@ export function createShellAdapter(
             strippedCredentials: stripped.length > 0 ? stripped : undefined,
             strippedIdeSockets: strippedIdeSockets.length > 0 ? strippedIdeSockets : undefined,
             originalCommand,
+            profileName: resolvedProfile?.name,
           });
         }
       );

--- a/packages/adapters/tests/shell-profiles.test.ts
+++ b/packages/adapters/tests/shell-profiles.test.ts
@@ -1,0 +1,401 @@
+// Tests for shell adapter privilege profiles
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('node:child_process', () => ({
+  exec: vi.fn(),
+}));
+
+import {
+  commandMatchesPattern,
+  checkProfile,
+  ShellProfileViolationError,
+  createShellAdapter,
+  READONLY_PROFILE,
+  DEVELOPER_PROFILE,
+  CI_PROFILE,
+  ADMIN_PROFILE,
+  SHELL_PROFILES,
+} from '@red-codes/adapters';
+import type { ShellPrivilegeProfile } from '@red-codes/adapters';
+import { exec } from 'node:child_process';
+import type { CanonicalAction } from '@red-codes/core';
+
+function makeAction(overrides: Record<string, unknown>): CanonicalAction {
+  return {
+    id: 'act_1',
+    type: 'shell.exec',
+    target: '',
+    class: 'shell',
+    justification: 'test',
+    timestamp: Date.now(),
+    fingerprint: 'fp_1',
+    ...overrides,
+  } as CanonicalAction;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// commandMatchesPattern
+// ---------------------------------------------------------------------------
+
+describe('commandMatchesPattern', () => {
+  it('matches exact command', () => {
+    expect(commandMatchesPattern('ls', 'ls')).toBe(true);
+  });
+
+  it('matches command with arguments', () => {
+    expect(commandMatchesPattern('ls -la /tmp', 'ls')).toBe(true);
+  });
+
+  it('does not match partial command name', () => {
+    expect(commandMatchesPattern('lsof', 'ls')).toBe(false);
+  });
+
+  it('matches wildcard *', () => {
+    expect(commandMatchesPattern('anything at all', '*')).toBe(true);
+  });
+
+  it('matches glob with trailing *', () => {
+    expect(commandMatchesPattern('git status -s', 'git status*')).toBe(true);
+  });
+
+  it('matches multi-word prefix', () => {
+    expect(commandMatchesPattern('git push origin main', 'git push')).toBe(true);
+  });
+
+  it('does not match unrelated command', () => {
+    expect(commandMatchesPattern('rm -rf /', 'ls')).toBe(false);
+  });
+
+  it('is case-insensitive', () => {
+    expect(commandMatchesPattern('Git Status', 'git status')).toBe(true);
+  });
+
+  it('handles empty command', () => {
+    expect(commandMatchesPattern('', 'ls')).toBe(false);
+  });
+
+  it('handles empty pattern', () => {
+    expect(commandMatchesPattern('ls', '')).toBe(false);
+  });
+
+  it('trims whitespace', () => {
+    expect(commandMatchesPattern('  ls -la  ', 'ls')).toBe(true);
+  });
+
+  it('matches mid-pattern wildcard', () => {
+    expect(commandMatchesPattern('git push --force origin', 'git push --force*')).toBe(true);
+  });
+
+  it('matches git push -f variant', () => {
+    expect(commandMatchesPattern('git push -f origin main', 'git push -f*')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkProfile
+// ---------------------------------------------------------------------------
+
+describe('checkProfile', () => {
+  it('returns null for allowed command', () => {
+    const profile: ShellPrivilegeProfile = {
+      name: 'test',
+      allow: ['ls', 'cat'],
+      deny: [],
+    };
+    expect(checkProfile('ls -la', profile)).toBeNull();
+  });
+
+  it('returns reason for non-allowed command', () => {
+    const profile: ShellPrivilegeProfile = {
+      name: 'test',
+      allow: ['ls', 'cat'],
+      deny: [],
+    };
+    const result = checkProfile('rm -rf /', profile);
+    expect(result).toContain('not in allowlist');
+    expect(result).toContain('test');
+  });
+
+  it('deny takes precedence over allow', () => {
+    const profile: ShellPrivilegeProfile = {
+      name: 'test',
+      allow: ['git *'],
+      deny: ['git push --force*'],
+    };
+    const result = checkProfile('git push --force origin main', profile);
+    expect(result).toContain('denied by pattern');
+  });
+
+  it('empty allow list means all non-denied allowed', () => {
+    const profile: ShellPrivilegeProfile = {
+      name: 'test',
+      allow: [],
+      deny: ['rm -rf *'],
+    };
+    expect(checkProfile('ls', profile)).toBeNull();
+    expect(checkProfile('git push', profile)).toBeNull();
+    expect(checkProfile('rm -rf /', profile)).toContain('denied');
+  });
+
+  it('admin profile allows everything', () => {
+    expect(checkProfile('rm -rf /', ADMIN_PROFILE)).toBeNull();
+    expect(checkProfile('git push --force', ADMIN_PROFILE)).toBeNull();
+    expect(checkProfile('shutdown now', ADMIN_PROFILE)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Built-in profiles
+// ---------------------------------------------------------------------------
+
+describe('READONLY_PROFILE', () => {
+  it('allows ls', () => {
+    expect(checkProfile('ls -la', READONLY_PROFILE)).toBeNull();
+  });
+
+  it('allows cat', () => {
+    expect(checkProfile('cat README.md', READONLY_PROFILE)).toBeNull();
+  });
+
+  it('allows git status', () => {
+    expect(checkProfile('git status', READONLY_PROFILE)).toBeNull();
+  });
+
+  it('allows git log with flags', () => {
+    expect(checkProfile('git log --oneline -5', READONLY_PROFILE)).toBeNull();
+  });
+
+  it('allows git diff', () => {
+    expect(checkProfile('git diff HEAD~1', READONLY_PROFILE)).toBeNull();
+  });
+
+  it('denies git push', () => {
+    expect(checkProfile('git push origin main', READONLY_PROFILE)).not.toBeNull();
+  });
+
+  it('denies git commit', () => {
+    expect(checkProfile('git commit -m "test"', READONLY_PROFILE)).not.toBeNull();
+  });
+
+  it('denies npm install', () => {
+    expect(checkProfile('npm install express', READONLY_PROFILE)).not.toBeNull();
+  });
+
+  it('denies rm', () => {
+    expect(checkProfile('rm -rf /tmp/test', READONLY_PROFILE)).not.toBeNull();
+  });
+
+  it('allows echo', () => {
+    expect(checkProfile('echo hello', READONLY_PROFILE)).toBeNull();
+  });
+
+  it('allows grep', () => {
+    expect(checkProfile('grep -r "pattern" src/', READONLY_PROFILE)).toBeNull();
+  });
+
+  it('allows node --version', () => {
+    expect(checkProfile('node --version', READONLY_PROFILE)).toBeNull();
+  });
+});
+
+describe('DEVELOPER_PROFILE', () => {
+  it('allows normal commands', () => {
+    expect(checkProfile('pnpm build', DEVELOPER_PROFILE)).toBeNull();
+  });
+
+  it('allows git push (non-force)', () => {
+    expect(checkProfile('git push origin main', DEVELOPER_PROFILE)).toBeNull();
+  });
+
+  it('denies git push --force', () => {
+    expect(checkProfile('git push --force origin main', DEVELOPER_PROFILE)).not.toBeNull();
+  });
+
+  it('denies git push -f', () => {
+    expect(checkProfile('git push -f origin main', DEVELOPER_PROFILE)).not.toBeNull();
+  });
+
+  it('denies git reset --hard', () => {
+    expect(checkProfile('git reset --hard HEAD~1', DEVELOPER_PROFILE)).not.toBeNull();
+  });
+
+  it('denies rm -rf /', () => {
+    expect(checkProfile('rm -rf /', DEVELOPER_PROFILE)).not.toBeNull();
+  });
+
+  it('denies shutdown', () => {
+    expect(checkProfile('shutdown now', DEVELOPER_PROFILE)).not.toBeNull();
+  });
+
+  it('allows npm install', () => {
+    expect(checkProfile('npm install express', DEVELOPER_PROFILE)).toBeNull();
+  });
+});
+
+describe('CI_PROFILE', () => {
+  it('allows pnpm build', () => {
+    expect(checkProfile('pnpm build', CI_PROFILE)).toBeNull();
+  });
+
+  it('allows pnpm test', () => {
+    expect(checkProfile('pnpm test', CI_PROFILE)).toBeNull();
+  });
+
+  it('allows pnpm lint', () => {
+    expect(checkProfile('pnpm lint', CI_PROFILE)).toBeNull();
+  });
+
+  it('allows git status', () => {
+    expect(checkProfile('git status', CI_PROFILE)).toBeNull();
+  });
+
+  it('denies git push', () => {
+    expect(checkProfile('git push origin main', CI_PROFILE)).not.toBeNull();
+  });
+
+  it('denies pnpm install', () => {
+    expect(checkProfile('pnpm install', CI_PROFILE)).not.toBeNull();
+  });
+
+  it('denies npm install', () => {
+    expect(checkProfile('npm install express', CI_PROFILE)).not.toBeNull();
+  });
+
+  it('allows npx commands', () => {
+    expect(checkProfile('npx vitest run', CI_PROFILE)).toBeNull();
+  });
+
+  it('allows node commands', () => {
+    expect(checkProfile('node apps/cli/dist/bin.js guard', CI_PROFILE)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SHELL_PROFILES lookup
+// ---------------------------------------------------------------------------
+
+describe('SHELL_PROFILES', () => {
+  it('contains all four built-in profiles', () => {
+    expect(Object.keys(SHELL_PROFILES)).toEqual(['readonly', 'developer', 'ci', 'admin']);
+  });
+
+  it('maps names to profile objects', () => {
+    expect(SHELL_PROFILES.readonly).toBe(READONLY_PROFILE);
+    expect(SHELL_PROFILES.developer).toBe(DEVELOPER_PROFILE);
+    expect(SHELL_PROFILES.ci).toBe(CI_PROFILE);
+    expect(SHELL_PROFILES.admin).toBe(ADMIN_PROFILE);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ShellProfileViolationError
+// ---------------------------------------------------------------------------
+
+describe('ShellProfileViolationError', () => {
+  it('has correct properties', () => {
+    const err = new ShellProfileViolationError('readonly', 'rm -rf /');
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('ShellProfileViolationError');
+    expect(err.profileName).toBe('readonly');
+    expect(err.command).toBe('rm -rf /');
+    expect(err.message).toContain('readonly');
+    expect(err.message).toContain('rm -rf /');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createShellAdapter with profile
+// ---------------------------------------------------------------------------
+
+describe('createShellAdapter with profile', () => {
+  it('blocks commands denied by profile', async () => {
+    const adapter = createShellAdapter({ profile: 'readonly' });
+    await expect(adapter(makeAction({ command: 'rm -rf /tmp/test' }))).rejects.toThrow(
+      ShellProfileViolationError
+    );
+  });
+
+  it('allows commands matching profile allowlist', async () => {
+    vi.mocked(exec).mockImplementation((_cmd, _opts, cb) => {
+      (cb as (...args: unknown[]) => void)(null, 'output', '');
+      return {} as ReturnType<typeof exec>;
+    });
+
+    const adapter = createShellAdapter({ profile: 'readonly' });
+    const result = await adapter(makeAction({ command: 'ls -la' }));
+    expect(result.stdout).toBe('output');
+    expect(result.profileName).toBe('readonly');
+  });
+
+  it('accepts a profile object directly', async () => {
+    const custom: ShellPrivilegeProfile = {
+      name: 'custom',
+      allow: ['echo *'],
+      deny: [],
+    };
+
+    vi.mocked(exec).mockImplementation((_cmd, _opts, cb) => {
+      (cb as (...args: unknown[]) => void)(null, 'hello', '');
+      return {} as ReturnType<typeof exec>;
+    });
+
+    const adapter = createShellAdapter({ profile: custom });
+    const result = await adapter(makeAction({ command: 'echo hello' }));
+    expect(result.stdout).toBe('hello');
+    expect(result.profileName).toBe('custom');
+  });
+
+  it('throws on unknown profile name', () => {
+    expect(() => createShellAdapter({ profile: 'nonexistent' })).toThrow(
+      /Unknown shell privilege profile/
+    );
+  });
+
+  it('does not enforce profile when not configured', async () => {
+    vi.mocked(exec).mockImplementation((_cmd, _opts, cb) => {
+      (cb as (...args: unknown[]) => void)(null, '', '');
+      return {} as ReturnType<typeof exec>;
+    });
+
+    const adapter = createShellAdapter();
+    const result = await adapter(makeAction({ command: 'rm -rf /tmp/test' }));
+    expect(result.profileName).toBeUndefined();
+  });
+
+  it('merges profile envRestrictions into credential stripping', async () => {
+    vi.mocked(exec).mockImplementation((_cmd, _opts, cb) => {
+      (cb as (...args: unknown[]) => void)(null, '', '');
+      return {} as ReturnType<typeof exec>;
+    });
+
+    const custom: ShellPrivilegeProfile = {
+      name: 'restricted',
+      allow: [],
+      deny: [],
+      envRestrictions: ['MY_SECRET_VAR'],
+    };
+
+    // Set the env var so stripping actually strips it
+    const origVal = process.env.MY_SECRET_VAR;
+    process.env.MY_SECRET_VAR = 'secret-value';
+    try {
+      const adapter = createShellAdapter({ profile: custom });
+      const result = await adapter(makeAction({ command: 'echo test' }));
+      // The env passed to exec should not contain MY_SECRET_VAR
+      const callArgs = vi.mocked(exec).mock.calls[0];
+      const opts = callArgs[1] as { env: Record<string, unknown> };
+      expect(opts.env).not.toHaveProperty('MY_SECRET_VAR');
+      expect(result.profileName).toBe('restricted');
+    } finally {
+      if (origVal === undefined) {
+        delete process.env.MY_SECRET_VAR;
+      } else {
+        process.env.MY_SECRET_VAR = origVal;
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add named privilege profiles (readonly, developer, ci, admin) to the shell adapter for command-level access control
- Profiles define allowlist/denylist command patterns and optional environment variable restrictions
- Closes #184

## Changes
- `packages/adapters/src/shell.ts` — Add `ShellPrivilegeProfile` interface, 4 built-in profiles, `commandMatchesPattern()` glob matching, `checkProfile()` evaluation, `ShellProfileViolationError`, profile resolution, and adapter integration
- `packages/adapters/tests/shell-profiles.test.ts` — 54 tests covering pattern matching, profile evaluation, all built-in profiles, adapter integration, and error handling

## Test Plan
- [x] TypeScript build passes (`pnpm build`)
- [x] Vitest tests pass (`pnpm test` — 188/188 in adapters, 54 new)
- [x] ESLint clean (`pnpm lint`)
- [x] Prettier clean (`pnpm format`)
- [ ] Pre-existing `repo-root.test.ts` failure in `@red-codes/core` (worktree detection — unrelated)

## Risk Assessment

| Metric | Value |
|--------|-------|
| Risk level | low |
| Risk score | 5/100 |
| Blast radius | 2 files (adapters package only) |
| Simulation result | not available |

## Governance Report

| Metric | Count |
|--------|-------|
| Total events | 4 |
| Actions allowed | 1 |
| Actions denied | 0 |
| Policy denials | 0 |
| Invariant violations | 0 |
| Escalation events | 0 |
| Decision records | 0 |

<details>
<summary>Governance details</summary>

**Source**: SQLite storage backend

**Decision Records**: 0 total, 0 denials
**Escalation levels observed**: NORMAL only
**Pre-push simulation**: not available

No governance denials or violations during implementation.

</details>
