### PR TITLE
chore(kernel-em): EM cycle report 2026-03-26T07:10Z

### DIFF
--- a/.agentguard/squads/kernel/em-report.json
+++ b/.agentguard/squads/kernel/em-report.json
@@ -1,27 +1,46 @@
 {
-  "generatedAt": "2026-03-26T04:10:00.000Z",
+  "generatedAt": "2026-03-26T07:10:00.000Z",
   "identity": "claude-code:opus:kernel:em",
   "runCycle": "3h",
   "health": "green",
-  "summary": "EM direct-implemented fix for #924 (null byte bypass via %00 in canonicalizePath) after blocker persisted 2 cycles with no branch from senior coder. Post-decode null byte guard added, empty-string edge case corrected, regression tests added to canonicalize-path.test.ts and PathMatcher URL-encoded evasion tests added to path-matcher.test.ts. All 114 matchers tests pass. PR #952 opened against main. No other open PRs, no blockers. Health promoted to green.",
+  "summary": "Strong cycle. Previous sprint (#924 security fix + v3.0 readiness) fully complete — all PRs merged. PR #952 (null byte bypass), #961 (shell.exec simulator + git.force-push), #962 (user capture funnel), #963 (site stats) all merged since last EM run. Stale PR #960 already closed. Sprint rotated to #955: wire Go kernel into npm hook path (100x latency win). Assigning #955 + #957 + #964 to senior coder. 0 open squad PRs, full PR budget available.",
   "prQueue": {
-    "open": 1,
-    "prs": [
-      {
-        "number": 952,
-        "title": "fix(matchers): reject URL-encoded null bytes (%00) in canonicalizePath (closes #924)",
-        "status": "open",
-        "ciStatus": "pending",
-        "note": "Awaiting CI and review. Mergeable once CI green + approved."
-      }
-    ]
+    "open": 0,
+    "prs": []
   },
-  "mergedThisCycle": [],
-  "closedThisCycle": [],
+  "mergedThisCycle": [
+    {
+      "number": 952,
+      "title": "fix(matchers): reject URL-encoded null bytes (%00) in canonicalizePath (closes #924)",
+      "mergedAt": "2026-03-25T21:14:32Z"
+    },
+    {
+      "number": 961,
+      "title": "fix(simulate): add shell.exec simulator and git.force-push action type",
+      "mergedAt": "2026-03-25T21:41:36Z"
+    },
+    {
+      "number": 962,
+      "title": "feat(issue-858): add user capture funnel",
+      "mergedAt": "2026-03-25T22:29:22Z"
+    },
+    {
+      "number": 963,
+      "title": "fix(site): update stale stats — invariants 23, action types 41, event kinds 47",
+      "mergedAt": "2026-03-25T23:02:12Z"
+    }
+  ],
+  "closedThisCycle": [
+    {
+      "number": 960,
+      "title": "chore(kernel-em): EM cycle report 2026-03-26T04:25Z",
+      "reason": "Stale — already closed, had merge conflicts"
+    }
+  ],
   "newIssues": [],
   "loopGuards": {
     "prBudget": {
-      "open": 1,
+      "open": 0,
       "max": 3,
       "pass": true
     },
@@ -37,42 +56,37 @@
   "triage": {
     "p0Issues": 0,
     "p1Issues": 0,
-    "newAssignments": [],
+    "newAssignments": [
+      {
+        "agent": "senior",
+        "issues": [955, 957, 964],
+        "note": "Go kernel hook delegation sprint: #955 (claude-hook delegates to Go binary), #957 (Go kernel needs flattened JSON from TS resolver), #964 (claude-init writes full binary path)"
+      }
+    ],
     "notableIssues": [
       {
-        "numbers": [924],
-        "note": "Security regression — null byte bypass in canonicalizePath. EM direct-implemented fix. PR #952 open."
+        "numbers": [955, 957, 964],
+        "note": "Sprint focus: wire Go kernel into npm hook path. #955 is the parent issue, #957 is the Go-side prerequisite, #964 is a related hook path fix."
       },
       {
         "numbers": [909, 910, 911, 912],
-        "note": "4 remaining analytics-proposed invariants (no-self-approve-pr, session-action-velocity, shared-state-write-lock, cost-anomaly-circuit-breaker). Backlog — not yet assigned."
-      },
-      {
-        "numbers": [919, 920],
-        "note": "v3.0 gate issues (stranger test, ActionContext) — no assignment yet"
+        "note": "4 analytics-proposed invariants — backlog, not assigned this sprint."
       }
     ]
   },
   "blockers": [],
-  "escalations": [
-    {
-      "type": "resolved",
-      "issue": 924,
-      "rule": "blocker persisted across 2 runs — EM implemented directly",
-      "action": "PR #952 opened. Blocker cleared. No further escalation required."
-    }
-  ],
+  "escalations": [],
   "metrics": {
-    "prsOpened": 1,
-    "prsMerged": 0,
-    "prsClosed": 0,
+    "prsOpened": 0,
+    "prsMerged": 4,
+    "prsClosed": 1,
     "issuesClosed": 0,
     "governanceDenials": 0,
     "retries": 0
   },
   "testHealth": {
-    "total": 4106,
-    "passed": 4106,
+    "total": 4120,
+    "passed": 4120,
     "failed": 0,
     "packages": 18,
     "status": "all_passing"
@@ -83,6 +97,6 @@
       "persistentBlocker": false,
       "governanceDenialsExceeded": false
     },
-    "notes": "Blocker #924 resolved this cycle via EM direct implementation. Health promoted green. PR budget 1/3. All CI green on main."
+    "notes": "All clear. 0 open PRs, 4 merged since last run. Sprint rotated to #955. Full PR budget available for Go kernel work."
   }
 }

--- a/.agentguard/squads/kernel/state.json
+++ b/.agentguard/squads/kernel/state.json
@@ -1,44 +1,26 @@
 {
   "squad": "kernel",
   "sprint": {
-    "goal": "Fix security regression #924 (null byte bypass in canonicalizePath). Continue v3.0 release readiness.",
-    "issues": [924, 958, 959]
+    "goal": "Wire Go kernel into npm hook path (#955). claude-hook.ts delegates to Go binary, TS pre-resolves policies to flat JSON, fallback to TS if Go unavailable.",
+    "issues": [955, 957, 964]
   },
   "assignments": {
     "senior": {
-      "issue": [958, 959],
-      "title": "simulate: add shell.exec simulator and git.force-push action type",
-      "status": "pr_open",
-      "branch": "agent/kernel-sr-20260325-213002",
-      "pr": 961,
-      "claimedAt": "2026-03-25T21:30:00.000Z",
-      "note": "Added git.force-push to ACTION_TYPES (#958), created shell-simulator for general shell.exec (#959). 889+194 tests passing. PR #961 opened."
+      "issue": [955, 957, 964],
+      "title": "Go kernel hook delegation: claude-hook → Go binary with TS policy flattening",
+      "status": "assigned",
+      "branch": null,
+      "pr": null,
+      "claimedAt": "2026-03-26T07:10:00.000Z",
+      "note": "Sprint: #955 (claude-hook delegates to Go binary), #957 (Go kernel needs flattened JSON from TS resolver), #964 (claude-init writes full binary path). Previous work (#958/#959) merged via PR #961."
     }
   },
   "blockers": [],
   "prQueue": {
-    "open": 1,
+    "open": 0,
     "reviewed": 0,
     "mergeable": 0,
-    "prs": [
-      {
-        "number": 952,
-        "title": "fix(matchers): reject URL-encoded null bytes (%00) in canonicalizePath (closes #924)",
-        "branch": "fix/matchers-url-encoded-null-byte-924",
-        "status": "merged",
-        "ciStatus": "passed",
-        "openedAt": "2026-03-26T04:10:00.000Z",
-        "mergedAt": "2026-03-25T21:14:32.000Z"
-      },
-      {
-        "number": 961,
-        "title": "fix(simulate): add shell.exec simulator and git.force-push action type",
-        "branch": "agent/kernel-sr-20260325-213002",
-        "status": "open",
-        "ciStatus": "pending",
-        "openedAt": "2026-03-25T21:37:00.000Z"
-      }
-    ]
+    "prs": []
   },
   "health": "green",
   "testHealth": {
@@ -49,7 +31,7 @@
     "lastRun": "2026-03-25T21:36:00.000Z",
     "status": "all_passing"
   },
-  "lastEmRun": "2026-03-26T04:10:00.000Z",
+  "lastEmRun": "2026-03-26T07:10:00.000Z",
   "lastQaRun": "2026-03-25T18:50:00.000Z",
-  "updatedAt": "2026-03-25T21:37:00.000Z"
+  "updatedAt": "2026-03-26T07:10:00.000Z"
 }


### PR DESCRIPTION
Closing as superseded — new EM cycle report will be filed by the current run. The sprint state tracked here has been incorporated into the current cycle.