### PR TITLE
fix(ci): resolve Prettier formatting in copilot-hook.ts

### DIFF
--- a/apps/cli/src/commands/copilot-hook.ts
+++ b/apps/cli/src/commands/copilot-hook.ts
@@ -38,7 +38,10 @@ function readSessionState(sessionId: string | undefined): CopilotSessionState {
   }
 }
 
-function writeSessionState(sessionId: string | undefined, patch: Partial<CopilotSessionState>): void {
+function writeSessionState(
+  sessionId: string | undefined,
+  patch: Partial<CopilotSessionState>
+): void {
   const key = sessionId || String(process.ppid) || 'default';
   try {
     mkdirSync(join(tmpdir(), 'agentguard'), { recursive: true });
@@ -467,7 +470,7 @@ function handlePostToolUse(data: Record<string, unknown>): void {
   // This satisfies the `requireFormat` policy condition on subsequent git.commit actions.
   const sessionId =
     (data.sessionId as string | undefined) || process.env.COPILOT_SESSION_ID || undefined;
-  const resolvedExitCode = exitCode !== -1 ? exitCode : (resultType === 'failure' ? 1 : 0);
+  const resolvedExitCode = exitCode !== -1 ? exitCode : resultType === 'failure' ? 1 : 0;
 
   if (resolvedExitCode === 0 && sessionId) {
     const isFormatCmd =


### PR DESCRIPTION
## Summary

Fixes Prettier formatting in `copilot-hook.ts` that was introduced by the full parity rewrite in #791.

🤖 Generated with [Claude Code](https://claude.com/claude-code)