### PR TITLE
fix: ensure stdout flushes before process.exit in PreToolUse hook (#620)

### DIFF
--- a/apps/cli/src/commands/claude-hook.ts
+++ b/apps/cli/src/commands/claude-hook.ts
@@ -315,7 +315,10 @@ async function handlePreToolUse(
   if (!result.allowed) {
     const response = formatHookResponse(result);
     if (response) {
-      process.stdout.write(response);
+      // Wait for stdout to flush before returning — process.exit() can fire
+      // before async writes complete, causing Claude Code to miss the deny
+      // response and treat exit code 2 as a no-op. This fixes #620.
+      await new Promise<void>((resolve) => process.stdout.write(response, () => resolve()));
     }
     return true;
   }


### PR DESCRIPTION
## Summary

Fixes #620. `process.stdout.write()` is async on Windows (and can be on other platforms). When the PreToolUse hook denies an action, it writes the deny JSON to stdout then returns `true`, which triggers `process.exit(2)`. If the exit fires before the write buffer is flushed, Claude Code receives an incomplete or empty response and treats it as exit 0 (allow), silently bypassing governance.

## Root Cause

```typescript
// Before (race condition)
process.stdout.write(response);  // async, may not flush
return true;  // → process.exit(2) fires immediately
```

## Fix

```typescript
// After (wait for flush)
await new Promise<void>((resolve) => 
  process.stdout.write(response, () => resolve())
);
return true;  // → process.exit(2) fires after flush
```

## Test plan

- [ ] `echo '{"tool":"Bash","input":{"command":"git push origin main"}}' | node apps/cli/dist/bin.js claude-hook pre` → exit code 2 with complete JSON on stdout
- [ ] Same test with `rtk git push origin main` → exit code 2
- [ ] Live Claude Code session: attempt `git push origin main` → should be blocked by hook
- [ ] Existing tests pass (`pnpm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)