### PR TITLE
chore(release): v2.3.0

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@red-codes/agentguard",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Runtime governance for AI coding agents — CLI",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary
- Version bump to 2.3.0 for Sunday demo
- 33 commits since v2.2.0 including path traversal fix, event mapper expansion, monitor mode, Agent SDK, KE-1 matchers

## After merge
Create a GitHub Release tagged `v2.3.0` to trigger the npm publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)