### PR TITLE
chore(kernel-qa): QA cycle report 2026-03-25T18:50Z

### DIFF
--- a/.agentguard/squads/kernel/state.json
+++ b/.agentguard/squads/kernel/state.json
@@ -18,10 +18,10 @@
     "passed": 4065,
     "failed": 0,
     "packages": 18,
-    "lastRun": "2026-03-25T15:50:00.000Z",
+    "lastRun": "2026-03-25T18:50:00.000Z",
     "status": "all_passing"
   },
   "lastEmRun": "2026-03-25T21:10:00.000Z",
-  "lastQaRun": "2026-03-25T15:50:00.000Z",
-  "updatedAt": "2026-03-25T21:10:00.000Z"
+  "lastQaRun": "2026-03-25T18:50:00.000Z",
+  "updatedAt": "2026-03-25T18:50:00.000Z"
 }


### PR DESCRIPTION
## Summary
- Full test suite: **4065 tests passed, 0 failures** across 18 packages
- No regressions since last QA run (2026-03-25T15:50Z)
- No open PRs requiring test coverage review
- Squad health: **green**

## Test plan
- [x] `pnpm test` — all 4065 tests pass
- [x] Regression check — no new failures
- [x] PR coverage audit — no open PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)