### PR TITLE
fix(site): update stale stats — invariants 23, action types 41, event kinds 47

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Install in 30 seconds. Your agents can't break what matters.</p>
 
 ---
 
-AI coding agents (Claude Code, GitHub Copilot, any MCP client) run autonomously — writing files, executing commands, pushing code. AgentGuard prevents them from doing catastrophic things: no accidental pushes to main, no credential leaks, no runaway destructive loops. 22 built-in safety checks, zero config required.
+AI coding agents (Claude Code, GitHub Copilot, any MCP client) run autonomously — writing files, executing commands, pushing code. AgentGuard prevents them from doing catastrophic things: no accidental pushes to main, no credential leaks, no runaway destructive loops. 23 built-in safety checks, zero config required.
 
 **For individuals:** stop your AI from wrecking your machine or repo.
 **For teams:** run fleets of agents safely at scale, with audit trails that pass compliance.
@@ -48,7 +48,7 @@ The `claude-init` wizard walks you through setup interactively:
 
   Enable a policy pack?
     ❯ 1) essentials — secrets, force push, protected branches, credentials
-      2) strict — all 22 invariants enforced
+      2) strict — all 23 invariants enforced
       3) none — monitor only, configure later
 ```
 
@@ -104,7 +104,7 @@ Identity consists of a **role** (`developer`, `reviewer`, `ops`, `security`, `pl
 | Capability | Details |
 |------------|---------|
 | **Policy enforcement** | YAML rules with deny / allow / escalate — drop `agentguard.yaml` in your repo |
-| **22 built-in invariants** | Secret exposure, protected branches, blast radius, path traversal, CI/CD config, package script injection, and more |
+| **23 built-in invariants** | Secret exposure, protected branches, blast radius, path traversal, CI/CD config, package script injection, and more |
 | **47 event kinds** | Full lifecycle telemetry: `ActionRequested → ActionAllowed/Denied → ActionExecuted` |
 | **Real-time cloud dashboard** | Telemetry streams to your team dashboard; opt-in, anonymous by default |
 | **Multi-tenant** | Team workspaces, GitHub/Google OAuth, SSO-ready |
@@ -276,7 +276,7 @@ rules:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `action` | `string \| string[]` | Action type(s): `file.read`, `git.push`, `shell.exec`, `mcp.call`, etc. (27 types across 9 classes) |
+| `action` | `string \| string[]` | Action type(s): `file.read`, `git.push`, `shell.exec`, `mcp.call`, etc. (41 types across 10 classes) |
 | `effect` | `string` | `deny` or `allow` |
 | `target` | `string` | Glob pattern for file paths or command patterns |
 | `branches` | `string[]` | Git branch names this rule applies to |
@@ -290,7 +290,7 @@ rules:
 
 ## Built-in Invariants
 
-22 safety invariants run on every action evaluation:
+23 safety invariants run on every action evaluation:
 
 | Invariant | Severity | What it blocks |
 |-----------|----------|----------------|
@@ -308,6 +308,7 @@ rules:
 | `transitive-effect-analysis` | High | Downstream policy violations from a file write |
 | `no-ide-socket-access` | High | VS Code IPC socket files |
 | `commit-scope-guard` | High | Staged files not written by the current session |
+| `script-execution-tracking` | High | Shell commands executing session-written scripts (write-then-execute bypass) |
 | `blast-radius-limit` | Medium | Caps file modification count per action (default: 20) |
 | `no-container-config-modification` | Medium | Dockerfile, docker-compose.yml |
 | `no-env-var-modification` | Medium | Shell profile and env var files |
@@ -326,7 +327,7 @@ Agent tool call
 AgentGuard Kernel
   1. Normalize   — map tool call to canonical action type
   2. Evaluate    — match policy rules (deny / allow / escalate)
-  3. Check       — run 22 built-in invariants
+  3. Check       — run 23 built-in invariants
   4. Execute     — run action via adapter (file, shell, git)
   5. Emit        — 47 event kinds → SQLite audit trail + cloud telemetry
 ```
@@ -370,7 +371,7 @@ For teams running agent fleets, governance becomes invisible. Agents get 8% more
 
 **Zero-dependency deployment** — the Go kernel is a single static binary. No `node_modules`, no `pnpm install`, no bootstrap deadlocks. Drop it in a worktree and it works. This is critical for CI/CD and fleet scenarios where agents spin up fresh environments.
 
-The Go kernel includes: action normalization with AST-based shell parsing, policy evaluation, 22 invariants, escalation state machine, blast radius engine, telemetry shipper (stdout/file/HTTP), and a control plane signals API. It ships automatically via `npm install` — a postinstall script downloads the prebuilt binary for your platform.
+The Go kernel includes: action normalization with AST-based shell parsing, policy evaluation, 23 invariants, escalation state machine, blast radius engine, telemetry shipper (stdout/file/HTTP), and a control plane signals API. It ships automatically via `npm install` — a postinstall script downloads the prebuilt binary for your platform.
 
 ## For Teams and Enterprise
 
@@ -468,7 +469,7 @@ extends:
 | `engineering-standards` | Balanced dev-friendly guardrails: test-before-push, format checks, safe deps |
 | `ci-safe` | Strict CI/CD pipeline protection |
 | `enterprise` | Full enterprise governance |
-| `strict` | Maximum restriction — all 22 invariants enforced |
+| `strict` | Maximum restriction — all 23 invariants enforced |
 | `open-source` | OSS contribution-friendly defaults |
 
 ## Community & Updates

--- a/site/index.html
+++ b/site/index.html
@@ -5,11 +5,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="google-site-verification" content="OeJuCct5Y8LRHQB95DkF5Y9hwUvZIvtYrpKy16x3o28" />
   <title>AgentGuard — Run AI Agents Without Fear</title>
-  <meta name="description" content="AgentGuard — default-deny governance for AI coding agents. 22 invariants, four enforcement modes, tamper-evident audit trail. Install in 30 seconds.">
+  <meta name="description" content="AgentGuard — default-deny governance for AI coding agents. 23 invariants, four enforcement modes, tamper-evident audit trail. Install in 30 seconds.">
 
   <!-- OpenGraph -->
   <meta property="og:title" content="AgentGuard — Run AI Agents Without Fear">
-  <meta property="og:description" content="Default-deny governance for AI coding agents. 22 invariants, four enforcement modes (monitor, educate, guide, enforce), tamper-evident audit trail. Install in 30 seconds.">
+  <meta property="og:description" content="Default-deny governance for AI coding agents. 23 invariants, four enforcement modes (monitor, educate, guide, enforce), tamper-evident audit trail. Install in 30 seconds.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://agentguardhq.github.io/agentguard/">
   <meta property="og:image" content="https://agentguardhq.github.io/agentguard/og-image.png">
@@ -28,7 +28,7 @@
     "name": "AgentGuard",
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "Windows, macOS, Linux",
-    "description": "AgentGuard — default-deny governance for AI coding agents. 22 invariants, four enforcement modes, tamper-evident audit trail.",
+    "description": "AgentGuard — default-deny governance for AI coding agents. 23 invariants, four enforcement modes, tamper-evident audit trail.",
     "url": "https://agentguardhq.github.io/agentguard/",
     "offers": {
       "@type": "Offer",
@@ -431,7 +431,7 @@
             Run AI Agents <span class="text-cta">Without Fear</span>
           </h1>
           <p class="text-muted text-lg leading-relaxed mb-8 max-w-xl">
-            Your AI agents can't push to main, leak credentials, or destroy your repo. 21 built-in safety checks block catastrophic actions before they execute. Install in 30 seconds. Sleep at night.
+            Your AI agents can't push to main, leak credentials, or destroy your repo. 23 built-in safety checks block catastrophic actions before they execute. Install in 30 seconds. Sleep at night.
           </p>
           <div class="flex flex-wrap gap-4">
             <a href="#quickstart" class="bg-cta hover:bg-cta-dark text-bg font-semibold px-6 py-3 rounded-lg transition-colors text-sm inline-flex items-center gap-2 cursor-pointer">
@@ -480,15 +480,15 @@
             <div class="text-muted text-sm mt-1">Destructive Patterns</div>
           </div>
           <div class="reveal">
-            <div class="font-mono font-bold text-3xl sm:text-4xl text-text counter" data-target="46">0</div>
+            <div class="font-mono font-bold text-3xl sm:text-4xl text-text counter" data-target="47">0</div>
             <div class="text-muted text-sm mt-1">Event Kinds</div>
           </div>
           <div class="reveal">
-            <div class="font-mono font-bold text-3xl sm:text-4xl text-text counter" data-target="23">0</div>
+            <div class="font-mono font-bold text-3xl sm:text-4xl text-text counter" data-target="41">0</div>
             <div class="text-muted text-sm mt-1">Action Types</div>
           </div>
           <div class="reveal">
-            <div class="font-mono font-bold text-3xl sm:text-4xl text-text counter" data-target="21">0</div>
+            <div class="font-mono font-bold text-3xl sm:text-4xl text-text counter" data-target="23">0</div>
             <div class="text-muted text-sm mt-1">Invariants</div>
           </div>
           <div class="reveal">
@@ -535,7 +535,7 @@
               <svg class="w-5 h-5 text-info" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><polyline points="9 12 11 14 15 10"/></svg>
             </div>
             <h3 class="font-mono font-semibold text-text mb-2">Production-Grade Kernel</h3>
-            <p class="text-muted text-sm leading-relaxed">Sub-millisecond evaluation latency. 22 invariants, 87 destructive patterns, tamper-evident audit chain. The reference monitor architecture enterprises require for autonomous agent deployment.</p>
+            <p class="text-muted text-sm leading-relaxed">Sub-millisecond evaluation latency. 23 invariants, 87 destructive patterns, tamper-evident audit chain. The reference monitor architecture enterprises require for autonomous agent deployment.</p>
           </div>
         </div>
       </div>
@@ -704,7 +704,7 @@
             </li>
             <li class="flex items-start gap-3">
               <svg class="w-5 h-5 text-cta mt-0.5 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
-              <span>21 built-in invariants + 87 destructive patterns detected <strong class="text-text">automatically</strong></span>
+              <span>23 built-in invariants + 87 destructive patterns detected <strong class="text-text">automatically</strong></span>
             </li>
             <li class="flex items-start gap-3">
               <svg class="w-5 h-5 text-cta mt-0.5 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
@@ -767,7 +767,7 @@
             <div class="w-10 h-10 rounded-lg bg-cta/10 flex items-center justify-center mb-4">
               <svg class="w-5 h-5 text-cta" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
             </div>
-            <h3 class="font-mono font-semibold text-text mb-2">21 Safety Invariants</h3>
+            <h3 class="font-mono font-semibold text-text mb-2">23 Safety Invariants</h3>
             <p class="text-muted text-sm leading-relaxed">Secret detection, credential protection, branch guards, blast radius limits, lockfile integrity, script injection, CI/CD protection, network egress control, governance self-modification prevention. Always on.</p>
           </div>
 
@@ -915,7 +915,7 @@
             <div class="pipeline-arrow flex-shrink-0">
               <div class="bg-surface border-2 border-warning rounded-lg px-4 py-4 text-center w-[110px]">
                 <div class="font-mono font-bold text-warning text-sm">Invariants</div>
-                <div class="text-muted text-xs mt-1">21 safety checks</div>
+                <div class="text-muted text-xs mt-1">23 safety checks</div>
               </div>
             </div>
 
@@ -953,7 +953,7 @@
         <div class="grid md:grid-cols-3 gap-6 mt-16 reveal-stagger">
           <div class="reveal bg-surface border border-surface-light rounded-xl p-6">
             <h3 class="font-mono font-semibold text-cta text-sm mb-3">Action Authorization Boundary</h3>
-            <p class="text-muted text-sm leading-relaxed">The AAB normalizes raw tool calls into 27 canonical action types across 9 classes. Every agent operation&mdash;whether a Bash command, file write, or git push&mdash;gets classified before evaluation.</p>
+            <p class="text-muted text-sm leading-relaxed">The AAB normalizes raw tool calls into 41 canonical action types across 10 classes. Every agent operation&mdash;whether a Bash command, file write, or git push&mdash;gets classified before evaluation.</p>
           </div>
           <div class="reveal bg-surface border border-surface-light rounded-xl p-6">
             <h3 class="font-mono font-semibold text-info text-sm mb-3">Simulation Engine</h3>
@@ -1053,7 +1053,7 @@
     <section id="invariants" class="py-24" aria-labelledby="inv-heading">
       <div class="max-w-7xl mx-auto px-6">
         <div class="text-center mb-16 reveal">
-          <h2 id="inv-heading" class="font-mono font-bold text-3xl sm:text-4xl mb-4">21 Built-in Invariants</h2>
+          <h2 id="inv-heading" class="font-mono font-bold text-3xl sm:text-4xl mb-4">23 Built-in Invariants</h2>
           <p class="text-muted text-lg max-w-2xl mx-auto">Safety checks that run on every action. Zero configuration. Always on.</p>
         </div>
 
@@ -1171,6 +1171,16 @@
                 <td class="py-3 px-4 font-mono text-text">no-ide-socket-access</td>
                 <td class="py-3 px-4"><span class="sev-high text-xs font-mono font-semibold px-2 py-0.5 rounded">HIGH</span></td>
                 <td class="py-3 px-4 text-muted">Blocks access to IDE socket files (vscode-ipc-*.sock)</td>
+              </tr>
+              <tr>
+                <td class="py-3 px-4 font-mono text-text">commit-scope-guard</td>
+                <td class="py-3 px-4"><span class="sev-high text-xs font-mono font-semibold px-2 py-0.5 rounded">HIGH</span></td>
+                <td class="py-3 px-4 text-muted">Flags staged files not written by the current session</td>
+              </tr>
+              <tr>
+                <td class="py-3 px-4 font-mono text-text">script-execution-tracking</td>
+                <td class="py-3 px-4"><span class="sev-high text-xs font-mono font-semibold px-2 py-0.5 rounded">HIGH</span></td>
+                <td class="py-3 px-4 text-muted">Prevents governance bypass via write-then-execute indirection</td>
               </tr>
             </tbody>
           </table>
@@ -2293,7 +2303,7 @@ rules:
       // ---- Terminal Typing Animation ----
       var terminalLines = [
         { text: '  AgentGuard Runtime Active', cls: 'text-cta', delay: 0 },
-        { text: '  policy: agentguard.yaml | invariants: 21 | patterns: 87', cls: 'text-muted', delay: 0 },
+        { text: '  policy: agentguard.yaml | invariants: 23 | patterns: 87', cls: 'text-muted', delay: 0 },
         { text: '', cls: '', delay: 300 },
         { text: '  \u2713 file.write  src/auth/service.ts', cls: 'text-cta', delay: 0 },
         { text: '  \u2713 shell.exec  npm test', cls: 'text-cta', delay: 0 },


### PR DESCRIPTION
Closes #936

## Implementation Summary

**What changed:**
- Updated invariant count from 21/22 → 23 in all locations across `site/index.html` and `README.md`
- Updated action types stats counter from 23 → 41 (10 classes, actual JSON data count)
- Updated event kinds counter from 46 → 47
- Added `commit-scope-guard` (HIGH) and `script-execution-tracking` (HIGH) to the invariant table in `site/index.html`
- Added `script-execution-tracking` to the invariant table in `README.md`
- Updated action types description from '27 types across 9 classes' → '41 types across 10 classes'
- Updated all meta tags, JSON-LD structured data, hero text, demo terminal output, and section headings

**How to verify:**
1. Open `site/index.html` — stats bar shows 23 invariants, 41 action types, 47 event kinds
2. Search `README.md` for '22 invariants' — no results
3. The invariant table in both files now contains 23 rows
4. Actual counts confirmed from source: `packages/invariants/src/definitions.ts` (23 invariants), `packages/core/src/data/actions.json` (41 types), `packages/events/src/schema.ts` (47 event kinds)

**Tier C scope check:**
- Files changed: 2 (limit: 5)
- Lines changed: ~55 (limit: 300)
- Breaking changes: None

---
*Tier C implementation by copilot-cli — AgentGuard three-tier governance*