### PR TITLE
docs: comprehensive update for v2.4.0 features

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -15,6 +15,11 @@ All system activity — agent tool calls, governance decisions, invariant violat
 └──────┬───────┘
        │
        ▼
+┌──────────────┐
+│   Identity   │  Declare role + driver (prompt or --agent-name flag)
+└──────┬───────┘
+       │
+       ▼
 ┌──────────────────────────────────────────────┐
 │              AgentGuard Kernel                │
 │                                              │
@@ -106,3 +111,18 @@ The `claude-init` command provides an interactive wizard that generates a starte
 4. **Escalation state machine** — Repeated violations escalate: NORMAL → ELEVATED → HIGH → LOCKDOWN
 5. **Adapter pattern** — Execution is abstracted behind adapters, making the kernel testable without real file/git operations
 6. **YAML-first policy** — Human-readable policy-as-code, version-controlled alongside the project
+
+## Agent Identity
+
+Agents declare their identity (role + driver) at the start of each governance session. If the `--agent-name` flag is not provided, an interactive prompt collects the identity.
+
+**Roles:** `developer`, `reviewer`, `ops`, `security`, `planner`
+**Drivers:** `human`, `claude-code`, `copilot`, `ci`
+
+Identity serves three purposes:
+
+1. **Persona-scoped policy rules** — Policy rules can match on agent role or driver, enabling different governance for different agent types (e.g., stricter rules for autonomous CI agents than for human-supervised development agents).
+2. **Telemetry attribution** — Every event in the audit trail carries the agent identity, enabling per-agent analysis in the cloud dashboard.
+3. **Cloud dashboard grouping** — The cloud dashboard groups sessions by agent identity for fleet-level visibility.
+
+The `telemetry-client` package (`packages/telemetry-client/`) handles identity signing, queue management, and sender logic. Identity is attached to all outbound telemetry payloads. Worktree enforcement ensures that agents operating in git worktrees are correctly identified and isolated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 2.4.0 (2026-03-22)
+
+### Features
+
+* **Agent identity system** — session identity prompt, auto-detecting wizard, MCP persona, and worktree enforcement. Agents declare identity (role + driver) for telemetry attribution and persona-scoped policy rules. Set via `--agent-name` flag or interactive prompt (#715, #714, #713, #712, #709, #707, #706)
+* **Pre-push branch protection** — enforce branch protection rules from `agentguard.yaml` via git pre-push hooks, installed automatically by `agentguard claude-init` (#704)
+* **Capability grants enforcement** — enforce capability grants before adapter execution (#681)
+* **Cloud credential storage** — store cloud credentials in project `.env` instead of global config (#679, #678)
+
+### Bug Fixes
+
+* **Security: governance bypass vectors** — closed three governance bypass vectors (#696)
+* **ESM bundle fix** — added `createRequire` shim and updated help text for ESM compatibility (#703)
+
+### Other
+
+* **Site redesign** — floating nav, dark/light toggle, social proof, newsletter signup (#708)
+* **Messaging pivot** — governance-first to outcome-first positioning (#701)
+* **CLI wizard docs** — YAML policy format documentation updated (#697)
+
 ## 1.0.0 (2026-03-07)
 
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,17 @@ agentguard cloud login
 | [agentguard-cloud-dashboard.vercel.app](https://agentguard-cloud-dashboard.vercel.app) | Team dashboard — runs, violations, analytics |
 | [agentguard-cloud-office-sim.vercel.app](https://agentguard-cloud-office-sim.vercel.app) | Live Office — 2D visualization of agent activity |
 
+## Agent Identity
+
+Every governed session has an identity. Set it via the CLI flag or let the interactive prompt ask:
+
+```bash
+agentguard guard --agent-name my-agent
+# Or omit --agent-name and an interactive prompt will ask for role + driver
+```
+
+Identity consists of a **role** (`developer`, `reviewer`, `ops`, `security`, `planner`) and a **driver** (`human`, `claude-code`, `copilot`, `ci`). Identity flows to cloud telemetry for attribution, dashboard grouping, and persona-scoped policy rules.
+
 ## What It Does
 
 | Capability | Details |
@@ -89,6 +100,8 @@ agentguard cloud login
 | **Multi-tenant** | Team workspaces, GitHub/Google OAuth, SSO-ready |
 | **Live Office visualization** | 2D view of agents working in real time — share a link with your team |
 | **Agent SDK** | Programmatic governance for custom integrations and RunManifest-driven workflows |
+| **Agent identity** | Declare agent role + driver for governance telemetry — automatic prompt or CLI flag |
+| **Pre-push hooks** | Branch protection enforcement via git pre-push hooks, configured from agentguard.yaml |
 | **Works with** | Claude Code, GitHub Copilot, any MCP client |
 
 ## Policy Format (YAML)
@@ -295,6 +308,7 @@ AgentGuard Kernel
 agentguard claude-init                    # Interactive wizard: mode + pack → creates policy + hooks
 agentguard claude-init --global           # Install hooks globally (~/.claude/settings.json)
 agentguard claude-init --mode monitor --pack essentials  # Non-interactive setup
+agentguard claude-init                    # Also installs pre-push hooks for branch protection
 agentguard init --template strict         # Scaffold policy from a template
 agentguard status                         # Show governance status
 
@@ -302,6 +316,7 @@ agentguard status                         # Show governance status
 agentguard guard                          # Start governed action runtime
 agentguard guard --policy <file>          # Use a specific policy file
 agentguard guard --dry-run                # Evaluate without executing
+agentguard guard --agent-name <name>      # Set agent identity for session
 
 # Inspect
 agentguard inspect --last                 # Show last run action graph

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -95,8 +95,8 @@ A comprehensive codebase audit assessed the current system against the strategic
 | Kernel-Level Tracing (eBPF / Project Azazel) | Not Started | Requires Go/Rust, kernel probes, privileged runtime |
 | OS-Level Sandboxing (Bubblewrap/Seatbelt) | Not Started | Only application-level plugin capability checking exists |
 | Transactional Adjudication (P-1b Protocol) | Not Started | No state snapshot at T_authorize, no re-verification at T_execute |
-| Confidence-Based HITL | Partial | Count-based escalation only. PAUSE/ROLLBACK/TEST_ONLY are labels, not enforced behaviors |
-| Multi-Agent Identity & Capability Tokens | Aspirational | Types defined but never used. Basic session ID hashing exists |
+| Confidence-Based HITL | Partial | Count-based escalation only. PAUSE intervention is now label-enforced for certain actions; ROLLBACK/TEST_ONLY remain labels |
+| Multi-Agent Identity & Capability Tokens | Partial — Shipped in v2.4.0 | Session identity prompt, agent-name CLI flag, MCP persona, worktree enforcement, cloud telemetry attribution. Capability tokens remain aspirational |
 | Shared State Contract & Heartbeat | Not Started | Would require architectural redesign |
 | Formal Verification (Z3/SMT) | Not Started | No dependencies, no symbolic analysis |
 | Automated Invariant Learning | Not Started | Analytics foundation removed; no synthesis/feedback loop |
@@ -118,8 +118,8 @@ A comprehensive codebase audit assessed the current system against the strategic
 | Project Azazel (eBPF) | Not Started | Aspirational |
 | OS-Level Sandboxing | Not Started | Aspirational |
 | P-1b Transactional Protocol | Not Started | Aspirational |
-| Confidence-Based HITL | Partial | Labels only |
-| Multi-Agent Identity | Aspirational | Types exist, no enforcement |
+| Confidence-Based HITL | Partial | PAUSE label-enforced for certain actions; ROLLBACK/TEST_ONLY remain labels |
+| Multi-Agent Identity | Partial — v2.4.0 | Session identity prompt, --agent-name flag, MCP persona, worktree enforcement |
 | Shared State & Heartbeat | Partial | Heartbeat implemented (`packages/kernel/src/heartbeat.ts`) |
 | Formal Verification (Z3) | Not Started | Aspirational |
 | Automated Invariant Learning | Not Started | Aspirational |
@@ -130,7 +130,7 @@ A comprehensive codebase audit assessed the current system against the strategic
 
 ### Reference Monitor Bypass Vectors
 
-One bypass path remains in the AAB (one previously identified vector has been resolved):
+Three additional governance bypass vectors were closed in #696 (v2.4.0). One bypass path remains in the AAB (one previously identified vector has been resolved):
 
 **1. Unknown actions default-allow.**
 `packages/policy/src/evaluator.ts` returns `allowed: true` when no policy rule matches an action. Unrecognized tool calls pass through governance unchecked. This violates the core principle of reference monitors: default deny.
@@ -256,6 +256,7 @@ This is the architectural hinge. These changes transform the AAB from advisory i
 - [ ] Enforce intervention types beyond DENY (implement PAUSE and ROLLBACK behaviors in kernel execution)
 - [x] Governance self-modification invariant — agents must not modify `agentguard.yaml`, `.agentguard/`, or `policies/` (`no-governance-self-modification` invariant, severity 5)
 - [x] Performance benchmark suite — formal latency measurement (p50/p95/p99) per action type for policy evaluation, invariant checking, and simulation overhead. Publish results as a marketing asset and regression gate in CI
+- [x] Pre-push branch protection — enforced from `agentguard.yaml` via git pre-push hook, installed automatically by `agentguard claude-init` (#704)
 
 ### Phase 6.5 — Invariant Expansion `STABLE`
 

--- a/docs/agent-identity-delegation.md
+++ b/docs/agent-identity-delegation.md
@@ -2,13 +2,36 @@
 
 This document describes the agent identity model, delegation chain tracking, and human-in-the-loop approval workflows.
 
+## Implementation Status
+
+> **Shipped in v2.4.0:** Session-level agent identity is now implemented. The features below marked with **(Shipped)** are live. Features marked with **(Aspirational)** remain planned.
+>
+> **Shipped capabilities:**
+> - Session identity prompt — agents are prompted for role + driver at session start if `--agent-name` is not set
+> - `agentguard guard --agent-name <name>` CLI flag for non-interactive identity declaration
+> - MCP persona — identity is surfaced through the MCP governance server
+> - Worktree enforcement — agents operating in git worktrees are correctly identified and isolated
+> - Cloud telemetry attribution — identity flows to cloud dashboard for per-agent grouping and analytics
+> - Supported roles: `developer`, `reviewer`, `ops`, `security`, `planner`
+> - Supported drivers: `human`, `claude-code`, `copilot`, `ci`
+>
+> **Still aspirational:** Full agent registry with lifecycle management, delegation chains with capability narrowing, capability tokens, cross-session identity persistence, and human-in-the-loop approval gates via external channels (Slack, webhook, email).
+
 ## Motivation
 
-AgentGuard events include an `agentId` field, but there is no first-class identity system. All agents are anonymous — the kernel cannot distinguish between a trusted production agent and an untrusted test agent. There is no tracking of delegation (human → agent → sub-agent) and no mechanism for human approval of high-risk actions.
+~~AgentGuard events include an `agentId` field, but there is no first-class identity system. All agents are anonymous — the kernel cannot distinguish between a trusted production agent and an untrusted test agent.~~ **(Partially addressed in v2.4.0 — session identity now distinguishes agents by role and driver.)** There is no tracking of delegation (human → agent → sub-agent) and no mechanism for human approval of high-risk actions beyond the PAUSE intervention type.
 
 ## Agent Identity Model
 
-### AgentIdentity
+### Session Identity (Shipped)
+
+The current implementation uses a lightweight session identity model. At session start, the agent declares:
+- **Role**: one of `developer`, `reviewer`, `ops`, `security`, `planner`
+- **Driver**: one of `human`, `claude-code`, `copilot`, `ci`
+
+This identity is set via `agentguard guard --agent-name <name>` or collected through an interactive prompt (auto-detecting wizard). Identity is attached to all governance events and telemetry payloads for the session.
+
+### AgentIdentity (Aspirational)
 
 ```
 AgentIdentity {
@@ -23,7 +46,7 @@ AgentIdentity {
 }
 ```
 
-### Trust Levels
+### Trust Levels (Aspirational)
 
 | Level | Grants | Use Case |
 |-------|--------|----------|
@@ -32,7 +55,7 @@ AgentIdentity {
 | ELEVATED | Git operations, limited shell execution | Trusted CI/CD agents |
 | TRUSTED | Full access per policy | Production agents with established history |
 
-### Agent Registry
+### Agent Registry (Aspirational)
 
 ```
 AgentRegistry {
@@ -45,7 +68,7 @@ AgentRegistry {
 }
 ```
 
-### Agent Lifecycle
+### Agent Lifecycle (Aspirational)
 
 ```
 Register → Active → (Suspended | Deactivated)
@@ -59,7 +82,7 @@ Register → Active → (Suspended | Deactivated)
 | Suspended | Agent's actions are auto-denied, capabilities frozen |
 | Deactivated | Agent removed from active registry, history preserved |
 
-## Delegation Chains
+## Delegation Chains (Aspirational)
 
 ### Model
 
@@ -117,7 +140,7 @@ human:jplev
 │           └── capabilities: file:read:src/**
 ```
 
-## Human-in-the-Loop Approval
+## Human-in-the-Loop Approval (Aspirational)
 
 ### Approval Gates
 
@@ -171,7 +194,7 @@ ApprovalRecord {
 }
 ```
 
-## Identity Persistence
+## Identity Persistence (Aspirational)
 
 ### Cross-Session
 

--- a/paper/agentguard-whitepaper.md
+++ b/paper/agentguard-whitepaper.md
@@ -596,7 +596,7 @@ Several extensions of this architecture merit investigation:
 
 4. **Agent debugging replay**: Using the canonical event stream to replay agent sessions, enabling post-hoc analysis of agent decision-making and governance interactions.
 
-5. **Distributed agent governance**: Extending the architecture to multi-agent systems where agents operate across different repositories, services, and infrastructure boundaries.
+5. **Distributed agent governance**: Extending the architecture to multi-agent systems where agents operate across different repositories, services, and infrastructure boundaries. *Note (v2.4.0):* A session-level identity system has been shipped as a first step toward multi-agent governance. Agents declare their role and driver at session start via an interactive prompt or `--agent-name` CLI flag. Identity flows to cloud telemetry for attribution and dashboard grouping. Full delegation chains, capability tokens, and cross-agent policy remain future work.
 
 6. **Enterprise control planes**: Building organization-level governance dashboards that aggregate evidence packs and escalation events across teams and projects.
 

--- a/site/index.html
+++ b/site/index.html
@@ -766,6 +766,24 @@
             <h3 class="font-mono font-semibold text-text mb-2">RTK Token Optimization</h3>
             <p class="text-muted text-sm leading-relaxed">Integrated with <a href="https://github.com/rtk-ai/rtk" class="text-cta hover:underline">RTK</a> for 60-90% token savings. Shell commands auto-rewrite to compact output after governance approval. Git, npm, cargo, docker, kubectl, and more.</p>
           </div>
+
+          <!-- Card 9: Agent Identity -->
+          <div class="reveal bg-surface border border-surface-light rounded-xl p-6 card-lift cursor-pointer">
+            <div class="w-10 h-10 rounded-lg bg-info/10 flex items-center justify-center mb-4">
+              <svg class="w-5 h-5 text-info" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M20 21v-2a4 4 0 00-4-4H8a4 4 0 00-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+            </div>
+            <h3 class="font-mono font-semibold text-text mb-2">Agent Identity</h3>
+            <p class="text-muted text-sm leading-relaxed">Declare agent role (developer, reviewer, ops, security) and driver (human, claude-code, copilot, ci). Identity flows to telemetry, persona-scoped policies, and cloud dashboard.</p>
+          </div>
+
+          <!-- Card 10: Pre-Push Hooks -->
+          <div class="reveal bg-surface border border-surface-light rounded-xl p-6 card-lift cursor-pointer">
+            <div class="w-10 h-10 rounded-lg bg-warning/10 flex items-center justify-center mb-4">
+              <svg class="w-5 h-5 text-warning" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M9 21H5a2 2 0 01-2-2V5a2 2 0 012-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
+            </div>
+            <h3 class="font-mono font-semibold text-text mb-2">Pre-Push Branch Protection</h3>
+            <p class="text-muted text-sm leading-relaxed">Git pre-push hooks enforce branch protection rules from <code class="text-cta text-xs">agentguard.yaml</code>. Blocks pushes to protected branches at the git layer, not just at the agent layer.</p>
+          </div>
         </div>
       </div>
     </section>
@@ -849,7 +867,7 @@
         <div class="grid md:grid-cols-3 gap-6 mt-16 reveal-stagger">
           <div class="reveal bg-surface border border-surface-light rounded-xl p-6">
             <h3 class="font-mono font-semibold text-cta text-sm mb-3">Action Authorization Boundary</h3>
-            <p class="text-muted text-sm leading-relaxed">The AAB normalizes raw tool calls into 23 canonical action types across 8 classes. Every agent operation&mdash;whether a Bash command, file write, or git push&mdash;gets classified before evaluation.</p>
+            <p class="text-muted text-sm leading-relaxed">The AAB normalizes raw tool calls into 27 canonical action types across 9 classes. Every agent operation&mdash;whether a Bash command, file write, or git push&mdash;gets classified before evaluation.</p>
           </div>
           <div class="reveal bg-surface border border-surface-light rounded-xl p-6">
             <h3 class="font-mono font-semibold text-info text-sm mb-3">Simulation Engine</h3>
@@ -1728,7 +1746,7 @@ rules:
             <svg class="w-5 h-5 text-cta mt-0.5 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18"/><path d="M9 21V9"/></svg>
             <div>
               <h3 class="font-mono font-semibold text-text text-sm">Policy Composition</h3>
-              <p class="text-muted text-sm mt-1">Org-wide base + team overrides. 4 built-in packs: ci-safe, enterprise, open-source, strict.</p>
+              <p class="text-muted text-sm mt-1">Org-wide base + team overrides. 8 built-in packs: essentials, strict, soc2, hipaa, enterprise, ci-safe, engineering-standards, open-source.</p>
             </div>
           </div>
           <div class="reveal flex items-start gap-3">
@@ -1822,6 +1840,17 @@ rules:
             </div>
           </div>
 
+          <!-- Agent Identity (Shipped) -->
+          <div class="reveal flex items-start gap-4 bg-surface border border-cta/30 rounded-xl p-5">
+            <div class="shrink-0 mt-0.5">
+              <span class="font-mono text-xs font-semibold px-2 py-1 rounded bg-cta/10 text-cta">SHIPPED</span>
+            </div>
+            <div class="flex-1 min-w-0">
+              <h3 class="font-mono font-semibold text-text text-sm">Agent Identity &amp; Telemetry Attribution</h3>
+              <p class="text-muted text-sm mt-1">Session identity prompt, <code class="text-xs text-cta">--agent-name</code> CLI flag, MCP persona, role-based policy scoping, cloud telemetry attribution. Pre-push branch protection hooks.</p>
+            </div>
+          </div>
+
           <!-- Phase 14 -->
           <div class="reveal flex items-start gap-4 bg-surface border border-surface-light rounded-xl p-5">
             <div class="shrink-0 mt-0.5">
@@ -1829,7 +1858,7 @@ rules:
             </div>
             <div class="flex-1 min-w-0">
               <h3 class="font-mono font-semibold text-text text-sm">Phase 14 &mdash; Multi-Agent Governance</h3>
-              <p class="text-muted text-sm mt-1">Agent identity verification, PID-bound capability tokens, cross-agent policy, fleet orchestration.</p>
+              <p class="text-muted text-sm mt-1">PID-bound capability tokens, cross-agent policy negotiation, fleet orchestration, shared state contracts.</p>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- **README.md**: Added Agent Identity section, pre-push hooks mention, new rows in "What It Does" table, `--agent-name` flag in CLI Reference
- **ARCHITECTURE.md**: Added Identity box to system diagram, new "Agent Identity" section after Key Design Decisions
- **ROADMAP.md**: Updated Multi-Agent Identity status to "Partial -- Shipped in v2.4.0", updated Confidence-Based HITL status, added bypass vector note for #696, added pre-push branch protection as shipped item
- **CHANGELOG.md**: Added v2.4.0 entries covering agent identity, pre-push hooks, capability grants, credential storage, security fixes, ESM fix, site redesign, messaging pivot
- **paper/agentguard-whitepaper.md**: Added v2.4.0 note to Future Work section on distributed agent governance
- **docs/agent-identity-delegation.md**: Added Implementation Status section, marked shipped vs aspirational features throughout
- **site/index.html**: Added Agent Identity and Pre-Push Hooks feature cards, updated action type and pack counts

## Test plan
- [ ] Verify all markdown renders correctly on GitHub
- [ ] Confirm no broken links in updated docs
- [ ] Review CHANGELOG entries match actual shipped PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)