### PR TITLE
fix(cli): add missing subpath exports for bin and postinstall

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -25,7 +25,9 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
-    }
+    },
+    "./dist/bin.js": "./dist/bin.js",
+    "./dist/postinstall.js": "./dist/postinstall.js"
   },
   "scripts": {
     "build": "tsc -b && tsx esbuild.config.ts",


### PR DESCRIPTION
## Summary

- `@red-codes/agentguard` v2.7.2 declares `"type": "module"` and an `exports` field, but the `exports` map only defined `"."` — it did not include the `./dist/bin.js` or `./dist/postinstall.js` subpaths
- Node's ESM module resolution blocks access to any subpath not explicitly listed in `exports`, so `agentguard` CLI fails on install with **"subpath not defined in exports"**
- This was discovered when deploying the readybench box — the CLI could not start after `npm install`
- Fix: add `"./dist/bin.js"` and `"./dist/postinstall.js"` to the `exports` map so both the bin entry point and the postinstall hook are resolvable

## What changed

`apps/cli/package.json` — added two subpath entries to the `exports` field:

```json
"exports": {
  ".": {
    "import": "./dist/index.js",
    "types": "./dist/index.d.ts"
  },
  "./dist/bin.js": "./dist/bin.js",
  "./dist/postinstall.js": "./dist/postinstall.js"
}
```

## Test plan

- [ ] `npm pack` the CLI package and verify `dist/bin.js` and `dist/postinstall.js` are accessible
- [ ] `npm install -g` the packed tarball and confirm `agentguard` command starts without "subpath not defined" error
- [ ] Verify postinstall script runs successfully on install

🤖 Generated with [Claude Code](https://claude.com/claude-code)