### PR TITLE
feat(issue-858): add user capture funnel

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,21 @@ extends:
 | `strict` | Maximum restriction — all 22 invariants enforced |
 | `open-source` | OSS contribution-friendly defaults |
 
+## Community & Updates
+
+Stay in the loop and connect with other AgentGuard users:
+
+- **[Sign up for early access](https://agentguard-cloud-dashboard.vercel.app/signup)** — cloud dashboard, team governance, real-time telemetry
+- **[GitHub Discussions](https://github.com/AgentGuardHQ/agentguard/discussions)** — ask questions, share setups, give feedback
+- **[Issues](https://github.com/AgentGuardHQ/agentguard/issues)** — bug reports and feature requests
+
+From the CLI:
+
+```bash
+agentguard cloud signup    # Open cloud early access signup
+agentguard cloud login     # Connect after you have an API key
+```
+
 ## Links
 
 | Resource | URL |

--- a/apps/cli/src/bin.ts
+++ b/apps/cli/src/bin.ts
@@ -454,7 +454,7 @@ const COMMANDS: Record<string, CommandHelp> = {
   cloud: {
     name: 'agentguard cloud',
     description:
-      'Manage AgentGuard Cloud connection and query data (connect, status, disconnect, events, runs, summary)',
+      'Manage AgentGuard Cloud connection and query data (signup, connect, status, disconnect, events, runs, summary)',
     usage: 'agentguard cloud <command> [options]',
     flags: [
       {
@@ -468,6 +468,7 @@ const COMMANDS: Record<string, CommandHelp> = {
       { flag: '--status <status>', description: 'Filter runs by status' },
     ],
     examples: [
+      'agentguard cloud signup',
       'agentguard cloud connect ag_live_abc123def456xyz',
       'agentguard cloud connect ag_test_key1234567890 --endpoint https://custom.example.com',
       'agentguard cloud status',
@@ -1059,6 +1060,7 @@ function printHelp(): void {
     agentguard config keys                    List available config keys
 
   \x1b[1mCloud:\x1b[0m
+    agentguard cloud signup                   Sign up for AgentGuard Cloud
     agentguard cloud connect <api-key>        Connect to AgentGuard Cloud
     agentguard cloud connect ... --endpoint   Use a custom cloud endpoint
     agentguard cloud status                   Show cloud connection status

--- a/apps/cli/src/commands/claude-init.ts
+++ b/apps/cli/src/commands/claude-init.ts
@@ -956,6 +956,19 @@ function showProtectionSummary(
   }
   process.stderr.write(`\n  ${DIM}ℹ Claude Desktop support coming soon.${RESET}\n`);
   process.stderr.write('\n');
+
+  // User capture funnel: cloud signup + community links
+  process.stderr.write(`  ${BOLD}Join the community:${RESET}\n`);
+  process.stderr.write(
+    `  ${DIM}Cloud dashboard:${RESET} ${FG.cyan}https://agentguard-cloud-dashboard.vercel.app/signup${RESET}\n`
+  );
+  process.stderr.write(
+    `  ${DIM}Discussions:${RESET}     ${FG.cyan}https://github.com/AgentGuardHQ/agentguard/discussions${RESET}\n`
+  );
+  process.stderr.write(
+    `\n  ${DIM}Run ${FG.cyan}agentguard cloud signup${RESET}${DIM} for early access to team governance.${RESET}\n`
+  );
+  process.stderr.write('\n');
 }
 
 function hasAgentGuardHook(settings: Settings): boolean {

--- a/apps/cli/src/commands/cloud.ts
+++ b/apps/cli/src/commands/cloud.ts
@@ -136,6 +136,8 @@ export async function cloud(args: string[]): Promise<number> {
       return cloudRuns(args.slice(1));
     case 'summary':
       return cloudSummary();
+    case 'signup':
+      return cloudSignup();
     case 'help':
     case undefined:
       return showCloudHelp();
@@ -501,11 +503,29 @@ async function cloudSummary(): Promise<number> {
   }
 }
 
+const SIGNUP_URL = 'https://agentguard-cloud-dashboard.vercel.app/signup';
+const DISCUSSIONS_URL = 'https://github.com/AgentGuardHQ/agentguard/discussions';
+
+function cloudSignup(): number {
+  process.stderr.write('\n');
+  process.stderr.write(`  ${BOLD}AgentGuard Cloud — Early Access${RESET}\n\n`);
+  process.stderr.write(`  Sign up for AgentGuard Cloud to get team governance,\n`);
+  process.stderr.write(`  real-time telemetry, and multi-tenant management.\n\n`);
+  process.stderr.write(`  ${FG.cyan}${SIGNUP_URL}${RESET}\n\n`);
+  process.stderr.write(`  ${DIM}Already have an API key? Run:${RESET}\n`);
+  process.stderr.write(`  ${DIM}  agentguard cloud connect <api-key>${RESET}\n\n`);
+  process.stderr.write(`  ${BOLD}Community${RESET}\n\n`);
+  process.stderr.write(`  ${DIM}Join the discussion:${RESET}\n`);
+  process.stderr.write(`  ${FG.cyan}${DISCUSSIONS_URL}${RESET}\n\n`);
+  return 0;
+}
+
 function showCloudHelp(): number {
   process.stderr.write(`
   ${BOLD}agentguard cloud${RESET} — Manage AgentGuard Cloud connection and query data
 
   ${BOLD}Usage:${RESET}
+    agentguard cloud signup                         Sign up for AgentGuard Cloud
     agentguard cloud connect <api-key>              Connect to cloud
     agentguard cloud connect <api-key> --endpoint <url>  Use custom endpoint
     agentguard cloud status                         Show connection status

--- a/apps/cli/tests/cloud-query.test.ts
+++ b/apps/cli/tests/cloud-query.test.ts
@@ -83,6 +83,37 @@ describe('cloud summary — not connected', () => {
   });
 });
 
+describe('cloud signup', () => {
+  it('returns 0 and shows signup URL', async () => {
+    const code = await cloud(['signup']);
+    expect(code).toBe(0);
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      expect.stringContaining('agentguard-cloud-dashboard.vercel.app/signup')
+    );
+  });
+
+  it('shows early access heading', async () => {
+    await cloud(['signup']);
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      expect.stringContaining('Early Access')
+    );
+  });
+
+  it('shows discussions link', async () => {
+    await cloud(['signup']);
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      expect.stringContaining('github.com/AgentGuardHQ/agentguard/discussions')
+    );
+  });
+
+  it('suggests connect command for existing users', async () => {
+    await cloud(['signup']);
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      expect.stringContaining('agentguard cloud connect')
+    );
+  });
+});
+
 describe('cloud help includes new subcommands', () => {
   it('help text mentions events subcommand', async () => {
     const code = await cloud(['help']);
@@ -100,5 +131,11 @@ describe('cloud help includes new subcommands', () => {
     const code = await cloud(['help']);
     expect(code).toBe(0);
     expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('cloud summary'));
+  });
+
+  it('help text mentions signup subcommand', async () => {
+    const code = await cloud(['help']);
+    expect(code).toBe(0);
+    expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('cloud signup'));
   });
 });


### PR DESCRIPTION
## Summary
- Add `agentguard cloud signup` CLI subcommand directing users to cloud early access signup
- Add post-init community/signup call-to-action after `agentguard claude-init` completes
- Add "Community & Updates" section to README.md with signup, Discussions, and CLI links
- Enable GitHub Discussions on the repository (Q&A, Show and tell categories already present)
- Closes #858

## Changes
- `apps/cli/src/commands/cloud.ts` — Add `signup` subcommand with early access URL and community links
- `apps/cli/src/commands/claude-init.ts` — Add community/signup CTA in `showProtectionSummary()`
- `apps/cli/src/bin.ts` — Update help text and cloud command description to include `signup`
- `README.md` — Add "Community & Updates" section before Links
- `apps/cli/tests/cloud-query.test.ts` — Add 5 tests for signup subcommand and help text

## Test Plan
- [x] TypeScript build passes (`pnpm build`)
- [x] Type-check passes (`pnpm ts:check`)
- [x] Vitest tests pass (`pnpm test` — 765 CLI tests, all green)
- [x] ESLint clean (`pnpm lint`)
- [x] Prettier clean (`pnpm format`)

## Risk Assessment

| Metric | Value |
|--------|-------|
| Risk level | low |
| Blast radius | 5 files |
| Simulation result | not available |

## Governance Report

| Metric | Count |
|--------|-------|
| Total events | 0 |
| Actions allowed | 0 |
| Actions denied | 0 |
| Policy denials | 0 |
| Invariant violations | 0 |
| Escalation events | 0 |
| Decision records | 0 |

<details>
<summary>Governance details</summary>

**Escalation levels observed**: NORMAL only
**Pre-push simulation**: not available
**Verdict**: All actions passed governance checks.

</details>

---
`claude-code:opus:developer`