### PR TITLE
docs: sync documentation with team-report, JSONL sink, and kernel 1.0.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,11 +126,13 @@ packages/
 │   ├── tui-renderer.ts         # TUI renderer implementation
 │   ├── types.ts                # Renderer type definitions
 │   └── index.ts                # Module re-exports
-├── storage/src/                # @red-codes/storage — Storage backends (SQLite, opt-in)
+├── storage/src/                # @red-codes/storage — Storage backends (SQLite + optional JSONL streaming)
 │   ├── adoption-analytics.ts   # Adoption analytics engine
+│   ├── aggregation-queries.ts  # SQL aggregation queries (agent summaries, team reports)
 │   ├── denial-learner.ts       # Denial pattern learning
 │   ├── factory.ts              # Storage bundle factory
 │   ├── index.ts                # Module re-exports
+│   ├── jsonl-sink.ts           # JSONL streaming event/decision sink (append-only, real-time tailing)
 │   ├── migrations.ts           # Schema migrations (version-based)
 │   ├── sqlite-session.ts       # SQLite session lifecycle (insert on start, update on end)
 │   ├── sqlite-sink.ts          # SQLite event/decision sink
@@ -166,7 +168,7 @@ apps/
 │   ├── session-store.ts        # Session management
 │   ├── file-event-store.ts     # File-based event persistence
 │   ├── evidence-summary.ts     # Evidence summary generator for PR reports
-│   └── commands/               # guard, inspect, replay, export, import, simulate, ci-check, plugin, policy, policy-verify, claude-hook, claude-init, copilot-hook, copilot-init, cloud, init, diff, evidence-pr, traces, session-viewer, status, analytics, auto-setup, config, audit-verify, demo, adoption, learn, migrate, trust
+│   └── commands/               # guard, inspect, replay, export, import, simulate, ci-check, plugin, policy, policy-verify, claude-hook, claude-init, copilot-hook, copilot-init, cloud, init, diff, evidence-pr, traces, session-viewer, status, analytics, auto-setup, config, audit-verify, demo, adoption, learn, migrate, trust, team-report
 ├── mcp-server/src/             # @red-codes/mcp-server — MCP governance server
 │   ├── index.ts                # Entry point
 │   ├── server.ts               # MCP server implementation
@@ -227,7 +229,7 @@ The kernel loop is the core of AgentGuard. Every agent action passes through it:
 4. Invariant checker verifies system state (21 defaults)
 5. If allowed: execute via adapter (file/shell/git handlers)
 6. Emit lifecycle events: `ACTION_REQUESTED` → `ACTION_ALLOWED/DENIED` → `ACTION_EXECUTED/FAILED`
-7. Sink all events to SQLite for audit trail
+7. Sink all events to SQLite for audit trail (optional JSONL streaming sink via `--jsonl`)
 
 Key files: `packages/kernel/src/kernel.ts`, `packages/kernel/src/aab.ts`, `packages/kernel/src/decision.ts`, `packages/kernel/src/monitor.ts`
 See `docs/unified-architecture.md` for the full model.
@@ -243,7 +245,7 @@ Each workspace package maps to a single architectural concept:
 - **packages/plugins/** — Plugin ecosystem (discovery, registry, validation, sandboxing)
 - **packages/renderers/** — Renderer plugin system (registry, TUI renderer)
 - **packages/core/** — Shared utilities (types, actions, hash, execution-log)
-- **packages/storage/** — Storage backend: SQLite (indexed queries, the only storage backend)
+- **packages/storage/** — Storage backends: SQLite (primary, indexed queries) + optional JSONL streaming sink; team aggregation queries
 - **packages/telemetry/** — Runtime telemetry and logging
 - **packages/telemetry-client/** — Telemetry client (identity, signing, queue, sender)
 - **packages/sdk/** — Agent SDK for programmatic governance integration
@@ -257,6 +259,7 @@ Each workspace package maps to a single architectural concept:
 - `agentguard guard --policy <file>` — Use a specific policy file (YAML or JSON)
 - `agentguard guard --dry-run` — Evaluate without executing actions
 - `agentguard guard --agent-name <name>` — Set agent identity for this session (required; prompts if not set)
+- `agentguard guard --jsonl <dir>` — Stream events/decisions as JSONL files for real-time tailing (also via `AGENTGUARD_JSONL_PATH` env var)
 - `agentguard inspect [runId]` — Show action graph and decisions for a run
 - `agentguard events [runId]` — Show raw event stream for a run
 - `agentguard export <runId>` — Export a governance session to a portable JSONL file
@@ -287,6 +290,7 @@ Each workspace package maps to a single architectural concept:
 - `agentguard cloud login|connect|status|events|runs|summary|disconnect` — Cloud governance analytics
 - `agentguard copilot-hook` — Handle GitHub Copilot PreToolUse/PostToolUse hook events
 - `agentguard copilot-init` — Set up GitHub Copilot hook integration
+- `agentguard team-report` — Team-level governance observability (per-agent metrics, compliance rates, denial trends; supports text, JSON, CSV, Markdown output)
 
 ### Event Model
 The canonical event model is the architectural spine. Event kinds defined in `packages/events/src/schema.ts`:

--- a/README.md
+++ b/README.md
@@ -294,7 +294,8 @@ AgentGuard Kernel
 | Feature | Details |
 |---------|---------|
 | **Compliance packs** | `extends: soc2`, `extends: hipaa` — pre-built policy packs mapping to SOC 2 CC6/CC7 and HIPAA 164.312 controls |
-| **Audit trail** | Tamper-resistant SQLite event chain; export to JSONL for SIEM ingestion |
+| **Audit trail** | Tamper-resistant SQLite event chain; optional JSONL streaming sink (`--jsonl`) for real-time tailing and SIEM ingestion |
+| **Team reporting** | `agentguard team-report` — per-agent compliance rates, denial trends, multi-format output (text, JSON, CSV, Markdown) |
 | **Evidence PRs** | `agentguard evidence-pr` — attach governance evidence summary to any PR |
 | **CI gates** | `agentguard ci-check <session>` — fail CI if a governance session contains violations |
 | **Branch protection** | Policy-enforced push controls on top of GitHub branch rules |
@@ -317,6 +318,7 @@ agentguard guard                          # Start governed action runtime
 agentguard guard --policy <file>          # Use a specific policy file
 agentguard guard --dry-run                # Evaluate without executing
 agentguard guard --agent-name <name>      # Set agent identity for session
+agentguard guard --jsonl <dir>            # Stream events/decisions as JSONL (real-time tailing)
 
 # Inspect
 agentguard inspect --last                 # Show last run action graph
@@ -336,6 +338,8 @@ agentguard ci-check <session>             # Verify session for violations (CI ga
 agentguard evidence-pr                    # Attach evidence summary to PR
 agentguard audit-verify                   # Verify tamper-resistant audit chain
 agentguard analytics                      # Violation pattern analysis
+agentguard team-report                    # Team-level governance observability across agents
+agentguard team-report --format json      # Output as JSON (also: csv, markdown)
 
 # Policy
 agentguard policy validate <file>         # Validate a policy file
@@ -345,10 +349,10 @@ agentguard init --template <name>         # Scaffold from template (strict/permi
 
 ## Agent SDK
 
-Use AgentGuard programmatically in your own tooling:
+The kernel stack is published to npm at **1.0.0** — use AgentGuard programmatically in your own tooling:
 
 ```bash
-npm install @red-codes/core @red-codes/events
+npm install @red-codes/kernel @red-codes/policy @red-codes/invariants
 ```
 
 ```typescript

--- a/docs/unified-architecture.md
+++ b/docs/unified-architecture.md
@@ -36,7 +36,7 @@ The system has one architectural spine: the **canonical event model**. All syste
          │  1. ACTION_REQUESTED event                          │
          │  2. AAB normalizes intent                           │
          │  3. Policy evaluation (match → allow/deny)          │
-         │  4. Invariant checking (6 default invariants)       │
+         │  4. Invariant checking (21 built-in invariants)      │
          │  5. Evidence pack generation                        │
          │  6. If allowed: execute via adapter                 │
          │  7. ACTION_ALLOWED/DENIED + ACTION_EXECUTED/FAILED  │
@@ -48,13 +48,13 @@ The system has one architectural spine: the **canonical event model**. All syste
                ┌────────────────┼────────────────┐
                │                │                │
                ▼                ▼                ▼
-     ┌─────────────┐  ┌─────────────┐  ┌─────────────┐
-     │ TUI Renderer │  │ JSONL Sink   │  │  EventBus   │
-     │              │  │              │  │             │
-     │ Terminal     │  │ .agentguard/ │  │ Pub/sub     │
-     │ action       │  │ events/      │  │ broadcast   │
-     │ stream       │  │ <runId>.jsonl│  │             │
-     └──────────────┘  └──────────────┘  └──────┬──────┘
+     ┌─────────────┐  ┌──────────────┐  ┌─────────────┐  ┌─────────────┐
+     │ TUI Renderer │  │ SQLite Sink  │  │ JSONL Sink  │  │  EventBus   │
+     │              │  │  (primary)   │  │ (optional)  │  │             │
+     │ Terminal     │  │ .agentguard/ │  │ --jsonl dir │  │ Pub/sub     │
+     │ action       │  │ agentguard.db│  │ <runId>.jsonl│  │ broadcast   │
+     │ stream       │  │              │  │             │  │             │
+     └──────────────┘  └──────────────┘  └─────────────┘  └──────┬──────┘
                                                 │
                                                 ▼
                                     ┌───────────────────┐
@@ -79,7 +79,7 @@ Agent proposes action (RawAgentAction)
     │
     ▼ Engine.evaluate() → EngineDecision
     │   ├── Policy evaluator: match rules, check deny/allow
-    │   ├── Invariant checker: 6 defaults + custom invariants
+    │   ├── Invariant checker: 21 defaults + custom invariants
     │   └── Evidence pack: structured audit record
     │
     ▼ Monitor.process() → MonitorDecision
@@ -88,14 +88,14 @@ Agent proposes action (RawAgentAction)
     │
     ├── If DENIED:
     │   ├── emit ACTION_DENIED
-    │   ├── sink events to JSONL
+    │   ├── sink events to SQLite (+ optional JSONL)
     │   └── return { allowed: false, intervention }
     │
     └── If ALLOWED:
         ├── emit ACTION_ALLOWED
         ├── Execute via adapter registry (file/shell/git handlers)
         ├── emit ACTION_EXECUTED or ACTION_FAILED
-        ├── sink events to JSONL
+        ├── sink events to SQLite (+ optional JSONL)
         └── return { allowed: true, executed: true/false, execution result }
 ```
 
@@ -121,7 +121,8 @@ The kernel is the **governance producer and action executor**. It is the core of
 | Git adapter | `packages/adapters/src/git.ts` | Git operations with validation |
 | Claude Code adapter | `packages/adapters/src/claude-code.ts` | Hook payload normalization |
 | TUI renderer | `packages/renderers/src/tui-renderer.ts` | Terminal action stream display |
-| JSONL sink | `packages/events/src/jsonl.ts` | Event persistence |
+| SQLite sink | `packages/storage/src/sqlite-sink.ts` | Primary event/decision persistence |
+| JSONL sink | `packages/storage/src/jsonl-sink.ts` | Optional streaming event persistence (real-time tailing) |
 
 ### Domain Layer (Shared)
 
@@ -129,7 +130,7 @@ Pure domain logic with no environment dependencies.
 
 | Component | File | Responsibility |
 |-----------|------|----------------|
-| Canonical actions | `packages/core/src/actions.ts` | 23 action types, 8 classes |
+| Canonical actions | `packages/core/src/actions.ts` | 27 action types, 9 classes |
 | Canonical events | `packages/events/src/schema.ts` | 50+ event kinds, factory, validation |
 | Reference monitor | `packages/kernel/src/decision.ts` | Action authorization with decision trail |
 | Adapter registry | `packages/adapters/src/registry.ts` | Action class → handler mapping |
@@ -142,6 +143,7 @@ Pure domain logic with no environment dependencies.
 | `agentguard guard` | `apps/cli/src/commands/guard.ts` | Start governed action runtime |
 | `agentguard inspect` | `apps/cli/src/commands/inspect.ts` | Show action graph for a run |
 | `agentguard events` | `apps/cli/src/commands/inspect.ts` | Show raw event stream for a run |
+| `agentguard team-report` | `apps/cli/src/commands/team-report.ts` | Team-level governance observability across agents |
 
 ## Integration Guarantees
 
@@ -153,6 +155,6 @@ Pure domain logic with no environment dependencies.
 
 4. **Deterministic evaluation.** Same action + same policy + same state = same decision. No inference, no heuristics.
 
-5. **Observable.** Every decision produces events. Every event is sunk to JSONL. Every run is inspectable.
+5. **Observable.** Every decision produces events. Every event is sunk to SQLite (with optional JSONL streaming). Every run is inspectable.
 
 6. **Default-deny (complete mediation).** When a policy file is loaded, any action without an explicit `allow` rule is denied. Agents cannot escalate privileges by requesting action types absent from the policy. Fail-open only applies when no policy is configured, preserving zero-friction onboarding while enforcing closed posture in governed environments.


### PR DESCRIPTION
## Summary
- Document `agentguard team-report` CLI command (PR #745) in README, CLAUDE.md, and architecture docs
- Document `--jsonl <dir>` streaming sink flag and `AGENTGUARD_JSONL_PATH` env var (PR #740) across all docs
- Update Agent SDK section in README to reflect kernel stack 1.0.0 npm publication (PR #755)
- Fix stale counts in `docs/unified-architecture.md`: 6→21 invariants, 23→27 action types, 8→9 action classes
- Correct storage model from JSONL-primary to SQLite-primary with optional JSONL streaming

## Files changed
- `README.md` — CLI reference, "For Teams" table, Agent SDK section
- `CLAUDE.md` — storage package structure, CLI commands list, package layout description
- `docs/unified-architecture.md` — system diagram, kernel loop detail, component tables, integration guarantees

## Test plan
- [x] Documentation-only changes — no source code or tests modified
- [x] All counts verified against current codebase (`packages/core/src/actions.ts`, `packages/invariants/src/definitions.ts`)
- [x] New files verified to exist (`packages/storage/src/jsonl-sink.ts`, `packages/storage/src/aggregation-queries.ts`, `apps/cli/src/commands/team-report.ts`)

🤖 Generated with [Claude Code](https://claude.ai/code) · Agent: `claude-code:opus:ops`