### PR TITLE
fix(claude-init): write hooks with full binary path (closes #964)

### DIFF
--- a/apps/cli/src/commands/claude-init.ts
+++ b/apps/cli/src/commands/claude-init.ts
@@ -21,13 +21,23 @@ const HOOK_MARKER = 'claude-hook';
 const BUILD_MARKER = 'apps/cli/dist/bin.js';
 const LOCAL_BIN = 'node apps/cli/dist/bin.js';
 
-/** Detect if we're in the agentguard development repo (local dev) vs. globally installed. */
-function resolveCliPrefix(): { cli: string; isLocal: boolean } {
+/** Detect if we're in the agentguard development repo (local dev) vs. globally installed.
+ *  For project-level npm installs, resolves to ./node_modules/.bin/agentguard so hooks
+ *  work even when the binary isn't on PATH (#964). */
+function resolveCliPrefix(isGlobal: boolean): { cli: string; isLocal: boolean } {
   // If apps/cli/src/bin.ts exists, we're in the agentguard source repo (works in worktrees too)
   const mainRoot = resolveMainRepoRoot();
   const localMarker = join(mainRoot, 'apps', 'cli', 'src', 'bin.ts');
   if (existsSync(localMarker)) {
     return { cli: LOCAL_BIN, isLocal: true };
+  }
+  // For project-level settings, prefer the local node_modules binary.
+  // Global settings apply across projects, so they must use a bare command (on PATH).
+  if (!isGlobal) {
+    const nmBin = join(mainRoot, 'node_modules', '.bin', 'agentguard');
+    if (existsSync(nmBin)) {
+      return { cli: './node_modules/.bin/agentguard', isLocal: false };
+    }
   }
   return { cli: 'agentguard', isLocal: false };
 }
@@ -250,7 +260,7 @@ export async function claudeInit(args: string[] = []): Promise<void> {
 
   if (!settings.hooks) settings.hooks = {};
 
-  const { cli, isLocal } = resolveCliPrefix();
+  const { cli, isLocal } = resolveCliPrefix(isGlobal);
 
   // PreToolUse — governance enforcement (routes all tool calls through the kernel)
   if (!settings.hooks.PreToolUse) settings.hooks.PreToolUse = [];

--- a/apps/cli/src/commands/copilot-init.ts
+++ b/apps/cli/src/commands/copilot-init.ts
@@ -11,12 +11,20 @@ import type { EnforcementMode } from '@red-codes/core';
 const HOOK_MARKER = 'copilot-hook';
 const LOCAL_BIN = 'node apps/cli/dist/bin.js';
 
-/** Detect if we're in the agentguard development repo (local dev) vs. globally installed. */
-function resolveCliPrefix(): { cli: string; isLocal: boolean } {
+/** Detect if we're in the agentguard development repo (local dev) vs. globally installed.
+ *  For project-level npm installs, resolves to ./node_modules/.bin/agentguard so hooks
+ *  work even when the binary isn't on PATH (#964). */
+function resolveCliPrefix(isGlobal: boolean): { cli: string; isLocal: boolean } {
   const mainRoot = resolveMainRepoRoot();
   const localMarker = join(mainRoot, 'apps', 'cli', 'src', 'bin.ts');
   if (existsSync(localMarker)) {
     return { cli: LOCAL_BIN, isLocal: true };
+  }
+  if (!isGlobal) {
+    const nmBin = join(mainRoot, 'node_modules', '.bin', 'agentguard');
+    if (existsSync(nmBin)) {
+      return { cli: './node_modules/.bin/agentguard', isLocal: false };
+    }
   }
   return { cli: 'agentguard', isLocal: false };
 }
@@ -108,7 +116,7 @@ export async function copilotInit(args: string[] = []): Promise<void> {
 
   if (!config.hooks) config.hooks = {};
 
-  const { cli } = resolveCliPrefix();
+  const { cli } = resolveCliPrefix(isGlobal);
 
   // preToolUse — governance enforcement (routes all tool calls through the kernel)
   if (!config.hooks.preToolUse) config.hooks.preToolUse = [];

--- a/apps/cli/tests/cli-claude-init.test.ts
+++ b/apps/cli/tests/cli-claude-init.test.ts
@@ -595,6 +595,58 @@ describe('claudeInit', () => {
     expect(written.hooks.PreToolUse[0].hooks[0].command).toContain('claude-hook-wrapper.sh');
   });
 
+  // --- Binary path resolution (#964) ---
+
+  it('resolves ./node_modules/.bin/agentguard for project-level npm installs', async () => {
+    vi.mocked(existsSync).mockImplementation((p: unknown) => {
+      const path = String(p);
+      // Simulate npm-installed package: node_modules/.bin/agentguard exists,
+      // but NOT the local dev marker (apps/cli/src/bin.ts)
+      if (path.includes(join('node_modules', '.bin', 'agentguard'))) return true;
+      return false;
+    });
+
+    await claudeInit([]);
+
+    const written = writtenSettings();
+    // PostToolUse, Stop, Notification hooks should use resolved binary path
+    expect(written.hooks.PostToolUse[0].hooks[0].command).toContain(
+      './node_modules/.bin/agentguard'
+    );
+    expect(written.hooks.PostToolUse[0].hooks[0].command).not.toMatch(/^agentguard /);
+
+    // SessionStart status hook should also use resolved path
+    const statusHook = written.hooks.SessionStart[0].hooks.find(
+      (h: { command: string }) => h.command.includes('status')
+    );
+    expect(statusHook.command).toContain('./node_modules/.bin/agentguard');
+  });
+
+  it('uses bare agentguard for --global even when node_modules/.bin exists', async () => {
+    vi.mocked(existsSync).mockImplementation((p: unknown) => {
+      const path = String(p);
+      if (path.includes(join('node_modules', '.bin', 'agentguard'))) return true;
+      return false;
+    });
+
+    await claudeInit(['--global']);
+
+    const written = writtenSettings();
+    // Global hooks should use bare command (on PATH), not relative node_modules path
+    expect(written.hooks.PostToolUse[0].hooks[0].command).toMatch(/^agentguard /);
+    expect(written.hooks.PostToolUse[0].hooks[0].command).not.toContain('node_modules');
+  });
+
+  it('falls back to bare agentguard when node_modules/.bin does not exist', async () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    await claudeInit([]);
+
+    const written = writtenSettings();
+    // No node_modules binary, no local dev — should fall back to bare command
+    expect(written.hooks.PostToolUse[0].hooks[0].command).toMatch(/^agentguard /);
+  });
+
   it('adds SessionStart persona check hook', async () => {
     vi.mocked(existsSync).mockReturnValue(false);
 


### PR DESCRIPTION
## Summary
- **Closes #964**: `resolveCliPrefix()` now checks `./node_modules/.bin/agentguard` for project-level installs, so PostToolUse, Stop, Notification, and status hooks resolve correctly even when the binary isn't on PATH
- Same fix applied to `copilot-init.ts` (identical pattern)
- Global settings (`--global`) still use bare `agentguard` since they apply across projects and the binary should be on PATH for global installs

## Changes
| File | Change |
|------|--------|
| `apps/cli/src/commands/claude-init.ts` | `resolveCliPrefix(isGlobal)` checks `node_modules/.bin/agentguard` for project-level installs |
| `apps/cli/src/commands/copilot-init.ts` | Same fix for Copilot CLI integration |
| `apps/cli/tests/cli-claude-init.test.ts` | 3 new tests: npm-install resolution, global fallback, bare command fallback |

## Test plan
- [x] `pnpm test --filter=@red-codes/agentguard` — 768/768 passing (includes 3 new tests)
- [x] `pnpm build` — all 18 packages build cleanly
- [ ] Manual: `agentguard claude-init` in an npm-installed project writes `./node_modules/.bin/agentguard` in hook commands
- [ ] Manual: `agentguard claude-init --global` still writes bare `agentguard` in hook commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)