### PR TITLE
chore(kernel-em): EM cycle report 2026-03-26T09:00Z

### DIFF
--- a/.agentguard/squads/kernel/em-report.json
+++ b/.agentguard/squads/kernel/em-report.json
@@ -1,32 +1,52 @@
 {
-  "generatedAt": "2026-03-25T23:05:00.000Z",
+  "generatedAt": "2026-03-26T09:00:00.000Z",
   "identity": "claude-code:opus:kernel:em",
   "runCycle": "3h",
-  "health": "green",
-  "summary": "Steady-state cycle. Closed stale PR #960 (EM report with merge conflicts). PR #961 (shell.exec simulator + git.force-push) confirmed merged. Sprint goal updated from #924 (resolved) to #955 (wire Go kernel into npm hook path — 100x latency win). Senior coder assigned #955/#957/#964 bundle. 0 open PRs, full budget available. 4129 tests passing across 19 packages.",
+  "health": "yellow",
+  "summary": "Health downgraded to YELLOW. Three new dogfood bugs discovered (#971, #972, #973). #972 is P0 — hook deny reason includes retry metadata text that causes Claude Code to block ALL tool use in governed sessions. #973 compounds it — essentials pack not bundled in npm, so every hook invocation hits default-deny. Sprint reprioritized: fix #972 + #973 first, then resume #955 (Go kernel delegation). PR #969 (closes #964) has merge conflicts — needs rebase. Closed stale EM PR #966.",
   "prQueue": {
-    "open": 0,
-    "prs": []
+    "open": 1,
+    "prs": [
+      {
+        "number": 969,
+        "title": "fix(claude-init): write hooks with full binary path (closes #964)",
+        "ciStatus": "passed",
+        "mergeState": "CONFLICTING",
+        "note": "CI green but merge conflicts — needs rebase before merge"
+      }
+    ]
   },
-  "mergedThisCycle": [
-    {
-      "number": 961,
-      "title": "fix(simulate): add shell.exec simulator and git.force-push action type",
-      "mergedAt": "2026-03-25T21:41:36Z",
-      "note": "Confirmed merged (was stale-open in state.json)"
-    }
-  ],
   "closedThisCycle": [
     {
-      "number": 960,
-      "title": "chore(kernel-em): EM cycle report 2026-03-26T04:25Z",
-      "note": "Stale EM report with merge conflicts — superseded by current cycle"
+      "number": 966,
+      "title": "chore(kernel-em): EM cycle report 2026-03-26T07:10Z",
+      "note": "Stale EM report — superseded by current cycle"
     }
   ],
-  "newIssues": [],
+  "mergedThisCycle": [],
+  "newIssues": [
+    {
+      "number": 972,
+      "title": "Hook deny reason includes '(attempt N/N)' text that Claude Code misinterprets as blocking error",
+      "severity": "P0",
+      "note": "Breaks ALL governed sessions. Deny reason text causes Claude Code to block all tool use. Sprint-blocking."
+    },
+    {
+      "number": 973,
+      "title": "claude-init --reset references essentials pack not bundled in npm package",
+      "severity": "P0",
+      "note": "Essentials pack only exists in repo source tree, not npm. Every hook invocation warns 'Pack not found' → default-deny."
+    },
+    {
+      "number": 971,
+      "title": "Hook crash after aguard rename + cross-user queue lock permission",
+      "severity": "P1",
+      "note": "Two dogfood bugs: (1) hook config references old 'agentguard' binary after rename to 'aguard', (2) cross-user queue.lock permission denied on jared box. Bug 1 is kernel, Bug 2 is ops."
+    }
+  ],
   "loopGuards": {
     "prBudget": {
-      "open": 0,
+      "open": 1,
       "max": 3,
       "pass": true
     },
@@ -40,31 +60,56 @@
     }
   },
   "triage": {
-    "p0Issues": 0,
-    "p1Issues": 0,
+    "p0Issues": 2,
+    "p1Issues": 1,
+    "sprintReprioritized": true,
+    "reprioritizationReason": "Can't ship Go kernel delegation (#955) if the TS hook path itself is broken. #972 + #973 must be fixed first — they affect every npm user running governed sessions.",
     "newAssignments": [
       {
         "agent": "senior",
+        "issues": [972, 973],
+        "note": "P0 fast-track: fix deny reason retry text (#972) + bundle essentials pack (#973). Both break the hook integration path."
+      }
+    ],
+    "deferredWork": [
+      {
         "issues": [955, 957, 964],
-        "note": "P0 sprint bundle: wire Go kernel into claude-hook.ts, resolve pack/YAML in Go, fix binary path in hook init"
+        "note": "Go kernel wire-up — resume after #972/#973 are fixed. PR #969 (closes #964) needs rebase."
       }
     ],
     "notableIssues": [
       {
-        "numbers": [955, 957, 964],
-        "note": "Current sprint: Go kernel integration — claude-hook.ts → Go binary delegation, pack resolution, hook binary path. P0 per roadmap."
+        "number": 965,
+        "note": "Dogfood gap: direct push to master not blocked. Needs investigation but lower priority than #972/#973."
       },
       {
-        "numbers": [919, 920],
-        "note": "v3.0 gate issues (stranger test, ActionContext) — priority:high, next-up after #955 bundle ships"
+        "number": 971,
+        "note": "Two bugs: aguard rename compat (kernel) + queue lock perms (ops). Bug 2 should be escalated to ops."
       }
     ]
   },
-  "blockers": [],
-  "escalations": [],
+  "blockers": [
+    {
+      "issue": 972,
+      "description": "P0: Hook deny reason retry text breaks Claude Code integration",
+      "since": "2026-03-26"
+    },
+    {
+      "issue": 973,
+      "description": "P0: Essentials pack not in npm → all hooks default-deny",
+      "since": "2026-03-26"
+    }
+  ],
+  "escalations": [
+    {
+      "target": "ops",
+      "issue": 971,
+      "reason": "Bug 2 (cross-user queue.lock permission denied) is an ops/deploy issue — jared workers can't dequeue"
+    }
+  ],
   "metrics": {
     "prsOpened": 0,
-    "prsMerged": 1,
+    "prsMerged": 0,
     "prsClosed": 1,
     "issuesClosed": 0,
     "governanceDenials": 0,
@@ -83,6 +128,6 @@
       "persistentBlocker": false,
       "governanceDenialsExceeded": false
     },
-    "notes": "No escalation triggers. All clear. Sprint transitioned from #924 (closed) to #955 (Go kernel integration)."
+    "notes": "No CI escalation triggers, but #972 is a P0 production blocker discovered via dogfooding. Health set to YELLOW per severity."
   }
 }

--- a/.agentguard/squads/kernel/state.json
+++ b/.agentguard/squads/kernel/state.json
@@ -1,48 +1,61 @@
 {
   "squad": "kernel",
   "sprint": {
-    "goal": "Wire Go kernel into npm hook path (#955). TS claude-hook must delegate to Go binary for 100x latency win.",
-    "issues": [955, 957, 964]
+    "goal": "Fix P0 hook-breaking bugs (#972, #973), then resume Go kernel wire-up (#955). Hook path must work before Go delegation can ship.",
+    "issues": [972, 973, 955, 957, 964]
   },
   "assignments": {
     "senior": {
-      "issue": [955, 957, 964],
-      "title": "Wire Go kernel into claude-hook.ts — delegate evaluation to Go binary",
+      "issue": [972, 973],
+      "title": "P0: Fix hook deny reason retry metadata (#972) + bundle essentials pack in npm (#973)",
       "status": "unassigned",
       "branch": null,
       "pr": null,
       "claimedAt": null,
-      "note": "P0: claude-hook.ts must detect Go binary, pre-resolve YAML/pack policies to flat JSON, delegate to go/bin/agentguard evaluate on stdin. #957 (Go pack resolution) and #964 (full binary path in hooks) are sub-tasks."
+      "note": "P0 fast-track: #972 breaks all governed sessions (retry text in deny reason → Claude Code blocks all tool use). #973 compounds it (essentials pack missing → default-deny on everything). Fix both before resuming #955 Go delegation."
     }
   },
-  "blockers": [],
+  "blockers": [
+    {
+      "issue": 972,
+      "description": "Hook deny reason includes '(attempt N/N)' — Claude Code misinterprets as blocking error, killing all tool use in governed sessions",
+      "severity": "P0",
+      "since": "2026-03-26T00:00:00.000Z"
+    },
+    {
+      "issue": 973,
+      "description": "essentials policy pack not bundled in npm — all hook invocations hit default-deny",
+      "severity": "P0",
+      "since": "2026-03-26T00:00:00.000Z"
+    }
+  ],
   "prQueue": {
-    "open": 0,
+    "open": 1,
     "reviewed": 0,
     "mergeable": 0,
     "prs": [
       {
-        "number": 961,
-        "title": "fix(simulate): add shell.exec simulator and git.force-push action type",
-        "branch": "agent/kernel-sr-20260325-213002",
-        "status": "merged",
+        "number": 969,
+        "title": "fix(claude-init): write hooks with full binary path (closes #964)",
+        "branch": "agent/kernel-sr-20260325-230503",
+        "status": "open",
         "ciStatus": "passed",
-        "openedAt": "2026-03-25T21:37:00.000Z",
-        "mergedAt": "2026-03-25T21:41:36.000Z"
+        "mergeState": "CONFLICTING",
+        "openedAt": "2026-03-26T00:00:00.000Z",
+        "note": "CI green but merge conflicts. Needs rebase before merge."
       },
       {
-        "number": 960,
-        "title": "chore(kernel-em): EM cycle report 2026-03-26T04:25Z",
-        "branch": "agent/kernel-em-20260326-042500",
+        "number": 966,
+        "title": "chore(kernel-em): EM cycle report 2026-03-26T07:10Z",
+        "branch": "agent/kernel-em-20260326-001002",
         "status": "closed",
-        "ciStatus": null,
-        "openedAt": "2026-03-25T21:27:00.000Z",
-        "closedAt": "2026-03-25T23:05:00.000Z",
-        "note": "Stale EM report with merge conflicts, closed this cycle"
+        "ciStatus": "passed",
+        "closedAt": "2026-03-26T09:00:00.000Z",
+        "note": "Stale EM report, superseded by current cycle"
       }
     ]
   },
-  "health": "green",
+  "health": "yellow",
   "testHealth": {
     "total": 4129,
     "passed": 4129,
@@ -51,7 +64,7 @@
     "lastRun": "2026-03-25T23:05:00.000Z",
     "status": "all_passing"
   },
-  "lastEmRun": "2026-03-25T23:05:00.000Z",
+  "lastEmRun": "2026-03-26T09:00:00.000Z",
   "lastQaRun": "2026-03-25T18:50:00.000Z",
-  "updatedAt": "2026-03-25T23:05:00.000Z"
+  "updatedAt": "2026-03-26T09:00:00.000Z"
 }


### PR DESCRIPTION
## Summary
- **Health: YELLOW** — P0 dogfood bugs discovered, sprint reprioritized
- Three new issues from dogfooding: #972 (P0), #973 (P0), #971 (P1)
- #972: Hook deny reason includes `(attempt N/N)` text → Claude Code blocks ALL tool use
- #973: Essentials pack not bundled in npm → all hooks default-deny
- Sprint reprioritized: fix #972 + #973 before resuming Go kernel delegation (#955)
- PR #969 (closes #964): CI green but merge conflicts — needs rebase
- Closed stale EM PR #966

## Metrics
| Metric | Value |
|--------|-------|
| PRs merged | 0 |
| PRs closed | 1 (#966 stale) |
| Open squad PRs | 1 (#969 conflicting) |
| P0 blockers | 2 (#972, #973) |
| Tests | 4129/4129 passing |

## Escalations
- **ops**: #971 bug 2 (cross-user queue.lock permission denied) — jared workers can't dequeue

🤖 Generated with [Claude Code](https://claude.com/claude-code)