### PR TITLE
feat(issue-857): stranger test protocol and install fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ agentguard claude-init
 # → Creates agentguard.yaml, installs Claude Code hooks, and activates governance
 ```
 
+Or use `npx` without a global install:
+
+```bash
+cd your-project
+npx @red-codes/agentguard claude-init
+```
+
 The `claude-init` wizard walks you through setup interactively:
 
 ```

--- a/apps/cli/src/commands/claude-init.ts
+++ b/apps/cli/src/commands/claude-init.ts
@@ -221,7 +221,7 @@ export async function claudeInit(args: string[] = []): Promise<void> {
       'Enable a policy pack?',
       [
         `essentials ${DIM}— secrets, force push, protected branches, credentials${RESET}`,
-        `strict ${DIM}— all 21 invariants enforced${RESET}`,
+        `strict ${DIM}— all 22 invariants enforced${RESET}`,
         `none ${DIM}— monitor only, configure later${RESET}`,
       ],
       0
@@ -636,7 +636,7 @@ function removeHook(settingsPath: string, settingsLabel: string): void {
 const STARTER_POLICY_TEMPLATE = (mode: EnforcementMode, pack?: string) => {
   const packLine = pack ? `pack: ${pack}` : '# pack: essentials';
   return `# AgentGuard policy — runtime protection for AI coding agents.
-# Docs: https://github.com/AgentGuardHQ/agent-guard
+# Docs: https://github.com/AgentGuardHQ/agentguard
 
 id: default-policy
 name: Default Safety Policy

--- a/apps/cli/src/postinstall.ts
+++ b/apps/cli/src/postinstall.ts
@@ -21,13 +21,13 @@ const POLICY_CANDIDATES = [
 
 const STARTER_POLICY = `# AgentGuard policy — safety rules for AI coding agents.
 # Customize this file to match your project's security requirements.
-# Docs: https://github.com/AgentGuardHQ/agent-guard
+# Docs: https://github.com/AgentGuardHQ/agentguard
 
 id: default-policy
 name: Default Safety Policy
 description: Baseline safety rules for AI coding agents
 severity: 4
-mode: monitor
+mode: guide
 pack: essentials
 
 rules:

--- a/apps/cli/tests/cli-postinstall.test.ts
+++ b/apps/cli/tests/cli-postinstall.test.ts
@@ -335,7 +335,7 @@ describe('writeStarterPolicy', () => {
     expect(existsSync(policyPath)).toBe(true);
 
     const content = readFileSync(policyPath, 'utf8');
-    expect(content).toContain('mode: monitor');
+    expect(content).toContain('mode: guide');
     expect(content).toContain('pack: essentials');
     expect(content).toContain('git.push');
     expect(content).toContain('git.force-push');
@@ -343,6 +343,13 @@ describe('writeStarterPolicy', () => {
     expect(content).toContain('rm -rf');
     expect(content).toContain('deploy.trigger');
     expect(content).toContain('infra.destroy');
+  });
+
+  it('starter policy links to correct GitHub URL', () => {
+    writeStarterPolicy(tempDir);
+    const content = readFileSync(join(tempDir, 'agentguard.yaml'), 'utf8');
+    expect(content).toContain('https://github.com/AgentGuardHQ/agentguard');
+    expect(content).not.toContain('agent-guard');
   });
 
   it('skips when agentguard.yaml already exists', () => {
@@ -413,7 +420,7 @@ describe('postinstall integration', () => {
 
     // Policy file
     const policy = readFileSync(join(tempDir, 'agentguard.yaml'), 'utf8');
-    expect(policy).toContain('mode: monitor');
+    expect(policy).toContain('mode: guide');
     expect(policy).toContain('pack: essentials');
   });
 

--- a/spec/stranger-test-protocol.md
+++ b/spec/stranger-test-protocol.md
@@ -1,0 +1,169 @@
+# Stranger Test Protocol
+
+Validates the zero-context install experience for AgentGuard. A "stranger" is someone who has never seen the project before and follows the README from scratch.
+
+## Prerequisites
+
+- Tester has Node.js >= 18 installed
+- Tester has Claude Code (or Copilot CLI) installed
+- Tester has NO prior AgentGuard installation (run `npm uninstall -g @red-codes/agentguard` first)
+- Tester has a test project with a git repo initialized
+
+## Success Criteria
+
+The entire flow must complete without errors, confusion, or manual workarounds:
+
+1. Install resolves and completes in < 30 seconds
+2. `claude-init` wizard runs interactively with clear prompts
+3. Governance hooks are active and intercepting tool calls
+4. `agentguard status` confirms all components are healthy
+5. A dry-run deny correctly blocks a protected-branch push
+6. No 404 links, missing files, or confusing error messages
+
+## Test Steps
+
+### Step 1: Install (Global)
+
+```bash
+npm install -g @red-codes/agentguard
+```
+
+**Pass criteria:**
+- [ ] Installs without errors
+- [ ] No confusing postinstall output
+- [ ] `agentguard --version` prints a version number
+- [ ] `agentguard --help` lists available commands
+
+**Friction point taxonomy:** `install-error`, `postinstall-noise`, `missing-binary`
+
+### Step 2: Install (npx alternative)
+
+```bash
+npx @red-codes/agentguard --version
+```
+
+**Pass criteria:**
+- [ ] Resolves and runs without 404
+- [ ] Version output matches global install
+
+**Known issue:** `npx agentguard` (unscoped) returns 404 — the package is `@red-codes/agentguard`.
+
+**Friction point taxonomy:** `npx-discovery`, `package-naming`
+
+### Step 3: Initialize Claude Code Integration
+
+```bash
+cd /path/to/test-project
+agentguard claude-init
+```
+
+**Pass criteria:**
+- [ ] Interactive wizard launches with mode selection
+- [ ] Pack selection prompt appears
+- [ ] Role selection prompt appears
+- [ ] `.claude/settings.json` is created with PreToolUse hooks
+- [ ] `agentguard.yaml` is created with selected mode and pack
+- [ ] `scripts/` directory is created with identity scripts
+- [ ] `.agentguard-identity` file is created
+- [ ] Summary output shows all components as green checkmarks
+
+**Friction point taxonomy:** `wizard-unclear`, `file-creation-error`, `permission-denied`, `path-resolution`
+
+### Step 4: Verify Status
+
+```bash
+agentguard status
+```
+
+**Pass criteria:**
+- [ ] Shows hooks as installed
+- [ ] Shows policy file as detected
+- [ ] Shows runtime as active (or ready)
+- [ ] No error output
+
+**Friction point taxonomy:** `status-error`, `misleading-status`
+
+### Step 5: Test Dry-Run Deny
+
+```bash
+echo '{"tool":"Bash","command":"git push origin main"}' | agentguard guard --dry-run
+```
+
+**Pass criteria:**
+- [ ] Action is correctly classified as `git.push`
+- [ ] Policy denies the push to `main`
+- [ ] Output clearly shows the deny reason
+- [ ] Exit code is non-zero (denial)
+
+**Friction point taxonomy:** `dry-run-error`, `classification-wrong`, `output-unclear`
+
+### Step 6: Live Governance Test
+
+Start a Claude Code session in the test project and attempt a governed action:
+
+```bash
+claude "Show me the git status"
+```
+
+**Pass criteria:**
+- [ ] Claude Code session starts without hook errors
+- [ ] Tool calls are intercepted by PreToolUse hook
+- [ ] `agentguard inspect --last` shows the governed session
+- [ ] Events are persisted to SQLite (`.agentguard/agentguard.db`)
+
+**Friction point taxonomy:** `hook-execution-error`, `session-crash`, `event-missing`
+
+### Step 7: Non-Interactive Setup (CI)
+
+```bash
+agentguard claude-init --remove
+agentguard claude-init --mode guide --pack essentials
+```
+
+**Pass criteria:**
+- [ ] `--remove` cleanly removes hooks
+- [ ] Non-interactive init completes without prompts
+- [ ] Same result as interactive wizard with matching options
+
+**Friction point taxonomy:** `flag-parse-error`, `incomplete-removal`, `non-interactive-fail`
+
+### Step 8: Documentation Verification
+
+- [ ] All links in README.md resolve (no 404s)
+- [ ] All CLI commands shown in README work as documented
+- [ ] Policy YAML examples are valid (pass `agentguard policy validate`)
+- [ ] Architecture diagram matches actual behavior
+
+**Friction point taxonomy:** `broken-link`, `outdated-docs`, `invalid-example`
+
+## Friction Point Classification
+
+| Severity | Definition | Action |
+|----------|-----------|--------|
+| **Blocker** | Prevents installation or basic usage | Must fix before v3.0 |
+| **Major** | Causes confusion but has a workaround | Should fix before v3.0 |
+| **Minor** | Cosmetic or edge case | Fix post-v3.0 |
+
+## Known Friction Points (Pre-Test)
+
+| ID | Step | Description | Severity | Status |
+|----|------|-------------|----------|--------|
+| FP-1 | 2 | `npx agentguard` fails with 404 (unscoped name not on npm) | Blocker | Open (#848) |
+| FP-2 | 3,8 | Generated policy comments linked to wrong GitHub URL (`agent-guard` vs `agentguard`) | Major | Fixed (this PR) |
+| FP-3 | 3 | Wizard says "21 invariants" instead of 22 | Minor | Fixed (this PR) |
+| FP-4 | 3 | Postinstall auto-policy used `monitor` mode but wizard defaults to `guide` | Minor | Fixed (this PR) |
+| FP-5 | 1,2 | README Quick Start only showed global install, no npx alternative | Major | Fixed (this PR) |
+
+## Reporting Template
+
+For each friction point discovered during testing:
+
+```
+### FP-N: [Short description]
+- **Step**: [Which test step]
+- **Expected**: [What should happen]
+- **Actual**: [What actually happened]
+- **Severity**: Blocker / Major / Minor
+- **Screenshot/Output**: [paste]
+- **Environment**: [OS, Node version, Claude Code version]
+```


### PR DESCRIPTION
## Summary
- Define the stranger test protocol with 8-step validation flow, success criteria, and friction point taxonomy
- Fix 4 install-experience friction points found by tracing through the README → install → claude-init flow
- Closes #857

## Changes
- `spec/stranger-test-protocol.md` — New stranger test protocol document with steps, pass criteria, and friction point reporting template
- `apps/cli/src/postinstall.ts` — Fix wrong GitHub URL (`agent-guard` → `agentguard`); align starter policy mode with wizard default (`monitor` → `guide`)
- `apps/cli/src/commands/claude-init.ts` — Fix wrong GitHub URL in generated policy; fix invariant count (21 → 22)
- `README.md` — Add npx alternative to Quick Start section
- `apps/cli/tests/cli-postinstall.test.ts` — Update test expectations for corrected mode; add URL regression test

## Friction Points Fixed

| ID | Description | Severity |
|----|-------------|----------|
| FP-2 | Generated policy comments linked to `agent-guard` (404) instead of `agentguard` | Major |
| FP-3 | Wizard said "21 invariants" instead of 22 | Minor |
| FP-4 | Postinstall auto-policy used `monitor` but wizard defaults to `guide` | Minor |
| FP-5 | README Quick Start had no npx alternative | Major |

## Test Plan
- [x] TypeScript build passes (`pnpm build`)
- [x] All 760 vitest tests pass (`pnpm test`)
- [x] ESLint clean (`pnpm lint`)
- [x] Prettier clean (`pnpm format`)
- [x] Type-check clean (`pnpm ts:check`)

## Risk Assessment

| Metric | Value |
|--------|-------|
| Risk level | low |
| Blast radius | 5 files |
| Simulation result | allowed |

## Governance Report

| Metric | Count |
|--------|-------|
| Total events | 8 |
| Actions allowed | 0 |
| Actions denied | 1 |
| Policy denials | 1 |
| Invariant violations | 2 |
| Escalation events | 1 |

<details>
<summary>Governance details</summary>

**Source**: `.agentguard/agentguard.db` (SQLite)
**Escalation levels observed**: NORMAL only
**Pre-push simulation**: low risk, allowed

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code) (`claude-code:opus:developer`)