### PR TITLE
fix(postinstall): use npx --no-install in generated hook commands

### DIFF
--- a/apps/cli/src/postinstall.ts
+++ b/apps/cli/src/postinstall.ts
@@ -202,12 +202,14 @@ export function writeClaudeCodeHooks(projectRoot: string): 'created' | 'skipped'
   if (!settings.hooks) settings.hooks = {};
 
   // PreToolUse — governance enforcement for all tools
+  // Use `npx --no-install` so the command resolves via local node_modules/.bin
+  // without falling back to downloading a (nonexistent) `agentguard` package from npm.
   if (!settings.hooks.PreToolUse) settings.hooks.PreToolUse = [];
   settings.hooks.PreToolUse.push({
     hooks: [
       {
         type: 'command',
-        command: 'agentguard claude-hook pre --store sqlite',
+        command: 'npx --no-install agentguard claude-hook pre --store sqlite',
         timeout: 30000,
       },
     ],
@@ -220,7 +222,7 @@ export function writeClaudeCodeHooks(projectRoot: string): 'created' | 'skipped'
     hooks: [
       {
         type: 'command',
-        command: 'agentguard claude-hook post --store sqlite',
+        command: 'npx --no-install agentguard claude-hook post --store sqlite',
         timeout: 10000,
       },
     ],
@@ -232,7 +234,7 @@ export function writeClaudeCodeHooks(projectRoot: string): 'created' | 'skipped'
     hooks: [
       {
         type: 'command',
-        command: 'agentguard claude-hook notification --store sqlite',
+        command: 'npx --no-install agentguard claude-hook notification --store sqlite',
         timeout: 10000,
       },
     ],
@@ -244,7 +246,7 @@ export function writeClaudeCodeHooks(projectRoot: string): 'created' | 'skipped'
     hooks: [
       {
         type: 'command',
-        command: 'agentguard claude-hook stop --store sqlite',
+        command: 'npx --no-install agentguard claude-hook stop --store sqlite',
         timeout: 10000,
       },
     ],
@@ -286,10 +288,11 @@ export function writeCopilotCliHooks(projectRoot: string): 'created' | 'skipped'
   if (!config.hooks) config.hooks = {};
 
   // preToolUse — governance enforcement
+  // Use `npx --no-install` to resolve via local node_modules/.bin (see Claude Code hooks comment).
   if (!config.hooks.preToolUse) config.hooks.preToolUse = [];
   config.hooks.preToolUse.push({
     type: 'command',
-    bash: 'agentguard copilot-hook pre --store sqlite',
+    bash: 'npx --no-install agentguard copilot-hook pre --store sqlite',
     timeoutSec: 30,
   });
 
@@ -297,7 +300,7 @@ export function writeCopilotCliHooks(projectRoot: string): 'created' | 'skipped'
   if (!config.hooks.postToolUse) config.hooks.postToolUse = [];
   config.hooks.postToolUse.push({
     type: 'command',
-    bash: 'agentguard copilot-hook post --store sqlite',
+    bash: 'npx --no-install agentguard copilot-hook post --store sqlite',
     timeoutSec: 10,
   });
 

--- a/apps/cli/tests/cli-postinstall.test.ts
+++ b/apps/cli/tests/cli-postinstall.test.ts
@@ -483,3 +483,99 @@ describe('postinstall integration', () => {
     expect(config.hooks.preToolUse[0].bash).toContain('copilot-hook pre');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Regression: hook commands must use `npx --no-install` to resolve binaries
+// ---------------------------------------------------------------------------
+// The published package is `@red-codes/agentguard` but registers bin name `agentguard`.
+// Bare `agentguard` fails because node_modules/.bin isn't in PATH for hook subprocesses.
+// `npx agentguard` (without --no-install) falls back to downloading a nonexistent
+// `agentguard` package from npm, producing a 404 error.
+// `npx --no-install agentguard` resolves the local binary without registry fallback.
+
+describe('regression: hook commands use npx --no-install', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir('npx-regression');
+    writeFileSync(join(tempDir, 'package.json'), '{}');
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('Claude Code hooks use npx --no-install for all commands', () => {
+    writeClaudeCodeHooks(tempDir);
+    const settings = JSON.parse(
+      readFileSync(join(tempDir, '.claude', 'settings.json'), 'utf8')
+    );
+
+    const allCommands: string[] = [];
+    for (const hookType of ['PreToolUse', 'PostToolUse', 'Notification', 'Stop']) {
+      for (const group of settings.hooks[hookType] ?? []) {
+        for (const hook of group.hooks ?? []) {
+          if (hook.command) allCommands.push(hook.command);
+        }
+      }
+    }
+
+    expect(allCommands.length).toBeGreaterThanOrEqual(4);
+    for (const cmd of allCommands) {
+      expect(cmd).toMatch(/^npx --no-install agentguard /);
+    }
+  });
+
+  it('Copilot CLI hooks use npx --no-install for all commands', () => {
+    writeCopilotCliHooks(tempDir);
+    const config = JSON.parse(
+      readFileSync(join(tempDir, '.github', 'hooks', 'hooks.json'), 'utf8')
+    );
+
+    const allCommands: string[] = [];
+    for (const hookType of ['preToolUse', 'postToolUse']) {
+      for (const entry of config.hooks[hookType] ?? []) {
+        if (entry.bash) allCommands.push(entry.bash);
+      }
+    }
+
+    expect(allCommands.length).toBeGreaterThanOrEqual(2);
+    for (const cmd of allCommands) {
+      expect(cmd).toMatch(/^npx --no-install agentguard /);
+    }
+  });
+
+  it('no hook command uses bare agentguard without npx', () => {
+    writeClaudeCodeHooks(tempDir);
+    writeCopilotCliHooks(tempDir);
+
+    const settings = JSON.parse(
+      readFileSync(join(tempDir, '.claude', 'settings.json'), 'utf8')
+    );
+    const copilotConfig = JSON.parse(
+      readFileSync(join(tempDir, '.github', 'hooks', 'hooks.json'), 'utf8')
+    );
+
+    // Collect all hook commands from both configs
+    const allCommands: string[] = [];
+    for (const hookType of Object.keys(settings.hooks)) {
+      for (const group of settings.hooks[hookType]) {
+        for (const hook of group.hooks ?? []) {
+          if (hook.command) allCommands.push(hook.command);
+        }
+      }
+    }
+    for (const hookType of Object.keys(copilotConfig.hooks)) {
+      for (const entry of copilotConfig.hooks[hookType]) {
+        if (entry.bash) allCommands.push(entry.bash);
+      }
+    }
+
+    for (const cmd of allCommands) {
+      // Must NOT start with bare `agentguard` (no npx)
+      expect(cmd).not.toMatch(/^agentguard /);
+      // Must NOT use `npx` without `--no-install` (would try to download from registry)
+      expect(cmd).not.toMatch(/^npx agentguard /);
+    }
+  });
+});

--- a/apps/cli/tests/e2e-postinstall-pipeline.test.ts
+++ b/apps/cli/tests/e2e-postinstall-pipeline.test.ts
@@ -336,7 +336,7 @@ describe('E2E postinstall pipeline: hook config structure', () => {
     const preHook = settings.hooks.PreToolUse[0];
     expect(preHook.hooks).toBeDefined();
     expect(preHook.hooks[0].type).toBe('command');
-    expect(preHook.hooks[0].command).toContain('agentguard');
+    expect(preHook.hooks[0].command).toMatch(/^npx --no-install agentguard /);
     expect(preHook.hooks[0].timeout).toBe(30000);
 
     // PostToolUse should have a Bash matcher
@@ -376,7 +376,7 @@ describe('E2E postinstall pipeline: hook config structure', () => {
     expect(config.hooks.preToolUse.length).toBeGreaterThan(0);
     const preHook = config.hooks.preToolUse[0];
     expect(preHook.type).toBe('command');
-    expect(preHook.bash).toContain('agentguard');
+    expect(preHook.bash).toMatch(/^npx --no-install agentguard /);
     expect(preHook.timeoutSec).toBe(30);
 
     // postToolUse
@@ -385,7 +385,7 @@ describe('E2E postinstall pipeline: hook config structure', () => {
     expect(config.hooks.postToolUse.length).toBeGreaterThan(0);
     const postHook = config.hooks.postToolUse[0];
     expect(postHook.type).toBe('command');
-    expect(postHook.bash).toContain('agentguard');
+    expect(postHook.bash).toMatch(/^npx --no-install agentguard /);
     expect(postHook.timeoutSec).toBe(10);
   });
 });


### PR DESCRIPTION
## Summary
- Generated hook commands (Claude Code + Copilot CLI) now use `npx --no-install agentguard` instead of bare `agentguard`
- Bare commands fail because `node_modules/.bin` isn't in PATH for hook subprocesses; `npx` without `--no-install` falls back to downloading `agentguard` from npm (404, since the package is `@red-codes/agentguard`)
- Adds 3 regression tests ensuring all generated hooks use `npx --no-install` and never bare binary names

## Test plan
- [x] All 40 postinstall + e2e pipeline tests pass
- [ ] Verify `npm install @red-codes/agentguard` in a fresh project creates hooks with `npx --no-install` prefix
- [ ] Verify hooks execute successfully in Claude Code session after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)