### PR TITLE
fix(cli): scaffold identity, validate hooks, check status (#849-#852)

### DIFF
--- a/apps/cli/src/commands/claude-init.ts
+++ b/apps/cli/src/commands/claude-init.ts
@@ -1,7 +1,7 @@
 // agentguard claude-init — set up Claude Code integration
 
 import { readFileSync, writeFileSync, existsSync, mkdirSync, unlinkSync } from 'node:fs';
-import { execSync } from 'node:child_process';
+import { execSync, execFileSync } from 'node:child_process';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { createInterface } from 'node:readline';
@@ -135,15 +135,51 @@ export async function claudeInit(args: string[] = []): Promise<void> {
     process.stderr.write(
       `  ${FG.green}✓${RESET}  Hook baseline refreshed for ${settingsLabel}\n\n`
     );
+
+    // Ensure .agentguard-identity exists even on --refresh (fresh worktrees/clones won't have it)
+    const refreshRepoRoot = resolveMainRepoRoot();
+    const refreshIdentityPath = join(refreshRepoRoot, '.agentguard-identity');
+    if (!existsSync(refreshIdentityPath)) {
+      const refreshDriver = driverArg ?? detectDriver();
+      const refreshModel = detectModel();
+      const refreshRole = roleArg ?? 'developer';
+      writeFileSync(refreshIdentityPath, `${refreshDriver}:${refreshModel}:${refreshRole}`);
+      process.stderr.write(
+        `  ${FG.green}✓${RESET}  Identity file created: ${FG.cyan}.agentguard-identity${RESET}\n\n`
+      );
+    }
+
     return;
   }
 
   if (hasAgentGuardHook(settings)) {
-    process.stderr.write(
-      `  ${FG.yellow}Already configured.${RESET} AgentGuard hook found in ${settingsLabel}.\n`
-    );
-    process.stderr.write(`  ${DIM}Use --remove to uninstall.${RESET}\n\n`);
-    return;
+    // Hooks exist in settings — but verify referenced scripts/binaries are intact
+    const integrity = validateHookIntegrity();
+    if (!integrity.ok || !integrity.binaryResolved) {
+      const issues: string[] = [];
+      if (integrity.missingScripts.length > 0) {
+        issues.push(`missing scripts: ${integrity.missingScripts.join(', ')}`);
+      }
+      if (!integrity.binaryResolved) {
+        issues.push('agentguard binary not found');
+      }
+      process.stderr.write(
+        `  ${FG.yellow}Hooks are configured but some referenced scripts are missing:${RESET}\n`
+      );
+      for (const issue of issues) {
+        process.stderr.write(`    ${FG.red}✗${RESET} ${issue}\n`);
+      }
+      process.stderr.write(
+        `  ${DIM}Continuing with init to repair...${RESET}\n\n`
+      );
+      // Fall through to re-run init and repair the broken state
+    } else {
+      process.stderr.write(
+        `  ${FG.yellow}Already configured.${RESET} AgentGuard hook found in ${settingsLabel}.\n`
+      );
+      process.stderr.write(`  ${DIM}Use --remove to uninstall.${RESET}\n\n`);
+      return;
+    }
   }
 
   // Parse --mode and --pack flags for non-interactive mode
@@ -337,6 +373,20 @@ export async function claudeInit(args: string[] = []): Promise<void> {
   process.stderr.write(
     `  ${FG.green}✓${RESET}  Identity set: ${FG.cyan}${driver}:${model}:${selectedRole}${RESET} (project: ${project})\n`
   );
+
+  // Create .agentguard-identity file (gitignored — each clone/worktree creates its own).
+  // This file is required by the PreToolUse hook; without it all tool calls are blocked (#850).
+  // For CI/cron agents, AGENTGUARD_AGENT_NAME env var overrides this file at runtime.
+  const identityFilePath = join(repoRoot, '.agentguard-identity');
+  if (!existsSync(identityFilePath)) {
+    writeFileSync(identityFilePath, `${driver}:${model}:${selectedRole}`);
+    process.stderr.write(
+      `  ${FG.green}✓${RESET}  Identity file created: ${FG.cyan}.agentguard-identity${RESET}\n`
+    );
+    process.stderr.write(
+      `  ${DIM}   CI/cron agents: set AGENTGUARD_AGENT_NAME env var to override${RESET}\n`
+    );
+  }
 
   // Scaffold starter skills
   if (!noSkills) {
@@ -597,6 +647,10 @@ description: Baseline safety rules for AI coding agents
 #   enforce — block dangerous actions, no suggestions
 mode: ${mode}
 
+# Agent identity: defaults to .agentguard-identity file (created by claude-init).
+# For CI/cron agents, set AGENTGUARD_AGENT_NAME env var to override.
+# e.g., AGENTGUARD_AGENT_NAME=ci:github-actions:ops
+
 # Policy pack — curated invariant enforcement profiles
 ${packLine}
 
@@ -783,4 +837,56 @@ function hasAgentGuardHook(settings: Settings): boolean {
     const hooks = entry.hooks || [];
     return hooks.some((h) => h.command && h.command.includes(HOOK_MARKER));
   });
+}
+
+/** Wrapper scripts that hooks may reference. */
+const WRAPPER_SCRIPTS = [
+  'scripts/claude-hook-wrapper.sh',
+  'scripts/session-persona-check.sh',
+  'scripts/agent-identity-bridge.sh',
+  'scripts/write-persona.sh',
+];
+
+interface HookIntegrityResult {
+  ok: boolean;
+  missingScripts: string[];
+  binaryResolved: boolean;
+}
+
+/** Validate that hook-referenced scripts and binaries actually exist on disk. */
+export function validateHookIntegrity(): HookIntegrityResult {
+  const repoRoot = resolveMainRepoRoot();
+  const missingScripts: string[] = [];
+
+  for (const script of WRAPPER_SCRIPTS) {
+    const scriptPath = join(repoRoot, script);
+    if (!existsSync(scriptPath)) {
+      missingScripts.push(script);
+    }
+  }
+
+  // Check if the agentguard binary can be resolved
+  let binaryResolved = false;
+  const localBinPath = join(repoRoot, 'node_modules', '.bin', 'agentguard');
+  if (existsSync(localBinPath)) {
+    binaryResolved = true;
+  } else {
+    // Check PATH via execFileSync (safe — no shell injection)
+    try {
+      execFileSync('which', ['agentguard'], { stdio: 'pipe', timeout: 3000 });
+      binaryResolved = true;
+    } catch {
+      // Also check if we're in local dev mode (apps/cli/dist/bin.js exists)
+      const localDevBin = join(repoRoot, 'apps', 'cli', 'dist', 'bin.js');
+      if (existsSync(localDevBin)) {
+        binaryResolved = true;
+      }
+    }
+  }
+
+  return {
+    ok: missingScripts.length === 0,
+    missingScripts,
+    binaryResolved,
+  };
 }

--- a/apps/cli/src/commands/status.ts
+++ b/apps/cli/src/commands/status.ts
@@ -1,11 +1,11 @@
 // agentguard status — quick health check for AgentGuard governance runtime
 
 import { existsSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, dirname, parse as parsePath } from 'node:path';
 import { homedir } from 'node:os';
 import { RESET, BOLD, DIM, FG } from '../colors.js';
 import { findDefaultPolicy } from '../policy-resolver.js';
-import { detectRtk } from '@red-codes/core';
+import { detectRtk, resolveMainRepoRoot } from '@red-codes/core';
 
 interface HookEntry {
   hooks?: Array<{ type?: string; command?: string }>;
@@ -79,6 +79,14 @@ export async function status(args: string[]): Promise<number> {
 
   // Directories
   printCheck(checks.dirs.ok, 'Event directories', checks.dirs.detail);
+
+  // Agent identity (informational — does not affect exit code)
+  const identityCheck = checkAgentIdentity();
+  printCheck(identityCheck.ok, 'Agent identity', identityCheck.detail);
+
+  // Hook scripts (informational — does not affect exit code)
+  const hookScriptsCheck = checkHookScripts();
+  printCheck(hookScriptsCheck.ok, 'Hook scripts', hookScriptsCheck.detail);
 
   // Token optimization (optional — does not affect exit code)
   const rtkCheck = checkRtkInstalled();
@@ -223,6 +231,73 @@ async function checkPolicyTrust(): Promise<{ ok: boolean; detail: string }> {
   } catch {
     return { ok: false, detail: '(trust check unavailable)' };
   }
+}
+
+/** Walk up from CWD looking for .agentguard-identity (same resolution as claude-hook.ts). */
+function findAgentIdentityFile(): string | null {
+  let dir = process.cwd();
+  const fsRoot = parsePath(dir).root;
+  while (dir !== fsRoot) {
+    const candidate = join(dir, '.agentguard-identity');
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+export function checkAgentIdentity(): { ok: boolean; detail: string } {
+  const identityPath = findAgentIdentityFile();
+  if (!identityPath) {
+    return {
+      ok: false,
+      detail: '(missing — will be created on first Claude session)',
+    };
+  }
+  try {
+    const value = readFileSync(identityPath, 'utf8').trim();
+    if (value) {
+      return { ok: true, detail: `(${value})` };
+    }
+    return {
+      ok: false,
+      detail: '(empty — will be set on first Claude session)',
+    };
+  } catch {
+    return {
+      ok: false,
+      detail: '(unreadable — will be recreated on first Claude session)',
+    };
+  }
+}
+
+/** Wrapper scripts referenced by hooks. */
+const WRAPPER_SCRIPTS = [
+  'scripts/claude-hook-wrapper.sh',
+  'scripts/session-persona-check.sh',
+  'scripts/agent-identity-bridge.sh',
+  'scripts/write-persona.sh',
+];
+
+export function checkHookScripts(): { ok: boolean; detail: string } {
+  const repoRoot = resolveMainRepoRoot();
+  const missing: string[] = [];
+
+  for (const script of WRAPPER_SCRIPTS) {
+    const scriptPath = join(repoRoot, script);
+    if (!existsSync(scriptPath)) {
+      missing.push(script);
+    }
+  }
+
+  if (missing.length === 0) {
+    return { ok: true, detail: '(all scripts present)' };
+  }
+  return {
+    ok: false,
+    detail: `(missing — run 'agentguard claude-init --refresh')`,
+  };
 }
 
 async function checkDenialInsights(): Promise<{ detail: string }> {

--- a/apps/cli/tests/cli-claude-init.test.ts
+++ b/apps/cli/tests/cli-claude-init.test.ts
@@ -631,6 +631,74 @@ describe('claudeInit', () => {
     expect(skillWrites).toHaveLength(0);
   });
 
+  // --- .agentguard-identity file creation (#850) ---
+
+  it('creates .agentguard-identity file during fresh install', async () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    await claudeInit(['--role', 'developer']);
+
+    const identityCalls = writeCalls('.agentguard-identity');
+    expect(identityCalls).toHaveLength(1);
+    const content = identityCalls[0][1] as string;
+    // Format: driver:model:role
+    expect(content).toMatch(/^.+:.+:developer$/);
+  });
+
+  it('does not overwrite existing .agentguard-identity file', async () => {
+    vi.mocked(existsSync).mockImplementation((p: unknown) => {
+      const path = String(p);
+      if (path.endsWith('.agentguard-identity')) return true;
+      return false;
+    });
+
+    await claudeInit([]);
+
+    const identityCalls = writeCalls('.agentguard-identity');
+    expect(identityCalls).toHaveLength(0);
+  });
+
+  it('creates .agentguard-identity during --refresh if missing', async () => {
+    // Simulate existing settings with a hook (so --refresh path is taken)
+    vi.mocked(existsSync).mockImplementation((p: unknown) => {
+      const path = String(p);
+      if (path.includes('settings.json')) return true;
+      // .agentguard-identity does NOT exist
+      if (path.endsWith('.agentguard-identity')) return false;
+      return false;
+    });
+    vi.mocked(readFileSync).mockReturnValue(
+      JSON.stringify({
+        hooks: {
+          PreToolUse: [
+            {
+              hooks: [{ type: 'command', command: 'bash scripts/claude-hook-wrapper.sh' }],
+            },
+          ],
+        },
+      })
+    );
+
+    await claudeInit(['--refresh']);
+
+    const identityCalls = writeCalls('.agentguard-identity');
+    expect(identityCalls).toHaveLength(1);
+    const content = identityCalls[0][1] as string;
+    expect(content).toMatch(/^.+:.+:.+$/);
+  });
+
+  it('uses detected driver and model in .agentguard-identity', async () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    await claudeInit(['--role', 'security']);
+
+    const identityCalls = writeCalls('.agentguard-identity');
+    expect(identityCalls).toHaveLength(1);
+    const content = identityCalls[0][1] as string;
+    // Mock returns human:unknown, role is security
+    expect(content).toBe('human:unknown:security');
+  });
+
   it('appends identity block to existing CLAUDE.md', async () => {
     vi.mocked(existsSync).mockImplementation((p: unknown) => {
       const path = String(p);

--- a/apps/cli/tests/status.test.ts
+++ b/apps/cli/tests/status.test.ts
@@ -1,0 +1,149 @@
+// Tests for status command — agent identity and hook scripts checks (#849, #851)
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { join } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  writeFileSync: vi.fn(),
+}));
+
+vi.mock('node:os', () => ({
+  homedir: vi.fn(() => '/mock-home'),
+}));
+
+vi.mock('@red-codes/core', () => ({
+  resolveMainRepoRoot: vi.fn(() => '/mock-repo-root'),
+  detectRtk: vi.fn(() => ({ available: false })),
+}));
+
+vi.mock('../src/policy-resolver.js', () => ({
+  findDefaultPolicy: vi.fn(() => null),
+}));
+
+vi.mock('@red-codes/adapters', () => ({
+  verifyHookIntegrity: vi.fn(() => 'no_baseline'),
+}));
+
+vi.mock('@red-codes/policy', () => ({
+  verifyPolicyTrust: vi.fn(async () => ({ status: 'untrusted' })),
+}));
+
+vi.mock('@red-codes/storage', () => ({
+  resolveSqlitePath: vi.fn(() => '/mock-db-path'),
+  queryEventsByKindAcrossRuns: vi.fn(() => []),
+}));
+
+import { checkAgentIdentity, checkHookScripts } from '../src/commands/status.js';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('checkAgentIdentity', () => {
+  it('returns ok:false when .agentguard-identity file is missing', () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    const result = checkAgentIdentity();
+    expect(result.ok).toBe(false);
+    expect(result.detail).toContain('missing');
+    expect(result.detail).toContain('will be created on first Claude session');
+  });
+
+  it('returns ok:true with identity value when file exists and has content', () => {
+    vi.mocked(existsSync).mockImplementation((p: unknown) => {
+      const path = String(p);
+      if (path.endsWith('.agentguard-identity')) return true;
+      return false;
+    });
+    vi.mocked(readFileSync).mockReturnValue('claude-code:opus:developer');
+
+    const result = checkAgentIdentity();
+    expect(result.ok).toBe(true);
+    expect(result.detail).toContain('claude-code:opus:developer');
+  });
+
+  it('returns ok:false when file exists but is empty', () => {
+    vi.mocked(existsSync).mockImplementation((p: unknown) => {
+      const path = String(p);
+      if (path.endsWith('.agentguard-identity')) return true;
+      return false;
+    });
+    vi.mocked(readFileSync).mockReturnValue('');
+
+    const result = checkAgentIdentity();
+    expect(result.ok).toBe(false);
+    expect(result.detail).toContain('empty');
+  });
+
+  it('returns ok:false when file exists but is unreadable', () => {
+    vi.mocked(existsSync).mockImplementation((p: unknown) => {
+      const path = String(p);
+      if (path.endsWith('.agentguard-identity')) return true;
+      return false;
+    });
+    vi.mocked(readFileSync).mockImplementation(() => {
+      throw new Error('EACCES: permission denied');
+    });
+
+    const result = checkAgentIdentity();
+    expect(result.ok).toBe(false);
+    expect(result.detail).toContain('unreadable');
+  });
+});
+
+describe('checkHookScripts', () => {
+  it('returns ok:true when all wrapper scripts exist', () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+
+    const result = checkHookScripts();
+    expect(result.ok).toBe(true);
+    expect(result.detail).toContain('all scripts present');
+  });
+
+  it('returns ok:false when wrapper scripts are missing', () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    const result = checkHookScripts();
+    expect(result.ok).toBe(false);
+    expect(result.detail).toContain('missing');
+    expect(result.detail).toContain('agentguard claude-init --refresh');
+  });
+
+  it('returns ok:false when some scripts are missing', () => {
+    vi.mocked(existsSync).mockImplementation((p: unknown) => {
+      const path = String(p);
+      // Only claude-hook-wrapper.sh exists
+      if (path.includes('claude-hook-wrapper.sh')) return true;
+      return false;
+    });
+
+    const result = checkHookScripts();
+    expect(result.ok).toBe(false);
+    expect(result.detail).toContain('missing');
+  });
+
+  it('checks scripts at the repo root path', () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+
+    checkHookScripts();
+
+    // Verify existsSync was called with repo root paths
+    const calls = vi.mocked(existsSync).mock.calls;
+    const scriptCalls = calls.filter(
+      (call) => String(call[0]).includes('/mock-repo-root/scripts/')
+    );
+    expect(scriptCalls.length).toBe(4);
+    expect(scriptCalls.some((c) => String(c[0]).includes('claude-hook-wrapper.sh'))).toBe(true);
+    expect(scriptCalls.some((c) => String(c[0]).includes('session-persona-check.sh'))).toBe(true);
+    expect(scriptCalls.some((c) => String(c[0]).includes('agent-identity-bridge.sh'))).toBe(true);
+    expect(scriptCalls.some((c) => String(c[0]).includes('write-persona.sh'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- **#850**: Create `.agentguard-identity` during `claude-init` with auto-detected `driver:model:role`. CI/cron agents override via `AGENTGUARD_AGENT_NAME` env var.
- **#852**: Verify wrapper scripts exist; refresh-path creates them for worktrees
- **#849**: `validateHookIntegrity()` checks scripts + binary exist. "Already configured" warns and offers repair when broken
- **#851**: `agentguard status` checks `.agentguard-identity` and wrapper scripts, shows actionable hints

## Test plan
- [x] 759 tests pass (43 test files)
- [x] New tests for identity scaffolding (4 tests), status checks (8 tests)
- [x] `--refresh` path creates identity for fresh worktrees

Closes #849, closes #850, closes #851, closes #852

🤖 Generated with [Claude Code](https://claude.com/claude-code)