### PR TITLE
fix(cli): add missing exports subpaths + bump to v2.7.3

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@red-codes/agentguard",
-  "version": "2.7.0",
+  "version": "2.7.3",
   "description": "Run AI agents without fear — CLI safety layer",
   "type": "module",
   "license": "Apache-2.0",
@@ -25,7 +25,9 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
-    }
+    },
+    "./dist/bin.js": "./dist/bin.js",
+    "./dist/postinstall.js": "./dist/postinstall.js"
   },
   "scripts": {
     "build": "tsc -b && tsx esbuild.config.ts",


### PR DESCRIPTION
## Summary
- Add `./dist/bin.js` and `./dist/postinstall.js` to package exports field
- Bump `@red-codes/agentguard` from 2.7.0 → 2.7.3
- Fixes broken CLI install on ESM-aware Node (subpath not defined in exports)
- Unblocks readybench box deployment

## After merge
Create GitHub Release `v2.7.3` to trigger npm publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)