### PR TITLE
feat(issue-685): KE-2 ActionContext normalization

### DIFF
--- a/packages/adapters/src/claude-code.ts
+++ b/packages/adapters/src/claude-code.ts
@@ -62,6 +62,19 @@ function normalizeFilePath(filePath: string | undefined, projectRoot?: string): 
   return lastSlash >= 0 ? normalized.slice(lastSlash + 1) : normalized;
 }
 
+/**
+ * Detect if running inside a git worktree and return the worktree path.
+ * Returns undefined if not in a worktree or if detection fails.
+ */
+function detectWorktree(projectRoot?: string): string | undefined {
+  const root = projectRoot || process.cwd();
+  // Git worktrees typically live under .claude/worktrees/ or .git/worktrees/
+  const normalized = root.replace(/\\/g, '/');
+  const worktreeMatch = normalized.match(/[/\\]\.claude[/\\]worktrees[/\\]([^/\\]+)/);
+  if (worktreeMatch) return normalized;
+  return undefined;
+}
+
 export function normalizeClaudeCodeAction(
   payload: ClaudeCodeHookPayload,
   persona?: AgentPersona,
@@ -72,6 +85,10 @@ export function normalizeClaudeCodeAction(
   const envPersona = personaFromEnv();
   const resolvedPersona = persona || (envPersona as AgentPersona | undefined);
 
+  // KE-2: Capture context-enrichment fields for ActionContext construction in the AAB
+  const timestamp = Date.now();
+  const worktree = detectWorktree(projectRoot);
+
   let baseAction: RawAgentAction;
 
   switch (payload.tool_name) {
@@ -81,7 +98,7 @@ export function normalizeClaudeCodeAction(
         file: normalizeFilePath(input.file_path as string | undefined, projectRoot),
         content: input.content as string | undefined,
         agent,
-        metadata: { hook: payload.hook, sessionId: payload.session_id },
+        metadata: { hook: payload.hook, sessionId: payload.session_id, timestamp, worktree },
       };
       break;
 
@@ -95,6 +112,8 @@ export function normalizeClaudeCodeAction(
           hook: payload.hook,
           old_string: input.old_string,
           sessionId: payload.session_id,
+          timestamp,
+          worktree,
         },
       };
       break;
@@ -104,7 +123,7 @@ export function normalizeClaudeCodeAction(
         tool: 'Read',
         file: normalizeFilePath(input.file_path as string | undefined, projectRoot),
         agent,
-        metadata: { hook: payload.hook, sessionId: payload.session_id },
+        metadata: { hook: payload.hook, sessionId: payload.session_id, timestamp, worktree },
       };
       break;
 
@@ -120,6 +139,8 @@ export function normalizeClaudeCodeAction(
           timeout: input.timeout,
           description: input.description,
           sessionId: payload.session_id,
+          timestamp,
+          worktree,
         },
       };
       break;
@@ -130,7 +151,13 @@ export function normalizeClaudeCodeAction(
         tool: 'Glob',
         target: input.pattern as string | undefined,
         agent,
-        metadata: { hook: payload.hook, path: input.path, sessionId: payload.session_id },
+        metadata: {
+          hook: payload.hook,
+          path: input.path,
+          sessionId: payload.session_id,
+          timestamp,
+          worktree,
+        },
       };
       break;
 
@@ -139,7 +166,13 @@ export function normalizeClaudeCodeAction(
         tool: 'Grep',
         target: input.pattern as string | undefined,
         agent,
-        metadata: { hook: payload.hook, path: input.path, sessionId: payload.session_id },
+        metadata: {
+          hook: payload.hook,
+          path: input.path,
+          sessionId: payload.session_id,
+          timestamp,
+          worktree,
+        },
       };
       break;
 
@@ -148,7 +181,13 @@ export function normalizeClaudeCodeAction(
         tool: 'NotebookEdit',
         file: input.notebook_path as string | undefined,
         agent,
-        metadata: { hook: payload.hook, cell_id: input.cell_id, sessionId: payload.session_id },
+        metadata: {
+          hook: payload.hook,
+          cell_id: input.cell_id,
+          sessionId: payload.session_id,
+          timestamp,
+          worktree,
+        },
       };
       break;
 
@@ -156,7 +195,13 @@ export function normalizeClaudeCodeAction(
       baseAction = {
         tool: 'TodoWrite',
         agent,
-        metadata: { hook: payload.hook, todos: input.todos, sessionId: payload.session_id },
+        metadata: {
+          hook: payload.hook,
+          todos: input.todos,
+          sessionId: payload.session_id,
+          timestamp,
+          worktree,
+        },
       };
       break;
 
@@ -165,7 +210,13 @@ export function normalizeClaudeCodeAction(
         tool: 'WebFetch',
         target: input.url as string | undefined,
         agent,
-        metadata: { hook: payload.hook, prompt: input.prompt, sessionId: payload.session_id },
+        metadata: {
+          hook: payload.hook,
+          prompt: input.prompt,
+          sessionId: payload.session_id,
+          timestamp,
+          worktree,
+        },
       };
       break;
 
@@ -174,7 +225,13 @@ export function normalizeClaudeCodeAction(
         tool: 'WebSearch',
         target: input.query as string | undefined,
         agent,
-        metadata: { hook: payload.hook, query: input.query, sessionId: payload.session_id },
+        metadata: {
+          hook: payload.hook,
+          query: input.query,
+          sessionId: payload.session_id,
+          timestamp,
+          worktree,
+        },
       };
       break;
 
@@ -183,7 +240,13 @@ export function normalizeClaudeCodeAction(
         tool: 'Agent',
         target: (input.prompt as string | undefined)?.slice(0, 100),
         agent,
-        metadata: { hook: payload.hook, prompt: input.prompt, sessionId: payload.session_id },
+        metadata: {
+          hook: payload.hook,
+          prompt: input.prompt,
+          sessionId: payload.session_id,
+          timestamp,
+          worktree,
+        },
       };
       break;
 
@@ -197,6 +260,8 @@ export function normalizeClaudeCodeAction(
           skill: input.skill,
           args: input.args,
           sessionId: payload.session_id,
+          timestamp,
+          worktree,
         },
       };
       break;
@@ -205,7 +270,7 @@ export function normalizeClaudeCodeAction(
       baseAction = {
         tool: payload.tool_name,
         agent,
-        metadata: { hook: payload.hook, input, sessionId: payload.session_id },
+        metadata: { hook: payload.hook, input, sessionId: payload.session_id, timestamp, worktree },
       };
       break;
   }

--- a/packages/adapters/tests/claude-code-adapter.test.ts
+++ b/packages/adapters/tests/claude-code-adapter.test.ts
@@ -350,3 +350,66 @@ describe('formatHookResponse', () => {
     expect(parsed.hookSpecificOutput.permissionDecisionReason).toContain('Destructive command');
   });
 });
+
+describe('KE-2: ActionContext enrichment in Claude Code adapter', () => {
+  it('includes timestamp in metadata for all tool types', () => {
+    const before = Date.now();
+    const payload: ClaudeCodeHookPayload = {
+      hook: 'PreToolUse',
+      tool_name: 'Write',
+      tool_input: { file_path: 'src/test.ts', content: 'hello' },
+      session_id: 'sess-ke2',
+    };
+    const action = normalizeClaudeCodeAction(payload);
+    const after = Date.now();
+
+    expect(action.metadata).toBeDefined();
+    expect(action.metadata!.timestamp).toBeGreaterThanOrEqual(before);
+    expect(action.metadata!.timestamp).toBeLessThanOrEqual(after);
+    expect(action.metadata!.sessionId).toBe('sess-ke2');
+  });
+
+  it('includes worktree in metadata when in a worktree directory', () => {
+    const worktreePath = '/project/.claude/worktrees/my-branch';
+    const payload: ClaudeCodeHookPayload = {
+      hook: 'PreToolUse',
+      tool_name: 'Bash',
+      tool_input: { command: 'echo hello' },
+    };
+    const action = normalizeClaudeCodeAction(payload, undefined, worktreePath);
+
+    expect(action.metadata).toBeDefined();
+    expect(action.metadata!.worktree).toBe(worktreePath.replace(/\\/g, '/'));
+  });
+
+  it('sets worktree to undefined when not in a worktree directory', () => {
+    const payload: ClaudeCodeHookPayload = {
+      hook: 'PreToolUse',
+      tool_name: 'Read',
+      tool_input: { file_path: 'src/index.ts' },
+    };
+    const action = normalizeClaudeCodeAction(payload, undefined, '/normal/project');
+
+    expect(action.metadata).toBeDefined();
+    expect(action.metadata!.worktree).toBeUndefined();
+  });
+
+  it('enriches all tool types with timestamp and worktree', () => {
+    const tools = ['Write', 'Edit', 'Read', 'Bash', 'Glob', 'Grep', 'WebFetch', 'WebSearch', 'Agent', 'Skill', 'TodoWrite', 'NotebookEdit'];
+    const worktreePath = '/repo/.claude/worktrees/test';
+
+    for (const toolName of tools) {
+      const payload: ClaudeCodeHookPayload = {
+        hook: 'PreToolUse',
+        tool_name: toolName,
+        tool_input: toolName === 'Bash' ? { command: 'ls' } : { file_path: 'x' },
+        session_id: 'sess-all',
+      };
+      const action = normalizeClaudeCodeAction(payload, undefined, worktreePath);
+
+      expect(action.metadata?.timestamp, `${toolName} should have timestamp`).toBeDefined();
+      expect(typeof action.metadata?.timestamp).toBe('number');
+      expect(action.metadata?.sessionId, `${toolName} should have sessionId`).toBe('sess-all');
+    }
+  });
+});

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -831,6 +831,88 @@ export interface AgentPersona {
   readonly tags?: readonly string[];
 }
 
+// ---------------------------------------------------------------------------
+// KE-2: ActionContext — Vendor-Neutral Action Representation
+// ---------------------------------------------------------------------------
+
+/**
+ * Actor identity — who is performing the action.
+ * Vendor-neutral: works for Claude Code, Copilot, LangGraph, or any runtime.
+ */
+export interface ActionActor {
+  /** Resolved agent identity (e.g., 'claude-code:abc123') */
+  readonly agentId: string;
+  /** Raw session identifier from the runtime */
+  readonly sessionId?: string;
+  /** Git worktree path if running in a worktree */
+  readonly worktree?: string;
+}
+
+/**
+ * Action classification — what kind of action is being performed.
+ * Maps provider-specific tool names to canonical action types.
+ */
+export interface ActionClassification {
+  /** Canonical action type (e.g., 'file.write', 'git.push', 'shell.exec') */
+  readonly type: string;
+  /** Action class category (file, git, shell, npm, etc.) */
+  readonly category: ActionClass;
+  /** Original tool name before normalization (e.g., 'Write', 'Bash') */
+  readonly originalTool?: string;
+}
+
+/**
+ * Structured action arguments — tool-agnostic representation of action parameters.
+ * Decouples policy evaluation from provider-specific payload shapes.
+ */
+export interface ActionArguments {
+  /** Primary target (file path, branch name, URL, command text, etc.) */
+  readonly target: string;
+  /** Shell command text (for shell.exec actions) */
+  readonly command?: string;
+  /** Git branch (for git actions) */
+  readonly branch?: string;
+}
+
+/**
+ * Environment snapshot captured at action time.
+ * Provides situational awareness for context-sensitive policy rules.
+ */
+export interface ActionEnvironment {
+  /** Working directory at action time */
+  readonly workingDirectory?: string;
+  /** Repository root path */
+  readonly repoRoot?: string;
+  /** Currently checked-out git branch */
+  readonly currentBranch?: string;
+  /** Timestamp (ms since epoch) when the action was captured */
+  readonly timestamp?: number;
+}
+
+/**
+ * ActionContext — the vendor-neutral action representation contract (KE-2).
+ *
+ * Decouples the policy engine from provider-specific payloads.
+ * All runtime adapters (Claude Code, Copilot, LangGraph) produce ActionContext
+ * through their normalization layer. The policy engine consumes only this contract.
+ *
+ * Structure:
+ * - actor: who is performing the action
+ * - action: what kind of action (canonical type + class)
+ * - args: structured, tool-agnostic arguments
+ * - environment: optional situational context
+ */
+export interface ActionContext {
+  /** Actor identity (agent, session, worktree) */
+  readonly actor: ActionActor;
+  /** Normalized action classification */
+  readonly action: ActionClassification;
+  /** Structured, tool-agnostic arguments */
+  readonly args: ActionArguments;
+  /** Environment snapshot at action time */
+  readonly environment?: ActionEnvironment;
+}
+
 /** Raw agent action before normalization */
 export interface RawAgentAction {
   readonly tool?: string;
@@ -853,6 +935,8 @@ export interface NormalizedIntent {
   readonly filesAffected?: number;
   readonly persona?: AgentPersona;
   readonly destructive: boolean;
+  /** KE-2: Vendor-neutral action context for cross-runtime policy evaluation */
+  readonly context?: ActionContext;
 }
 
 /** AAB authorization result */

--- a/packages/kernel/src/aab.ts
+++ b/packages/kernel/src/aab.ts
@@ -2,7 +2,13 @@
 // The central gatekeeper in the Runtime Assurance Architecture.
 // Pure domain logic. No DOM, no Node.js-specific APIs.
 
-import type { DomainEvent, AgentPersona, CompiledDestructivePattern } from '@red-codes/core';
+import type {
+  DomainEvent,
+  AgentPersona,
+  CompiledDestructivePattern,
+  ActionContext,
+  ActionClass,
+} from '@red-codes/core';
 import {
   TOOL_ACTION_MAP_DATA,
   DESTRUCTIVE_PATTERNS_DATA,
@@ -108,6 +114,32 @@ function extractBranch(command: string | undefined): string | null {
   return match ? match[1] : null;
 }
 
+/** Valid action class prefixes derived from canonical action types. */
+const KNOWN_CLASSES = new Set<string>([
+  'file',
+  'test',
+  'git',
+  'shell',
+  'npm',
+  'http',
+  'deploy',
+  'infra',
+  'mcp',
+]);
+
+/**
+ * Derive the ActionClass from a canonical action type string.
+ * e.g., 'file.write' → 'file', 'git.push' → 'git', 'mcp.call' → 'shell' (fallback).
+ */
+function deriveActionClass(actionType: string): ActionClass {
+  const prefix = actionType.split('.')[0] || '';
+  if (KNOWN_CLASSES.has(prefix) && prefix !== 'mcp') {
+    return prefix as ActionClass;
+  }
+  // MCP calls and unknown types fall back to 'shell' as the closest class
+  return 'shell';
+}
+
 export function normalizeIntent(rawAction: RawAgentAction | null): NormalizedIntent {
   if (!rawAction || typeof rawAction !== 'object') {
     return { action: 'unknown', target: '', agent: 'unknown', destructive: false };
@@ -139,16 +171,42 @@ export function normalizeIntent(rawAction: RawAgentAction | null): NormalizedInt
     }
   }
 
+  const agent = rawAction.agent || 'unknown';
+  const branch = rawAction.branch || extractBranch(rawAction.command) || undefined;
+
+  // KE-2: Build vendor-neutral ActionContext
+  const context: ActionContext = {
+    actor: {
+      agentId: agent,
+      sessionId: (rawAction.metadata?.sessionId as string) || undefined,
+      worktree: (rawAction.metadata?.worktree as string) || undefined,
+    },
+    action: {
+      type: action,
+      category: deriveActionClass(action),
+      originalTool: tool || undefined,
+    },
+    args: {
+      target,
+      command: rawAction.command || undefined,
+      branch,
+    },
+    environment: rawAction.metadata?.timestamp
+      ? { timestamp: rawAction.metadata.timestamp as number }
+      : undefined,
+  };
+
   return {
     action,
     target,
-    agent: rawAction.agent || 'unknown',
-    branch: rawAction.branch || extractBranch(rawAction.command) || undefined,
+    agent,
+    branch,
     command: rawAction.command || undefined,
     filesAffected: rawAction.filesAffected || undefined,
     metadata: rawAction.metadata || undefined,
     persona: rawAction.persona || undefined,
     destructive: action === 'shell.exec' && isDestructiveCommand(rawAction.command || ''),
+    context,
   };
 }
 

--- a/packages/kernel/tests/action-context-benchmark.test.ts
+++ b/packages/kernel/tests/action-context-benchmark.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeIntent } from '@red-codes/kernel';
+import type { RawAgentAction } from '@red-codes/kernel';
+
+describe('KE-2: ActionContext normalization benchmark', () => {
+  it('normalizes intent (including ActionContext) within 100µs at p50', () => {
+    const raw: RawAgentAction = {
+      tool: 'Write',
+      file: 'src/components/Button.tsx',
+      content: 'export const Button = () => <button>Click</button>;',
+      agent: 'claude-code:session-abc123',
+      persona: { trustTier: 'standard', role: 'developer' },
+      filesAffected: 1,
+      metadata: {
+        hook: 'PreToolUse',
+        sessionId: 'sess-benchmark-001',
+        worktree: '/project/.claude/worktrees/feature-branch',
+        timestamp: Date.now(),
+      },
+    };
+
+    // Warm up (JIT compilation, V8 optimization)
+    for (let i = 0; i < 100; i++) {
+      normalizeIntent(raw);
+    }
+
+    // Measure
+    const iterations = 1000;
+    const durations: number[] = [];
+
+    for (let i = 0; i < iterations; i++) {
+      const start = performance.now();
+      normalizeIntent(raw);
+      const end = performance.now();
+      durations.push((end - start) * 1000); // Convert to µs
+    }
+
+    durations.sort((a, b) => a - b);
+    const p50 = durations[Math.floor(iterations * 0.5)]!;
+    const p95 = durations[Math.floor(iterations * 0.95)]!;
+    const p99 = durations[Math.floor(iterations * 0.99)]!;
+
+    // SLO: p50 < 100µs
+    expect(p50).toBeLessThan(100);
+
+    // Log for visibility (won't fail tests but useful for CI reporting)
+    console.log(
+      `ActionContext normalization: p50=${p50.toFixed(1)}µs, p95=${p95.toFixed(1)}µs, p99=${p99.toFixed(1)}µs`
+    );
+  });
+
+  it('normalizes git action (Bash → git.push) within 100µs at p50', () => {
+    const raw: RawAgentAction = {
+      tool: 'Bash',
+      command: 'git push origin feature-branch',
+      agent: 'claude-code:session-def456',
+      metadata: { sessionId: 'sess-git-001', timestamp: Date.now() },
+    };
+
+    // Warm up
+    for (let i = 0; i < 100; i++) {
+      normalizeIntent(raw);
+    }
+
+    const iterations = 1000;
+    const durations: number[] = [];
+
+    for (let i = 0; i < iterations; i++) {
+      const start = performance.now();
+      normalizeIntent(raw);
+      const end = performance.now();
+      durations.push((end - start) * 1000);
+    }
+
+    durations.sort((a, b) => a - b);
+    const p50 = durations[Math.floor(iterations * 0.5)]!;
+
+    expect(p50).toBeLessThan(100);
+
+    console.log(`Git action normalization: p50=${p50.toFixed(1)}µs`);
+  });
+});

--- a/packages/kernel/tests/action-context.test.ts
+++ b/packages/kernel/tests/action-context.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeIntent } from '@red-codes/kernel';
+import type { RawAgentAction } from '@red-codes/kernel';
+
+describe('KE-2: ActionContext normalization', () => {
+  describe('normalizeIntent builds ActionContext', () => {
+    it('produces context for a file.write action', () => {
+      const raw: RawAgentAction = {
+        tool: 'Write',
+        file: 'src/index.ts',
+        agent: 'claude-code:abc',
+        metadata: { sessionId: 'sess-123', worktree: '/tmp/wt' },
+      };
+      const intent = normalizeIntent(raw);
+
+      expect(intent.context).toBeDefined();
+      expect(intent.context!.actor.agentId).toBe('claude-code:abc');
+      expect(intent.context!.actor.sessionId).toBe('sess-123');
+      expect(intent.context!.actor.worktree).toBe('/tmp/wt');
+      expect(intent.context!.action.type).toBe('file.write');
+      expect(intent.context!.action.category).toBe('file');
+      expect(intent.context!.action.originalTool).toBe('Write');
+      expect(intent.context!.args.target).toBe('src/index.ts');
+    });
+
+    it('produces context for a git.push action via Bash', () => {
+      const raw: RawAgentAction = {
+        tool: 'Bash',
+        command: 'git push origin main',
+        agent: 'claude-code:def',
+        metadata: { sessionId: 'sess-456' },
+      };
+      const intent = normalizeIntent(raw);
+
+      expect(intent.context).toBeDefined();
+      expect(intent.context!.action.type).toBe('git.push');
+      expect(intent.context!.action.category).toBe('git');
+      expect(intent.context!.action.originalTool).toBe('Bash');
+      expect(intent.context!.args.branch).toBe('main');
+      expect(intent.context!.args.command).toBe('git push origin main');
+    });
+
+    it('produces context for shell.exec (non-git)', () => {
+      const raw: RawAgentAction = {
+        tool: 'Bash',
+        command: 'npm install lodash',
+        agent: 'copilot:xyz',
+      };
+      const intent = normalizeIntent(raw);
+
+      expect(intent.context).toBeDefined();
+      expect(intent.context!.action.type).toBe('shell.exec');
+      expect(intent.context!.action.category).toBe('shell');
+      expect(intent.context!.args.command).toBe('npm install lodash');
+    });
+
+    it('produces context for http.request via WebFetch', () => {
+      const raw: RawAgentAction = {
+        tool: 'WebFetch',
+        target: 'https://example.com/api',
+        agent: 'agent-1',
+      };
+      const intent = normalizeIntent(raw);
+
+      expect(intent.context).toBeDefined();
+      expect(intent.context!.action.type).toBe('http.request');
+      expect(intent.context!.action.category).toBe('http');
+      expect(intent.context!.args.target).toBe('https://example.com/api');
+    });
+
+    it('produces context for MCP tool calls', () => {
+      const raw: RawAgentAction = {
+        tool: 'mcp__scheduled-tasks__create_scheduled_task',
+        agent: 'claude-code:ghi',
+      };
+      const intent = normalizeIntent(raw);
+
+      expect(intent.context).toBeDefined();
+      expect(intent.context!.action.type).toBe('mcp.call');
+      // MCP calls fall back to shell class
+      expect(intent.context!.action.category).toBe('shell');
+      expect(intent.context!.action.originalTool).toBe(
+        'mcp__scheduled-tasks__create_scheduled_task'
+      );
+    });
+
+    it('handles null/undefined rawAction gracefully', () => {
+      const intent = normalizeIntent(null);
+      expect(intent.action).toBe('unknown');
+      expect(intent.context).toBeUndefined();
+    });
+
+    it('defaults agent to unknown when not provided', () => {
+      const raw: RawAgentAction = { tool: 'Read', file: 'test.ts' };
+      const intent = normalizeIntent(raw);
+
+      expect(intent.context).toBeDefined();
+      expect(intent.context!.actor.agentId).toBe('unknown');
+      expect(intent.context!.actor.sessionId).toBeUndefined();
+    });
+
+    it('captures worktree from metadata', () => {
+      const raw: RawAgentAction = {
+        tool: 'Write',
+        file: 'src/foo.ts',
+        agent: 'a',
+        metadata: { worktree: '/project/.claude/worktrees/my-branch' },
+      };
+      const intent = normalizeIntent(raw);
+
+      expect(intent.context!.actor.worktree).toBe('/project/.claude/worktrees/my-branch');
+    });
+
+    it('captures environment timestamp from metadata', () => {
+      const ts = 1711029600000;
+      const raw: RawAgentAction = {
+        tool: 'Read',
+        file: 'readme.md',
+        agent: 'a',
+        metadata: { timestamp: ts },
+      };
+      const intent = normalizeIntent(raw);
+
+      expect(intent.context!.environment).toBeDefined();
+      expect(intent.context!.environment!.timestamp).toBe(ts);
+    });
+  });
+
+  describe('backward compatibility', () => {
+    it('preserves all existing NormalizedIntent fields', () => {
+      const raw: RawAgentAction = {
+        tool: 'Write',
+        file: 'src/app.ts',
+        command: undefined,
+        agent: 'claude-code:test',
+        persona: { trustTier: 'standard', role: 'developer' },
+        filesAffected: 3,
+        metadata: { sessionId: 'sess-1' },
+      };
+      const intent = normalizeIntent(raw);
+
+      expect(intent.action).toBe('file.write');
+      expect(intent.target).toBe('src/app.ts');
+      expect(intent.agent).toBe('claude-code:test');
+      expect(intent.persona).toEqual({ trustTier: 'standard', role: 'developer' });
+      expect(intent.filesAffected).toBe(3);
+      expect(intent.metadata).toEqual({ sessionId: 'sess-1' });
+      expect(intent.destructive).toBe(false);
+      // context is additive — doesn't affect existing fields
+      expect(intent.context).toBeDefined();
+    });
+  });
+});

--- a/packages/policy/src/evaluator.ts
+++ b/packages/policy/src/evaluator.ts
@@ -1,7 +1,7 @@
 // Policy evaluator — matches actions against loaded policies.
 // Pure domain logic. No DOM, no Node.js-specific APIs.
 
-import type { AgentPersona } from '@red-codes/core';
+import type { AgentPersona, ActionContext, ActionClass } from '@red-codes/core';
 import { PolicyMatcher } from '@red-codes/matchers';
 
 export interface PersonaCondition {
@@ -71,6 +71,8 @@ export interface PolicyRule {
     requireFormat?: boolean;
     persona?: PersonaCondition;
     forecast?: ForecastCondition;
+    /** KE-2: Match against vendor-neutral ActionContext fields */
+    context?: ContextCondition;
   };
   reason?: string;
   /** Optional intervention type override for deny rules. When set, the kernel uses this
@@ -99,6 +101,22 @@ export interface LoadedPolicy {
   pack?: string;
 }
 
+/**
+ * Context-based policy condition (KE-2) — evaluates against the vendor-neutral
+ * ActionContext attached to the intent. Allows cross-runtime policy rules such as
+ * "deny if actor is from an untrusted worktree" or "allow only file actions".
+ */
+export interface ContextCondition {
+  /** Match when actor's agentId contains one of these substrings */
+  agentId?: string[];
+  /** Match when action category is one of these */
+  category?: ActionClass[];
+  /** Match when original tool name is one of these */
+  originalTool?: string[];
+  /** Match when running in a worktree (true) or not (false) */
+  inWorktree?: boolean;
+}
+
 export interface NormalizedIntent {
   action: string;
   target: string;
@@ -111,6 +129,8 @@ export interface NormalizedIntent {
   /** Impact forecast data from simulation, used for predictive policy rules */
   forecast?: IntentForecast;
   destructive: boolean;
+  /** KE-2: Vendor-neutral action context for cross-runtime policy evaluation */
+  context?: ActionContext;
 }
 
 /** Evaluation result for a single rule against an intent */
@@ -129,6 +149,8 @@ export interface RuleEvaluation {
     forecastMatched?: boolean;
     /** Actual vs. threshold values for each evaluated forecast field */
     forecastValues?: ForecastMatchValues;
+    /** KE-2: Whether the ActionContext condition matched */
+    contextMatched?: boolean;
   };
   outcome: 'match' | 'no-match' | 'skipped';
 }
@@ -183,6 +205,7 @@ interface ConditionMatchResult {
   personaMatched?: boolean;
   forecastMatched?: boolean;
   forecastValues?: ForecastMatchValues;
+  contextMatched?: boolean;
 }
 
 function matchPersonaCondition(
@@ -270,6 +293,33 @@ function matchForecastCondition(
   return { matched: true, values };
 }
 
+function matchContextCondition(
+  contextCond: ContextCondition,
+  context: ActionContext | undefined
+): boolean {
+  if (!context) return false;
+
+  if (contextCond.agentId && contextCond.agentId.length > 0) {
+    if (!contextCond.agentId.some((id) => context.actor.agentId.includes(id))) return false;
+  }
+
+  if (contextCond.category && contextCond.category.length > 0) {
+    if (!contextCond.category.includes(context.action.category)) return false;
+  }
+
+  if (contextCond.originalTool && contextCond.originalTool.length > 0) {
+    if (!context.action.originalTool) return false;
+    if (!contextCond.originalTool.includes(context.action.originalTool)) return false;
+  }
+
+  if (contextCond.inWorktree !== undefined) {
+    const isInWorktree = !!context.actor.worktree;
+    if (contextCond.inWorktree !== isInWorktree) return false;
+  }
+
+  return true;
+}
+
 function matchConditions(
   conditions: PolicyRule['conditions'],
   intent: NormalizedIntent
@@ -349,6 +399,23 @@ function matchConditions(
     }
   }
 
+  let contextMatched: boolean | undefined;
+  if (conditions.context) {
+    contextMatched = matchContextCondition(conditions.context, intent.context);
+    if (!contextMatched) {
+      return {
+        matched: false,
+        scopeMatched,
+        limitExceeded,
+        branchMatched,
+        personaMatched,
+        forecastMatched,
+        forecastValues,
+        contextMatched,
+      };
+    }
+  }
+
   return {
     matched: true,
     scopeMatched,
@@ -357,6 +424,7 @@ function matchConditions(
     personaMatched,
     forecastMatched,
     forecastValues,
+    contextMatched,
   };
 }
 
@@ -387,6 +455,7 @@ function createRuleEval(
           personaMatched: conditionResult.personaMatched,
           forecastMatched: conditionResult.forecastMatched,
           forecastValues: conditionResult.forecastValues,
+          contextMatched: conditionResult.contextMatched,
         }
       : {},
     outcome,
@@ -564,4 +633,10 @@ export function evaluate(
   };
 }
 
-export { matchAction, matchScope, matchPersonaCondition, matchForecastCondition };
+export {
+  matchAction,
+  matchScope,
+  matchPersonaCondition,
+  matchForecastCondition,
+  matchContextCondition,
+};

--- a/packages/policy/tests/evaluator-context.test.ts
+++ b/packages/policy/tests/evaluator-context.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect } from 'vitest';
+import { evaluate, matchContextCondition } from '@red-codes/policy';
+import type { NormalizedIntent, LoadedPolicy, ContextCondition } from '@red-codes/policy';
+import type { ActionContext } from '@red-codes/core';
+
+function makeContext(overrides: Partial<ActionContext> = {}): ActionContext {
+  return {
+    actor: { agentId: 'claude-code:abc123', ...overrides.actor },
+    action: { type: 'file.write', category: 'file', originalTool: 'Write', ...overrides.action },
+    args: { target: 'src/index.ts', ...overrides.args },
+    ...overrides,
+  };
+}
+
+function makeIntent(overrides: Partial<NormalizedIntent> = {}): NormalizedIntent {
+  return {
+    action: 'file.write',
+    target: 'src/index.ts',
+    agent: 'claude-code:abc123',
+    destructive: false,
+    context: makeContext(),
+    ...overrides,
+  };
+}
+
+function makePolicy(rules: LoadedPolicy['rules']): LoadedPolicy {
+  return {
+    id: 'test-policy',
+    name: 'Test Policy',
+    rules,
+    severity: 3,
+  };
+}
+
+describe('KE-2: ActionContext policy conditions', () => {
+  describe('matchContextCondition', () => {
+    it('returns false when context is undefined', () => {
+      const cond: ContextCondition = { agentId: ['claude-code'] };
+      expect(matchContextCondition(cond, undefined)).toBe(false);
+    });
+
+    it('matches agentId by substring', () => {
+      const ctx = makeContext();
+      expect(matchContextCondition({ agentId: ['claude-code'] }, ctx)).toBe(true);
+      expect(matchContextCondition({ agentId: ['copilot'] }, ctx)).toBe(false);
+    });
+
+    it('matches action category', () => {
+      const ctx = makeContext();
+      expect(matchContextCondition({ category: ['file'] }, ctx)).toBe(true);
+      expect(matchContextCondition({ category: ['git', 'shell'] }, ctx)).toBe(false);
+    });
+
+    it('matches originalTool', () => {
+      const ctx = makeContext();
+      expect(matchContextCondition({ originalTool: ['Write'] }, ctx)).toBe(true);
+      expect(matchContextCondition({ originalTool: ['Bash'] }, ctx)).toBe(false);
+    });
+
+    it('matches inWorktree=true when worktree is set', () => {
+      const ctx = makeContext({ actor: { agentId: 'a', worktree: '/tmp/wt' } });
+      expect(matchContextCondition({ inWorktree: true }, ctx)).toBe(true);
+      expect(matchContextCondition({ inWorktree: false }, ctx)).toBe(false);
+    });
+
+    it('matches inWorktree=false when worktree is not set', () => {
+      const ctx = makeContext({ actor: { agentId: 'a' } });
+      expect(matchContextCondition({ inWorktree: false }, ctx)).toBe(true);
+      expect(matchContextCondition({ inWorktree: true }, ctx)).toBe(false);
+    });
+
+    it('matches with all conditions combined', () => {
+      const ctx = makeContext({
+        actor: { agentId: 'claude-code:xyz', worktree: '/wt' },
+        action: { type: 'file.write', category: 'file', originalTool: 'Write' },
+      });
+      expect(
+        matchContextCondition(
+          { agentId: ['claude-code'], category: ['file'], originalTool: ['Write'], inWorktree: true },
+          ctx
+        )
+      ).toBe(true);
+    });
+
+    it('fails when any sub-condition fails', () => {
+      const ctx = makeContext({
+        actor: { agentId: 'claude-code:xyz' },
+        action: { type: 'file.write', category: 'file', originalTool: 'Write' },
+      });
+      // agentId matches but category does not
+      expect(
+        matchContextCondition({ agentId: ['claude-code'], category: ['git'] }, ctx)
+      ).toBe(false);
+    });
+  });
+
+  describe('evaluate with context conditions', () => {
+    it('denies when context condition matches a deny rule', () => {
+      const intent = makeIntent({
+        context: makeContext({
+          action: { type: 'file.write', category: 'file', originalTool: 'Write' },
+        }),
+      });
+      const policy = makePolicy([
+        {
+          action: 'file.write',
+          effect: 'deny',
+          conditions: {
+            context: { originalTool: ['Write'] },
+          },
+          reason: 'Write tool blocked by context rule',
+        },
+      ]);
+
+      const result = evaluate(intent, [policy]);
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe('Write tool blocked by context rule');
+    });
+
+    it('allows when context condition matches an allow rule', () => {
+      const intent = makeIntent({
+        context: makeContext({
+          actor: { agentId: 'claude-code:trusted' },
+        }),
+      });
+      const policy = makePolicy([
+        {
+          action: 'file.*',
+          effect: 'allow',
+          conditions: {
+            context: { agentId: ['claude-code'] },
+          },
+          reason: 'Claude Code agents allowed for file ops',
+        },
+      ]);
+
+      const result = evaluate(intent, [policy]);
+      expect(result.allowed).toBe(true);
+      expect(result.reason).toBe('Claude Code agents allowed for file ops');
+    });
+
+    it('skips rule when context condition does not match', () => {
+      const intent = makeIntent({
+        context: makeContext({
+          actor: { agentId: 'copilot:session1' },
+        }),
+      });
+      const policy = makePolicy([
+        {
+          action: 'file.*',
+          effect: 'deny',
+          conditions: {
+            context: { agentId: ['claude-code'] },
+          },
+          reason: 'Only blocks Claude agents',
+        },
+        {
+          action: '*',
+          effect: 'allow',
+          reason: 'Default allow',
+        },
+      ]);
+
+      const result = evaluate(intent, [policy]);
+      expect(result.allowed).toBe(true);
+    });
+
+    it('denies worktree-only actions when not in a worktree', () => {
+      const intent = makeIntent({
+        action: 'git.push',
+        context: makeContext({
+          actor: { agentId: 'agent-1' },
+          action: { type: 'git.push', category: 'git' },
+        }),
+      });
+      const policy = makePolicy([
+        {
+          action: 'git.push',
+          effect: 'deny',
+          conditions: {
+            context: { inWorktree: false },
+          },
+          reason: 'Push only allowed from worktrees',
+        },
+        {
+          action: '*',
+          effect: 'allow',
+        },
+      ]);
+
+      const result = evaluate(intent, [policy]);
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe('Push only allowed from worktrees');
+    });
+
+    it('records contextMatched in evaluation trace', () => {
+      const intent = makeIntent({
+        context: makeContext({
+          action: { type: 'file.write', category: 'file', originalTool: 'Write' },
+        }),
+      });
+      const policy = makePolicy([
+        {
+          action: 'file.write',
+          effect: 'deny',
+          conditions: {
+            context: { category: ['file'] },
+          },
+          reason: 'denied',
+        },
+      ]);
+
+      const result = evaluate(intent, [policy]);
+      expect(result.trace).toBeDefined();
+      const matchedRule = result.trace!.rulesEvaluated.find((r) => r.outcome === 'match');
+      expect(matchedRule).toBeDefined();
+      expect(matchedRule!.conditionDetails.contextMatched).toBe(true);
+    });
+
+    it('works without context (backward compatibility)', () => {
+      const intent: NormalizedIntent = {
+        action: 'file.write',
+        target: 'src/app.ts',
+        agent: 'test',
+        destructive: false,
+        // No context field
+      };
+      const policy = makePolicy([
+        {
+          action: 'file.*',
+          effect: 'allow',
+          reason: 'Allowed',
+        },
+      ]);
+
+      const result = evaluate(intent, [policy]);
+      expect(result.allowed).toBe(true);
+    });
+
+    it('denies when context is missing but context condition is set', () => {
+      const intent: NormalizedIntent = {
+        action: 'file.write',
+        target: 'src/app.ts',
+        agent: 'test',
+        destructive: false,
+        // No context — rule with context condition should not match
+      };
+      const policy = makePolicy([
+        {
+          action: 'file.*',
+          effect: 'allow',
+          conditions: {
+            context: { agentId: ['claude-code'] },
+          },
+          reason: 'Only for Claude',
+        },
+      ]);
+
+      // Allow rule with context condition won't match (no context) → default deny
+      const result = evaluate(intent, [policy]);
+      expect(result.allowed).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implements the vendor-neutral `ActionContext` contract that decouples the policy engine from provider-specific payloads (KE-2)
- Adds `ActionContext` to the normalization pipeline: Claude Code adapter → AAB → policy evaluator
- Closes #685

## Changes
- `packages/core/src/types.ts` — Define `ActionContext`, `ActionActor`, `ActionClassification`, `ActionArguments`, `ActionEnvironment` types; add `context?: ActionContext` to `NormalizedIntent`
- `packages/kernel/src/aab.ts` — Build `ActionContext` in `normalizeIntent()` from raw action fields (actor identity, action classification, structured args, environment)
- `packages/adapters/src/claude-code.ts` — Enrich all tool normalizations with `timestamp` and `worktree` metadata for ActionContext construction
- `packages/policy/src/evaluator.ts` — Add `ContextCondition` type and `matchContextCondition()` for context-aware policy rules (`agentId`, `category`, `originalTool`, `inWorktree`); add `context?: ActionContext` to evaluator's `NormalizedIntent`
- `packages/kernel/tests/action-context.test.ts` — 10 tests for AAB ActionContext building
- `packages/kernel/tests/action-context-benchmark.test.ts` — Performance SLO validation (p50 < 100µs)
- `packages/policy/tests/evaluator-context.test.ts` — 14 tests for context-based policy conditions
- `packages/adapters/tests/claude-code-adapter.test.ts` — 4 tests for adapter context enrichment

## Test Plan
- [x] TypeScript build passes (`pnpm build`) — 17/17 packages
- [x] Type-check passes (`pnpm ts:check`) — 29/29 tasks
- [x] Vitest tests pass — kernel: 735, policy: 412, adapters: 199
- [x] ESLint clean (`pnpm lint`) — 16/16 tasks
- [x] Prettier clean (`pnpm format`)
- [x] Normalization benchmark: p50 < 100µs

## Risk Assessment

| Metric | Value |
|--------|-------|
| Risk level | low |
| Risk score | 0/100 |
| Blast radius | 0 (weighted) |
| Simulation result | allowed (low risk) |

## Governance Report

| Metric | Count |
|--------|-------|
| Total events | 4 |
| Actions allowed | 1 |
| Actions denied | 0 |
| Policy denials | 0 |
| Invariant violations | 0 |
| Escalation events | 0 |
| Decision records | 0 |

<details>
<summary>Governance details</summary>

**Source**: `.agentguard/events/`, `.agentguard/decisions/`, `logs/runtime-events.jsonl`

**Decision Records**: 0 total, 0 denials
**Escalation levels observed**: NORMAL only
**Pre-push simulation**: low risk, blast radius 0

No notable denials or violations.

</details>

<details>
<summary>Pre-existing test note</summary>

`packages/core/tests/repo-root.test.ts` has a pre-existing failure (`isWorktree` returns true in worktree environments). This test fails identically on `main` — not related to this change.

</details>