### PR TITLE
fix(hooks): add escape hatch for identity gate

### DIFF
--- a/apps/cli/src/commands/claude-hook.ts
+++ b/apps/cli/src/commands/claude-hook.ts
@@ -181,15 +181,33 @@ export async function claudeHook(hookType?: string, extraArgs: string[] = []): P
 
     if (isPreToolUse) {
       // Agent identity hard gate — block all actions until identity is set.
-      // Blank stale identity on first PreToolUse of a session, then resolve fresh.
       // If resolved from env var, persist to identity file for subsequent hook calls.
+      // Exception: allow Write/Bash calls targeting .agentguard-identity so the agent
+      // can prompt the user for their name and write it — breaking the chicken-and-egg lockout.
       const agentIdentity = resolveAgentIdentity();
       if (!agentIdentity) {
+        const toolInput = (data.tool_input || {}) as Record<string, unknown>;
+        const isIdentityWrite =
+          // Write tool targeting the identity file
+          ((data.tool_name === 'Write' || data.tool_name === 'Edit') &&
+            typeof toolInput.file_path === 'string' &&
+            toolInput.file_path.replace(/\\/g, '/').endsWith('.agentguard-identity')) ||
+          // Bash writing to the identity file
+          (data.tool_name === 'Bash' &&
+            typeof toolInput.command === 'string' &&
+            toolInput.command.includes('.agentguard-identity'));
+
+        if (isIdentityWrite) {
+          // Allow through — agent is setting the identity file. Skip kernel evaluation.
+          process.exit(0);
+          return;
+        }
+
         process.stdout.write(
           JSON.stringify({
             decision: 'block',
             reason:
-              'Agent identity not set. Write your agent name to .agentguard-identity or set AGENTGUARD_AGENT_NAME env var.',
+              'Agent identity not set. Ask the user for their agent name (e.g. "claude-code", their name, or a team identifier), then write it to the file .agentguard-identity in the project root. This is required before any other actions can proceed.',
           })
         );
         process.exit(2);


### PR DESCRIPTION
## Summary
- The identity hard gate blocked **all** tool calls when no identity was set, including the Write/Bash calls needed to actually set the identity — creating an irrecoverable agent lockout
- Adds an escape hatch: Write/Edit/Bash calls targeting `.agentguard-identity` are allowed through even when no identity is set
- Updates the blocking message to instruct the agent to prompt the user for their name, enabling in-session identity setup

## Test plan
- [x] Verified gate blocks non-identity tool calls when identity is empty (exit 2)
- [x] Verified Write to `.agentguard-identity` is allowed through (exit 0)
- [x] Verified Bash writing to `.agentguard-identity` is allowed through (exit 0)
- [x] Verified Windows-style paths are correctly detected
- [x] Verified normal tool calls proceed after identity is set (exit 0)
- [x] End-to-end test: cleared identity → gate blocked Read → agent prompted user → user provided name → Bash wrote identity → subsequent calls unblocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)