### PR TITLE
feat(site): add aguard short-name install to Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ AI coding agents (Claude Code, GitHub Copilot, any MCP client) run autonomously 
 ## Quick Start
 
 ```bash
-npm install -g @red-codes/agentguard
+npm install -g aguard
+# or: npm install -g @red-codes/agentguard
 cd your-project
 agentguard claude-init
 # Interactive wizard: choose enforcement mode and a policy pack

--- a/site/index.html
+++ b/site/index.html
@@ -1196,8 +1196,9 @@
               <span class="text-text font-semibold text-sm">Install globally</span>
             </div>
             <div class="relative group">
-              <pre class="bg-surface border border-surface-light rounded-xl p-5 font-mono text-sm overflow-x-auto"><code><span class="text-muted">$</span> <span class="text-text">npm install -g @red-codes/agentguard</span></code></pre>
-              <button class="copy-btn absolute top-3 right-3 text-muted hover:text-text p-2 rounded-lg hover:bg-surface-light transition-colors opacity-0 group-hover:opacity-100 cursor-pointer" data-code="npm install -g @red-codes/agentguard" aria-label="Copy to clipboard">
+              <pre class="bg-surface border border-surface-light rounded-xl p-5 font-mono text-sm overflow-x-auto"><code><span class="text-muted">$</span> <span class="text-text">npm install -g aguard</span>
+<span class="text-muted text-xs"># or: npm install -g @red-codes/agentguard</span></code></pre>
+              <button class="copy-btn absolute top-3 right-3 text-muted hover:text-text p-2 rounded-lg hover:bg-surface-light transition-colors opacity-0 group-hover:opacity-100 cursor-pointer" data-code="npm install -g aguard" aria-label="Copy to clipboard">
                 <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
               </button>
             </div>


### PR DESCRIPTION
Closes #937

## Implementation Summary

**What changed:**
- `site/index.html`: Updated Quick Start step 01 to show `npm install -g aguard` as the primary install command, with `@red-codes/agentguard` as an inline comment alternative. Updated copy button `data-code` to use the short name.
- `README.md`: Updated Quick Start code block to show `npm install -g aguard` first with `@red-codes/agentguard` as an alternate comment.

**How to verify:**
1. Open `site/index.html` in a browser and check Quick Start step 01 shows `npm install -g aguard`
2. Check `README.md` Quick Start shows `aguard` as the primary install
3. Confirm `npm-wrapper/aguard/` package exists (confirmed: v2.7.0)

**Tier C scope check:**
- Files changed: 2 (limit: 5)
- Lines changed: ~5 (limit: 300)
- Breaking changes: None

---
*Tier C implementation by copilot-cli — AgentGuard three-tier governance*