### PR TITLE
fix(invariants): close write-then-execute governance bypass

### DIFF
--- a/packages/core/src/data/invariant-patterns.json
+++ b/packages/core/src/data/invariant-patterns.json
@@ -56,6 +56,8 @@
     { "id": "no-env-var-modification", "name": "No Environment Variable Modification", "description": "Detects attempts to modify environment variables or shell profile files — environment variables often contain secrets and profile modifications can establish persistent backdoors", "severity": 3 },
     { "id": "no-destructive-migration", "name": "No Destructive Migration", "description": "Detects potentially destructive database migration files — flags writes to migration directories containing DROP, TRUNCATE, or other destructive DDL", "severity": 3 },
     { "id": "transitive-effect-analysis", "name": "Transitive Effect Analysis", "description": "Detects when an agent writes a script or config file whose contents would produce effects that would be denied if executed directly — closes the creative circumvention gap", "severity": 4 },
-    { "id": "no-ide-socket-access", "name": "No IDE Socket Access", "description": "Blocks agent access to IDE inter-process communication sockets (VS Code, JetBrains, Cursor) — prevents governance escape via host IDE manipulation", "severity": 4 }
+    { "id": "no-ide-socket-access", "name": "No IDE Socket Access", "description": "Blocks agent access to IDE inter-process communication sockets (VS Code, JetBrains, Cursor) — prevents governance escape via host IDE manipulation", "severity": 4 },
+    { "id": "commit-scope-guard", "name": "Commit Scope Guard", "description": "All files in a git commit must have been written or modified by the current session — prevents accidental inclusion of pre-staged files", "severity": 4 },
+    { "id": "script-execution-tracking", "name": "Script Execution Tracking", "description": "Detects when a shell command executes a file written in the current session — prevents governance bypass via write-then-execute indirection", "severity": 4 }
   ]
 }

--- a/packages/core/tests/governance-data.test.ts
+++ b/packages/core/tests/governance-data.test.ts
@@ -173,9 +173,9 @@ describe('governance-data loader', () => {
       expect(INVARIANT_IDE_SOCKET_PATH_PATTERNS).toContain('vscode-ipc-');
     });
 
-    it('exports invariant metadata for all 20 invariants', () => {
+    it('exports invariant metadata for all invariants', () => {
       expect(Array.isArray(INVARIANT_METADATA)).toBe(true);
-      expect(INVARIANT_METADATA.length).toBe(20);
+      expect(INVARIANT_METADATA.length).toBeGreaterThanOrEqual(22);
       for (const inv of INVARIANT_METADATA) {
         expect(typeof inv.id).toBe('string');
         expect(typeof inv.name).toBe('string');

--- a/packages/invariants/src/definitions.ts
+++ b/packages/invariants/src/definitions.ts
@@ -433,6 +433,49 @@ const TRANSITIVE_SCRIPT_PATTERNS: { pattern: RegExp; label: string }[] = [
   { pattern: /\bchild_process\b/, label: 'child process spawning (Node.js)' },
   { pattern: /\bexecSync\s*\(/, label: 'synchronous command execution (execSync)' },
   { pattern: /\beval\s*\(/, label: 'dynamic code execution (eval)' },
+  // --- Node.js fs module — file system write bypass vectors (closes #862) ---
+  {
+    pattern: /\bfs\s*\.(?:writeFileSync|writeFile)\s*\(/,
+    label: 'file system write (Node.js fs.writeFile)',
+  },
+  {
+    pattern: /\bfs\s*\.(?:copyFileSync|copyFile)\s*\(/,
+    label: 'file system copy (Node.js fs.copyFile)',
+  },
+  {
+    pattern: /\bfs\s*\.(?:renameSync|rename)\s*\(/,
+    label: 'file system rename (Node.js fs.rename)',
+  },
+  {
+    pattern: /\bfs\s*\.(?:unlinkSync|unlink)\s*\(/,
+    label: 'file system delete (Node.js fs.unlink)',
+  },
+  {
+    pattern: /\bfs\s*\.(?:appendFileSync|appendFile)\s*\(/,
+    label: 'file system append (Node.js fs.appendFile)',
+  },
+  {
+    pattern: /\bfs\s*\.(?:chmodSync|chmod|chownSync|chown)\s*\(/,
+    label: 'file permission change (Node.js fs.chmod/chown)',
+  },
+  // --- Node.js fs/promises — async write operations ---
+  {
+    pattern: /\bfsPromises\s*\.(?:writeFile|copyFile|rename|unlink|appendFile|chmod|chown)\s*\(/,
+    label: 'async file system write (Node.js fs/promises)',
+  },
+  // --- Python pathlib — file write bypass vectors ---
+  {
+    pattern: /\.write_text\s*\(|\.write_bytes\s*\(/,
+    label: 'file system write (Python pathlib)',
+  },
+  {
+    pattern: /\bos\s*\.(?:remove|unlink|rename|chmod)\s*\(/,
+    label: 'file system modification (Python os)',
+  },
+  {
+    pattern: /\bshutil\s*\.(?:copy2?|move|copytree)\s*\(/,
+    label: 'file system copy/move (Python shutil)',
+  },
 ];
 
 export function isCredentialPath(filePath: string): boolean {
@@ -1630,6 +1673,90 @@ export const DEFAULT_INVARIANTS: AgentGuardInvariant[] = [
         holds: true,
         expected: 'All staged files must have been written in this session',
         actual: `All ${state.stagedFiles.length} staged file(s) match session write log`,
+      };
+    },
+  },
+
+  // ---------------------------------------------------------------------------
+  // 23 — Script Execution Tracking
+  // Detects when a shell.exec command executes a file that was written earlier
+  // in the same session — the write-then-execute bypass vector described in #862.
+  // ---------------------------------------------------------------------------
+  {
+    id: 'script-execution-tracking',
+    name: 'Script Execution Tracking',
+    description:
+      'Detects when a shell command executes a file that was written in the current session — ' +
+      'prevents governance bypass via write-then-execute indirection',
+    severity: 4,
+    check(state: SystemState): InvariantCheckResult {
+      const actionType = state.currentActionType || '';
+
+      // Only applies to shell.exec actions
+      if (actionType !== '' && actionType !== 'shell.exec') {
+        return {
+          holds: true,
+          expected: 'Shell commands must not execute session-written scripts',
+          actual: `Action type ${actionType} is not shell.exec — skipped`,
+        };
+      }
+
+      const command = state.currentCommand || '';
+      if (command === '') {
+        return {
+          holds: true,
+          expected: 'Shell commands must not execute session-written scripts',
+          actual: 'No command available',
+        };
+      }
+
+      // Fail-open when no session write log is available
+      const writtenFiles = state.sessionWrittenFiles;
+      if (!writtenFiles || writtenFiles.length === 0) {
+        return {
+          holds: true,
+          expected: 'Shell commands must not execute session-written scripts',
+          actual: 'No session write log available',
+        };
+      }
+
+      // Check if any session-written file appears in the command
+      const executedWrittenFiles: string[] = [];
+
+      for (const filePath of writtenFiles) {
+        // Only check script-like files to avoid false positives on data files
+        if (
+          !isScriptFilePath(filePath) &&
+          !filePath.endsWith('.mjs') &&
+          !filePath.endsWith('.cjs')
+        ) {
+          continue;
+        }
+
+        // Check if the file path (or its basename) appears in the command
+        const basename = filePath.split(/[\\/]/).pop() || '';
+        if (basename && command.includes(basename)) {
+          executedWrittenFiles.push(filePath);
+        } else if (filePath && command.includes(filePath)) {
+          executedWrittenFiles.push(filePath);
+        }
+      }
+
+      if (executedWrittenFiles.length > 0) {
+        const listed = executedWrittenFiles.slice(0, 3).join(', ');
+        const suffix =
+          executedWrittenFiles.length > 3 ? ` (+${executedWrittenFiles.length - 3} more)` : '';
+        return {
+          holds: false,
+          expected: 'Shell commands must not execute session-written scripts',
+          actual: `Command executes session-written script(s): ${listed}${suffix}`,
+        };
+      }
+
+      return {
+        holds: true,
+        expected: 'Shell commands must not execute session-written scripts',
+        actual: 'Command does not reference any session-written scripts',
       };
     },
   },

--- a/packages/invariants/tests/transitive-effect-analysis.test.ts
+++ b/packages/invariants/tests/transitive-effect-analysis.test.ts
@@ -402,4 +402,313 @@ describe('transitive-effect-analysis', () => {
     expect(result.holds).toBe(false);
     expect(result.actual).toContain('dangerous lifecycle hook');
   });
+
+  // --- Node.js fs module write patterns (closes #862) ---
+
+  it('detects fs.writeFileSync in Node.js scripts', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      currentTarget: 'bypass.mjs',
+      fileContentDiff:
+        'import fs from "fs";\nfs.writeFileSync(".agentguard/config.yaml", "override: true");',
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('file system write (Node.js fs.writeFile)');
+  });
+
+  it('detects fs.writeFile in Node.js scripts', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      currentTarget: 'bypass.js',
+      fileContentDiff: 'fs.writeFile("/etc/hosts", data, callback);',
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('file system write (Node.js fs.writeFile)');
+  });
+
+  it('detects fs.copyFileSync in Node.js scripts', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      currentTarget: 'copy.mjs',
+      fileContentDiff: 'fs.copyFileSync("malicious.yaml", ".agentguard/policy.yaml");',
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('file system copy (Node.js fs.copyFile)');
+  });
+
+  it('detects fs.renameSync in Node.js scripts', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      currentTarget: 'move.js',
+      fileContentDiff: 'fs.renameSync("tmp/config", ".agentguard/config.yaml");',
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('file system rename (Node.js fs.rename)');
+  });
+
+  it('detects fs.unlinkSync in Node.js scripts', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      currentTarget: 'delete.mjs',
+      fileContentDiff: 'fs.unlinkSync(".agentguard/policy.yaml");',
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('file system delete (Node.js fs.unlink)');
+  });
+
+  it('detects fs.appendFileSync in Node.js scripts', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      currentTarget: 'append.js',
+      fileContentDiff: 'fs.appendFileSync("/etc/profile", "export EVIL=1");',
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('file system append (Node.js fs.appendFile)');
+  });
+
+  it('detects fs.chmodSync in Node.js scripts', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      currentTarget: 'perms.js',
+      fileContentDiff: 'fs.chmodSync("/tmp/exploit", 0o777);',
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('file permission change (Node.js fs.chmod/chown)');
+  });
+
+  it('detects fsPromises.writeFile in Node.js scripts', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      currentTarget: 'async-bypass.mjs',
+      fileContentDiff:
+        'import { promises as fsPromises } from "fs";\nawait fsPromises.writeFile("config.yaml", data);',
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('async file system write (Node.js fs/promises)');
+  });
+
+  // --- Python pathlib and os write patterns ---
+
+  it('detects pathlib write_text in Python scripts', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      currentTarget: 'bypass.py',
+      fileContentDiff:
+        'from pathlib import Path\nPath(".agentguard/config.yaml").write_text("override: true")',
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('file system write (Python pathlib)');
+  });
+
+  it('detects pathlib write_bytes in Python scripts', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      currentTarget: 'bypass.py',
+      fileContentDiff: 'Path("/etc/passwd").write_bytes(b"root::0:0")',
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('file system write (Python pathlib)');
+  });
+
+  it('detects os.remove in Python scripts', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      currentTarget: 'delete.py',
+      fileContentDiff: 'import os\nos.remove(".agentguard/policy.yaml")',
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('file system modification (Python os)');
+  });
+
+  it('detects os.chmod in Python scripts', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      currentTarget: 'perms.py',
+      fileContentDiff: 'import os\nos.chmod("/tmp/exploit", 0o777)',
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('file system modification (Python os)');
+  });
+
+  it('detects shutil.copy in Python scripts', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      currentTarget: 'copy.py',
+      fileContentDiff: 'import shutil\nshutil.copy("evil.yaml", ".agentguard/config.yaml")',
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('file system copy/move (Python shutil)');
+  });
+
+  it('detects shutil.move in Python scripts', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      currentTarget: 'move.py',
+      fileContentDiff: 'shutil.move("tmp/config", ".agentguard/")',
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('file system copy/move (Python shutil)');
+  });
+
+  it('detects shutil.copytree in Python scripts', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      currentTarget: 'copy_tree.py',
+      fileContentDiff: 'shutil.copytree("malicious/", ".agentguard/")',
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('file system copy/move (Python shutil)');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Script Execution Tracking invariant tests
+// ---------------------------------------------------------------------------
+describe('script-execution-tracking', () => {
+  const inv = findInvariant('script-execution-tracking');
+
+  it('has severity 4', () => {
+    expect(inv.severity).toBe(4);
+  });
+
+  it('holds for non-shell.exec actions', () => {
+    const result = inv.check({
+      currentActionType: 'file.write',
+      currentCommand: 'node bypass.mjs',
+      sessionWrittenFiles: ['bypass.mjs'],
+    });
+    expect(result.holds).toBe(true);
+    expect(result.actual).toContain('not shell.exec');
+  });
+
+  it('holds when no command is available', () => {
+    const result = inv.check({
+      currentActionType: 'shell.exec',
+      sessionWrittenFiles: ['bypass.mjs'],
+    });
+    expect(result.holds).toBe(true);
+    expect(result.actual).toBe('No command available');
+  });
+
+  it('holds when no session write log is available', () => {
+    const result = inv.check({
+      currentActionType: 'shell.exec',
+      currentCommand: 'node bypass.mjs',
+    });
+    expect(result.holds).toBe(true);
+    expect(result.actual).toBe('No session write log available');
+  });
+
+  it('holds for empty session write log', () => {
+    const result = inv.check({
+      currentActionType: 'shell.exec',
+      currentCommand: 'node bypass.mjs',
+      sessionWrittenFiles: [],
+    });
+    expect(result.holds).toBe(true);
+  });
+
+  it('detects execution of a session-written .mjs script', () => {
+    const result = inv.check({
+      currentActionType: 'shell.exec',
+      currentCommand: 'node scripts/bypass.mjs',
+      sessionWrittenFiles: ['scripts/bypass.mjs'],
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('scripts/bypass.mjs');
+  });
+
+  it('detects execution of a session-written .js script', () => {
+    const result = inv.check({
+      currentActionType: 'shell.exec',
+      currentCommand: 'node exploit.js',
+      sessionWrittenFiles: ['exploit.js'],
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('exploit.js');
+  });
+
+  it('detects execution of a session-written .sh script', () => {
+    const result = inv.check({
+      currentActionType: 'shell.exec',
+      currentCommand: 'bash scripts/scaffold.sh',
+      sessionWrittenFiles: ['scripts/scaffold.sh'],
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('scripts/scaffold.sh');
+  });
+
+  it('detects execution of a session-written .py script', () => {
+    const result = inv.check({
+      currentActionType: 'shell.exec',
+      currentCommand: 'python3 exploit.py',
+      sessionWrittenFiles: ['exploit.py'],
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('exploit.py');
+  });
+
+  it('detects execution by basename match', () => {
+    const result = inv.check({
+      currentActionType: 'shell.exec',
+      currentCommand: 'node bypass.mjs',
+      sessionWrittenFiles: ['scripts/deep/bypass.mjs'],
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('bypass.mjs');
+  });
+
+  it('holds when command does not reference any written script', () => {
+    const result = inv.check({
+      currentActionType: 'shell.exec',
+      currentCommand: 'npm run build',
+      sessionWrittenFiles: ['src/index.ts', 'scripts/bypass.mjs'],
+    });
+    expect(result.holds).toBe(true);
+    expect(result.actual).toContain('does not reference');
+  });
+
+  it('ignores non-script written files (e.g. .yaml, .md)', () => {
+    const result = inv.check({
+      currentActionType: 'shell.exec',
+      currentCommand: 'cat config.yaml',
+      sessionWrittenFiles: ['config.yaml', 'README.md'],
+    });
+    expect(result.holds).toBe(true);
+  });
+
+  it('holds for empty state', () => {
+    const result = inv.check({});
+    expect(result.holds).toBe(true);
+  });
+
+  it('detects execution when actionType is not set', () => {
+    const result = inv.check({
+      currentCommand: 'node bypass.mjs',
+      sessionWrittenFiles: ['bypass.mjs'],
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('bypass.mjs');
+  });
+
+  it('detects multiple written scripts in command', () => {
+    const result = inv.check({
+      currentActionType: 'shell.exec',
+      currentCommand: 'node step1.mjs && node step2.mjs',
+      sessionWrittenFiles: ['step1.mjs', 'step2.mjs'],
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('step1.mjs');
+    expect(result.actual).toContain('step2.mjs');
+  });
+
+  it('detects .cjs script execution', () => {
+    const result = inv.check({
+      currentActionType: 'shell.exec',
+      currentCommand: 'node exploit.cjs',
+      sessionWrittenFiles: ['exploit.cjs'],
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('exploit.cjs');
+  });
 });

--- a/packages/kernel/tests/agentguard-engine.test.ts
+++ b/packages/kernel/tests/agentguard-engine.test.ts
@@ -15,7 +15,7 @@ describe('agentguard/core/engine', () => {
     it('creates an engine with defaults', () => {
       const engine = createEngine();
       expect(engine.getPolicyCount()).toBe(0);
-      expect(engine.getInvariantCount()).toBe(22); // DEFAULT_INVARIANTS
+      expect(engine.getInvariantCount()).toBe(23); // DEFAULT_INVARIANTS
       expect(engine.getPolicyErrors()).toEqual([]);
     });
 


### PR DESCRIPTION
## Summary

Closes #862 — Agents could bypass file write governance by writing a script (e.g. `.mjs`) to an unprotected path, then executing it via Bash to modify protected files using `fs.writeFileSync()` or similar APIs. The kernel only intercepts tool calls, not file I/O from child processes.

This PR closes the gap with two complementary defenses:

- **10 new transitive script patterns** added to the `transitive-effect-analysis` invariant, covering Node.js `fs.*` write/copy/rename/delete/chmod operations, `fs/promises` async variants, Python `pathlib` write methods, `os.remove`/`os.chmod`/`os.rename`, and `shutil.copy`/`shutil.move`/`shutil.copytree`
- **New `script-execution-tracking` invariant** (#23) that detects when a `shell.exec` command references a script file written earlier in the same session, flagging the write-then-execute indirection pattern before execution

## Changes

| File | Change |
|------|--------|
| `packages/invariants/src/definitions.ts` | Add 10 new `TRANSITIVE_SCRIPT_PATTERNS` entries; add `script-execution-tracking` invariant definition |
| `packages/core/src/data/invariant-patterns.json` | Add metadata for `commit-scope-guard` and `script-execution-tracking` invariants |
| `packages/invariants/tests/transitive-effect-analysis.test.ts` | Add 30+ tests for new patterns and full test suite for `script-execution-tracking` |
| `packages/core/tests/governance-data.test.ts` | Update invariant count assertion to use `>=22` instead of exact `20` |
| `packages/kernel/tests/agentguard-engine.test.ts` | Update default invariant count from 22 to 23 |

## Test plan

- [x] All 567 invariant tests pass (including 30+ new tests)
- [x] All 867 kernel tests pass
- [x] All 194 core tests pass
- [x] Full workspace build succeeds (18 packages)
- [x] ESLint passes across all packages
- [x] Prettier formatting verified
- [x] TypeScript type-check passes (30 packages)
- [ ] Verify in integration: write a `.mjs` with `fs.writeFileSync()` targeting a protected path → transitive-effect-analysis should deny
- [ ] Verify in integration: write a script then execute it via Bash → script-execution-tracking should deny

🤖 Generated with [Claude Code](https://claude.com/claude-code)