### PR TITLE
docs: update roadmap with AEG positioning

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > Deterministic governance for AI coding agents.
 
-**Last updated**: 2026-03-23
+**Last updated**: 2026-03-24
 **License**: Apache 2.0
 **Repository**: [AgentGuardHQ/agent-guard](https://github.com/AgentGuardHQ/agent-guard)
 
@@ -10,9 +10,11 @@
 
 ## Vision
 
-AgentGuard is the **mandatory execution control plane for AI agents** — the runtime governance layer that sits between autonomous agents and the real world. All agent side effects must pass through deterministic governance before reaching the environment.
+AgentGuard is the **Execution Control Plane for autonomous AI agents** — the independent governance layer that sits between autonomous agents and the real world. All agent side effects must pass through deterministic governance before reaching the environment, regardless of which orchestration framework, cloud provider, or AI model powers the agents.
 
-**Core thesis**: Once autonomous agents start modifying production systems, organizations need deterministic execution governance. Prompt alignment cannot solve this. Only a reference monitor architecture — default-deny, tamper-evident, fully auditable — provides the guarantees enterprises require.
+**Strategic positioning**: Autonomous Execution Governance (AEG). Like Okta for the application layer, AgentGuard controls the trust boundary without replacing the underlying systems. This is Layer 1 (OSS Kernel) of the four-layer architecture — the moat that makes everything else possible.
+
+**Core thesis**: Once autonomous agents start modifying production systems, organizations need deterministic execution governance. Prompt alignment cannot solve this. Only a reference monitor architecture — default-deny, tamper-evident, fully auditable — provides the guarantees enterprises require. Orchestration is commoditizing (LangGraph, CrewAI, AutoGen, platform-level tools); governance remains scarce.
 
 **Engineering thesis**: The enforcement boundary must achieve sub-millisecond latency (p50 < 0.25ms) with zero network or disk I/O dependencies. The governance layer must be invisible during operation yet impenetrable during a violation.
 


### PR DESCRIPTION
## Summary
- Update ROADMAP.md vision section with **Autonomous Execution Governance (AEG)** positioning
- Position AgentGuard as the independent **Execution Control Plane** for AI agents (Okta analogy)
- Add competitive context: orchestration is commoditizing, governance remains scarce
- Reference the 4-layer architecture (OSS Kernel → Adapters → SaaS Control Plane → Planning/Intent)

## Test plan
- [ ] Verify roadmap language consistency with internal strategy docs
- [ ] No code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)