### PR TITLE
docs: sync documentation with codebase state

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -55,12 +55,13 @@ packages/
 ├── telemetry/     @red-codes/telemetry — Runtime telemetry and logging
 ├── plugins/       @red-codes/plugins — Plugin ecosystem (discovery, registry, validation, sandboxing)
 ├── renderers/     @red-codes/renderers — Renderer plugin system (registry, TUI renderer)
+├── sdk/           @red-codes/sdk — Agent SDK for programmatic governance integration
 ├── swarm/         @red-codes/swarm — Shareable agent swarm templates
 └── telemetry-client/ @red-codes/telemetry-client — Telemetry client (identity, signing, queue, sender)
 
 apps/
 ├── cli/           @red-codes/agentguard — CLI entry point and commands (published npm package)
-├── mcp-server/    @red-codes/mcp-server — MCP governance server (14 governance tools)
+├── mcp-server/    @red-codes/mcp-server — MCP governance server (15 governance tools)
 └── vscode-extension/  agentguard-vscode — VS Code extension (sidebar panels, notifications, diagnostics)
 
 policies/          Policy packs (YAML: ci-safe, engineering-standards, enterprise, hipaa, open-source, soc2, strict)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ The system has one architectural spine: the **canonical event model**. All syste
 - Escalation tracking: NORMAL → ELEVATED → HIGH → LOCKDOWN
 - SQLite event persistence for audit trail and replay (JSONL export still supported)
 - Claude Code adapter for PreToolUse/PostToolUse hooks
-- **pnpm monorepo** with Turbo orchestration: 14 packages under `packages/`, 3 apps under `apps/`
+- **pnpm monorepo** with Turbo orchestration: 15 packages under `packages/`, 3 apps under `apps/`
 - Each package compiles independently via `tsc`; CLI bundle via `esbuild` in `apps/cli`
 - Scoped npm packages: `@red-codes/*` for workspace modules, `@red-codes/agentguard` for published CLI
 - CLI has runtime dependencies (`chokidar`, `commander`, `pino`); optional `better-sqlite3` for SQLite storage backend
@@ -43,7 +43,7 @@ This is a **pnpm monorepo** orchestrated by **Turbo**. Workspace packages live i
 packages/
 ├── core/src/                   # @red-codes/core — Shared utilities
 │   ├── types.ts                # Shared TypeScript type definitions (includes RunManifest)
-│   ├── actions.ts              # 23 canonical action types across 8 classes
+│   ├── actions.ts              # 24 canonical action types across 9 classes
 │   ├── governance-data.ts      # Governance data loader (typed access to shared JSON data)
 │   ├── data/                   # JSON governance data (actions, blast-radius, destructive-patterns, escalation, git-action-patterns, invariant-patterns, tool-action-map)
 │   ├── hash.ts                 # Content hashing utilities
@@ -144,6 +144,11 @@ packages/
 │   ├── scaffolder.ts           # Swarm scaffolding
 │   ├── types.ts                # Swarm type definitions
 │   └── index.ts                # Module re-exports
+├── sdk/src/                    # @red-codes/sdk — Agent SDK for programmatic governance
+│   ├── sdk.ts                  # SDK implementation
+│   ├── session.ts              # Session management
+│   ├── types.ts                # SDK type definitions
+│   └── index.ts                # Module re-exports
 └── invariant-data-protection/src/ # @red-codes/invariant-data-protection — Data protection invariant plugin
     ├── index.ts                # Module re-exports
     ├── invariants.ts           # Data protection invariant definitions
@@ -167,7 +172,7 @@ apps/
 │   ├── server.ts               # MCP server implementation
 │   ├── config.ts               # Server configuration
 │   ├── backends/               # Storage backends
-│   └── tools/                  # 14 governance MCP tools
+│   └── tools/                  # 15 governance MCP tools
 └── vscode-extension/src/       # agentguard-vscode — VS Code extension
     ├── extension.ts            # Extension entry point (sidebar panels, file watcher)
     ├── providers/              # Tree data providers (run status, run history, recent events)
@@ -175,7 +180,7 @@ apps/
 
 tests/
 └── *.test.js               # 14 JS test files (custom zero-dependency harness)
-# 147 TS test files (vitest) distributed across packages/ and apps/ directories
+# 157 TS test files (vitest) distributed across packages/ and apps/ directories
 policy/                     # Policy configuration (JSON: action_rules, capabilities)
 policies/                   # Policy packs (YAML: ci-safe, engineering-standards, enterprise, hipaa, open-source, soc2, strict)
 docs/                       # System documentation (architecture, event model, specs)
@@ -241,10 +246,11 @@ Each workspace package maps to a single architectural concept:
 - **packages/storage/** — Storage backend: SQLite (indexed queries, the only storage backend)
 - **packages/telemetry/** — Runtime telemetry and logging
 - **packages/telemetry-client/** — Telemetry client (identity, signing, queue, sender)
+- **packages/sdk/** — Agent SDK for programmatic governance integration
 - **packages/swarm/** — Shareable agent swarm templates (config, manifest, scaffolder)
 - **apps/cli/** — CLI entry point and commands (published as `@red-codes/agentguard`)
 - **packages/invariant-data-protection/** — Data protection invariant plugin
-- **apps/mcp-server/** — MCP governance server (14 governance tools)
+- **apps/mcp-server/** — MCP governance server (15 governance tools)
 
 ### CLI Commands
 - `agentguard guard` — Start the governed action runtime (policy + invariant enforcement)
@@ -298,10 +304,11 @@ The canonical event model is the architectural spine. Event kinds defined in `pa
 - **Adoption Analytics**: `AdoptionAnalyzed`, `AdoptionAnalysisFailed`
 - **Denial Learning**: `DenialPatternDetected`
 - **Intent Drift**: `IntentDriftDetected`
+- **Capability Validation**: `CapabilityValidated`
 - **Environmental Enforcement**: `IdeSocketAccessBlocked`
 
 ### Action Classes & Types
-23 canonical action types across 8 classes, defined in `packages/core/src/actions.ts`:
+24 canonical action types across 9 classes, defined in `packages/core/src/actions.ts`:
 - **file**: `file.read`, `file.write`, `file.delete`, `file.move`
 - **test**: `test.run`, `test.run.unit`, `test.run.integration`
 - **git**: `git.diff`, `git.commit`, `git.push`, `git.branch.create`, `git.branch.delete`, `git.checkout`, `git.reset`, `git.merge`
@@ -310,6 +317,7 @@ The canonical event model is the architectural spine. Event kinds defined in `pa
 - **http**: `http.request`
 - **deploy**: `deploy.trigger`
 - **infra**: `infra.apply`, `infra.destroy`
+- **mcp**: `mcp.call`
 
 ### Build & Module System
 Turbo orchestrates per-package `tsc` builds (incremental via TypeScript project references). The CLI app (`apps/cli`) is additionally bundled via `esbuild`. Workspace imports use `@red-codes/*` scoped package names.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ agentguard cloud login
 |------------|---------|
 | **Policy enforcement** | YAML rules with deny / allow / escalate — drop `agentguard.yaml` in your repo |
 | **21 built-in invariants** | Secret exposure, protected branches, blast radius, path traversal, CI/CD config, package script injection, and more |
-| **46 event kinds** | Full lifecycle telemetry: `ActionRequested → ActionAllowed/Denied → ActionExecuted` |
+| **47 event kinds** | Full lifecycle telemetry: `ActionRequested → ActionAllowed/Denied → ActionExecuted` |
 | **Real-time cloud dashboard** | Telemetry streams to your team dashboard; opt-in, anonymous by default |
 | **Multi-tenant** | Team workspaces, GitHub/Google OAuth, SSO-ready |
 | **Live Office visualization** | 2D view of agents working in real time — share a link with your team |
@@ -218,7 +218,7 @@ rules:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `action` | `string \| string[]` | Action type(s): `file.read`, `git.push`, `shell.exec`, etc. (23 types across 8 classes) |
+| `action` | `string \| string[]` | Action type(s): `file.read`, `git.push`, `shell.exec`, `mcp.call`, etc. (24 types across 9 classes) |
 | `effect` | `string` | `deny` or `allow` |
 | `target` | `string` | Glob pattern for file paths or command patterns |
 | `branches` | `string[]` | Git branch names this rule applies to |
@@ -269,7 +269,7 @@ AgentGuard Kernel
   2. Evaluate    — match policy rules (deny / allow / escalate)
   3. Check       — run 21 built-in invariants
   4. Execute     — run action via adapter (file, shell, git)
-  5. Emit        — 46 event kinds → SQLite audit trail + cloud telemetry
+  5. Emit        — 47 event kinds → SQLite audit trail + cloud telemetry
 ```
 
 **Storage:** SQLite audit trail at `.agentguard/`. Every decision is recorded and verifiable.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -58,11 +58,11 @@ A comprehensive codebase audit assessed the current system against the strategic
 
 | Component | Status | Key Files |
 |-----------|--------|-----------|
-| Canonical Action Representation (23 types, 8 classes) | Implemented | `packages/core/src/actions.ts` |
+| Canonical Action Representation (24 types, 9 classes) | Implemented | `packages/core/src/actions.ts` |
 | Action Authorization Boundary (AAB) | Implemented (2 bypass vectors) | `packages/kernel/src/aab.ts` |
 | Policy Evaluator (two-phase deny/allow) | Implemented | `packages/policy/src/evaluator.ts` |
 | 21 Built-in Invariants | Fully Implemented | `packages/invariants/src/definitions.ts`, `packages/invariants/src/checker.ts` |
-| Event Model (46 event kinds) | Comprehensive | `packages/events/src/schema.ts` |
+| Event Model (47 event kinds) | Comprehensive | `packages/events/src/schema.ts` |
 | SQLite Persistence | Implemented | `packages/storage/src/sqlite-store.ts` |
 | Simulation Engine (3 simulators + impact forecast) | Fully Implemented | `packages/kernel/src/simulation/` |
 | Blast Radius Computation | Implemented | `packages/kernel/src/blast-radius.ts` |
@@ -90,7 +90,7 @@ A comprehensive codebase audit assessed the current system against the strategic
 | Component | Status | Notes |
 |-----------|--------|-------|
 | KE-1 Structured Matchers (Aho-Corasick, globs) | **Shipped v2.3.0** | `packages/matchers/src/` — path-matcher, command-scanner, policy-matcher, reason-codes |
-| All 46 event kinds mapped to cloud AgentEvent format | **Shipped v2.3.0** | `packages/telemetry/src/event-mapper.ts` — full mapping coverage |
+| All 47 event kinds mapped to cloud AgentEvent format | **Shipped v2.3.0** | `packages/telemetry/src/event-mapper.ts` — full mapping coverage |
 | Telemetry path responsibilities documented | **Shipped v2.3.0** | Dual-path consolidation documented |
 | Kernel-Level Tracing (eBPF / Project Azazel) | Not Started | Requires Go/Rust, kernel probes, privileged runtime |
 | OS-Level Sandboxing (Bubblewrap/Seatbelt) | Not Started | Only application-level plugin capability checking exists |
@@ -111,7 +111,7 @@ A comprehensive codebase audit assessed the current system against the strategic
 | AAB Reference Monitor | Implemented | 1 bypass vector to close (missing-adapter fixed) |
 | Policy Evaluator | Implemented | Production |
 | 21 Built-in Invariants | Fully Implemented | Production |
-| Event Model (46 kinds) | Comprehensive | Production |
+| Event Model (47 kinds) | Comprehensive | Production |
 | Simulation & Forecasting | Fully Implemented | Production |
 | Escalation State Machine | Implemented | Functional (events persisted as StateChanged) |
 | Plugin Sandbox | Implemented | Application-level only |


### PR DESCRIPTION
## Summary

- Automated documentation sync detected drift between codebase and docs
- **Action types**: 23→24 across 8→9 classes (new `mcp.call` in `MCP` class added to `actions.json`)
- **Event kinds**: 46→47 (new `CapabilityValidated` event kind in `schema.ts`)
- **Package count**: 14→15 packages (added `sdk/` to structure listings)
- **TS test files**: 147→157 (10 new test files across packages/apps)
- **MCP governance tools**: 14→15 (actual `server.tool()` registrations counted)

## Changes

- **README.md** — Updated event kind count (46→47), action type count (23→24, 8→9 classes), architecture diagram event count
- **ARCHITECTURE.md** — Added `sdk/` package to package layout, updated MCP tools count (14→15)
- **CLAUDE.md** — Updated package count (14→15), action type count (23→24, 8→9), added `mcp` action class listing, added `sdk` to package layout and project structure tree, updated TS test file count (147→157), updated MCP tools count (14→15), added `CapabilityValidated` to event model
- **ROADMAP.md** — Updated action representation count (23→24, 8→9 classes), event model count (46→47) across architectural audit, maturity matrix, and shipped items

## Strategic Document Check

- `docs/current-priorities.md` — does not exist (no staleness to check)
- `docs/strategic-roadmap.md` — does not exist (no staleness to check)

## Source

Auto-generated by the **Scheduled Docs Sync** skill.

---
*Run: 2026-03-21*