### PR TITLE
feat(kernel): KE-4 Plane Separation

### DIFF
--- a/packages/events/src/index.ts
+++ b/packages/events/src/index.ts
@@ -2,3 +2,4 @@ export * from './schema.js';
 export { EventBus } from './bus.js';
 export * from './store.js';
 export * from './session-context.js';
+export * from './ring-buffer.js';

--- a/packages/events/src/ring-buffer.ts
+++ b/packages/events/src/ring-buffer.ts
@@ -1,0 +1,88 @@
+/**
+ * RingBuffer — Fixed-capacity circular buffer for the Emitter plane.
+ *
+ * Provides O(1) synchronous writes with bounded memory. When full,
+ * the oldest entries are silently overwritten. The Evaluator plane writes
+ * here with zero I/O; the Shipper plane drains periodically.
+ *
+ * @see KE-4 Plane Separation (Issue #687)
+ */
+
+export interface RingBuffer<T> {
+  /** Append an item. O(1), never blocks, never throws. Overwrites oldest if full. */
+  write(item: T): void;
+  /** Remove and return all buffered items in insertion order. Resets the buffer. */
+  drain(): T[];
+  /** Number of items currently buffered. */
+  size(): number;
+  /** Maximum capacity of the buffer. */
+  capacity(): number;
+  /** Number of items dropped (overwritten) since creation. */
+  dropped(): number;
+  /** Discard all buffered items. */
+  clear(): void;
+}
+
+/**
+ * Create a fixed-capacity ring buffer.
+ *
+ * @param capacity Maximum number of items the buffer can hold. Must be >= 1.
+ */
+export function createRingBuffer<T>(capacity: number): RingBuffer<T> {
+  if (capacity < 1) {
+    throw new Error(`RingBuffer capacity must be >= 1, got ${capacity}`);
+  }
+
+  const buf: (T | undefined)[] = new Array(capacity);
+  let head = 0; // next write position
+  let count = 0;
+  let totalDropped = 0;
+
+  return {
+    write(item: T): void {
+      if (count === capacity) {
+        // Buffer is full — overwrite oldest entry
+        totalDropped++;
+      } else {
+        count++;
+      }
+      buf[head] = item;
+      head = (head + 1) % capacity;
+    },
+
+    drain(): T[] {
+      if (count === 0) return [];
+
+      const result: T[] = new Array(count);
+      // Start position is (head - count) wrapped around
+      const start = (head - count + capacity) % capacity;
+
+      for (let i = 0; i < count; i++) {
+        result[i] = buf[(start + i) % capacity] as T;
+      }
+
+      // Reset
+      count = 0;
+      head = 0;
+
+      return result;
+    },
+
+    size(): number {
+      return count;
+    },
+
+    capacity(): number {
+      return capacity;
+    },
+
+    dropped(): number {
+      return totalDropped;
+    },
+
+    clear(): void {
+      count = 0;
+      head = 0;
+    },
+  };
+}

--- a/packages/events/tests/ring-buffer.test.ts
+++ b/packages/events/tests/ring-buffer.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { createRingBuffer } from '../src/ring-buffer.js';
+
+describe('RingBuffer', () => {
+  it('starts empty', () => {
+    const buf = createRingBuffer<number>(4);
+    expect(buf.size()).toBe(0);
+    expect(buf.capacity()).toBe(4);
+    expect(buf.dropped()).toBe(0);
+    expect(buf.drain()).toEqual([]);
+  });
+
+  it('writes and drains in order', () => {
+    const buf = createRingBuffer<number>(4);
+    buf.write(1);
+    buf.write(2);
+    buf.write(3);
+    expect(buf.size()).toBe(3);
+    expect(buf.drain()).toEqual([1, 2, 3]);
+    expect(buf.size()).toBe(0);
+  });
+
+  it('drain returns empty after drain', () => {
+    const buf = createRingBuffer<number>(4);
+    buf.write(1);
+    buf.drain();
+    expect(buf.drain()).toEqual([]);
+  });
+
+  it('overwrites oldest when full', () => {
+    const buf = createRingBuffer<number>(3);
+    buf.write(1);
+    buf.write(2);
+    buf.write(3);
+    buf.write(4); // overwrites 1
+    expect(buf.size()).toBe(3);
+    expect(buf.dropped()).toBe(1);
+    expect(buf.drain()).toEqual([2, 3, 4]);
+  });
+
+  it('tracks total dropped across multiple overwrites', () => {
+    const buf = createRingBuffer<number>(2);
+    buf.write(1);
+    buf.write(2);
+    buf.write(3); // overwrites 1
+    buf.write(4); // overwrites 2
+    buf.write(5); // overwrites 3
+    expect(buf.dropped()).toBe(3);
+    expect(buf.drain()).toEqual([4, 5]);
+  });
+
+  it('handles capacity of 1', () => {
+    const buf = createRingBuffer<string>(1);
+    buf.write('a');
+    expect(buf.size()).toBe(1);
+    buf.write('b'); // overwrites 'a'
+    expect(buf.dropped()).toBe(1);
+    expect(buf.drain()).toEqual(['b']);
+  });
+
+  it('rejects capacity < 1', () => {
+    expect(() => createRingBuffer<number>(0)).toThrow('capacity must be >= 1');
+    expect(() => createRingBuffer<number>(-1)).toThrow('capacity must be >= 1');
+  });
+
+  it('clear resets the buffer', () => {
+    const buf = createRingBuffer<number>(4);
+    buf.write(1);
+    buf.write(2);
+    buf.clear();
+    expect(buf.size()).toBe(0);
+    expect(buf.drain()).toEqual([]);
+  });
+
+  it('works correctly after drain and refill', () => {
+    const buf = createRingBuffer<number>(3);
+    buf.write(1);
+    buf.write(2);
+    buf.drain();
+    buf.write(3);
+    buf.write(4);
+    expect(buf.drain()).toEqual([3, 4]);
+  });
+
+  it('handles large number of writes and drains', () => {
+    const buf = createRingBuffer<number>(100);
+    for (let i = 0; i < 1000; i++) {
+      buf.write(i);
+    }
+    // Last 100 items should remain (900 dropped)
+    expect(buf.dropped()).toBe(900);
+    const drained = buf.drain();
+    expect(drained.length).toBe(100);
+    expect(drained[0]).toBe(900);
+    expect(drained[99]).toBe(999);
+  });
+
+  it('write is O(1) — does not depend on buffer size', () => {
+    const buf = createRingBuffer<number>(10000);
+    const start = performance.now();
+    for (let i = 0; i < 100000; i++) {
+      buf.write(i);
+    }
+    const elapsed = performance.now() - start;
+    // Should complete in well under 1 second even for 100k writes
+    expect(elapsed).toBeLessThan(1000);
+  });
+});

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -22,3 +22,4 @@ export * from './contract.js';
 export * from './enforcement-audit.js';
 export * from './intent.js';
 export * from './tier-router.js';
+export * from './planes/index.js';

--- a/packages/kernel/src/kernel.ts
+++ b/packages/kernel/src/kernel.ts
@@ -2,6 +2,10 @@
 // Connects monitor (AAB + policy + invariants) with execution adapters.
 // Emits full action lifecycle events: REQUESTED → ALLOWED/DENIED → EXECUTED/FAILED.
 // Builds GovernanceDecisionRecords and sinks them for audit.
+//
+// KE-4 Plane Separation: The kernel uses three failure-isolated planes:
+//   Evaluator (sync, pure) → Emitter (ring buffer) → Shipper (background persistence)
+// Telemetry failures never alter enforcement decisions.
 
 import type {
   DomainEvent,
@@ -54,6 +58,9 @@ import type { SimulatorRegistry, ImpactForecast } from './simulation/types.js';
 import { buildImpactForecast } from './simulation/forecast.js';
 import type { IntentSpec, IntentDriftResult } from './intent.js';
 import { checkIntentAlignment } from './intent.js';
+import { createEmitter } from './planes/emitter.js';
+import { createShipper } from './planes/shipper.js';
+import type { Emitter, Shipper, EmitterConfig } from './planes/types.js';
 /** Minimal tracer interface (previously from @red-codes/telemetry, now inlined). */
 interface TraceSpan {
   setAttribute(key: string, value: string | number | boolean): void;
@@ -170,6 +177,17 @@ export interface KernelConfig extends MonitorConfig {
    * and records it in governance decision records for audit trail.
    */
   manifest?: RunManifest;
+  /**
+   * KE-4: Emitter plane config (ring buffer capacities).
+   * When provided, events and decisions flow through a ring buffer instead
+   * of being written directly to sinks, decoupling the Evaluator from I/O.
+   */
+  emitterConfig?: EmitterConfig;
+  /**
+   * KE-4: Shipper plane drain interval (ms). Default: 50.
+   * Set to 0 to disable background shipping (flush-only mode for short-lived processes).
+   */
+  shipperIntervalMs?: number;
 }
 
 export interface Kernel {
@@ -186,6 +204,10 @@ export interface Kernel {
   getTierMetrics(): TierMetrics | null;
   /** Returns the run manifest if one was provided at initialization */
   getManifest(): RunManifest | null;
+  /** KE-4: Returns the Emitter plane instance for observability */
+  getEmitter(): Emitter;
+  /** KE-4: Returns the Shipper plane instance for observability */
+  getShipper(): Shipper;
   shutdown(): void;
 }
 
@@ -229,11 +251,32 @@ export function createKernel(config: KernelConfig = {}): Kernel {
     evaluateOptions: config.evaluateOptions,
   });
 
+  // KE-4 Plane Separation: Evaluator → Emitter → Shipper
+  // Events flow through an in-memory ring buffer (Emitter) instead of being
+  // written directly to sinks. The Shipper drains the buffer in the background.
+  const emitter = createEmitter(config.emitterConfig);
+  const shipper = createShipper({
+    emitter,
+    eventSinks: sinks,
+    decisionSinks,
+    intervalMs: config.shipperIntervalMs ?? 50,
+    onError: (err, ctx) => {
+      // Telemetry failures are non-fatal — log but never propagate to Evaluator
+      if (typeof process !== 'undefined' && process.stderr) {
+        process.stderr.write(`[agentguard:shipper] ${ctx}: ${err.message}\n`);
+      }
+    },
+  });
+
+  // Start background shipping if interval > 0
+  if ((config.shipperIntervalMs ?? 50) > 0) {
+    shipper.start();
+  }
+
+  // Evaluator plane: sinkEvent/sinkDecision write to the Emitter (zero I/O).
   function sinkEvent(event: DomainEvent): void {
     eventCount++;
-    for (const sink of sinks) {
-      sink.write(event);
-    }
+    emitter.eventSink.write(event);
   }
 
   function sinkEvents(events: DomainEvent[]): void {
@@ -243,9 +286,7 @@ export function createKernel(config: KernelConfig = {}): Kernel {
   }
 
   function sinkDecision(record: GovernanceDecisionRecord): void {
-    for (const sink of decisionSinks) {
-      sink.write(record);
-    }
+    emitter.decisionSink.write(record);
   }
 
   // Emit RUN_STARTED event with agent identity
@@ -1678,10 +1719,18 @@ export function createKernel(config: KernelConfig = {}): Kernel {
             result = { ...result, tier: outerTier };
           }
         }
+        // KE-4: Flush the Emitter → Shipper → Sinks pipeline after each proposal.
+        // This ensures events reach sinks before propose() returns, maintaining
+        // backward compatibility. The ring buffer still provides structural isolation —
+        // all sink write errors are caught by the Shipper, never reaching the Evaluator.
+        shipper.flush();
+
         span?.setAttribute('outcome', result.allowed ? 'allow' : 'deny');
         span?.end();
         return result;
       } catch (err) {
+        // Flush on error too — don't lose events from partial proposals
+        shipper.flush();
         span?.endWithError(err instanceof Error ? err.message : String(err));
         throw err;
       }
@@ -1711,13 +1760,19 @@ export function createKernel(config: KernelConfig = {}): Kernel {
       return manifest;
     },
 
+    getEmitter() {
+      return emitter;
+    },
+
+    getShipper() {
+      return shipper;
+    },
+
     shutdown() {
-      for (const sink of sinks) {
-        if (sink.flush) sink.flush();
-      }
-      for (const sink of decisionSinks) {
-        if (sink.flush) sink.flush();
-      }
+      // KE-4: Stop background shipping, then flush remaining events synchronously.
+      // This ensures no data loss even for short-lived processes (e.g. hook invocations).
+      shipper.stop();
+      shipper.flush();
       tracer?.shutdown();
     },
   };

--- a/packages/kernel/src/planes/emitter.ts
+++ b/packages/kernel/src/planes/emitter.ts
@@ -1,0 +1,77 @@
+/**
+ * Emitter plane — non-blocking event queuing via ring buffers.
+ *
+ * The Evaluator writes events/decisions here. Writes are O(1) in-memory
+ * with zero I/O. The Shipper plane drains these buffers periodically.
+ *
+ * Ring buffers have bounded capacity — when full, oldest entries are
+ * overwritten. This guarantees bounded memory and zero backpressure
+ * on the Evaluator, even if the Shipper falls behind.
+ *
+ * @see KE-4 Plane Separation (Issue #687)
+ */
+
+import type { DomainEvent, EventSink, DecisionSink } from '@red-codes/core';
+import type { GovernanceDecisionRecord } from '../decisions/types.js';
+import { createRingBuffer } from '@red-codes/events';
+import type { Emitter, EmitterConfig } from './types.js';
+
+const DEFAULT_EVENT_CAPACITY = 4096;
+const DEFAULT_DECISION_CAPACITY = 1024;
+
+/**
+ * Create an Emitter — the non-blocking bridge between the Evaluator and Shipper planes.
+ */
+export function createEmitter(config: EmitterConfig = {}): Emitter {
+  const eventBuffer = createRingBuffer<DomainEvent>(config.eventCapacity ?? DEFAULT_EVENT_CAPACITY);
+  const decisionBuffer = createRingBuffer<GovernanceDecisionRecord>(
+    config.decisionCapacity ?? DEFAULT_DECISION_CAPACITY
+  );
+
+  const eventSink: EventSink = {
+    write(event: DomainEvent): void {
+      eventBuffer.write(event);
+    },
+    flush(): void {
+      // No-op — the Shipper handles flushing
+    },
+  };
+
+  const decisionSink: DecisionSink = {
+    write(record: GovernanceDecisionRecord): void {
+      decisionBuffer.write(record);
+    },
+    flush(): void {
+      // No-op — the Shipper handles flushing
+    },
+  };
+
+  return {
+    eventSink,
+    decisionSink,
+
+    drainEvents(): DomainEvent[] {
+      return eventBuffer.drain();
+    },
+
+    drainDecisions(): GovernanceDecisionRecord[] {
+      return decisionBuffer.drain();
+    },
+
+    eventCount(): number {
+      return eventBuffer.size();
+    },
+
+    decisionCount(): number {
+      return decisionBuffer.size();
+    },
+
+    eventsDropped(): number {
+      return eventBuffer.dropped();
+    },
+
+    decisionsDropped(): number {
+      return decisionBuffer.dropped();
+    },
+  };
+}

--- a/packages/kernel/src/planes/index.ts
+++ b/packages/kernel/src/planes/index.ts
@@ -1,0 +1,3 @@
+export * from './types.js';
+export { createEmitter } from './emitter.js';
+export { createShipper } from './shipper.js';

--- a/packages/kernel/src/planes/shipper.ts
+++ b/packages/kernel/src/planes/shipper.ts
@@ -1,0 +1,126 @@
+/**
+ * Shipper plane — background persistence to sinks, crash-resilient.
+ *
+ * Periodically drains the Emitter's ring buffers and writes events/decisions
+ * to the registered sinks (SQLite, JSONL, etc.). All sink write errors are
+ * caught and reported via onError — they NEVER propagate to the Evaluator.
+ *
+ * On shutdown, `flush()` synchronously drains all remaining buffered data
+ * to ensure no events are lost, even for short-lived processes (e.g. hook
+ * invocations that spawn a process per tool call).
+ *
+ * @see KE-4 Plane Separation (Issue #687)
+ */
+
+import type { EventSink, DecisionSink } from '@red-codes/core';
+import type { Emitter, Shipper, ShipperConfig } from './types.js';
+
+const DEFAULT_INTERVAL_MS = 50;
+
+/**
+ * Create a Shipper — the background persistence layer that drains the Emitter.
+ */
+export function createShipper(config: ShipperConfig): Shipper {
+  const { emitter, eventSinks, decisionSinks } = config;
+  const intervalMs = config.intervalMs ?? DEFAULT_INTERVAL_MS;
+  const onError = config.onError ?? (() => {});
+
+  let timer: ReturnType<typeof setInterval> | null = null;
+  let eventsShipped = 0;
+  let decisionsShipped = 0;
+  let errorCount = 0;
+
+  function shipEvents(sinks: EventSink[], emitterRef: Emitter): void {
+    const events = emitterRef.drainEvents();
+    if (events.length === 0) return;
+
+    for (const sink of sinks) {
+      for (const event of events) {
+        try {
+          sink.write(event);
+        } catch (err) {
+          errorCount++;
+          onError(err as Error, `event_sink_write:${event.kind}`);
+          // Continue — never let one sink failure block others
+        }
+      }
+    }
+    eventsShipped += events.length;
+  }
+
+  function shipDecisions(sinks: DecisionSink[], emitterRef: Emitter): void {
+    const decisions = emitterRef.drainDecisions();
+    if (decisions.length === 0) return;
+
+    for (const sink of sinks) {
+      for (const decision of decisions) {
+        try {
+          sink.write(decision);
+        } catch (err) {
+          errorCount++;
+          onError(err as Error, `decision_sink_write:${decision.recordId}`);
+        }
+      }
+    }
+    decisionsShipped += decisions.length;
+  }
+
+  function drainAll(): void {
+    shipEvents(eventSinks, emitter);
+    shipDecisions(decisionSinks, emitter);
+  }
+
+  return {
+    start(): void {
+      if (timer !== null) return; // Already running
+      timer = setInterval(drainAll, intervalMs);
+      // Unref the timer so it doesn't prevent process exit
+      if (typeof timer === 'object' && 'unref' in timer) {
+        timer.unref();
+      }
+    },
+
+    stop(): void {
+      if (timer === null) return;
+      clearInterval(timer);
+      timer = null;
+    },
+
+    flush(): void {
+      drainAll();
+      // Also flush underlying sinks
+      for (const sink of eventSinks) {
+        try {
+          sink.flush?.();
+        } catch (err) {
+          errorCount++;
+          onError(err as Error, 'event_sink_flush');
+        }
+      }
+      for (const sink of decisionSinks) {
+        try {
+          sink.flush?.();
+        } catch (err) {
+          errorCount++;
+          onError(err as Error, 'decision_sink_flush');
+        }
+      }
+    },
+
+    isRunning(): boolean {
+      return timer !== null;
+    },
+
+    totalEventsShipped(): number {
+      return eventsShipped;
+    },
+
+    totalDecisionsShipped(): number {
+      return decisionsShipped;
+    },
+
+    totalErrors(): number {
+      return errorCount;
+    },
+  };
+}

--- a/packages/kernel/src/planes/types.ts
+++ b/packages/kernel/src/planes/types.ts
@@ -1,0 +1,73 @@
+/**
+ * Plane type definitions for KE-4 Plane Separation.
+ *
+ * Three failure-isolated planes:
+ *   Evaluator (sync, pure) → Emitter (non-blocking ring buffer) → Shipper (background, crash-resilient)
+ *
+ * Contract: telemetry failures NEVER alter enforcement decisions.
+ * The Evaluator plane has zero I/O — writes go to the Emitter's ring buffer.
+ * The Shipper drains the Emitter and persists to SQLite/external consumers.
+ *
+ * @see Issue #687
+ */
+
+import type { DomainEvent, EventSink, DecisionSink } from '@red-codes/core';
+import type { GovernanceDecisionRecord } from '../decisions/types.js';
+
+/** Emitter plane — non-blocking in-memory event queuing with zero backpressure on the Evaluator. */
+export interface Emitter {
+  /** EventSink adapter — the Evaluator writes events here (zero I/O). */
+  readonly eventSink: EventSink;
+  /** DecisionSink adapter — the Evaluator writes decisions here (zero I/O). */
+  readonly decisionSink: DecisionSink;
+  /** Drain all buffered events. Called by the Shipper. */
+  drainEvents(): DomainEvent[];
+  /** Drain all buffered decisions. Called by the Shipper. */
+  drainDecisions(): GovernanceDecisionRecord[];
+  /** Number of events currently buffered. */
+  eventCount(): number;
+  /** Number of decisions currently buffered. */
+  decisionCount(): number;
+  /** Total events dropped (ring buffer overflow) since creation. */
+  eventsDropped(): number;
+  /** Total decisions dropped since creation. */
+  decisionsDropped(): number;
+}
+
+export interface EmitterConfig {
+  /** Ring buffer capacity for events. Default: 4096. */
+  eventCapacity?: number;
+  /** Ring buffer capacity for decisions. Default: 1024. */
+  decisionCapacity?: number;
+}
+
+/** Shipper plane — background persistence to sinks, crash-resilient. */
+export interface Shipper {
+  /** Start background drain timer. */
+  start(): void;
+  /** Stop background drain timer. Does NOT flush remaining events. */
+  stop(): void;
+  /** Synchronously drain all buffered events/decisions and write to sinks. */
+  flush(): void;
+  /** True if the background timer is running. */
+  isRunning(): boolean;
+  /** Total events shipped since creation. */
+  totalEventsShipped(): number;
+  /** Total decisions shipped since creation. */
+  totalDecisionsShipped(): number;
+  /** Total shipping errors (sink write failures) since creation. */
+  totalErrors(): number;
+}
+
+export interface ShipperConfig {
+  /** The Emitter to drain events/decisions from. */
+  emitter: Emitter;
+  /** Event sinks to persist to (SQLite, JSONL, etc.). */
+  eventSinks: EventSink[];
+  /** Decision sinks to persist to. */
+  decisionSinks: DecisionSink[];
+  /** Background drain interval in ms. Default: 50. */
+  intervalMs?: number;
+  /** Error callback — invoked on sink write failures. Never rethrown. */
+  onError?: (error: Error, context: string) => void;
+}

--- a/packages/kernel/tests/planes.test.ts
+++ b/packages/kernel/tests/planes.test.ts
@@ -1,0 +1,308 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { createEmitter } from '../src/planes/emitter.js';
+import { createShipper } from '../src/planes/shipper.js';
+import type { DomainEvent, EventSink, DecisionSink } from '@red-codes/core';
+import type { GovernanceDecisionRecord } from '../src/decisions/types.js';
+
+function makeFakeEvent(kind: string, id?: string): DomainEvent {
+  return {
+    id: id || `evt_${Math.random().toString(36).slice(2)}`,
+    kind,
+    timestamp: Date.now(),
+    fingerprint: 'test',
+  } as DomainEvent;
+}
+
+function makeFakeDecision(recordId?: string): GovernanceDecisionRecord {
+  return {
+    recordId: recordId || `dec_${Math.random().toString(36).slice(2)}`,
+    runId: 'run_test',
+    timestamp: Date.now(),
+    outcome: 'allow',
+    action: { type: 'file.read', target: '/test.ts' },
+    reason: 'test',
+  } as GovernanceDecisionRecord;
+}
+
+describe('Emitter plane', () => {
+  it('buffers events via eventSink.write()', () => {
+    const emitter = createEmitter({ eventCapacity: 10 });
+    const event = makeFakeEvent('ActionRequested');
+    emitter.eventSink.write(event);
+    expect(emitter.eventCount()).toBe(1);
+    const drained = emitter.drainEvents();
+    expect(drained).toEqual([event]);
+    expect(emitter.eventCount()).toBe(0);
+  });
+
+  it('buffers decisions via decisionSink.write()', () => {
+    const emitter = createEmitter({ decisionCapacity: 10 });
+    const decision = makeFakeDecision();
+    emitter.decisionSink.write(decision);
+    expect(emitter.decisionCount()).toBe(1);
+    const drained = emitter.drainDecisions();
+    expect(drained).toEqual([decision]);
+    expect(emitter.decisionCount()).toBe(0);
+  });
+
+  it('drops oldest events when capacity exceeded', () => {
+    const emitter = createEmitter({ eventCapacity: 2 });
+    emitter.eventSink.write(makeFakeEvent('A', 'e1'));
+    emitter.eventSink.write(makeFakeEvent('B', 'e2'));
+    emitter.eventSink.write(makeFakeEvent('C', 'e3')); // drops e1
+    expect(emitter.eventsDropped()).toBe(1);
+    const drained = emitter.drainEvents();
+    expect(drained.map((e) => e.id)).toEqual(['e2', 'e3']);
+  });
+
+  it('uses default capacities when not configured', () => {
+    const emitter = createEmitter();
+    // Default: 4096 events, 1024 decisions — just verify no crash
+    for (let i = 0; i < 100; i++) {
+      emitter.eventSink.write(makeFakeEvent('test'));
+      emitter.decisionSink.write(makeFakeDecision());
+    }
+    expect(emitter.eventCount()).toBe(100);
+    expect(emitter.decisionCount()).toBe(100);
+  });
+});
+
+describe('Shipper plane', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('flush() drains emitter events to sinks synchronously', () => {
+    const emitter = createEmitter({ eventCapacity: 10 });
+    const written: DomainEvent[] = [];
+    const sink: EventSink = { write: (e) => written.push(e) };
+
+    const shipper = createShipper({
+      emitter,
+      eventSinks: [sink],
+      decisionSinks: [],
+      intervalMs: 0, // no background shipping
+    });
+
+    emitter.eventSink.write(makeFakeEvent('A'));
+    emitter.eventSink.write(makeFakeEvent('B'));
+
+    shipper.flush();
+    expect(written.length).toBe(2);
+    expect(written[0].kind).toBe('A');
+    expect(written[1].kind).toBe('B');
+    expect(shipper.totalEventsShipped()).toBe(2);
+  });
+
+  it('flush() drains emitter decisions to sinks synchronously', () => {
+    const emitter = createEmitter({ decisionCapacity: 10 });
+    const written: GovernanceDecisionRecord[] = [];
+    const sink: DecisionSink = { write: (d) => written.push(d) };
+
+    const shipper = createShipper({
+      emitter,
+      eventSinks: [],
+      decisionSinks: [sink],
+      intervalMs: 0,
+    });
+
+    emitter.decisionSink.write(makeFakeDecision('d1'));
+    shipper.flush();
+    expect(written.length).toBe(1);
+    expect(written[0].recordId).toBe('d1');
+    expect(shipper.totalDecisionsShipped()).toBe(1);
+  });
+
+  it('background timer drains events periodically', async () => {
+    vi.useFakeTimers();
+    const emitter = createEmitter({ eventCapacity: 10 });
+    const written: DomainEvent[] = [];
+    const sink: EventSink = { write: (e) => written.push(e) };
+
+    const shipper = createShipper({
+      emitter,
+      eventSinks: [sink],
+      decisionSinks: [],
+      intervalMs: 50,
+    });
+
+    shipper.start();
+    expect(shipper.isRunning()).toBe(true);
+
+    emitter.eventSink.write(makeFakeEvent('A'));
+    emitter.eventSink.write(makeFakeEvent('B'));
+
+    // Events not yet shipped
+    expect(written.length).toBe(0);
+
+    // Advance timer
+    vi.advanceTimersByTime(50);
+    expect(written.length).toBe(2);
+
+    shipper.stop();
+    expect(shipper.isRunning()).toBe(false);
+  });
+
+  it('sink write errors are caught and counted', () => {
+    const emitter = createEmitter({ eventCapacity: 10 });
+    const errors: string[] = [];
+    const failingSink: EventSink = {
+      write: () => {
+        throw new Error('disk full');
+      },
+    };
+
+    const shipper = createShipper({
+      emitter,
+      eventSinks: [failingSink],
+      decisionSinks: [],
+      intervalMs: 0,
+      onError: (err) => errors.push(err.message),
+    });
+
+    emitter.eventSink.write(makeFakeEvent('A'));
+    shipper.flush();
+
+    expect(shipper.totalErrors()).toBe(1);
+    expect(errors).toContain('disk full');
+    // Shipper continues despite errors — no crash
+  });
+
+  it('sink errors do not block other sinks', () => {
+    const emitter = createEmitter({ eventCapacity: 10 });
+    const written: DomainEvent[] = [];
+    const failingSink: EventSink = {
+      write: () => {
+        throw new Error('fail');
+      },
+    };
+    const goodSink: EventSink = { write: (e) => written.push(e) };
+
+    const shipper = createShipper({
+      emitter,
+      eventSinks: [failingSink, goodSink],
+      decisionSinks: [],
+      intervalMs: 0,
+      onError: () => {},
+    });
+
+    emitter.eventSink.write(makeFakeEvent('A'));
+    shipper.flush();
+
+    // Good sink still received the event despite failing sink
+    expect(written.length).toBe(1);
+  });
+
+  it('start() is idempotent', () => {
+    const emitter = createEmitter();
+    const shipper = createShipper({
+      emitter,
+      eventSinks: [],
+      decisionSinks: [],
+      intervalMs: 100,
+    });
+
+    shipper.start();
+    shipper.start(); // should not create duplicate timers
+    expect(shipper.isRunning()).toBe(true);
+    shipper.stop();
+    expect(shipper.isRunning()).toBe(false);
+  });
+
+  it('stop() is idempotent', () => {
+    const emitter = createEmitter();
+    const shipper = createShipper({
+      emitter,
+      eventSinks: [],
+      decisionSinks: [],
+    });
+
+    shipper.stop(); // should not throw when not running
+    expect(shipper.isRunning()).toBe(false);
+  });
+
+  it('flush calls sink.flush() on underlying sinks', () => {
+    const emitter = createEmitter();
+    const flushed: string[] = [];
+    const sink: EventSink = {
+      write: () => {},
+      flush: () => flushed.push('event_flushed'),
+    };
+    const decSink: DecisionSink = {
+      write: () => {},
+      flush: () => flushed.push('decision_flushed'),
+    };
+
+    const shipper = createShipper({
+      emitter,
+      eventSinks: [sink],
+      decisionSinks: [decSink],
+      intervalMs: 0,
+    });
+
+    shipper.flush();
+    expect(flushed).toContain('event_flushed');
+    expect(flushed).toContain('decision_flushed');
+  });
+});
+
+describe('Evaluator → Emitter → Shipper integration', () => {
+  it('events flow from evaluator writes through to sinks via flush', () => {
+    const emitter = createEmitter({ eventCapacity: 100, decisionCapacity: 100 });
+    const events: DomainEvent[] = [];
+    const decisions: GovernanceDecisionRecord[] = [];
+
+    const shipper = createShipper({
+      emitter,
+      eventSinks: [{ write: (e) => events.push(e) }],
+      decisionSinks: [{ write: (d) => decisions.push(d) }],
+      intervalMs: 0,
+    });
+
+    // Simulate evaluator writing events
+    for (let i = 0; i < 10; i++) {
+      emitter.eventSink.write(makeFakeEvent(`kind_${i}`));
+    }
+    emitter.decisionSink.write(makeFakeDecision());
+
+    // Nothing shipped yet
+    expect(events.length).toBe(0);
+    expect(decisions.length).toBe(0);
+
+    // Flush ships everything
+    shipper.flush();
+    expect(events.length).toBe(10);
+    expect(decisions.length).toBe(1);
+    expect(shipper.totalEventsShipped()).toBe(10);
+    expect(shipper.totalDecisionsShipped()).toBe(1);
+  });
+
+  it('shipper failure does not affect evaluator writes', () => {
+    const emitter = createEmitter({ eventCapacity: 10 });
+    const shipper = createShipper({
+      emitter,
+      eventSinks: [
+        {
+          write: () => {
+            throw new Error('catastrophic failure');
+          },
+        },
+      ],
+      decisionSinks: [],
+      intervalMs: 0,
+      onError: () => {},
+    });
+
+    // Evaluator writes succeed regardless of shipper state
+    emitter.eventSink.write(makeFakeEvent('A'));
+    expect(emitter.eventCount()).toBe(1);
+
+    // Shipper fails — but evaluator is unaffected
+    shipper.flush();
+    expect(shipper.totalErrors()).toBe(1);
+
+    // Evaluator can continue writing
+    emitter.eventSink.write(makeFakeEvent('B'));
+    expect(emitter.eventCount()).toBe(1); // 'A' was drained, 'B' is new
+  });
+});


### PR DESCRIPTION
## Summary
- Decouples enforcement from telemetry with three failure-isolated planes: Evaluator, Emitter, Shipper
- Telemetry failures can never alter enforcement decisions
- Closes #687

## Changes
- `packages/events/src/ring-buffer.ts` -- New generic fixed-capacity ring buffer
- `packages/kernel/src/planes/types.ts` -- Plane contracts: Emitter and Shipper interfaces
- `packages/kernel/src/planes/emitter.ts` -- Emitter plane wrapping ring buffers as EventSink/DecisionSink
- `packages/kernel/src/planes/shipper.ts` -- Background shipper: periodic drain, error isolation
- `packages/kernel/src/planes/index.ts` -- Re-exports
- `packages/kernel/src/kernel.ts` -- Wire planes into kernel: sinkEvent/sinkDecision write to Emitter
- `packages/events/src/index.ts` -- Re-export ring buffer
- `packages/kernel/src/index.ts` -- Re-export planes
- `packages/events/tests/ring-buffer.test.ts` -- 11 ring buffer tests
- `packages/kernel/tests/planes.test.ts` -- 14 Emitter/Shipper/integration tests

## Architecture

```
Evaluator (sync, pure)
    |
Emitter (non-blocking ring buffer)
    |
Shipper (background, catches errors)
    |
SQLite (WAL mode) + external consumers
```

## Test Plan
- [x] TypeScript build passes (pnpm build) -- all 17 packages
- [x] Type-check passes (pnpm ts:check) -- all 29 tasks
- [x] Vitest tests pass (pnpm test) -- 795 kernel + 87 event tests
- [x] ESLint clean (pnpm lint)
- [x] Prettier clean (pnpm format)
- [x] 25 new tests: 11 ring buffer + 14 plane integration

## Risk Assessment

| Metric | Value |
|--------|-------|
| Risk level | low |
| Blast radius | 5 files modified (kernel, events) |
| New test coverage | 25 tests covering all new code paths |

Generated with [Claude Code](https://claude.com/claude-code) (claude-code:opus:developer)
