### PR TITLE
fix(tests): invoke stdout.write callback in mock to prevent CI timeouts

### DIFF
--- a/apps/cli/tests/claude-hook-errors.test.ts
+++ b/apps/cli/tests/claude-hook-errors.test.ts
@@ -10,7 +10,13 @@ beforeEach(() => {
   // Disable cloud telemetry in tests to avoid network-dependent flush delays
   process.env.AGENTGUARD_TELEMETRY = 'off';
   vi.spyOn(process, 'exit').mockImplementation((() => {}) as never);
-  vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+  vi.spyOn(process.stdout, 'write').mockImplementation((...args: unknown[]) => {
+    // Invoke the flush callback if provided — the production code awaits it
+    // (see handlePreToolUse's stdout.write(response, () => resolve()) pattern).
+    const lastArg = args[args.length - 1];
+    if (typeof lastArg === 'function') (lastArg as () => void)();
+    return true;
+  });
   vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
 });
 

--- a/apps/cli/tests/cli-claude-hook.test.ts
+++ b/apps/cli/tests/cli-claude-hook.test.ts
@@ -7,7 +7,11 @@ beforeEach(() => {
   // Disable cloud telemetry in tests to avoid network-dependent flush delays
   process.env.AGENTGUARD_TELEMETRY = 'off';
   vi.spyOn(process, 'exit').mockImplementation((() => {}) as never);
-  vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+  vi.spyOn(process.stdout, 'write').mockImplementation((...args: unknown[]) => {
+    const lastArg = args[args.length - 1];
+    if (typeof lastArg === 'function') (lastArg as () => void)();
+    return true;
+  });
   vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
 });
 


### PR DESCRIPTION
## Summary

- **Root cause**: Commit `1fd4ca9` added `await new Promise(resolve => process.stdout.write(response, () => resolve()))` to ensure deny responses flush before `process.exit(2)`. The test mocks replaced `stdout.write` with `() => true`, which never calls the callback — causing the Promise to hang forever (11 tests timing out at 5000ms each).
- **Fix**: Updated `stdout.write` mock in `claude-hook-errors.test.ts` and `cli-claude-hook.test.ts` to invoke the callback argument when present, matching the real `Writable.write()` contract.
- **Impact**: Unblocks CI `test-and-build` on all open PRs (648/648 tests passing).

## Test plan

- [x] `pnpm test --filter=@red-codes/agentguard -- tests/claude-hook-errors.test.ts` — 27/27 pass (was 16/27)
- [x] `pnpm test --filter=@red-codes/agentguard -- tests/cli-claude-hook.test.ts` — 14/14 pass
- [x] Full suite `pnpm test` — 648/648 pass across 35 test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)