### PR TITLE
fix(aab): handle refspec syntax and git flags in branch extraction (#627)

### DIFF
--- a/packages/kernel/src/aab.ts
+++ b/packages/kernel/src/aab.ts
@@ -102,14 +102,53 @@ function getDestructiveDetails(command: string): DestructivePattern | null {
   };
 }
 
+/**
+ * Extracts the target branch name from a refspec or plain branch token.
+ * Handles: "main", "HEAD:main", "HEAD:refs/heads/main", "+main", ":main"
+ */
+function branchFromRefspec(ref: string): string {
+  // Strip leading '+' (force-push prefix for individual refs)
+  const cleaned = ref.startsWith('+') ? ref.slice(1) : ref;
+  // Refspec syntax: src:dst — extract the destination
+  if (cleaned.includes(':')) {
+    const dst = cleaned.split(':').pop()!;
+    return dst.replace(/^refs\/heads\//, '');
+  }
+  return cleaned;
+}
+
+// Flags that consume the next token as their value argument
+const PUSH_VALUE_FLAGS = new Set(['-o', '--push-option', '--receive-pack', '--exec', '--repo']);
+
 function extractBranch(command: string | undefined): string | null {
   if (!command) return null;
   // Split on shell chain operators so we can extract branches from commands
   // wrapped in chains like `cd /repo && git push origin main`
   const segments = command.split(/\s*(?:&&|\|\||;)\s*/);
   for (const segment of segments) {
-    const match = segment.match(/\bgit\s+push\s+\S+\s+(\S+)/);
-    if (match) return match[1]!;
+    const pushMatch = segment.match(/\bgit\s+push\b/);
+    if (!pushMatch) continue;
+
+    // Tokenize everything after 'git push', skipping flags to find positional args
+    const afterPush = segment.slice(pushMatch.index! + pushMatch[0].length).trim();
+    const tokens = afterPush.split(/\s+/).filter(Boolean);
+    const positionalArgs: string[] = [];
+
+    for (let i = 0; i < tokens.length; i++) {
+      const t = tokens[i]!;
+      if (t.startsWith('-')) {
+        // --flag=value style doesn't consume the next token
+        if (!t.includes('=') && PUSH_VALUE_FLAGS.has(t) && i + 1 < tokens.length) {
+          i++; // skip the value token
+        }
+        continue;
+      }
+      positionalArgs.push(t);
+    }
+
+    // positionalArgs: [remote, branch/refspec, ...]
+    if (positionalArgs.length < 2) continue;
+    return branchFromRefspec(positionalArgs[1]!);
   }
   return null;
 }

--- a/packages/kernel/tests/agentguard-aab.test.ts
+++ b/packages/kernel/tests/agentguard-aab.test.ts
@@ -745,6 +745,97 @@ describe('agentguard/core/aab', () => {
       expect(intent.branch).toBe('main');
     });
 
+    // --- Issue #627: refspec and flag handling ---
+    it('extracts branch when -f flag precedes remote', () => {
+      const intent = normalizeIntent({
+        tool: 'Bash',
+        command: 'git push -f origin main',
+      });
+      // -f is classified as git.force-push by the git action scanner
+      expect(intent.action).toBe('git.force-push');
+      expect(intent.branch).toBe('main');
+    });
+
+    it('extracts branch when --force flag precedes remote', () => {
+      const intent = normalizeIntent({
+        tool: 'Bash',
+        command: 'git push --force origin main',
+      });
+      expect(intent.branch).toBe('main');
+    });
+
+    it('extracts branch when -u flag precedes remote', () => {
+      const intent = normalizeIntent({
+        tool: 'Bash',
+        command: 'git push -u origin main',
+      });
+      expect(intent.branch).toBe('main');
+    });
+
+    it('extracts branch when --force-with-lease flag precedes remote', () => {
+      const intent = normalizeIntent({
+        tool: 'Bash',
+        command: 'git push --force-with-lease origin main',
+      });
+      expect(intent.branch).toBe('main');
+    });
+
+    it('extracts branch from refspec HEAD:branch', () => {
+      const intent = normalizeIntent({
+        tool: 'Bash',
+        command: 'git push origin HEAD:main',
+      });
+      expect(intent.branch).toBe('main');
+    });
+
+    it('extracts branch from refspec HEAD:refs/heads/branch', () => {
+      const intent = normalizeIntent({
+        tool: 'Bash',
+        command: 'git push origin HEAD:refs/heads/main',
+      });
+      expect(intent.branch).toBe('main');
+    });
+
+    it('extracts branch from force-push refspec +HEAD:main', () => {
+      const intent = normalizeIntent({
+        tool: 'Bash',
+        command: 'git push origin +HEAD:main',
+      });
+      expect(intent.branch).toBe('main');
+    });
+
+    it('extracts branch from delete refspec :main', () => {
+      const intent = normalizeIntent({
+        tool: 'Bash',
+        command: 'git push origin :main',
+      });
+      expect(intent.branch).toBe('main');
+    });
+
+    it('extracts branch with -o flag that consumes next token', () => {
+      const intent = normalizeIntent({
+        tool: 'Bash',
+        command: 'git push -o ci.skip origin main',
+      });
+      expect(intent.branch).toBe('main');
+    });
+
+    it('extracts branch with multiple flags and refspec in chain', () => {
+      const intent = normalizeIntent({
+        tool: 'Bash',
+        command: 'cd /repo && git push --force -u origin HEAD:refs/heads/production',
+      });
+      expect(intent.branch).toBe('production');
+    });
+
+    it('returns undefined branch when only remote is specified (no branch)', () => {
+      const intent = normalizeIntent({
+        tool: 'Bash',
+        command: 'git push origin',
+      });
+      expect(intent.branch).toBeUndefined();
+    });
+
     it('marks destructive shell commands', () => {
       const intent = normalizeIntent({ tool: 'Bash', command: 'rm -rf /' });
       expect(intent.destructive).toBe(true);
@@ -846,6 +937,82 @@ describe('agentguard/core/aab', () => {
       // Read action with 1 file: score = 1 * 0.1 = 0.1, should not exceed limit 100
       expect(result.blastRadius).toBeDefined();
       expect(result.blastRadius!.exceeded).toBe(false);
+    });
+
+    // --- Issue #627: deny rule fires for refspec push to protected branch ---
+    it('denies refspec push to protected branch via policy', () => {
+      const policies = [
+        {
+          id: 'protected-branches',
+          name: 'Protected Branches',
+          rules: [
+            {
+              action: 'git.push',
+              effect: 'deny' as const,
+              conditions: { branches: ['main', 'master'] },
+              reason: 'Direct push to protected branch',
+            },
+            { action: '*', effect: 'allow' as const },
+          ],
+          severity: 5,
+        },
+      ];
+      const result = authorize(
+        { tool: 'Bash', command: 'git push origin HEAD:refs/heads/main' },
+        policies
+      );
+      expect(result.result.allowed).toBe(false);
+      expect(result.result.reason).toContain('protected branch');
+    });
+
+    it('denies flagged push to protected branch via policy', () => {
+      const policies = [
+        {
+          id: 'protected-branches',
+          name: 'Protected Branches',
+          rules: [
+            {
+              // git push --force is classified as git.force-push, so both must be denied
+              action: ['git.push', 'git.force-push'],
+              effect: 'deny' as const,
+              conditions: { branches: ['main', 'master'] },
+              reason: 'Direct push to protected branch',
+            },
+            { action: '*', effect: 'allow' as const },
+          ],
+          severity: 5,
+        },
+      ];
+      const result = authorize(
+        { tool: 'Bash', command: 'git push --force origin main' },
+        policies
+      );
+      expect(result.result.allowed).toBe(false);
+      expect(result.result.reason).toContain('protected branch');
+    });
+
+    it('allows flagged push to non-protected branch via policy', () => {
+      const policies = [
+        {
+          id: 'protected-branches',
+          name: 'Protected Branches',
+          rules: [
+            {
+              action: 'git.push',
+              effect: 'deny' as const,
+              conditions: { branches: ['main', 'master'] },
+              reason: 'Direct push to protected branch',
+            },
+            { action: '*', effect: 'allow' as const },
+          ],
+          severity: 5,
+        },
+      ];
+      const result = authorize(
+        { tool: 'Bash', command: 'git push -u origin feature/my-branch' },
+        policies
+      );
+      expect(result.result.allowed).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Rewrites extractBranch() in packages/kernel/src/aab.ts to properly tokenize git push arguments, skip flag tokens and their value arguments, then extract the branch from positional args
- Handles refspec syntax: HEAD:main, HEAD:refs/heads/main, +HEAD:main, :main all correctly extract the destination branch name
- Adds 14 new test cases covering flag handling, refspec parsing, and end-to-end authorize() integration with protected branch deny policies

## Problem
The previous regex assumed git push remote branch without flags. When flags preceded the remote, the regex captured the wrong token as the branch. With refspec syntax, the full refspec was returned instead of just the branch name.

## Test plan
- [x] All 757 kernel tests pass (including 14 new tests)
- [x] Build passes across all 17 packages
- [x] Lint and type-check pass
- [ ] CI size-check workflow

## Governance Report
- **Agent identity**: `claude-code:opus:developer`
- **Session**: `fix/issue-627-refspec-branch-extraction`
- **Risk level**: NORMAL
- **Actions governed**: file reads, file writes, shell exec (tsc, vitest)
- **Invariants triggered**: none
- **Policy denials**: none
- **Scope**: Changes confined to `packages/kernel/src/aab.ts` and `packages/kernel/tests/agentguard-aab.test.ts`

Closes #627

<!-- agent:claude-code:opus:developer -->