### PR TITLE
feat(issue-188): RunManifest YAML format for declarative sessions

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -56,6 +56,7 @@
     "@red-codes/swarm": "workspace:*",
     "@red-codes/telemetry": "workspace:*",
     "@red-codes/telemetry-client": "workspace:*",
-    "@types/better-sqlite3": "^7.6.0"
+    "@types/better-sqlite3": "^7.6.0",
+    "yaml": "^2.7.1"
   }
 }

--- a/apps/cli/src/bin.ts
+++ b/apps/cli/src/bin.ts
@@ -90,11 +90,16 @@ const COMMANDS: Record<string, CommandHelp> = {
         description: 'SQLite database path (default: ~/.agentguard/agentguard.db)',
       },
       { flag: '--no-open', description: 'Do not auto-open session viewer in browser after run' },
+      {
+        flag: '--manifest <file>',
+        description: 'RunManifest YAML file for declarative session configuration',
+      },
     ],
     examples: [
       'agentguard guard',
       'agentguard guard --policy agentguard.yaml',
       'agentguard guard --policy base.yaml --policy overrides.yaml',
+      'agentguard guard --manifest session.yaml',
       'agentguard guard --dry-run',
       'echo \'{"tool":"Bash","command":"rm -rf /"}\' | agentguard guard',
     ],
@@ -565,11 +570,19 @@ async function main() {
       const trace = flags.includes('--trace') || flags.includes('-t');
       const noOpen = flags.includes('--no-open');
 
+      // Parse --manifest flag
+      let manifestPath: string | undefined;
+      const manifestIdx = flags.indexOf('--manifest');
+      if (manifestIdx !== -1 && flags[manifestIdx + 1]) {
+        manifestPath = flags[manifestIdx + 1];
+      }
+
       const { guard } = await import('./commands/guard.js');
       const storageConfig = resolveStorageConfig(flags);
       const code = await guard(args.slice(1), {
         policy: policyFiles.length === 1 ? policyFiles[0] : undefined,
         policies: policyFiles.length > 1 ? policyFiles : undefined,
+        manifest: manifestPath,
         dryRun,
         verbose,
         trace,

--- a/apps/cli/src/commands/guard.ts
+++ b/apps/cli/src/commands/guard.ts
@@ -7,6 +7,7 @@ import { createKernel } from '@red-codes/kernel';
 import type { KernelConfig } from '@red-codes/kernel';
 import { createLiveRegistry } from '@red-codes/adapters';
 import { loadPolicyDefs, loadComposedPolicies, describeComposition } from '../policy-resolver.js';
+import { loadManifestFile } from '../manifest-loader.js';
 import { createSimulatorRegistry } from '@red-codes/kernel';
 import { createGitSimulator } from '@red-codes/kernel';
 import { createFilesystemSimulator } from '@red-codes/kernel';
@@ -34,6 +35,8 @@ export interface GuardOptions {
   policy?: string;
   /** Multiple policy paths for composition */
   policies?: string[];
+  /** Path to a RunManifest YAML file for declarative session configuration */
+  manifest?: string;
   dryRun?: boolean;
   verbose?: boolean;
   trace?: boolean;
@@ -140,6 +143,9 @@ export async function guard(_args: string[], options: GuardOptions = {}): Promis
     }
   }
 
+  // Load manifest if provided
+  const manifest = options.manifest ? loadManifestFile(options.manifest) : undefined;
+
   // Build kernel config
   const kernelConfig: KernelConfig = {
     runId,
@@ -150,6 +156,7 @@ export async function guard(_args: string[], options: GuardOptions = {}): Promis
     sinks: [eventSink, cloudSinks.eventSink],
     decisionSinks: [decisionSink, cloudSinks.decisionSink],
     simulators: simulators.all().length > 0 ? simulators : undefined,
+    manifest,
   };
 
   const kernel = createKernel(kernelConfig);

--- a/apps/cli/src/manifest-loader.ts
+++ b/apps/cli/src/manifest-loader.ts
@@ -1,0 +1,246 @@
+// Manifest loader — parses and validates RunManifest YAML files.
+// Provides declarative session configuration for the governed action runtime.
+
+import { readFileSync } from 'node:fs';
+import { parse as parseYaml } from 'yaml';
+import type {
+  RunManifest,
+  AgentRole,
+  PermissionLevel,
+  CapabilityGrant,
+  ScopeRestriction,
+} from '@red-codes/core';
+
+const VALID_ROLES: readonly AgentRole[] = [
+  'architect',
+  'builder',
+  'tester',
+  'optimizer',
+  'auditor',
+];
+const VALID_PERMISSIONS: readonly PermissionLevel[] = ['read', 'write', 'execute', 'deploy'];
+
+/** Errors encountered during manifest validation */
+export class ManifestValidationError extends Error {
+  constructor(
+    message: string,
+    public readonly errors: readonly string[]
+  ) {
+    super(message);
+    this.name = 'ManifestValidationError';
+  }
+}
+
+/** Parse a YAML string into a validated RunManifest */
+export function parseManifestYaml(content: string): RunManifest {
+  const raw = parseYaml(content) as Record<string, unknown>;
+  if (!raw || typeof raw !== 'object') {
+    throw new ManifestValidationError('Manifest must be a YAML object', [
+      'Parsed content is not an object',
+    ]);
+  }
+  return validateManifest(raw);
+}
+
+/** Load a manifest YAML file from disk and return a validated RunManifest */
+export function loadManifestFile(filePath: string): RunManifest {
+  const content = readFileSync(filePath, 'utf8');
+  try {
+    return parseManifestYaml(content);
+  } catch (err) {
+    if (err instanceof ManifestValidationError) {
+      throw new ManifestValidationError(
+        `Invalid manifest file '${filePath}': ${err.message}`,
+        err.errors
+      );
+    }
+    throw new Error(`Failed to parse manifest file '${filePath}': ${(err as Error).message}`);
+  }
+}
+
+function validateManifest(raw: Record<string, unknown>): RunManifest {
+  const errors: string[] = [];
+
+  // Required: sessionId
+  if (typeof raw.sessionId !== 'string' || raw.sessionId.length === 0) {
+    errors.push("'sessionId' is required and must be a non-empty string");
+  }
+
+  // Required: role
+  if (typeof raw.role !== 'string' || !(VALID_ROLES as readonly string[]).includes(raw.role)) {
+    errors.push(`'role' must be one of: ${VALID_ROLES.join(', ')} (got '${String(raw.role)}')`);
+  }
+
+  // Required: grants (array)
+  if (!Array.isArray(raw.grants)) {
+    errors.push("'grants' is required and must be an array");
+  } else {
+    for (let i = 0; i < raw.grants.length; i++) {
+      const grantErrors = validateGrant(raw.grants[i] as Record<string, unknown>, i);
+      errors.push(...grantErrors);
+    }
+  }
+
+  // Required: scope (object)
+  if (!raw.scope || typeof raw.scope !== 'object' || Array.isArray(raw.scope)) {
+    errors.push("'scope' is required and must be an object");
+  } else {
+    const scopeErrors = validateScope(raw.scope as Record<string, unknown>);
+    errors.push(...scopeErrors);
+  }
+
+  // Optional: description
+  if (raw.description !== undefined && typeof raw.description !== 'string') {
+    errors.push("'description' must be a string if provided");
+  }
+
+  // Optional: maxDurationMs
+  if (raw.maxDurationMs !== undefined) {
+    if (typeof raw.maxDurationMs !== 'number' || raw.maxDurationMs <= 0) {
+      errors.push("'maxDurationMs' must be a positive number if provided");
+    }
+  }
+
+  // Optional: metadata
+  if (raw.metadata !== undefined) {
+    if (typeof raw.metadata !== 'object' || Array.isArray(raw.metadata) || raw.metadata === null) {
+      errors.push("'metadata' must be an object if provided");
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new ManifestValidationError(
+      `Manifest validation failed with ${errors.length} error(s)`,
+      errors
+    );
+  }
+
+  return {
+    sessionId: raw.sessionId as string,
+    role: raw.role as AgentRole,
+    grants: (raw.grants as Record<string, unknown>[]).map(toCapabilityGrant),
+    scope: toScopeRestriction(raw.scope as Record<string, unknown>),
+    ...(raw.description !== undefined && { description: raw.description as string }),
+    ...(raw.maxDurationMs !== undefined && { maxDurationMs: raw.maxDurationMs as number }),
+    ...(raw.metadata !== undefined && { metadata: raw.metadata as Record<string, unknown> }),
+  };
+}
+
+function validateGrant(raw: Record<string, unknown>, index: number): string[] {
+  const errors: string[] = [];
+  const prefix = `grants[${index}]`;
+
+  if (!raw || typeof raw !== 'object') {
+    return [`${prefix} must be an object`];
+  }
+
+  // Required: permissions
+  if (!Array.isArray(raw.permissions) || raw.permissions.length === 0) {
+    errors.push(`${prefix}.permissions is required and must be a non-empty array`);
+  } else {
+    for (const perm of raw.permissions) {
+      if (!(VALID_PERMISSIONS as readonly string[]).includes(perm as string)) {
+        errors.push(
+          `${prefix}.permissions contains invalid value '${String(perm)}' (expected: ${VALID_PERMISSIONS.join(', ')})`
+        );
+      }
+    }
+  }
+
+  // Required: actions
+  if (!Array.isArray(raw.actions) || raw.actions.length === 0) {
+    errors.push(`${prefix}.actions is required and must be a non-empty array`);
+  } else {
+    for (const action of raw.actions) {
+      if (typeof action !== 'string') {
+        errors.push(`${prefix}.actions contains non-string value`);
+      }
+    }
+  }
+
+  // Optional arrays: filePatterns, branchPatterns, commandAllowlist
+  for (const field of ['filePatterns', 'branchPatterns', 'commandAllowlist'] as const) {
+    const val = raw[field];
+    if (val !== undefined) {
+      if (!Array.isArray(val)) {
+        errors.push(`${prefix}.${field} must be an array if provided`);
+      } else {
+        for (const item of val) {
+          if (typeof item !== 'string') {
+            errors.push(`${prefix}.${field} contains non-string value`);
+          }
+        }
+      }
+    }
+  }
+
+  return errors;
+}
+
+function validateScope(raw: Record<string, unknown>): string[] {
+  const errors: string[] = [];
+
+  // Required: allowedPaths
+  if (!Array.isArray(raw.allowedPaths)) {
+    errors.push('scope.allowedPaths is required and must be an array');
+  } else {
+    for (const item of raw.allowedPaths) {
+      if (typeof item !== 'string') {
+        errors.push('scope.allowedPaths contains non-string value');
+      }
+    }
+  }
+
+  // Optional arrays
+  for (const field of [
+    'deniedPaths',
+    'allowedBranches',
+    'deniedBranches',
+    'allowedCommands',
+  ] as const) {
+    const val = raw[field];
+    if (val !== undefined) {
+      if (!Array.isArray(val)) {
+        errors.push(`scope.${field} must be an array if provided`);
+      } else {
+        for (const item of val) {
+          if (typeof item !== 'string') {
+            errors.push(`scope.${field} contains non-string value`);
+          }
+        }
+      }
+    }
+  }
+
+  // Optional: maxBlastRadius
+  if (raw.maxBlastRadius !== undefined) {
+    if (typeof raw.maxBlastRadius !== 'number' || raw.maxBlastRadius < 0) {
+      errors.push('scope.maxBlastRadius must be a non-negative number if provided');
+    }
+  }
+
+  return errors;
+}
+
+function toCapabilityGrant(raw: Record<string, unknown>): CapabilityGrant {
+  return {
+    permissions: raw.permissions as PermissionLevel[],
+    actions: raw.actions as string[],
+    ...(raw.filePatterns !== undefined && { filePatterns: raw.filePatterns as string[] }),
+    ...(raw.branchPatterns !== undefined && { branchPatterns: raw.branchPatterns as string[] }),
+    ...(raw.commandAllowlist !== undefined && {
+      commandAllowlist: raw.commandAllowlist as string[],
+    }),
+  };
+}
+
+function toScopeRestriction(raw: Record<string, unknown>): ScopeRestriction {
+  return {
+    allowedPaths: raw.allowedPaths as string[],
+    ...(raw.deniedPaths !== undefined && { deniedPaths: raw.deniedPaths as string[] }),
+    ...(raw.allowedBranches !== undefined && { allowedBranches: raw.allowedBranches as string[] }),
+    ...(raw.deniedBranches !== undefined && { deniedBranches: raw.deniedBranches as string[] }),
+    ...(raw.allowedCommands !== undefined && { allowedCommands: raw.allowedCommands as string[] }),
+    ...(raw.maxBlastRadius !== undefined && { maxBlastRadius: raw.maxBlastRadius as number }),
+  };
+}

--- a/apps/cli/tests/manifest-loader.test.ts
+++ b/apps/cli/tests/manifest-loader.test.ts
@@ -1,0 +1,344 @@
+// Tests for RunManifest YAML loader
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import {
+  parseManifestYaml,
+  loadManifestFile,
+  ManifestValidationError,
+} from '../src/manifest-loader.js';
+import { writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+// ---------------------------------------------------------------------------
+// parseManifestYaml — valid manifests
+// ---------------------------------------------------------------------------
+
+describe('parseManifestYaml', () => {
+  const minimalYaml = `
+sessionId: test-session
+role: builder
+grants:
+  - permissions:
+      - read
+      - write
+    actions:
+      - "file.*"
+scope:
+  allowedPaths:
+    - "src/**"
+`;
+
+  it('parses a minimal valid manifest', () => {
+    const manifest = parseManifestYaml(minimalYaml);
+    expect(manifest.sessionId).toBe('test-session');
+    expect(manifest.role).toBe('builder');
+    expect(manifest.grants).toHaveLength(1);
+    expect(manifest.grants[0].permissions).toEqual(['read', 'write']);
+    expect(manifest.grants[0].actions).toEqual(['file.*']);
+    expect(manifest.scope.allowedPaths).toEqual(['src/**']);
+  });
+
+  it('parses all optional fields', () => {
+    const yaml = `
+sessionId: full-session
+role: architect
+description: A fully-configured session
+maxDurationMs: 3600000
+grants:
+  - permissions:
+      - read
+      - write
+      - execute
+      - deploy
+    actions:
+      - "file.*"
+      - "git.*"
+    filePatterns:
+      - "src/**"
+    branchPatterns:
+      - "feature/*"
+    commandAllowlist:
+      - "npm test"
+scope:
+  allowedPaths:
+    - "src/**"
+  deniedPaths:
+    - ".env*"
+  allowedBranches:
+    - "feature/*"
+  deniedBranches:
+    - main
+  allowedCommands:
+    - "npm test"
+  maxBlastRadius: 10
+metadata:
+  template: full
+  version: "1.0"
+`;
+    const manifest = parseManifestYaml(yaml);
+    expect(manifest.description).toBe('A fully-configured session');
+    expect(manifest.maxDurationMs).toBe(3600000);
+    expect(manifest.grants[0].permissions).toEqual(['read', 'write', 'execute', 'deploy']);
+    expect(manifest.grants[0].filePatterns).toEqual(['src/**']);
+    expect(manifest.grants[0].branchPatterns).toEqual(['feature/*']);
+    expect(manifest.grants[0].commandAllowlist).toEqual(['npm test']);
+    expect(manifest.scope.deniedPaths).toEqual(['.env*']);
+    expect(manifest.scope.allowedBranches).toEqual(['feature/*']);
+    expect(manifest.scope.deniedBranches).toEqual(['main']);
+    expect(manifest.scope.allowedCommands).toEqual(['npm test']);
+    expect(manifest.scope.maxBlastRadius).toBe(10);
+    expect(manifest.metadata).toEqual({ template: 'full', version: '1.0' });
+  });
+
+  it('parses multiple grants', () => {
+    const yaml = `
+sessionId: multi-grant
+role: tester
+grants:
+  - permissions:
+      - read
+    actions:
+      - file.read
+  - permissions:
+      - execute
+    actions:
+      - test.run
+      - test.run.unit
+scope:
+  allowedPaths:
+    - "**/*"
+`;
+    const manifest = parseManifestYaml(yaml);
+    expect(manifest.grants).toHaveLength(2);
+    expect(manifest.grants[0].actions).toEqual(['file.read']);
+    expect(manifest.grants[1].actions).toEqual(['test.run', 'test.run.unit']);
+  });
+
+  it('accepts all valid agent roles', () => {
+    const roles = ['architect', 'builder', 'tester', 'optimizer', 'auditor'];
+    for (const role of roles) {
+      const yaml = `
+sessionId: role-test
+role: ${role}
+grants:
+  - permissions:
+      - read
+    actions:
+      - file.read
+scope:
+  allowedPaths:
+    - "src/**"
+`;
+      const manifest = parseManifestYaml(yaml);
+      expect(manifest.role).toBe(role);
+    }
+  });
+
+  it('omits undefined optional fields from the result', () => {
+    const manifest = parseManifestYaml(minimalYaml);
+    expect(manifest).not.toHaveProperty('description');
+    expect(manifest).not.toHaveProperty('maxDurationMs');
+    expect(manifest).not.toHaveProperty('metadata');
+    expect(manifest.grants[0]).not.toHaveProperty('filePatterns');
+    expect(manifest.grants[0]).not.toHaveProperty('branchPatterns');
+    expect(manifest.grants[0]).not.toHaveProperty('commandAllowlist');
+    expect(manifest.scope).not.toHaveProperty('deniedPaths');
+    expect(manifest.scope).not.toHaveProperty('allowedBranches');
+    expect(manifest.scope).not.toHaveProperty('deniedBranches');
+    expect(manifest.scope).not.toHaveProperty('allowedCommands');
+    expect(manifest.scope).not.toHaveProperty('maxBlastRadius');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseManifestYaml — validation errors
+// ---------------------------------------------------------------------------
+
+describe('parseManifestYaml validation', () => {
+  it('rejects non-object YAML', () => {
+    expect(() => parseManifestYaml('just a string')).toThrow(ManifestValidationError);
+  });
+
+  it('rejects missing sessionId', () => {
+    const yaml = `
+role: builder
+grants:
+  - permissions: [read]
+    actions: [file.read]
+scope:
+  allowedPaths: ["src/**"]
+`;
+    expect(() => parseManifestYaml(yaml)).toThrow(ManifestValidationError);
+    try {
+      parseManifestYaml(yaml);
+    } catch (err) {
+      expect((err as ManifestValidationError).errors).toContainEqual(
+        expect.stringContaining('sessionId')
+      );
+    }
+  });
+
+  it('rejects invalid role', () => {
+    const yaml = `
+sessionId: test
+role: hacker
+grants:
+  - permissions: [read]
+    actions: [file.read]
+scope:
+  allowedPaths: ["src/**"]
+`;
+    expect(() => parseManifestYaml(yaml)).toThrow(ManifestValidationError);
+    try {
+      parseManifestYaml(yaml);
+    } catch (err) {
+      expect((err as ManifestValidationError).errors).toContainEqual(
+        expect.stringContaining('role')
+      );
+    }
+  });
+
+  it('rejects missing grants', () => {
+    const yaml = `
+sessionId: test
+role: builder
+scope:
+  allowedPaths: ["src/**"]
+`;
+    expect(() => parseManifestYaml(yaml)).toThrow(ManifestValidationError);
+  });
+
+  it('rejects grants with invalid permissions', () => {
+    const yaml = `
+sessionId: test
+role: builder
+grants:
+  - permissions: [admin]
+    actions: [file.read]
+scope:
+  allowedPaths: ["src/**"]
+`;
+    expect(() => parseManifestYaml(yaml)).toThrow(ManifestValidationError);
+    try {
+      parseManifestYaml(yaml);
+    } catch (err) {
+      expect((err as ManifestValidationError).errors).toContainEqual(
+        expect.stringContaining('admin')
+      );
+    }
+  });
+
+  it('rejects grants with empty actions', () => {
+    const yaml = `
+sessionId: test
+role: builder
+grants:
+  - permissions: [read]
+    actions: []
+scope:
+  allowedPaths: ["src/**"]
+`;
+    expect(() => parseManifestYaml(yaml)).toThrow(ManifestValidationError);
+  });
+
+  it('rejects missing scope', () => {
+    const yaml = `
+sessionId: test
+role: builder
+grants:
+  - permissions: [read]
+    actions: [file.read]
+`;
+    expect(() => parseManifestYaml(yaml)).toThrow(ManifestValidationError);
+  });
+
+  it('rejects scope without allowedPaths', () => {
+    const yaml = `
+sessionId: test
+role: builder
+grants:
+  - permissions: [read]
+    actions: [file.read]
+scope:
+  deniedPaths: [".env"]
+`;
+    expect(() => parseManifestYaml(yaml)).toThrow(ManifestValidationError);
+  });
+
+  it('rejects negative maxDurationMs', () => {
+    const yaml = `
+sessionId: test
+role: builder
+maxDurationMs: -100
+grants:
+  - permissions: [read]
+    actions: [file.read]
+scope:
+  allowedPaths: ["src/**"]
+`;
+    expect(() => parseManifestYaml(yaml)).toThrow(ManifestValidationError);
+  });
+
+  it('collects multiple errors in a single throw', () => {
+    const yaml = `
+role: invalid
+grants: not-an-array
+scope: not-an-object
+`;
+    try {
+      parseManifestYaml(yaml);
+      expect.fail('Should have thrown');
+    } catch (err) {
+      const validationErr = err as ManifestValidationError;
+      expect(validationErr.errors.length).toBeGreaterThanOrEqual(3);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadManifestFile
+// ---------------------------------------------------------------------------
+
+describe('loadManifestFile', () => {
+  const tmpDir = join(tmpdir(), 'agentguard-manifest-test-' + Date.now());
+
+  // Setup and teardown
+  beforeAll(() => {
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterAll(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('loads and parses a YAML file from disk', () => {
+    const filePath = join(tmpDir, 'test-manifest.yaml');
+    writeFileSync(
+      filePath,
+      `
+sessionId: file-test
+role: tester
+grants:
+  - permissions: [read, execute]
+    actions: [test.run]
+scope:
+  allowedPaths: ["tests/**"]
+`
+    );
+
+    const manifest = loadManifestFile(filePath);
+    expect(manifest.sessionId).toBe('file-test');
+    expect(manifest.role).toBe('tester');
+  });
+
+  it('throws with file path in error message for invalid files', () => {
+    const filePath = join(tmpDir, 'invalid-manifest.yaml');
+    writeFileSync(filePath, 'role: invalid');
+
+    expect(() => loadManifestFile(filePath)).toThrow('invalid-manifest.yaml');
+  });
+
+  it('throws for non-existent files', () => {
+    expect(() => loadManifestFile(join(tmpDir, 'nonexistent.yaml'))).toThrow();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       '@types/better-sqlite3':
         specifier: ^7.6.0
         version: 7.6.13
+      yaml:
+        specifier: ^2.7.1
+        version: 2.8.2
 
   apps/mcp-server:
     dependencies:

--- a/templates/manifest-ci-only.yaml
+++ b/templates/manifest-ci-only.yaml
@@ -1,0 +1,60 @@
+# RunManifest — CI-Only
+#
+# Minimal permissions for CI pipeline verification.
+# Read files, run tests, check types — no writes, no git mutations.
+#
+# Usage: agentguard guard --manifest manifest-ci-only.yaml
+# Docs:  https://docs.agentguard.dev/manifests
+
+sessionId: ci-session
+role: tester
+description: CI verification session — read and test only, no file writes or git mutations
+
+grants:
+  - permissions:
+      - read
+    actions:
+      - file.read
+    filePatterns:
+      - "**/*"
+
+  - permissions:
+      - execute
+    actions:
+      - test.run
+      - test.run.unit
+      - test.run.integration
+      - shell.exec
+    commandAllowlist:
+      - "npm test"
+      - "npm run test*"
+      - "npm run lint*"
+      - "pnpm test"
+      - "pnpm lint"
+      - "pnpm ts:check"
+      - "vitest run"
+      - "tsc --noEmit"
+
+scope:
+  allowedPaths:
+    - "**/*"
+  deniedPaths:
+    - ".env*"
+    - "**/.env*"
+    - "**/credentials*"
+  allowedCommands:
+    - "npm test"
+    - "npm run test*"
+    - "npm run lint*"
+    - "pnpm test"
+    - "pnpm lint"
+    - "pnpm ts:check"
+    - "vitest run"
+    - "tsc --noEmit"
+  maxBlastRadius: 0
+
+maxDurationMs: 1800000
+
+metadata:
+  template: ci-only
+  version: "1.0"

--- a/templates/manifest-full-dev.yaml
+++ b/templates/manifest-full-dev.yaml
@@ -1,0 +1,81 @@
+# RunManifest — Full Development
+#
+# Grants broad development permissions: file read/write, git operations,
+# shell commands, and test execution. Suitable for feature development
+# with standard guardrails (protected branches, blast radius limits).
+#
+# Usage: agentguard guard --manifest manifest-full-dev.yaml
+# Docs:  https://docs.agentguard.dev/manifests
+
+sessionId: dev-session
+role: builder
+description: Full development session — read, write, test, and commit with standard guardrails
+
+grants:
+  - permissions:
+      - read
+      - write
+    actions:
+      - "file.*"
+    filePatterns:
+      - "src/**"
+      - "packages/**"
+      - "apps/**"
+      - "tests/**"
+
+  - permissions:
+      - read
+      - execute
+    actions:
+      - "git.*"
+    branchPatterns:
+      - "feature/*"
+      - "fix/*"
+      - "agent/*"
+
+  - permissions:
+      - execute
+    actions:
+      - shell.exec
+    commandAllowlist:
+      - "npm test"
+      - "npm run *"
+      - "pnpm *"
+      - "node *"
+      - "tsc *"
+      - "vitest *"
+      - "eslint *"
+      - "prettier *"
+
+  - permissions:
+      - execute
+    actions:
+      - "test.*"
+
+scope:
+  allowedPaths:
+    - "src/**"
+    - "packages/**"
+    - "apps/**"
+    - "tests/**"
+    - "templates/**"
+  deniedPaths:
+    - ".env*"
+    - "**/.env*"
+    - "**/credentials*"
+    - "agentguard.yaml"
+  allowedBranches:
+    - "feature/*"
+    - "fix/*"
+    - "agent/*"
+  deniedBranches:
+    - main
+    - master
+    - production
+  maxBlastRadius: 15
+
+maxDurationMs: 3600000
+
+metadata:
+  template: full-dev
+  version: "1.0"

--- a/templates/manifest-read-only-audit.yaml
+++ b/templates/manifest-read-only-audit.yaml
@@ -1,0 +1,39 @@
+# RunManifest — Read-Only Audit
+#
+# Grants read-only access for auditing and inspection.
+# No file writes, no git operations, no shell commands.
+#
+# Usage: agentguard guard --manifest manifest-read-only-audit.yaml
+# Docs:  https://docs.agentguard.dev/manifests
+
+sessionId: audit-session
+role: auditor
+description: Read-only audit session — inspect code and governance data without side effects
+
+grants:
+  - permissions:
+      - read
+    actions:
+      - file.read
+    filePatterns:
+      - "src/**"
+      - "packages/**"
+      - "apps/**"
+      - "tests/**"
+
+scope:
+  allowedPaths:
+    - "src/**"
+    - "packages/**"
+    - "apps/**"
+    - "tests/**"
+    - "docs/**"
+  deniedPaths:
+    - ".env*"
+    - "**/.env*"
+    - "**/credentials*"
+  maxBlastRadius: 0
+
+metadata:
+  template: read-only-audit
+  version: "1.0"


### PR DESCRIPTION
## Summary
- Implement RunManifest YAML loader for declarative session configuration
- Add `--manifest` CLI flag to `agentguard guard` for loading manifest files at startup
- Closes #188

## Changes
- `apps/cli/src/manifest-loader.ts` — new YAML parser/validator for RunManifest type with detailed error collection
- `apps/cli/src/commands/guard.ts` — add `manifest` field to `GuardOptions`, load manifest file, pass to kernel config
- `apps/cli/src/bin.ts` — parse `--manifest` flag, add to guard command help text
- `apps/cli/package.json` — add `yaml` as devDependency (bundled inline by esbuild)
- `apps/cli/tests/manifest-loader.test.ts` — 18 tests covering parsing, validation, file loading, and error handling
- `templates/manifest-read-only-audit.yaml` — example: read-only audit session (auditor role)
- `templates/manifest-full-dev.yaml` — example: full development session (builder role)
- `templates/manifest-ci-only.yaml` — example: CI verification session (tester role)
- `pnpm-lock.yaml` — updated lockfile

## Test Plan
- [x] TypeScript build passes (`pnpm build`)
- [x] Type-check passes (`pnpm ts:check`)
- [x] Vitest tests pass — 648/648 (`pnpm test`)
- [x] ESLint clean (`pnpm lint`)
- [x] Prettier clean (`pnpm format`)

## Risk Assessment

| Metric | Value |
|--------|-------|
| Risk level | low |
| Risk score | 5/100 |
| Blast radius | 2 (new files + CLI integration) |
| Simulation result | not available |

## Governance Report

| Metric | Count |
|--------|-------|
| Total events | 4 |
| Actions allowed | 1 |
| Actions denied | 0 |
| Policy denials | 0 |
| Invariant violations | 0 |
| Escalation events | 0 |

<details>
<summary>Governance details</summary>

**Source**: SQLite governance database
**Escalation levels observed**: NORMAL only
**Verdict**: All actions passed governance checks. No denials or violations recorded.

</details>