### PR TITLE
fix(matchers): harden scope matching against path manipulation

### DIFF
--- a/.agentguard/squads/kernel/state.json
+++ b/.agentguard/squads/kernel/state.json
@@ -4,7 +4,15 @@
     "goal": "Post-v2.6.0 stabilization complete. Monitoring CI health and tracking new issues.",
     "issues": []
   },
-  "assignments": {},
+  "assignments": {
+    "senior": {
+      "issue": 640,
+      "title": "Policy scope matching vulnerable to path manipulation",
+      "status": "pr-created",
+      "branch": "agent/kernel-sr-20260325-193002",
+      "claimedAt": "2026-03-25T19:30:00.000Z"
+    }
+  },
   "blockers": [],
   "prQueue": {
     "open": 0,

--- a/packages/matchers/src/canonicalize-path.ts
+++ b/packages/matchers/src/canonicalize-path.ts
@@ -1,0 +1,59 @@
+import { posix } from 'node:path';
+
+/**
+ * Canonicalize a file path for secure scope matching.
+ *
+ * Applies the following transformations in order:
+ * 1. Reject null bytes (path injection)
+ * 2. Decode URL-encoded characters (%2e, %2f, etc.)
+ * 3. Normalize path separators (backslash → forward slash)
+ * 4. Collapse multiple consecutive slashes
+ * 5. Resolve `.` and `..` segments via POSIX normalize
+ * 6. Strip leading `./`
+ * 7. Reject paths that escape the project root (leading `..`)
+ *
+ * This function is pure (no I/O) and does not resolve symlinks.
+ * Symlink resolution is an execution-time concern handled by adapters.
+ */
+export function canonicalizePath(filePath: string): string {
+  // 1. Reject null bytes — these can truncate paths in C-level APIs
+  if (filePath.includes('\0')) {
+    return '';
+  }
+
+  // 2. Decode URL-encoded characters (e.g. %2e%2e → .., %2f → /)
+  let p: string;
+  try {
+    p = decodeURIComponent(filePath);
+  } catch {
+    // Invalid percent-encoding — use the raw string
+    p = filePath;
+  }
+
+  // 3. Normalize path separators (Windows backslash → forward slash)
+  p = p.replace(/\\/g, '/');
+
+  // 4. Collapse multiple consecutive slashes (e.g. src//foo → src/foo)
+  p = p.replace(/\/{2,}/g, '/');
+
+  // 5. Resolve `.` and `..` segments via POSIX path normalization
+  p = posix.normalize(p);
+
+  // 6. Strip leading `./` (POSIX normalize may produce it)
+  if (p.startsWith('./')) {
+    p = p.slice(2);
+  }
+
+  // 7. Reject paths that escape the project root (start with `..`)
+  //    These would bypass any scope constraint.
+  if (p === '..' || p.startsWith('../')) {
+    return '';
+  }
+
+  // Strip leading `/` for consistent relative paths
+  if (p.startsWith('/')) {
+    p = p.slice(1);
+  }
+
+  return p;
+}

--- a/packages/matchers/src/index.ts
+++ b/packages/matchers/src/index.ts
@@ -83,3 +83,4 @@ export { CommandScanner } from './command-scanner.js';
 export { PathMatcher } from './path-matcher.js';
 export type { PathPatternInput } from './path-matcher.js';
 export { PolicyMatcher } from './policy-matcher.js';
+export { canonicalizePath } from './canonicalize-path.js';

--- a/packages/matchers/src/path-matcher.ts
+++ b/packages/matchers/src/path-matcher.ts
@@ -1,6 +1,7 @@
 import picomatch from 'picomatch';
 import type { MatchResult } from './types.js';
 import { RC_FILE_CREDENTIAL } from './reason-codes.js';
+import { canonicalizePath } from './canonicalize-path.js';
 
 // ─── Input type ──────────────────────────────────────────────────────────────
 
@@ -28,14 +29,12 @@ interface CompiledPattern {
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 /**
- * Normalize a file path for consistent matching:
- * - Convert Windows backslashes to forward slashes
- * - Strip leading `./`
+ * Normalize a file path for consistent matching.
+ * Delegates to canonicalizePath for URL-decoding, traversal resolution,
+ * separator normalization, and null-byte rejection.
  */
 function normalizePath(filePath: string): string {
-  let p = filePath.replace(/\\/g, '/');
-  if (p.startsWith('./')) p = p.slice(2);
-  return p;
+  return canonicalizePath(filePath);
 }
 
 // ─── PathMatcher ─────────────────────────────────────────────────────────────

--- a/packages/matchers/src/policy-matcher.ts
+++ b/packages/matchers/src/policy-matcher.ts
@@ -1,4 +1,5 @@
 import picomatch from 'picomatch';
+import { canonicalizePath } from './canonicalize-path.js';
 
 // ─── PolicyMatcher ──────────────────────────────────────────────────────────
 
@@ -55,11 +56,14 @@ export class PolicyMatcher {
     // Empty target = no match
     if (!target) return false;
 
-    // Normalize backslashes to forward slashes
-    const normalized = target.replace(/\\/g, '/');
+    // Canonicalize target: decode URL-encoding, resolve traversal, normalize separators
+    const normalized = canonicalizePath(target);
+
+    // Reject if canonicalization emptied the path (e.g. pure traversal)
+    if (!normalized) return false;
 
     for (const pattern of scopePatterns) {
-      // Normalize pattern backslashes too
+      // Canonicalize pattern (separators + traversal only, no URL-decoding for patterns)
       const normalizedPattern = pattern.replace(/\\/g, '/');
 
       // Wildcard matches everything

--- a/packages/matchers/tests/canonicalize-path.test.ts
+++ b/packages/matchers/tests/canonicalize-path.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { canonicalizePath } from '../src/canonicalize-path.js';
+
+describe('canonicalizePath', () => {
+  it('passes through simple relative paths unchanged', () => {
+    expect(canonicalizePath('src/foo.ts')).toBe('src/foo.ts');
+    expect(canonicalizePath('README.md')).toBe('README.md');
+  });
+
+  it('normalizes backslashes to forward slashes', () => {
+    expect(canonicalizePath('src\\foo\\bar.ts')).toBe('src/foo/bar.ts');
+  });
+
+  it('collapses multiple consecutive slashes', () => {
+    expect(canonicalizePath('src//foo///bar.ts')).toBe('src/foo/bar.ts');
+  });
+
+  it('resolves . segments', () => {
+    expect(canonicalizePath('src/./foo.ts')).toBe('src/foo.ts');
+    expect(canonicalizePath('./src/foo.ts')).toBe('src/foo.ts');
+  });
+
+  it('resolves .. segments within project boundary', () => {
+    expect(canonicalizePath('src/nested/../foo.ts')).toBe('src/foo.ts');
+    expect(canonicalizePath('a/b/c/../../d.ts')).toBe('a/d.ts');
+  });
+
+  it('returns empty string for traversal that escapes project root', () => {
+    expect(canonicalizePath('../etc/passwd')).toBe('');
+    expect(canonicalizePath('../../etc/shadow')).toBe('');
+    expect(canonicalizePath('src/../../etc/passwd')).toBe('');
+    expect(canonicalizePath('..')).toBe('');
+  });
+
+  it('decodes URL-encoded characters', () => {
+    expect(canonicalizePath('src/%66oo.ts')).toBe('src/foo.ts');
+    expect(canonicalizePath('config%2Eenv')).toBe('config.env');
+  });
+
+  it('decodes and blocks URL-encoded traversal that escapes root', () => {
+    // %2e%2e = ..  — decodes then resolves
+    expect(canonicalizePath('%2e%2e/etc/passwd')).toBe('');
+    // src/../etc/passwd resolves to etc/passwd (still within root)
+    expect(canonicalizePath('src/%2e%2e/etc/passwd')).toBe('etc/passwd');
+    // src/../../etc/passwd escapes root
+    expect(canonicalizePath('src/%2e%2e/%2e%2e/etc/passwd')).toBe('');
+  });
+
+  it('rejects paths with null bytes', () => {
+    expect(canonicalizePath('src/foo.ts\0')).toBe('');
+    expect(canonicalizePath('src/\0../etc/passwd')).toBe('');
+    expect(canonicalizePath('\0')).toBe('');
+  });
+
+  it('strips leading / for consistent relative paths', () => {
+    expect(canonicalizePath('/src/foo.ts')).toBe('src/foo.ts');
+  });
+
+  it('handles invalid percent-encoding gracefully', () => {
+    // Invalid %XX sequences — should use raw string
+    expect(canonicalizePath('src/%ZZfoo.ts')).toBe('src/%ZZfoo.ts');
+  });
+
+  it('handles empty string', () => {
+    expect(canonicalizePath('')).toBe('.');
+  });
+
+  it('handles dotfiles correctly', () => {
+    expect(canonicalizePath('.env')).toBe('.env');
+    expect(canonicalizePath('.gitignore')).toBe('.gitignore');
+    expect(canonicalizePath('src/.hidden/file')).toBe('src/.hidden/file');
+  });
+});

--- a/packages/matchers/tests/policy-matcher.test.ts
+++ b/packages/matchers/tests/policy-matcher.test.ts
@@ -113,6 +113,54 @@ describe('PolicyMatcher', () => {
       expect(PolicyMatcher.matchScope(patterns, 'test/bar.test.ts')).toBe(true);
       expect(PolicyMatcher.matchScope(patterns, 'lib/baz.ts')).toBe(false);
     });
+
+    // ─── Path traversal hardening (issue #640) ──────────────────────────
+
+    it('blocks path traversal via .. segments', () => {
+      // src/../etc/passwd resolves to etc/passwd — does NOT match src/ scope
+      expect(PolicyMatcher.matchScope(['src/'], 'src/../etc/passwd')).toBe(false);
+      // Direct traversal out of project root — rejected entirely
+      expect(PolicyMatcher.matchScope(['src/**'], '../../../etc/passwd')).toBe(false);
+    });
+
+    it('blocks URL-encoded traversal', () => {
+      // src/%2e%2e/etc/passwd decodes to src/../etc/passwd → etc/passwd — not under src/
+      expect(PolicyMatcher.matchScope(['src/'], 'src/%2e%2e/etc/passwd')).toBe(false);
+      // Traversal that escapes project root — rejected entirely
+      expect(PolicyMatcher.matchScope(['src/**'], '%2e%2e/%2e%2e/etc/passwd')).toBe(false);
+    });
+
+    it('blocks null bytes in paths', () => {
+      expect(PolicyMatcher.matchScope(['src/**'], 'src/foo.ts\0.jpg')).toBe(false);
+      expect(PolicyMatcher.matchScope(['src/'], 'src/\0../etc/passwd')).toBe(false);
+    });
+
+    it('collapses multiple slashes', () => {
+      // src//foo.ts should match src/ scope after collapsing
+      expect(PolicyMatcher.matchScope(['src/'], 'src//foo.ts')).toBe(true);
+      expect(PolicyMatcher.matchScope(['src/**'], 'src///nested///bar.ts')).toBe(true);
+    });
+
+    it('resolves dot segments in paths', () => {
+      // src/./foo.ts should match src/ scope
+      expect(PolicyMatcher.matchScope(['src/'], 'src/./foo.ts')).toBe(true);
+      // src/nested/../foo.ts resolves to src/foo.ts
+      expect(PolicyMatcher.matchScope(['src/'], 'src/nested/../foo.ts')).toBe(true);
+    });
+
+    it('strips leading ./ from targets', () => {
+      expect(PolicyMatcher.matchScope(['src/'], './src/foo.ts')).toBe(true);
+    });
+
+    it('handles URL-encoded extension bypass', () => {
+      // *.env pattern should catch %2Eenv after decoding
+      expect(PolicyMatcher.matchScope(['*.env'], 'config%2Eenv')).toBe(true);
+    });
+
+    it('rejects pure traversal paths', () => {
+      expect(PolicyMatcher.matchScope(['*'], '..')).toBe(false);
+      expect(PolicyMatcher.matchScope(['**'], '../..')).toBe(false);
+    });
   });
 
   // ─── toSet ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Fixes **#640** — policy scope matching vulnerable to path manipulation
- Adds `canonicalizePath()` to `packages/matchers` that decodes URL-encoded characters, resolves `..` traversal, collapses multiple slashes, rejects null bytes, and normalizes separators
- Applied to both `PolicyMatcher.matchScope()` and `PathMatcher.normalizePath()`, closing the gap between pre-execution scope evaluation and execution-time adapter validation
- Paths that escape the project root (via `..` or encoded `%2e%2e`) are now rejected before policy evaluation

## Test plan
- [x] 13 new tests in `canonicalize-path.test.ts` covering URL decoding, traversal blocking, null bytes, slash collapsing, dot segments
- [x] 8 new tests in `policy-matcher.test.ts` covering traversal, encoded traversal, null bytes, slash collapsing, dot resolution, leading `./`, encoded extension bypass, pure traversal rejection
- [x] All 109 matchers tests pass (was 88)
- [x] Full suite: 36/36 tasks successful, all packages build and pass
- [x] Type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)