### PR TITLE
fix(hooks): fail-closed governance — block on crash, enforce by default

### DIFF
--- a/apps/cli/src/commands/claude-hook.ts
+++ b/apps/cli/src/commands/claude-hook.ts
@@ -316,15 +316,30 @@ export async function claudeHook(hookType?: string, extraArgs: string[] = []): P
         }
       }
 
-      const payload = { ...data, session_id: sessionId } as unknown as ClaudeCodeHookPayload;
-      const denied = await handlePreToolUse(payload, extraArgs, parentSessionId);
-      // Exit code 2 tells Claude Code to block the action
-      process.exit(denied ? 2 : 0);
+      try {
+        const payload = { ...data, session_id: sessionId } as unknown as ClaudeCodeHookPayload;
+        const denied = await handlePreToolUse(payload, extraArgs, parentSessionId);
+        // Exit code 2 tells Claude Code to block the action
+        process.exit(denied ? 2 : 0);
+      } catch (preErr) {
+        // SECURITY: fail closed on PreToolUse — if the kernel crashes, block the action
+        // rather than silently allowing it through.
+        process.stderr.write(
+          `[agentguard] PreToolUse hook error: ${preErr instanceof Error ? preErr.message : String(preErr)}\n`
+        );
+        process.stdout.write(
+          JSON.stringify({
+            decision: 'block',
+            reason: `AgentGuard governance hook crashed: ${preErr instanceof Error ? preErr.message : 'unknown error'}. Action blocked for safety.`,
+          })
+        );
+        process.exit(2);
+      }
     } else {
       handlePostToolUse(data, extraArgs);
     }
   } catch {
-    // Swallow all errors — hooks must never fail (fail-open)
+    // PostToolUse/stdin parsing errors are non-fatal — fail open
   }
   process.exit(0);
 }

--- a/apps/cli/src/mode-resolver.ts
+++ b/apps/cli/src/mode-resolver.ts
@@ -44,6 +44,7 @@ export function resolveInvariantMode(
     return config.packModes[invariantId];
   }
 
-  // Top-level mode
-  return config.mode ?? 'monitor';
+  // Top-level mode — default to enforce so policy denials are not silently ignored.
+  // Users who want gradual rollout must explicitly set mode: monitor in agentguard.yaml.
+  return config.mode ?? 'enforce';
 }

--- a/apps/cli/src/templates/scripts.ts
+++ b/apps/cli/src/templates/scripts.ts
@@ -174,8 +174,29 @@ export function claudeHookWrapper(
   storeSuffix: string,
   dbPathSuffix: string
 ): string {
+  // For local dev (cliPrefix = "node apps/cli/dist/bin.js"), the binary is always resolvable.
+  // For installed package (cliPrefix = "agentguard"), we need to resolve from node_modules/.bin.
+  const isLocal = cliPrefix.startsWith('node ');
+  const resolveBlock = isLocal
+    ? `AGENTGUARD_BIN="${cliPrefix}"`
+    : `# Resolve the agentguard binary: local node_modules first, then PATH
+AGENTGUARD_BIN=""
+if [ -x "\$AGENTGUARD_WORKSPACE/node_modules/.bin/agentguard" ]; then
+  AGENTGUARD_BIN="\$AGENTGUARD_WORKSPACE/node_modules/.bin/agentguard"
+elif command -v agentguard &>/dev/null; then
+  AGENTGUARD_BIN="agentguard"
+fi
+
+# SECURITY: fail closed — if kernel binary is missing, block the action
+if [ -z "\$AGENTGUARD_BIN" ]; then
+  echo '{"decision":"block","reason":"AgentGuard kernel binary not found — governance cannot evaluate this action. Run: pnpm install"}'
+  exit 0
+fi`;
+
   return `#!/usr/bin/env bash
 # claude-hook-wrapper.sh — Sources persona identity before running governance hook
+# SECURITY: This script MUST fail closed. If the kernel binary cannot be found,
+# it outputs a block response so Claude Code denies the action.
 
 # Resolve project root (hook CWD may not match the project directory)
 AGENTGUARD_WORKSPACE="\$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
@@ -188,7 +209,9 @@ if [ -f "\$AGENTGUARD_WORKSPACE/.agentguard/persona.env" ]; then
   set +a
 fi
 
+${resolveBlock}
+
 # Pass through to the actual hook
-exec ${cliPrefix} claude-hook pre${storeSuffix}${dbPathSuffix}
+exec \$AGENTGUARD_BIN claude-hook pre${storeSuffix}${dbPathSuffix}
 `;
 }


### PR DESCRIPTION
## Summary
- **PreToolUse fail-closed**: kernel crash now outputs `{"decision":"block"}` + exit 2 instead of silently allowing (catch-all was swallowing errors)
- **Default mode → enforce**: policy denials were logged but not blocked unless `mode: enforce` was explicitly set. Default changed from `monitor` to `enforce`
- **Wrapper template binary resolution**: generated wrapper resolves from `node_modules/.bin/` with fail-closed fallback when binary not on PATH

## Context
The dashboard deployment failure in agentguard-cloud led to discovering that `git push` to `main` was not being blocked by governance. Root cause chain:
1. Wrapper used bare `agentguard` — not on PATH in pnpm workspaces
2. Published npm v2.0.0 CLI crashed on `better-sqlite3` version mismatch — catch-all swallowed the error
3. Even when kernel ran, `mode-resolver.ts` defaulted to `monitor`, so denials were warnings only

## Test plan
- [ ] `echo '{"tool":"Bash","input":{"command":"git push origin main"},"hook":"PreToolUse"}' | node apps/cli/dist/bin.js claude-hook pre` → exits 2 with block response
- [ ] `echo '{"tool":"Read","input":{"file_path":"/tmp/test"},"hook":"PreToolUse"}' | node apps/cli/dist/bin.js claude-hook pre` → exits 0 (allowed)
- [ ] Existing tests pass: `pnpm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)