### PR TITLE
docs: sync documentation with codebase state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,7 +180,7 @@ apps/
 
 tests/
 └── *.test.js               # 14 JS test files (custom zero-dependency harness)
-# 157 TS test files (vitest) distributed across packages/ and apps/ directories
+# 159 TS test files (vitest) distributed across packages/ and apps/ directories
 policy/                     # Policy configuration (JSON: action_rules, capabilities)
 policies/                   # Policy packs (YAML: ci-safe, engineering-standards, enterprise, hipaa, open-source, soc2, strict)
 docs/                       # System documentation (architecture, event model, specs)
@@ -284,7 +284,7 @@ Each workspace package maps to a single architectural concept:
 - `agentguard learn` — Interactive tutorials and learning paths
 - `agentguard migrate` — Migrate configuration between versions
 - `agentguard trust` — Manage policy and hook trust verification
-- `agentguard cloud connect|status|events|runs|summary|disconnect` — Cloud governance analytics
+- `agentguard cloud login|connect|status|events|runs|summary|disconnect` — Cloud governance analytics
 - `agentguard copilot-hook` — Handle GitHub Copilot PreToolUse/PostToolUse hook events
 - `agentguard copilot-init` — Set up GitHub Copilot hook integration
 

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ rules:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `action` | `string \| string[]` | Action type(s): `file.read`, `git.push`, `shell.exec`, `mcp.call`, etc. (24 types across 9 classes) |
+| `action` | `string \| string[]` | Action type(s): `file.read`, `git.push`, `shell.exec`, `mcp.call`, etc. (27 types across 9 classes) |
 | `effect` | `string` | `deny` or `allow` |
 | `target` | `string` | Glob pattern for file paths or command patterns |
 | `branches` | `string[]` | Git branch names this rule applies to |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -58,7 +58,7 @@ A comprehensive codebase audit assessed the current system against the strategic
 
 | Component | Status | Key Files |
 |-----------|--------|-----------|
-| Canonical Action Representation (24 types, 9 classes) | Implemented | `packages/core/src/actions.ts` |
+| Canonical Action Representation (27 types, 9 classes) | Implemented | `packages/core/src/actions.ts` |
 | Action Authorization Boundary (AAB) | Implemented (2 bypass vectors) | `packages/kernel/src/aab.ts` |
 | Policy Evaluator (two-phase deny/allow) | Implemented | `packages/policy/src/evaluator.ts` |
 | 21 Built-in Invariants | Fully Implemented | `packages/invariants/src/definitions.ts`, `packages/invariants/src/checker.ts` |


### PR DESCRIPTION
## Summary

- Automated documentation sync detected drift between codebase and docs
- **CLAUDE.md**: TS test file count was 157, actual is 159 (2 new test files added)
- **CLAUDE.md**: Cloud subcommand list was missing `login`
- **README.md**: Action type count in rule field table was 24, actual is 27
- **ROADMAP.md**: Action type count in architectural audit table was 24, actual is 27

## Changes

- `CLAUDE.md` — Updated test count (157→159), added `login` to cloud subcommands
- `README.md` — Corrected action type count in supported rule fields table (24→27)
- `ROADMAP.md` — Corrected action type count in architectural audit table (24→27)

## Strategic Document Check

- `docs/current-priorities.md` — Does not exist (no staleness check needed)
- `docs/strategic-roadmap.md` — Does not exist (no staleness check needed)
- No contradictions found between ROADMAP.md and ARCHITECTURE.md

## Source

Auto-generated by the **documentation-maintainer-agent** (`claude-code:opus:ops`).

---
*Run: 2026-03-22*