### PR TITLE
fix(matchers): reject URL-encoded null bytes after decoding (#924)

### DIFF
--- a/packages/matchers/src/canonicalize-path.ts
+++ b/packages/matchers/src/canonicalize-path.ts
@@ -16,6 +16,8 @@ import { posix } from 'node:path';
  * Symlink resolution is an execution-time concern handled by adapters.
  */
 export function canonicalizePath(filePath: string): string {
+  if (!filePath) return '';
+
   // 1. Reject null bytes — these can truncate paths in C-level APIs
   if (filePath.includes('\0')) {
     return '';
@@ -28,6 +30,11 @@ export function canonicalizePath(filePath: string): string {
   } catch {
     // Invalid percent-encoding — use the raw string
     p = filePath;
+  }
+
+  // Re-check for null bytes after decoding (e.g. %00 → \0)
+  if (p.includes('\0')) {
+    return '';
   }
 
   // 3. Normalize path separators (Windows backslash → forward slash)

--- a/packages/matchers/src/policy-matcher.ts
+++ b/packages/matchers/src/policy-matcher.ts
@@ -63,7 +63,7 @@ export class PolicyMatcher {
     if (!normalized) return false;
 
     for (const pattern of scopePatterns) {
-      // Canonicalize pattern (separators + traversal only, no URL-decoding for patterns)
+      // Normalize pattern separators (backslash → forward slash)
       const normalizedPattern = pattern.replace(/\\/g, '/');
 
       // Wildcard matches everything

--- a/packages/matchers/tests/canonicalize-path.test.ts
+++ b/packages/matchers/tests/canonicalize-path.test.ts
@@ -52,6 +52,12 @@ describe('canonicalizePath', () => {
     expect(canonicalizePath('\0')).toBe('');
   });
 
+  it('rejects URL-encoded null bytes after decoding', () => {
+    expect(canonicalizePath('src/%00../etc/passwd')).toBe('');
+    expect(canonicalizePath('%00')).toBe('');
+    expect(canonicalizePath('src/foo%00.ts')).toBe('');
+  });
+
   it('strips leading / for consistent relative paths', () => {
     expect(canonicalizePath('/src/foo.ts')).toBe('src/foo.ts');
   });
@@ -62,7 +68,7 @@ describe('canonicalizePath', () => {
   });
 
   it('handles empty string', () => {
-    expect(canonicalizePath('')).toBe('.');
+    expect(canonicalizePath('')).toBe('');
   });
 
   it('handles dotfiles correctly', () => {


### PR DESCRIPTION
## Summary
- Add post-decode null byte check in `canonicalizePath()` to catch `%00` sequences that decode to literal `\0` bytes
- Fix empty string edge case: `canonicalizePath('')` now returns `''` instead of `'.'`
- Fix misleading comment in `policy-matcher.ts` line 66

Closes #924

## Root Cause
The null byte check ran **before** URL decoding. An input like `src/%00../etc/passwd` passed the check (no literal `\0` in the raw string), then `decodeURIComponent` produced a path with a literal null byte — bypassing the security hardening from PR #915.

## Changes
| File | Change |
|------|--------|
| `packages/matchers/src/canonicalize-path.ts` | Add `if (!filePath) return ''` + post-decode `\0` check |
| `packages/matchers/src/policy-matcher.ts` | Fix misleading comment |
| `packages/matchers/tests/canonicalize-path.test.ts` | 3 new URL-encoded null byte tests + fix empty string assertion |

## Test plan
- [x] `pnpm test --filter=@red-codes/matchers` — all 110 tests pass
- [x] New tests: `src/%00../etc/passwd`, `%00`, `src/foo%00.ts` all return `''`
- [x] Empty string test updated: `canonicalizePath('')` → `''`

🤖 Generated with [Claude Code](https://claude.com/claude-code)