### PR TITLE
fix(hooks): use resolved agent identity for cloud telemetry sinks

### DIFF
--- a/apps/cli/src/commands/claude-hook.ts
+++ b/apps/cli/src/commands/claude-hook.ts
@@ -342,7 +342,7 @@ async function handlePreToolUse(
           identity?.server_url ??
           'https://telemetry.agentguard.dev',
         runId: cloudSessionId,
-        agentId: 'claude-code',
+        agentId: resolveAgentIdentity() ?? 'claude-code',
         installId: identity?.install_id,
         apiKey,
         flushIntervalMs: 0, // No interval — we flush manually before exit


### PR DESCRIPTION
The agentId passed to createCloudSinks() was hardcoded as 'claude-code', causing all governance events to hit the DB with a generic agent_id instead of the persona-derived name (e.g. 'claude-code:opus:developer'). Now uses resolveAgentIdentity() which reads from .agentguard-identity file or AGENTGUARD_AGENT_NAME env var, falling back to 'claude-code' only when neither is available.