### PR TITLE
feat(issue-83): add team-level governance observability

### DIFF
--- a/apps/cli/src/bin.ts
+++ b/apps/cli/src/bin.ts
@@ -554,6 +554,13 @@ async function main() {
       break;
     }
 
+    case 'team-report': {
+      const { teamReportCommand } = await import('./commands/team-report.js');
+      const code = await teamReportCommand(args.slice(1), resolveStorageConfig(args.slice(1)));
+      process.exit(code);
+      break;
+    }
+
     case 'guard': {
       if (wantsHelp) {
         console.log(formatHelp(COMMANDS.guard));
@@ -953,6 +960,7 @@ function printHelp(): void {
     agentguard inspect [runId]                Inspect action graph and decisions
     agentguard events [runId]                 Show raw event stream for a run
     agentguard analytics                      Analyze blocked action patterns across sessions
+    agentguard team-report                    Team-level governance observability across agents
     agentguard adoption                       Show how much agent activity is protected
     agentguard learn                          Analyze denial patterns and suggest policy improvements
 

--- a/apps/cli/src/commands/team-report.ts
+++ b/apps/cli/src/commands/team-report.ts
@@ -1,0 +1,314 @@
+// CLI command: agentguard team-report — team-level governance observability.
+// Aggregates governance data across multiple agents/sessions for team leads
+// and security teams. Supports text, JSON, CSV, and markdown output formats.
+
+import { parseArgs } from '../args.js';
+import { bold, color, dim } from '../colors.js';
+import type { StorageConfig, TeamReport, AgentSummary } from '@red-codes/storage';
+
+function fmtDate(ts: number | null): string {
+  if (ts === null) return dim('n/a');
+  return new Date(ts).toISOString().replace('T', ' ').slice(0, 19);
+}
+
+function fmtDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  if (ms < 3_600_000) return `${(ms / 60_000).toFixed(1)}m`;
+  return `${(ms / 3_600_000).toFixed(1)}h`;
+}
+
+function bar(value: number, max: number, width: number = 20): string {
+  if (max === 0) return dim('░'.repeat(width));
+  const filled = Math.round((value / max) * width);
+  return color('█'.repeat(filled), 'green') + dim('░'.repeat(width - filled));
+}
+
+function complianceColor(rate: number): string {
+  if (rate >= 95) return 'green';
+  if (rate >= 80) return 'yellow';
+  return 'red';
+}
+
+function renderTextOutput(report: TeamReport): void {
+  const { overview, agents, topDeniedActions, topViolatedInvariants, denialTrends } = report;
+
+  // Header
+  process.stderr.write('\n');
+  process.stderr.write(`  ${bold('Team Governance Report')}\n`);
+  process.stderr.write(`  ${dim('═'.repeat(60))}\n\n`);
+
+  // Overview
+  process.stderr.write(`  ${bold('Overview')}\n`);
+  process.stderr.write(`  Agents:      ${bold(String(agents.length))}\n`);
+  process.stderr.write(`  Sessions:    ${bold(String(overview.totalSessions))}\n`);
+  process.stderr.write(`  Events:      ${bold(String(overview.totalEvents))}\n`);
+  process.stderr.write(`  Decisions:   ${bold(String(overview.totalDecisions))}\n`);
+  process.stderr.write(
+    `  Period:      ${fmtDate(overview.firstEventAt)} → ${fmtDate(overview.lastEventAt)}\n`
+  );
+  if (overview.firstEventAt && overview.lastEventAt) {
+    process.stderr.write(
+      `  Duration:    ${fmtDuration(overview.lastEventAt - overview.firstEventAt)}\n`
+    );
+  }
+
+  // Overall compliance
+  const overallCompliance =
+    overview.totalDecisions > 0
+      ? Math.round((overview.allowedCount / overview.totalDecisions) * 1000) / 10
+      : 100;
+  process.stderr.write(
+    `  Compliance:  ${color(`${overallCompliance}%`, complianceColor(overallCompliance))}\n`
+  );
+  process.stderr.write('\n');
+
+  // Per-agent summary
+  if (agents.length > 0) {
+    process.stderr.write(`  ${bold('Agent Profiles')}\n`);
+    process.stderr.write(`  ${dim('─'.repeat(60))}\n`);
+
+    const maxSessions = Math.max(...agents.map((a) => a.sessions));
+    for (const agent of agents) {
+      const rate = agent.complianceRate;
+      process.stderr.write(`\n  ${bold(agent.agent)}\n`);
+      process.stderr.write(
+        `    Sessions:   ${bar(agent.sessions, maxSessions, 15)} ${String(agent.sessions).padStart(4)}\n`
+      );
+      process.stderr.write(
+        `    Actions:    ${color(String(agent.allowed), 'green')} allowed / ${color(String(agent.denied), 'red')} denied / ${color(String(agent.escalated), 'yellow')} escalated\n`
+      );
+      if (agent.violations > 0) {
+        process.stderr.write(`    Violations: ${color(String(agent.violations), 'red')}\n`);
+      }
+      process.stderr.write(`    Compliance: ${color(`${rate}%`, complianceColor(rate))}\n`);
+      process.stderr.write(
+        `    Active:     ${fmtDate(agent.firstSeen)} → ${fmtDate(agent.lastSeen)}\n`
+      );
+    }
+    process.stderr.write('\n');
+  }
+
+  // Top denied actions
+  if (topDeniedActions.length > 0) {
+    process.stderr.write(`  ${bold('Top Denied Actions')}\n`);
+    process.stderr.write(`  ${dim('─'.repeat(60))}\n`);
+    const maxDenied = topDeniedActions[0].count;
+    for (const d of topDeniedActions) {
+      process.stderr.write(
+        `  ${color(d.actionType.padEnd(20), 'red')} ${bar(d.count, maxDenied, 15)} ${String(d.count).padStart(4)} ${dim(`(${d.distinctSessions} sessions)`)}\n`
+      );
+    }
+    process.stderr.write('\n');
+  }
+
+  // Invariant violations
+  if (topViolatedInvariants.length > 0) {
+    process.stderr.write(`  ${bold('Most Violated Invariants')}\n`);
+    process.stderr.write(`  ${dim('─'.repeat(60))}\n`);
+    const maxViol = topViolatedInvariants[0].count;
+    for (const v of topViolatedInvariants) {
+      process.stderr.write(
+        `  ${v.invariant.padEnd(30)} ${bar(v.count, maxViol, 15)} ${String(v.count).padStart(4)} ${dim(`(${v.distinctSessions} sessions)`)}\n`
+      );
+    }
+    process.stderr.write('\n');
+  }
+
+  // Denial patterns
+  if (denialTrends.length > 0) {
+    process.stderr.write(`  ${bold('Denial Patterns')}\n`);
+    process.stderr.write(`  ${dim('─'.repeat(60))}\n`);
+    for (const p of denialTrends.slice(0, 10)) {
+      process.stderr.write(
+        `  ${color(p.actionType, 'yellow')} ${dim('→')} ${p.reason}\n` +
+          `    ${dim(`${p.occurrences} occurrences across ${p.distinctSessions} sessions`)}\n`
+      );
+    }
+    process.stderr.write('\n');
+  }
+}
+
+function renderMarkdownOutput(report: TeamReport): void {
+  const { overview, agents, topDeniedActions, topViolatedInvariants, denialTrends } = report;
+
+  const overallCompliance =
+    overview.totalDecisions > 0
+      ? Math.round((overview.allowedCount / overview.totalDecisions) * 1000) / 10
+      : 100;
+
+  const lines: string[] = [];
+  lines.push('# Team Governance Report');
+  lines.push('');
+  lines.push('## Overview');
+  lines.push('');
+  lines.push('| Metric | Value |');
+  lines.push('|--------|-------|');
+  lines.push(`| Agents | ${agents.length} |`);
+  lines.push(`| Sessions | ${overview.totalSessions} |`);
+  lines.push(`| Total events | ${overview.totalEvents} |`);
+  lines.push(`| Total decisions | ${overview.totalDecisions} |`);
+  lines.push(`| Allowed | ${overview.allowedCount} |`);
+  lines.push(`| Denied | ${overview.deniedCount} |`);
+  lines.push(`| Escalated | ${overview.escalatedCount} |`);
+  lines.push(`| Compliance rate | ${overallCompliance}% |`);
+  lines.push('');
+
+  if (agents.length > 0) {
+    lines.push('## Agent Profiles');
+    lines.push('');
+    lines.push('| Agent | Sessions | Allowed | Denied | Escalated | Violations | Compliance |');
+    lines.push('|-------|----------|---------|--------|-----------|------------|------------|');
+    for (const agent of agents) {
+      lines.push(
+        `| ${agent.agent} | ${agent.sessions} | ${agent.allowed} | ${agent.denied} | ${agent.escalated} | ${agent.violations} | ${agent.complianceRate}% |`
+      );
+    }
+    lines.push('');
+  }
+
+  if (topDeniedActions.length > 0) {
+    lines.push('## Top Denied Actions');
+    lines.push('');
+    lines.push('| Action Type | Count | Sessions |');
+    lines.push('|-------------|-------|----------|');
+    for (const d of topDeniedActions) {
+      lines.push(`| ${d.actionType} | ${d.count} | ${d.distinctSessions} |`);
+    }
+    lines.push('');
+  }
+
+  if (topViolatedInvariants.length > 0) {
+    lines.push('## Most Violated Invariants');
+    lines.push('');
+    lines.push('| Invariant | Count | Sessions |');
+    lines.push('|-----------|-------|----------|');
+    for (const v of topViolatedInvariants) {
+      lines.push(`| ${v.invariant} | ${v.count} | ${v.distinctSessions} |`);
+    }
+    lines.push('');
+  }
+
+  if (denialTrends.length > 0) {
+    lines.push('## Denial Patterns');
+    lines.push('');
+    lines.push('| Action | Reason | Occurrences | Sessions |');
+    lines.push('|--------|--------|-------------|----------|');
+    for (const p of denialTrends) {
+      lines.push(`| ${p.actionType} | ${p.reason} | ${p.occurrences} | ${p.distinctSessions} |`);
+    }
+    lines.push('');
+  }
+
+  process.stdout.write(lines.join('\n') + '\n');
+}
+
+function renderCsvOutput(agents: AgentSummary[]): void {
+  const lines: string[] = [];
+  lines.push(
+    'agent,sessions,total_actions,allowed,denied,escalated,violations,compliance_rate,first_seen,last_seen'
+  );
+  for (const a of agents) {
+    lines.push(
+      `${a.agent},${a.sessions},${a.totalActions},${a.allowed},${a.denied},${a.escalated},${a.violations},${a.complianceRate},${new Date(a.firstSeen).toISOString()},${new Date(a.lastSeen).toISOString()}`
+    );
+  }
+  process.stdout.write(lines.join('\n') + '\n');
+}
+
+export async function teamReportCommand(
+  args: string[],
+  storageConfig?: StorageConfig
+): Promise<number> {
+  const parsed = parseArgs(args, {
+    boolean: ['--json', '--markdown', '--md', '--csv', '--help', '-h'],
+    string: ['--since', '--until', '--sessions', '--db-path'],
+  });
+
+  if (parsed.flags['help'] || parsed.flags['h']) {
+    process.stderr.write(
+      '\n' +
+        bold('  agentguard team-report') +
+        dim(' — team-level governance observability\n\n') +
+        '  Aggregates governance data across agents and sessions for team leads\n' +
+        '  and security teams.\n\n' +
+        '  Options:\n' +
+        '    --json              Output as JSON\n' +
+        '    --markdown, --md    Output as Markdown\n' +
+        '    --csv               Output agent profiles as CSV\n' +
+        '    --since <date>      Filter events after this ISO date\n' +
+        '    --until <date>      Filter events before this ISO date\n' +
+        '    --sessions <n>      Limit to N most recent sessions\n' +
+        '    --db-path <path>    Path to SQLite database\n\n' +
+        '  Examples:\n' +
+        '    agentguard team-report\n' +
+        '    agentguard team-report --json\n' +
+        '    agentguard team-report --markdown > report.md\n' +
+        '    agentguard team-report --csv > agents.csv\n' +
+        '    agentguard team-report --since 2026-03-01\n\n'
+    );
+    return 0;
+  }
+
+  const jsonOutput = parsed.flags['json'] === true;
+  const markdownOutput = parsed.flags['markdown'] === true || parsed.flags['md'] === true;
+  const csvOutput = parsed.flags['csv'] === true;
+  const sinceStr = parsed.flags['since'] as string | undefined;
+  const untilStr = parsed.flags['until'] as string | undefined;
+  const sessionsStr = parsed.flags['sessions'] as string | undefined;
+  const dbPathFlag = parsed.flags['db-path'] as string | undefined;
+
+  const filter: import('@red-codes/storage').AggregationTimeFilter = {
+    since: sinceStr ? new Date(sinceStr).getTime() : undefined,
+    until: untilStr ? new Date(untilStr).getTime() : undefined,
+    sessionLimit: sessionsStr ? parseInt(sessionsStr, 10) : undefined,
+  };
+
+  const config: StorageConfig = storageConfig ?? {
+    backend: 'sqlite',
+    dbPath: dbPathFlag ?? process.env['AGENTGUARD_DB_PATH'],
+  };
+
+  const { createStorageBundle, teamReport } = await import('@red-codes/storage');
+
+  let storage: Awaited<ReturnType<typeof createStorageBundle>> | null = null;
+  try {
+    storage = await createStorageBundle(config);
+  } catch {
+    process.stderr.write(
+      '  Error: Could not open SQLite database.\n' +
+        '  Ensure AgentGuard has recorded governance sessions.\n'
+    );
+    return 1;
+  }
+
+  if (!storage.db) {
+    process.stderr.write('  Error: No database available.\n');
+    return 1;
+  }
+
+  const db = storage.db as import('better-sqlite3').Database;
+
+  try {
+    const report = teamReport(db, filter);
+
+    if (report.overview.totalEvents === 0) {
+      process.stderr.write('\n  No governance events found.\n\n');
+      return 0;
+    }
+
+    if (jsonOutput) {
+      process.stdout.write(JSON.stringify(report, null, 2) + '\n');
+    } else if (markdownOutput) {
+      renderMarkdownOutput(report);
+    } else if (csvOutput) {
+      renderCsvOutput(report.agents);
+    } else {
+      renderTextOutput(report);
+    }
+  } finally {
+    storage.close();
+  }
+
+  return 0;
+}

--- a/apps/cli/tests/cli-team-report.test.ts
+++ b/apps/cli/tests/cli-team-report.test.ts
@@ -1,0 +1,193 @@
+// Tests for CLI team-report command — team-level governance observability
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { runMigrations } from '@red-codes/storage';
+import { unlinkSync } from 'node:fs';
+
+const stderrChunks: string[] = [];
+vi.spyOn(process.stderr, 'write').mockImplementation((chunk: string | Uint8Array) => {
+  stderrChunks.push(chunk.toString());
+  return true;
+});
+
+const stdoutChunks: string[] = [];
+vi.spyOn(process.stdout, 'write').mockImplementation((chunk: string | Uint8Array) => {
+  stdoutChunks.push(chunk.toString());
+  return true;
+});
+
+const tmpFiles: string[] = [];
+
+beforeEach(() => {
+  stderrChunks.length = 0;
+  stdoutChunks.length = 0;
+});
+
+afterEach(() => {
+  for (const f of tmpFiles) {
+    try {
+      unlinkSync(f);
+    } catch {
+      // ignore
+    }
+  }
+  tmpFiles.length = 0;
+});
+
+function createSeededDb(): string {
+  const tmpPath = `/tmp/team-report-test-${Date.now()}-${Math.random().toString(36).slice(2, 6)}.db`;
+  tmpFiles.push(tmpPath);
+
+  const db = new Database(tmpPath);
+  runMigrations(db);
+
+  const now = Date.now();
+
+  // Agent alpha: 2 sessions, 4 decisions (3 allowed, 1 denied)
+  db.prepare(
+    'INSERT INTO events (id, run_id, kind, timestamp, fingerprint, data) VALUES (?, ?, ?, ?, ?, ?)'
+  ).run('e1', 'run_1', 'RunStarted', now - 5000, 'fp1', JSON.stringify({ agentName: 'alpha' }));
+  db.prepare(
+    'INSERT INTO events (id, run_id, kind, timestamp, fingerprint, data) VALUES (?, ?, ?, ?, ?, ?)'
+  ).run('e2', 'run_1', 'ActionAllowed', now - 4000, 'fp2', '{}');
+
+  db.prepare(
+    'INSERT INTO events (id, run_id, kind, timestamp, fingerprint, data) VALUES (?, ?, ?, ?, ?, ?)'
+  ).run('e3', 'run_2', 'RunStarted', now - 3000, 'fp3', JSON.stringify({ agentName: 'alpha' }));
+  db.prepare(
+    'INSERT INTO events (id, run_id, kind, timestamp, fingerprint, data) VALUES (?, ?, ?, ?, ?, ?)'
+  ).run('e4', 'run_2', 'ActionDenied', now - 2000, 'fp4', '{}');
+
+  // Agent beta: 1 session, 2 decisions (2 allowed)
+  db.prepare(
+    'INSERT INTO events (id, run_id, kind, timestamp, fingerprint, data) VALUES (?, ?, ?, ?, ?, ?)'
+  ).run('e5', 'run_3', 'RunStarted', now - 1000, 'fp5', JSON.stringify({ agentName: 'beta' }));
+  db.prepare(
+    'INSERT INTO events (id, run_id, kind, timestamp, fingerprint, data) VALUES (?, ?, ?, ?, ?, ?)'
+  ).run('e6', 'run_3', 'ActionAllowed', now - 500, 'fp6', '{}');
+
+  // Decisions for alpha
+  db.prepare(
+    `INSERT INTO decisions (record_id, run_id, timestamp, outcome, action_type, target, reason, data)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run('d1', 'run_1', now - 4000, 'allowed', 'file.write', 'a.ts', 'match', '{}');
+  db.prepare(
+    `INSERT INTO decisions (record_id, run_id, timestamp, outcome, action_type, target, reason, data)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run('d2', 'run_1', now - 3500, 'allowed', 'file.write', 'b.ts', 'match', '{}');
+  db.prepare(
+    `INSERT INTO decisions (record_id, run_id, timestamp, outcome, action_type, target, reason, data)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run('d3', 'run_1', now - 3000, 'allowed', 'file.read', 'c.ts', 'match', '{}');
+  db.prepare(
+    `INSERT INTO decisions (record_id, run_id, timestamp, outcome, action_type, target, reason, data)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run('d4', 'run_2', now - 2000, 'denied', 'git.push', 'main', 'protected branch', '{}');
+
+  // Decisions for beta
+  db.prepare(
+    `INSERT INTO decisions (record_id, run_id, timestamp, outcome, action_type, target, reason, data)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run('d5', 'run_3', now - 500, 'allowed', 'file.write', 'd.ts', 'match', '{}');
+  db.prepare(
+    `INSERT INTO decisions (record_id, run_id, timestamp, outcome, action_type, target, reason, data)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run('d6', 'run_3', now - 400, 'allowed', 'file.read', 'e.ts', 'match', '{}');
+
+  db.close();
+  return tmpPath;
+}
+
+describe('teamReportCommand()', () => {
+  it('prints help text with --help flag', async () => {
+    const { teamReportCommand } = await import('../src/commands/team-report.js');
+    const code = await teamReportCommand(['--help']);
+
+    expect(code).toBe(0);
+    const output = stderrChunks.join('');
+    expect(output).toContain('agentguard team-report');
+    expect(output).toContain('--json');
+    expect(output).toContain('--markdown');
+    expect(output).toContain('--csv');
+  });
+
+  it('reports no events on an empty database', async () => {
+    const { teamReportCommand } = await import('../src/commands/team-report.js');
+    const code = await teamReportCommand([], { backend: 'sqlite', dbPath: ':memory:' });
+
+    expect(code).toBe(0);
+    const output = stderrChunks.join('');
+    expect(output).toContain('No governance events found');
+  });
+
+  it('renders text output with agent profiles', async () => {
+    const tmpPath = createSeededDb();
+
+    const { teamReportCommand } = await import('../src/commands/team-report.js');
+    const code = await teamReportCommand([], {
+      backend: 'sqlite',
+      dbPath: tmpPath,
+    });
+
+    expect(code).toBe(0);
+    const output = stderrChunks.join('');
+    expect(output).toContain('Team Governance Report');
+    expect(output).toContain('Agent Profiles');
+    expect(output).toContain('alpha');
+    expect(output).toContain('beta');
+  });
+
+  it('outputs JSON with --json flag', async () => {
+    const tmpPath = createSeededDb();
+
+    const { teamReportCommand } = await import('../src/commands/team-report.js');
+    const code = await teamReportCommand(['--json'], {
+      backend: 'sqlite',
+      dbPath: tmpPath,
+    });
+
+    expect(code).toBe(0);
+    const json = JSON.parse(stdoutChunks.join(''));
+    expect(json.overview).toBeDefined();
+    expect(json.agents).toBeInstanceOf(Array);
+    expect(json.agents.length).toBe(2);
+
+    const alpha = json.agents.find((a: { agent: string }) => a.agent === 'alpha');
+    expect(alpha.sessions).toBe(2);
+    expect(alpha.allowed).toBe(3);
+    expect(alpha.denied).toBe(1);
+  });
+
+  it('outputs markdown with --markdown flag', async () => {
+    const tmpPath = createSeededDb();
+
+    const { teamReportCommand } = await import('../src/commands/team-report.js');
+    const code = await teamReportCommand(['--markdown'], {
+      backend: 'sqlite',
+      dbPath: tmpPath,
+    });
+
+    expect(code).toBe(0);
+    const output = stdoutChunks.join('');
+    expect(output).toContain('# Team Governance Report');
+    expect(output).toContain('## Agent Profiles');
+    expect(output).toContain('| alpha |');
+    expect(output).toContain('| beta |');
+  });
+
+  it('outputs CSV with --csv flag', async () => {
+    const tmpPath = createSeededDb();
+
+    const { teamReportCommand } = await import('../src/commands/team-report.js');
+    const code = await teamReportCommand(['--csv'], {
+      backend: 'sqlite',
+      dbPath: tmpPath,
+    });
+
+    expect(code).toBe(0);
+    const output = stdoutChunks.join('');
+    expect(output).toContain('agent,sessions,total_actions,allowed,denied');
+    expect(output).toContain('alpha,');
+    expect(output).toContain('beta,');
+  });
+});

--- a/packages/storage/src/aggregation-queries.ts
+++ b/packages/storage/src/aggregation-queries.ts
@@ -309,3 +309,185 @@ export function denialPatterns(
     distinctSessions: number;
   }>;
 }
+
+// ─── Team-Level Aggregation Queries ───────────────────────────────────────────
+
+/** Per-agent governance summary */
+export interface AgentSummary {
+  readonly agent: string;
+  readonly sessions: number;
+  readonly totalActions: number;
+  readonly allowed: number;
+  readonly denied: number;
+  readonly escalated: number;
+  readonly violations: number;
+  readonly complianceRate: number;
+  readonly firstSeen: number;
+  readonly lastSeen: number;
+}
+
+/** Team-wide governance report */
+export interface TeamReport {
+  readonly overview: GovernanceStats;
+  readonly agents: AgentSummary[];
+  readonly topDeniedActions: DeniedActionCount[];
+  readonly topViolatedInvariants: ViolationByInvariant[];
+  readonly denialTrends: DenialPatternEntry[];
+}
+
+/** Denial pattern entry for team reports */
+export interface DenialPatternEntry {
+  readonly actionType: string;
+  readonly reason: string;
+  readonly occurrences: number;
+  readonly distinctSessions: number;
+}
+
+/**
+ * Per-agent governance summaries.
+ *
+ * Resolves agent identity from RunStarted events (agentName field in JSON data),
+ * then joins with decision outcomes to compute per-agent compliance metrics.
+ */
+export function agentSummaries(
+  db: Database.Database,
+  filter?: AggregationTimeFilter
+): AgentSummary[] {
+  const { where, params } = buildTimeConditions(filter, 'events');
+
+  // Step 1: Map run_id → agent name from RunStarted events
+  const agentMapSql = `
+    SELECT
+      run_id,
+      COALESCE(
+        json_extract(data, '$.agentName'),
+        json_extract(data, '$.agentId'),
+        'unknown'
+      ) as agent
+    FROM events
+    ${where ? `${where} AND kind = 'RunStarted'` : "WHERE kind = 'RunStarted'"}
+  `;
+  const agentMap = db.prepare(agentMapSql).all(...params) as Array<{
+    run_id: string;
+    agent: string;
+  }>;
+
+  // Build a lookup of run_id → agent
+  const runToAgent = new Map<string, string>();
+  for (const row of agentMap) {
+    runToAgent.set(row.run_id, row.agent);
+  }
+
+  // Step 2: Get per-run decision summaries
+  const runSummarySql = `
+    SELECT
+      run_id as runId,
+      COUNT(*) as totalActions,
+      SUM(CASE WHEN outcome = 'allowed' THEN 1 ELSE 0 END) as allowed,
+      SUM(CASE WHEN outcome = 'denied' THEN 1 ELSE 0 END) as denied,
+      SUM(CASE WHEN outcome = 'escalated' THEN 1 ELSE 0 END) as escalated,
+      MIN(timestamp) as firstSeen,
+      MAX(timestamp) as lastSeen
+    FROM decisions
+    ${buildTimeConditions(filter, 'decisions').where}
+    GROUP BY run_id
+  `;
+  const runSummaries = db
+    .prepare(runSummarySql)
+    .all(...buildTimeConditions(filter, 'decisions').params) as Array<{
+    runId: string;
+    totalActions: number;
+    allowed: number;
+    denied: number;
+    escalated: number;
+    firstSeen: number;
+    lastSeen: number;
+  }>;
+
+  // Step 3: Get per-run violation counts
+  const violationSql = `
+    SELECT
+      run_id,
+      COUNT(*) as violations
+    FROM events
+    ${where ? `${where} AND kind = 'InvariantViolation'` : "WHERE kind = 'InvariantViolation'"}
+    GROUP BY run_id
+  `;
+  const violationRows = db.prepare(violationSql).all(...params) as Array<{
+    run_id: string;
+    violations: number;
+  }>;
+  const runViolations = new Map<string, number>();
+  for (const row of violationRows) {
+    runViolations.set(row.run_id, row.violations);
+  }
+
+  // Step 4: Aggregate by agent
+  const agentData = new Map<
+    string,
+    {
+      sessions: number;
+      totalActions: number;
+      allowed: number;
+      denied: number;
+      escalated: number;
+      violations: number;
+      firstSeen: number;
+      lastSeen: number;
+    }
+  >();
+
+  for (const run of runSummaries) {
+    const agent = runToAgent.get(run.runId) ?? 'unknown';
+    const existing = agentData.get(agent);
+    const violations = runViolations.get(run.runId) ?? 0;
+
+    if (existing) {
+      existing.sessions += 1;
+      existing.totalActions += run.totalActions;
+      existing.allowed += run.allowed;
+      existing.denied += run.denied;
+      existing.escalated += run.escalated;
+      existing.violations += violations;
+      existing.firstSeen = Math.min(existing.firstSeen, run.firstSeen);
+      existing.lastSeen = Math.max(existing.lastSeen, run.lastSeen);
+    } else {
+      agentData.set(agent, {
+        sessions: 1,
+        totalActions: run.totalActions,
+        allowed: run.allowed,
+        denied: run.denied,
+        escalated: run.escalated,
+        violations,
+        firstSeen: run.firstSeen,
+        lastSeen: run.lastSeen,
+      });
+    }
+  }
+
+  // Convert to sorted array
+  return [...agentData.entries()]
+    .map(([agent, data]) => ({
+      agent,
+      ...data,
+      complianceRate:
+        data.totalActions > 0 ? Math.round((data.allowed / data.totalActions) * 1000) / 10 : 100,
+    }))
+    .sort((a, b) => b.sessions - a.sessions);
+}
+
+/**
+ * Build a complete team governance report.
+ *
+ * Aggregates per-agent summaries, overall stats, top denied actions,
+ * most violated invariants, and denial patterns.
+ */
+export function teamReport(db: Database.Database, filter?: AggregationTimeFilter): TeamReport {
+  return {
+    overview: governanceStats(db, filter),
+    agents: agentSummaries(db, filter),
+    topDeniedActions: topDeniedActions(db, 10, filter),
+    topViolatedInvariants: countViolationsByInvariant(db, filter),
+    denialTrends: denialPatterns(db, 15, filter) as DenialPatternEntry[],
+  };
+}

--- a/packages/storage/tests/team-aggregation.test.ts
+++ b/packages/storage/tests/team-aggregation.test.ts
@@ -1,0 +1,325 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { runMigrations, agentSummaries, teamReport } from '@red-codes/storage';
+
+function insertEvent(
+  db: Database.Database,
+  overrides: {
+    id?: string;
+    runId?: string;
+    kind?: string;
+    timestamp?: number;
+    data?: Record<string, unknown>;
+  } = {}
+): void {
+  const id = overrides.id ?? `evt_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+  const runId = overrides.runId ?? 'run_1';
+  const kind = overrides.kind ?? 'ActionRequested';
+  const timestamp = overrides.timestamp ?? Date.now();
+  const data = overrides.data ?? {};
+
+  db.prepare(
+    'INSERT INTO events (id, run_id, kind, timestamp, fingerprint, data) VALUES (?, ?, ?, ?, ?, ?)'
+  ).run(id, runId, kind, timestamp, 'fp_test', JSON.stringify(data));
+}
+
+function insertDecision(
+  db: Database.Database,
+  overrides: {
+    recordId?: string;
+    runId?: string;
+    outcome?: string;
+    actionType?: string;
+    target?: string;
+    reason?: string;
+    timestamp?: number;
+  } = {}
+): void {
+  const recordId =
+    overrides.recordId ?? `dec_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+  const runId = overrides.runId ?? 'run_1';
+  const outcome = overrides.outcome ?? 'allowed';
+  const actionType = overrides.actionType ?? 'file.write';
+  const target = overrides.target ?? 'src/main.ts';
+  const reason = overrides.reason ?? 'policy match';
+  const timestamp = overrides.timestamp ?? Date.now();
+
+  db.prepare(
+    `INSERT INTO decisions (record_id, run_id, timestamp, outcome, action_type, target, reason, data)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run(recordId, runId, timestamp, outcome, actionType, target, reason, JSON.stringify({}));
+}
+
+describe('Team Aggregation Queries', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    runMigrations(db);
+  });
+
+  describe('agentSummaries', () => {
+    it('returns empty array for empty database', () => {
+      expect(agentSummaries(db)).toEqual([]);
+    });
+
+    it('groups sessions by agent name from RunStarted events', () => {
+      const now = Date.now();
+
+      // Agent 1: two sessions
+      insertEvent(db, {
+        runId: 'run_1',
+        kind: 'RunStarted',
+        timestamp: now - 3000,
+        data: { agentName: 'agent-alpha' },
+      });
+      insertDecision(db, { runId: 'run_1', outcome: 'allowed', timestamp: now - 2000 });
+      insertDecision(db, { runId: 'run_1', outcome: 'allowed', timestamp: now - 1000 });
+
+      insertEvent(db, {
+        runId: 'run_2',
+        kind: 'RunStarted',
+        timestamp: now - 500,
+        data: { agentName: 'agent-alpha' },
+      });
+      insertDecision(db, { runId: 'run_2', outcome: 'denied', timestamp: now - 400 });
+
+      // Agent 2: one session
+      insertEvent(db, {
+        runId: 'run_3',
+        kind: 'RunStarted',
+        timestamp: now - 200,
+        data: { agentName: 'agent-beta' },
+      });
+      insertDecision(db, { runId: 'run_3', outcome: 'allowed', timestamp: now - 100 });
+
+      const summaries = agentSummaries(db);
+
+      expect(summaries).toHaveLength(2);
+
+      const alpha = summaries.find((s) => s.agent === 'agent-alpha');
+      expect(alpha).toBeDefined();
+      expect(alpha!.sessions).toBe(2);
+      expect(alpha!.totalActions).toBe(3);
+      expect(alpha!.allowed).toBe(2);
+      expect(alpha!.denied).toBe(1);
+
+      const beta = summaries.find((s) => s.agent === 'agent-beta');
+      expect(beta).toBeDefined();
+      expect(beta!.sessions).toBe(1);
+      expect(beta!.totalActions).toBe(1);
+      expect(beta!.allowed).toBe(1);
+      expect(beta!.denied).toBe(0);
+    });
+
+    it('falls back to agentId when agentName is absent', () => {
+      const now = Date.now();
+
+      insertEvent(db, {
+        runId: 'run_1',
+        kind: 'RunStarted',
+        timestamp: now,
+        data: { agentId: 'user-123' },
+      });
+      insertDecision(db, { runId: 'run_1', outcome: 'allowed', timestamp: now });
+
+      const summaries = agentSummaries(db);
+      expect(summaries).toHaveLength(1);
+      expect(summaries[0].agent).toBe('user-123');
+    });
+
+    it('labels sessions without agent identity as "unknown"', () => {
+      const now = Date.now();
+
+      insertEvent(db, {
+        runId: 'run_1',
+        kind: 'RunStarted',
+        timestamp: now,
+        data: {},
+      });
+      insertDecision(db, { runId: 'run_1', outcome: 'allowed', timestamp: now });
+
+      const summaries = agentSummaries(db);
+      expect(summaries).toHaveLength(1);
+      expect(summaries[0].agent).toBe('unknown');
+    });
+
+    it('computes compliance rate correctly', () => {
+      const now = Date.now();
+
+      insertEvent(db, {
+        runId: 'run_1',
+        kind: 'RunStarted',
+        timestamp: now,
+        data: { agentName: 'test-agent' },
+      });
+      // 7 allowed, 3 denied = 70% compliance
+      for (let i = 0; i < 7; i++) {
+        insertDecision(db, { runId: 'run_1', outcome: 'allowed', timestamp: now + i });
+      }
+      for (let i = 0; i < 3; i++) {
+        insertDecision(db, { runId: 'run_1', outcome: 'denied', timestamp: now + 10 + i });
+      }
+
+      const summaries = agentSummaries(db);
+      expect(summaries[0].complianceRate).toBe(70);
+    });
+
+    it('counts violations from InvariantViolation events', () => {
+      const now = Date.now();
+
+      insertEvent(db, {
+        runId: 'run_1',
+        kind: 'RunStarted',
+        timestamp: now,
+        data: { agentName: 'risky-agent' },
+      });
+      insertEvent(db, {
+        runId: 'run_1',
+        kind: 'InvariantViolation',
+        timestamp: now + 1,
+        data: { invariant: 'no-secret-exposure' },
+      });
+      insertEvent(db, {
+        runId: 'run_1',
+        kind: 'InvariantViolation',
+        timestamp: now + 2,
+        data: { invariant: 'protected-branch' },
+      });
+      insertDecision(db, { runId: 'run_1', outcome: 'denied', timestamp: now + 3 });
+
+      const summaries = agentSummaries(db);
+      expect(summaries[0].violations).toBe(2);
+    });
+
+    it('sorts agents by session count descending', () => {
+      const now = Date.now();
+
+      insertEvent(db, {
+        runId: 'run_1',
+        kind: 'RunStarted',
+        timestamp: now,
+        data: { agentName: 'few-sessions' },
+      });
+      insertDecision(db, { runId: 'run_1', outcome: 'allowed', timestamp: now });
+
+      insertEvent(db, {
+        runId: 'run_2',
+        kind: 'RunStarted',
+        timestamp: now + 1,
+        data: { agentName: 'many-sessions' },
+      });
+      insertDecision(db, { runId: 'run_2', outcome: 'allowed', timestamp: now + 1 });
+      insertEvent(db, {
+        runId: 'run_3',
+        kind: 'RunStarted',
+        timestamp: now + 2,
+        data: { agentName: 'many-sessions' },
+      });
+      insertDecision(db, { runId: 'run_3', outcome: 'allowed', timestamp: now + 2 });
+
+      const summaries = agentSummaries(db);
+      expect(summaries[0].agent).toBe('many-sessions');
+      expect(summaries[1].agent).toBe('few-sessions');
+    });
+  });
+
+  describe('teamReport', () => {
+    it('returns a complete report structure', () => {
+      const now = Date.now();
+
+      insertEvent(db, {
+        runId: 'run_1',
+        kind: 'RunStarted',
+        timestamp: now,
+        data: { agentName: 'dev-agent' },
+      });
+      insertEvent(db, {
+        runId: 'run_1',
+        kind: 'ActionAllowed',
+        timestamp: now + 1,
+      });
+      insertDecision(db, { runId: 'run_1', outcome: 'allowed', timestamp: now + 1 });
+
+      const report = teamReport(db);
+
+      expect(report.overview).toBeDefined();
+      expect(report.overview.totalSessions).toBeGreaterThan(0);
+      expect(report.agents).toHaveLength(1);
+      expect(report.agents[0].agent).toBe('dev-agent');
+      expect(report.topDeniedActions).toBeDefined();
+      expect(report.topViolatedInvariants).toBeDefined();
+      expect(report.denialTrends).toBeDefined();
+    });
+
+    it('returns empty report for empty database', () => {
+      const report = teamReport(db);
+
+      expect(report.overview.totalSessions).toBe(0);
+      expect(report.overview.totalEvents).toBe(0);
+      expect(report.agents).toEqual([]);
+    });
+
+    it('aggregates across multiple agents', () => {
+      const now = Date.now();
+
+      // Two agents, each with one session
+      insertEvent(db, {
+        runId: 'run_1',
+        kind: 'RunStarted',
+        timestamp: now,
+        data: { agentName: 'agent-a' },
+      });
+      insertDecision(db, { runId: 'run_1', outcome: 'allowed', timestamp: now });
+
+      insertEvent(db, {
+        runId: 'run_2',
+        kind: 'RunStarted',
+        timestamp: now + 1,
+        data: { agentName: 'agent-b' },
+      });
+      insertDecision(db, { runId: 'run_2', outcome: 'denied', timestamp: now + 1 });
+      insertDecision(db, {
+        runId: 'run_2',
+        outcome: 'denied',
+        actionType: 'git.push',
+        reason: 'policy deny',
+        timestamp: now + 2,
+      });
+
+      const report = teamReport(db);
+
+      expect(report.overview.totalDecisions).toBe(3);
+      expect(report.agents).toHaveLength(2);
+      expect(report.topDeniedActions.length).toBeGreaterThan(0);
+    });
+
+    it('respects time filter', () => {
+      const now = Date.now();
+      const oneHourAgo = now - 3_600_000;
+      const twoHoursAgo = now - 7_200_000;
+
+      insertEvent(db, {
+        runId: 'run_old',
+        kind: 'RunStarted',
+        timestamp: twoHoursAgo,
+        data: { agentName: 'old-agent' },
+      });
+      insertDecision(db, { runId: 'run_old', outcome: 'allowed', timestamp: twoHoursAgo });
+
+      insertEvent(db, {
+        runId: 'run_new',
+        kind: 'RunStarted',
+        timestamp: now,
+        data: { agentName: 'new-agent' },
+      });
+      insertDecision(db, { runId: 'run_new', outcome: 'allowed', timestamp: now });
+
+      const report = teamReport(db, { since: oneHourAgo });
+
+      // Should only include the recent agent
+      expect(report.agents).toHaveLength(1);
+      expect(report.agents[0].agent).toBe('new-agent');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds team-level governance observability with per-agent metrics aggregation and multi-format reporting
- Implements `agentguard team-report` CLI command with text, JSON, Markdown, and CSV output
- Closes #83

## Changes
- `packages/storage/src/aggregation-queries.ts` — Added `agentSummaries()` and `teamReport()` functions that aggregate governance data by agent identity (extracted from RunStarted event data via `json_extract`)
- `apps/cli/src/commands/team-report.ts` — New CLI command with 4 output formats (text, JSON, Markdown, CSV) and time-range filtering
- `apps/cli/src/bin.ts` — Wired `team-report` command into CLI router and help text
- `packages/storage/tests/team-aggregation.test.ts` — 10 tests covering agent summaries and team report aggregation
- `apps/cli/tests/cli-team-report.test.ts` — 6 tests covering CLI help, empty DB, and all 4 output formats

## Test Plan
- [x] TypeScript build passes (`pnpm build`)
- [x] Vitest tests pass (`pnpm test`) — 3,556+ tests, 0 failures
- [x] ESLint clean (`pnpm lint`)
- [x] Prettier clean (`pnpm format`)

## Risk Assessment

| Metric | Value |
|--------|-------|
| Risk level | low |
| Risk score | 0/100 |
| Blast radius | 5 files (additive) |
| Simulation result | not applicable (additive feature) |

## Governance Report

| Metric | Count |
|--------|-------|
| Total events | 4 |
| Actions allowed | 1 |
| Actions denied | 0 |
| Policy denials | 0 |
| Invariant violations | 0 |
| Escalation events | 0 |
| Decision records | 0 |

<details>
<summary>Governance details</summary>

**Source**: SQLite governance database (`~/.agentguard/agentguard.db`)

**Decision Records**: 0 total, 0 denials
**Escalation levels observed**: NORMAL only
**Pre-push simulation**: low risk, blast radius 0

All actions passed governance checks.

</details>