### PR TITLE
fix(telemetry): deduplicate decision events in cloud telemetry

### DIFF
--- a/packages/telemetry/src/cloud-sink.ts
+++ b/packages/telemetry/src/cloud-sink.ts
@@ -14,6 +14,7 @@ import { homedir } from 'node:os';
 import type {
   DomainEvent,
   DecisionSink,
+  EventKind,
   EventSink,
   GovernanceDecisionRecord,
 } from '@red-codes/core';
@@ -128,9 +129,20 @@ export async function createCloudSinks(config: CloudSinkConfig): Promise<CloudSi
     return prepared;
   }
 
+  // Domain event kinds whose decision information is already captured by the
+  // richer GovernanceDecisionRecord via the decisionSink.  Emitting them from
+  // both sinks produces duplicate 'decision'-typed rows in cloud telemetry.
+  const DECISION_SINK_COVERED: ReadonlySet<EventKind> = new Set([
+    'DecisionRecorded',
+    'ActionAllowed',
+    'ActionDenied',
+    'ActionEscalated',
+  ]);
+
   const eventSink: EventSink = {
     write(event: DomainEvent): void {
       try {
+        if (DECISION_SINK_COVERED.has(event.kind)) return;
         const agentEvent = mapDomainEventToAgentEvent(event);
         queue.enqueue(prepareEvent(agentEvent));
       } catch {

--- a/packages/telemetry/tests/cloud-sink.test.ts
+++ b/packages/telemetry/tests/cloud-sink.test.ts
@@ -283,7 +283,46 @@ describe('CloudSinkBundle', () => {
   });
 
   // -------------------------------------------------------------------------
-  // 5. DecisionSink.write maps GovernanceDecisionRecord
+  // 5. Decision-covered domain events are deduplicated
+  // -------------------------------------------------------------------------
+
+  it('skips DecisionRecorded, ActionAllowed, ActionDenied, ActionEscalated domain events', async () => {
+    const config: CloudSinkConfig = {
+      mode: 'verified',
+      serverUrl: 'https://api.example.com',
+      runId: 'run-dedup',
+      agentId: 'agent-1',
+      queueDir: tmpDir,
+      batchSize: 50,
+    };
+
+    const bundle = await createCloudSinks(config);
+
+    // These should be silently skipped (covered by decisionSink)
+    bundle.eventSink.write(makeDomainEvent({ kind: 'DecisionRecorded' }));
+    bundle.eventSink.write(makeDomainEvent({ kind: 'ActionAllowed' }));
+    bundle.eventSink.write(makeDomainEvent({ kind: 'ActionDenied' }));
+    bundle.eventSink.write(makeDomainEvent({ kind: 'ActionEscalated' }));
+
+    // This should still go through
+    bundle.eventSink.write(makeDomainEvent({ kind: 'ActionExecuted' }));
+
+    await bundle.flush();
+    bundle.stop();
+
+    const eventsCall = fetchMock.mock.calls.find(
+      ([url]: [string]) => typeof url === 'string' && url.includes('/v1/events')
+    );
+    expect(eventsCall).toBeDefined();
+
+    const body = JSON.parse(eventsCall![1].body);
+    // Only the ActionExecuted event should have been enqueued
+    expect(body.events).toHaveLength(1);
+    expect(body.events[0].eventType).toBe('tool_call');
+  });
+
+  // -------------------------------------------------------------------------
+  // 6. DecisionSink.write maps GovernanceDecisionRecord
   // -------------------------------------------------------------------------
 
   it('handles decisionSink.write for GovernanceDecisionRecord', async () => {


### PR DESCRIPTION
## Summary

- Cloud telemetry was logging **3 `decision`-typed rows per action** because both the `eventSink` (domain events) and `decisionSink` (governance records) independently mapped to the same `AgentEvent` wire format
- The `DecisionRecorded`, `ActionAllowed`, `ActionDenied`, and `ActionEscalated` domain events are now filtered from the cloud `eventSink` — their decision information is already captured with richer governance context by the `GovernanceDecisionRecord` via the `decisionSink`
- Local event stores (SQLite, replay engine, VS Code extension) are **unaffected** — they continue receiving all domain events

## Before/After

**Before** (6 rows per action):
| eventType | action | outcome | source |
|-----------|--------|---------|--------|
| `decision` | shell.exec | `—` | ActionAllowed via eventSink |
| `decision` | shell.exec | `success` | GovernanceDecisionRecord via decisionSink |
| `decision` | shell.exec | `success` | DecisionRecorded via eventSink |
| `decision` | EvidencePackGenerated | — | EvidencePackGenerated via eventSink |
| `policy_evaluation` | shell.exec | — | PolicyTraceRecorded via eventSink |
| `tool_call` | Bash | — | ActionRequested via eventSink |

**After** (3 rows per action):
| eventType | action | outcome | source |
|-----------|--------|---------|--------|
| `decision` | shell.exec | `success` | GovernanceDecisionRecord via decisionSink |
| `decision` | EvidencePackGenerated | — | EvidencePackGenerated via eventSink |
| `policy_evaluation` | shell.exec | — | PolicyTraceRecorded via eventSink |
| `tool_call` | Bash | — | ActionRequested via eventSink |

## Test plan

- [x] New test verifies `DecisionRecorded`, `ActionAllowed`, `ActionDenied`, `ActionEscalated` are skipped by cloud eventSink
- [x] New test verifies non-decision events (`ActionExecuted`) still pass through
- [x] All 97 existing telemetry tests pass
- [ ] Verify cloud dashboard shows ~60% fewer rows after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)