### PR TITLE
fix: resolve Prettier violations and malformed skill file

### DIFF
--- a/.claude/skills/governance-audit.md
+++ b/.claude/skills/governance-audit.md
@@ -2,7 +2,7 @@
 name: governance-audit
 description: "Analyze governance logs for violations and trends"
 ---
-# Governance Audit
+# Skill: Governance Audit
 
 ## Agent Identity
 

--- a/apps/cli/src/commands/claude-hook.ts
+++ b/apps/cli/src/commands/claude-hook.ts
@@ -695,7 +695,8 @@ async function handlePreToolUse(
 
       // Capture lesson for agent memory
       try {
-        const { generateLesson, mergeLesson, readLessonStore, writeLessonStore } = await import('@red-codes/kernel');
+        const { generateLesson, mergeLesson, readLessonStore, writeLessonStore } =
+          await import('@red-codes/kernel');
         const action = result.decision?.intent?.action ?? 'unknown';
         const reason = result.decision?.decision?.reason ?? 'Action flagged by governance';
         const squad = detectSquad(normalizedPayload as unknown as Record<string, unknown>);

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -24,5 +24,20 @@ export * from './intent.js';
 export * from './tier-router.js';
 export * from './suggestion-registry.js';
 
-export { generateLesson, mergeLesson, emptyLessonStore, formatLessonContext, readLessonStore, writeLessonStore, patternsToLessons, learnFromDenials } from './lessons.js';
-export type { Lesson, LessonInput, LessonStore, LessonContext, DenialPatternLike } from './lessons.js';
+export {
+  generateLesson,
+  mergeLesson,
+  emptyLessonStore,
+  formatLessonContext,
+  readLessonStore,
+  writeLessonStore,
+  patternsToLessons,
+  learnFromDenials,
+} from './lessons.js';
+export type {
+  Lesson,
+  LessonInput,
+  LessonStore,
+  LessonContext,
+  DenialPatternLike,
+} from './lessons.js';

--- a/packages/kernel/src/lessons.ts
+++ b/packages/kernel/src/lessons.ts
@@ -76,7 +76,7 @@ function lessonId(pattern: string, action: string): string {
   const str = `${pattern}:${action}`;
   for (let i = 0; i < str.length; i++) {
     const char = str.charCodeAt(i);
-    hash = ((hash << 5) - hash) + char;
+    hash = (hash << 5) - hash + char;
     hash |= 0;
   }
   return `lesson-${Math.abs(hash).toString(36)}`;
@@ -140,9 +140,7 @@ export function mergeLesson(store: LessonStore, lesson: Lesson): LessonStore {
   if (existing) {
     // Update hit count and last seen
     const updated = store.lessons.map((l) =>
-      l.id === lesson.id
-        ? { ...l, hitCount: l.hitCount + 1, lastSeen: now }
-        : l,
+      l.id === lesson.id ? { ...l, hitCount: l.hitCount + 1, lastSeen: now } : l
     );
     return { ...store, lessons: updated, lastUpdated: now };
   }
@@ -167,10 +165,13 @@ export function emptyLessonStore(): LessonStore {
 // ── Lesson context formatting ──
 
 /** Format lessons for injection into agent context */
-export function formatLessonContext(store: LessonStore, options?: {
-  maxLessons?: number;
-  minSeverity?: 'info' | 'warning' | 'critical';
-}): LessonContext {
+export function formatLessonContext(
+  store: LessonStore,
+  options?: {
+    maxLessons?: number;
+    minSeverity?: 'info' | 'warning' | 'critical';
+  }
+): LessonContext {
   const maxLessons = options?.maxLessons ?? 20;
   const minSeverity = options?.minSeverity ?? 'info';
 
@@ -201,9 +202,12 @@ export function formatLessonContext(store: LessonStore, options?: {
   ];
 
   for (const lesson of filtered) {
-    const icon = lesson.severity === 'critical' ? '[CRITICAL]'
-      : lesson.severity === 'warning' ? '[WARNING]'
-      : '[INFO]';
+    const icon =
+      lesson.severity === 'critical'
+        ? '[CRITICAL]'
+        : lesson.severity === 'warning'
+          ? '[WARNING]'
+          : '[INFO]';
     lines.push(`- ${icon} **${lesson.rule}**: ${lesson.why}`);
     lines.push(`  Instead: ${lesson.instead}`);
     if (lesson.correctedCommand) {
@@ -246,11 +250,7 @@ export function writeLessonStore(root: string, squad: string, store: LessonStore
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true });
   }
-  writeFileSync(
-    `${dir}/learnings.json`,
-    JSON.stringify(store, null, 2),
-    'utf8',
-  );
+  writeFileSync(`${dir}/learnings.json`, JSON.stringify(store, null, 2), 'utf8');
 }
 
 // ── Bridge: denial-learner patterns → lessons ──
@@ -270,7 +270,7 @@ export interface DenialPatternLike {
  *  High-confidence patterns (0.8+) become critical lessons. */
 export function patternsToLessons(
   patterns: readonly DenialPatternLike[],
-  context: { agentId: string; squad: string },
+  context: { agentId: string; squad: string }
 ): Lesson[] {
   return patterns.map((p) => {
     // Map confidence to severity
@@ -296,7 +296,7 @@ export function learnFromDenials(
   patterns: readonly DenialPatternLike[],
   root: string,
   squad: string,
-  agentId: string,
+  agentId: string
 ): { lessonsAdded: number; totalLessons: number } {
   const lessons = patternsToLessons(patterns, { agentId, squad });
   let store = readLessonStore(root, squad);

--- a/packages/scheduler/src/dispatcher.ts
+++ b/packages/scheduler/src/dispatcher.ts
@@ -23,7 +23,7 @@ export class Dispatcher {
   constructor(
     private readonly store: TaskStore,
     private readonly leases: LeaseManager,
-    private readonly config: DispatcherConfig,
+    private readonly config: DispatcherConfig
   ) {
     this.cooldownMs = config.cooldownMs ?? DEFAULT_COOLDOWN_MS;
     this.leaseTimeMs = config.leaseTimeMs ?? 10 * 60 * 1000;
@@ -61,7 +61,8 @@ export class Dispatcher {
   start(taskId: string, workerId: string): Task {
     const task = this.store.get(taskId);
     if (!task) throw new Error(`Task ${taskId} not found`);
-    if (task.leaseOwner !== workerId) throw new Error(`Worker ${workerId} does not hold lease on ${taskId}`);
+    if (task.leaseOwner !== workerId)
+      throw new Error(`Worker ${workerId} does not hold lease on ${taskId}`);
 
     return this.store.transition(taskId, 'running', {
       startedAt: Date.now(),

--- a/packages/scheduler/src/lease-manager.ts
+++ b/packages/scheduler/src/lease-manager.ts
@@ -11,7 +11,7 @@ export class LeaseManager {
     resourceType: Lease['resourceType'],
     resourceKey: string,
     owner: string,
-    ttlMs: number = DEFAULT_LEASE_TTL_MS,
+    ttlMs: number = DEFAULT_LEASE_TTL_MS
   ): Lease | null {
     const key = leaseKey(resourceType, resourceKey);
     const existing = this.leases.get(key);
@@ -51,7 +51,7 @@ export class LeaseManager {
     resourceType: Lease['resourceType'],
     resourceKey: string,
     owner: string,
-    ttlMs: number = DEFAULT_LEASE_TTL_MS,
+    ttlMs: number = DEFAULT_LEASE_TTL_MS
   ): Lease | null {
     const key = leaseKey(resourceType, resourceKey);
     const existing = this.leases.get(key);

--- a/packages/scheduler/src/metrics.ts
+++ b/packages/scheduler/src/metrics.ts
@@ -35,10 +35,11 @@ export function computeMetrics(store: TaskStore): QueueMetrics {
 
   // Retry rate
   const finishedTasks = tasks.filter(
-    (t) => t.state === 'succeeded' || t.state === 'failed_terminal' || t.state === 'dead_letter',
+    (t) => t.state === 'succeeded' || t.state === 'failed_terminal' || t.state === 'dead_letter'
   );
   const totalAttempts = finishedTasks.reduce((sum, t) => sum + t.attemptCount, 0);
-  const retryRate = finishedTasks.length > 0 ? (totalAttempts - finishedTasks.length) / finishedTasks.length : 0;
+  const retryRate =
+    finishedTasks.length > 0 ? (totalAttempts - finishedTasks.length) / finishedTasks.length : 0;
 
   const deadLetterCount = tasks.filter((t) => t.state === 'dead_letter').length;
 

--- a/packages/scheduler/src/task-store.ts
+++ b/packages/scheduler/src/task-store.ts
@@ -58,7 +58,22 @@ export class TaskStore {
     return this.tasks.get(id) ?? null;
   }
 
-  transition(id: string, newState: TaskState, patch?: Partial<Pick<Task, 'leaseOwner' | 'leaseExpiresAt' | 'startedAt' | 'finishedAt' | 'resultSummary' | 'attemptCount' | 'cooldownUntil'>>): Task {
+  transition(
+    id: string,
+    newState: TaskState,
+    patch?: Partial<
+      Pick<
+        Task,
+        | 'leaseOwner'
+        | 'leaseExpiresAt'
+        | 'startedAt'
+        | 'finishedAt'
+        | 'resultSummary'
+        | 'attemptCount'
+        | 'cooldownUntil'
+      >
+    >
+  ): Task {
     const task = this.tasks.get(id);
     if (!task) throw new Error(`Task ${id} not found`);
 
@@ -86,7 +101,7 @@ export class TaskStore {
         (t) =>
           t.state === 'queued' &&
           t.scheduledAt <= now &&
-          (!workerClass || t.workerClass === workerClass),
+          (!workerClass || t.workerClass === workerClass)
       )
       .sort((a, b) => {
         const pa = priorityOrder(a.priority);
@@ -99,7 +114,7 @@ export class TaskStore {
   /** Count active (leased + running) tasks per class */
   activeCount(workerClass: WorkerClass): number {
     return [...this.tasks.values()].filter(
-      (t) => t.workerClass === workerClass && (t.state === 'leased' || t.state === 'running'),
+      (t) => t.workerClass === workerClass && (t.state === 'leased' || t.state === 'running')
     ).length;
   }
 
@@ -133,10 +148,14 @@ export class TaskStore {
 
 function priorityOrder(p: Task['priority']): number {
   switch (p) {
-    case 'P0': return 0;
-    case 'P1': return 1;
-    case 'P2': return 2;
-    case 'P3': return 3;
+    case 'P0':
+      return 0;
+    case 'P1':
+      return 1;
+    case 'P2':
+      return 2;
+    case 'P3':
+      return 3;
   }
 }
 
@@ -147,7 +166,7 @@ function isTerminal(state: TaskState): boolean {
 export class DedupeError extends Error {
   constructor(
     public readonly dedupeKey: string,
-    public readonly existingTaskId: string,
+    public readonly existingTaskId: string
   ) {
     super(`Duplicate task: key=${dedupeKey} exists as ${existingTaskId}`);
     this.name = 'DedupeError';
@@ -157,7 +176,7 @@ export class DedupeError extends Error {
 export class InvalidTransitionError extends Error {
   constructor(
     public readonly from: TaskState,
-    public readonly to: TaskState,
+    public readonly to: TaskState
   ) {
     super(`Invalid transition: ${from} → ${to}`);
     this.name = 'InvalidTransitionError';

--- a/packages/swarm/src/loop-guards.ts
+++ b/packages/swarm/src/loop-guards.ts
@@ -17,7 +17,7 @@ export interface LoopGuardResult {
 export function checkLoopGuards(
   config: LoopGuardConfig,
   state: SquadState,
-  context: LoopGuardContext,
+  context: LoopGuardContext
 ): LoopGuardResult {
   const violations: GuardViolation[] = [];
   const messages: string[] = [];
@@ -26,7 +26,7 @@ export function checkLoopGuards(
   if (state.prQueue.open >= config.maxOpenPRsPerSquad) {
     violations.push('budget');
     messages.push(
-      `PR budget exceeded: ${state.prQueue.open} open (max ${config.maxOpenPRsPerSquad}). Skip implementation, focus on review/merge.`,
+      `PR budget exceeded: ${state.prQueue.open} open (max ${config.maxOpenPRsPerSquad}). Skip implementation, focus on review/merge.`
     );
   }
 
@@ -34,7 +34,7 @@ export function checkLoopGuards(
   if (context.retryCount > config.maxRetries) {
     violations.push('retry');
     messages.push(
-      `Retry limit exceeded: ${context.retryCount} attempts (max ${config.maxRetries}). Create escalation issue.`,
+      `Retry limit exceeded: ${context.retryCount} attempts (max ${config.maxRetries}). Create escalation issue.`
     );
   }
 
@@ -42,7 +42,7 @@ export function checkLoopGuards(
   if (context.predictedFileChanges > config.maxBlastRadius) {
     violations.push('blast-radius');
     messages.push(
-      `Blast radius exceeded: ${context.predictedFileChanges} files (max ${config.maxBlastRadius}). Escalate to Architect.`,
+      `Blast radius exceeded: ${context.predictedFileChanges} files (max ${config.maxBlastRadius}). Escalate to Architect.`
     );
   }
 
@@ -52,7 +52,7 @@ export function checkLoopGuards(
   if (elapsedMin > config.maxRunMinutes) {
     violations.push('time');
     messages.push(
-      `Run time exceeded: ${Math.round(elapsedMin)}min (max ${config.maxRunMinutes}min). Force-stop, EM investigates.`,
+      `Run time exceeded: ${Math.round(elapsedMin)}min (max ${config.maxRunMinutes}min). Force-stop, EM investigates.`
     );
   }
 

--- a/packages/swarm/src/types.ts
+++ b/packages/swarm/src/types.ts
@@ -74,7 +74,14 @@ export interface ScaffoldedAgent {
 
 // --- Squad hierarchy types ---
 
-export type SquadRank = 'director' | 'em' | 'product-lead' | 'architect' | 'senior' | 'junior' | 'qa';
+export type SquadRank =
+  | 'director'
+  | 'em'
+  | 'product-lead'
+  | 'architect'
+  | 'senior'
+  | 'junior'
+  | 'qa';
 export type AgentDriver = 'claude-code' | 'copilot-cli';
 export type AgentModel = 'opus' | 'sonnet' | 'haiku' | 'copilot';
 
@@ -89,7 +96,7 @@ export interface SquadAgent {
 
 export interface Squad {
   readonly name: string;
-  readonly repo: string;       // repo name or '*' for cross-repo
+  readonly repo: string; // repo name or '*' for cross-repo
   readonly em: SquadAgent;
   readonly agents: Readonly<Record<string, SquadAgent>>;
 }
@@ -116,11 +123,16 @@ export interface SquadState {
     readonly goal: string;
     readonly issues: readonly string[];
   };
-  readonly assignments: Readonly<Record<string, {
-    readonly current: string | null;
-    readonly status: string;
-    readonly waiting?: string;
-  }>>;
+  readonly assignments: Readonly<
+    Record<
+      string,
+      {
+        readonly current: string | null;
+        readonly status: string;
+        readonly waiting?: string;
+      }
+    >
+  >;
   readonly blockers: readonly string[];
   readonly prQueue: {
     readonly open: number;


### PR DESCRIPTION
## Summary

- Fixes 9 Prettier format violations across `kernel`, `scheduler`, `swarm`, and `cli` packages that were causing CI failures
- Fixes `governance-audit.md` skill file heading from `# Governance Audit` to `# Skill: Governance Audit` to match the convention used by all 39 other skill files

## Motivation

Addresses the "reduce noise" sprint goal. These formatting violations were flagged in #868 (critical: PRs merging with failing CI) as a recurring pattern where agents introduce violations that other agents then fix — wasted compute. This PR cleans up the current violations.

## Test plan

- [x] `pnpm format` — all files pass Prettier check
- [x] `pnpm lint` — 17/17 packages clean
- [x] `pnpm build` — 18/18 packages build successfully
- [x] `pnpm test` — 757/759 tests pass (2 pre-existing failures in `guide-mode-e2e.test.ts`, unrelated)

Closes #871

🤖 Generated with [Claude Code](https://claude.com/claude-code)