### PR TITLE
fix: bundle policies/ in npm package and resolve packs from dist

### DIFF
--- a/apps/cli/esbuild.config.ts
+++ b/apps/cli/esbuild.config.ts
@@ -35,9 +35,10 @@ await esbuild.build({
   entryPoints: ['src/bin.ts', 'src/postinstall.ts'],
 });
 
-// Copy hooks/ and templates/ into dist so they ship with the npm package
+// Copy hooks/, templates/, and policies/ into dist so they ship with the npm package
 // (npm rejects path traversals like ../../hooks/ in the files array)
 cpSync('../../hooks', 'dist/hooks', { recursive: true });
 cpSync('../../templates', 'dist/templates', { recursive: true });
+cpSync('../../policies', 'dist/policies', { recursive: true });
 
 console.log('CLI build complete.');

--- a/apps/cli/src/policy-resolver.ts
+++ b/apps/cli/src/policy-resolver.ts
@@ -3,6 +3,7 @@
 
 import { readFileSync, existsSync } from 'node:fs';
 import { resolve, dirname, join, normalize } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { homedir } from 'node:os';
 import { loadYamlPolicy, parseYamlPolicy } from '@red-codes/policy';
 import { resolveExtends, mergePolicies } from '@red-codes/policy';
@@ -250,7 +251,9 @@ export function loadComposedPolicies(policyPaths?: string[]): CompositionResult 
  * Resolve a pack short name to a file path.
  * Search order:
  * 1. <project-root>/policies/<name>.yaml
- * 2. <agentguard-install-dir>/policies/<name>.yaml (bundled packs)
+ * 2. <cwd>/policies/<name>.yaml
+ * 3. <agentguard-install-dir>/dist/policies/<name>.yaml (bundled packs)
+ * 4. <main-git-repo-root>/policies/<name>.yaml (dev/source tree fallback)
  */
 export function resolvePackByName(name: string, projectRoot?: string): string | null {
   // Project-local packs
@@ -263,10 +266,19 @@ export function resolvePackByName(name: string, projectRoot?: string): string | 
   const cwdLocal = join(process.cwd(), 'policies', `${name}.yaml`);
   if (existsSync(cwdLocal)) return cwdLocal;
 
-  // Bundled packs (relative to main repo root)
+  // Bundled packs — shipped in dist/policies/ alongside the installed CLI binary
+  try {
+    const thisDir = fileURLToPath(new URL('.', import.meta.url));
+    const bundledInDist = join(thisDir, 'policies', `${name}.yaml`);
+    if (existsSync(bundledInDist)) return bundledInDist;
+  } catch {
+    // import.meta.url unavailable in some environments — skip
+  }
+
+  // Source tree fallback (dev mode — main repo root)
   const mainRoot = resolveMainRepoRoot();
-  const bundled = join(mainRoot, 'policies', `${name}.yaml`);
-  if (existsSync(bundled)) return bundled;
+  const sourceTree = join(mainRoot, 'policies', `${name}.yaml`);
+  if (existsSync(sourceTree)) return sourceTree;
 
   return null;
 }


### PR DESCRIPTION
Closes #973

## Implementation Summary

**What changed:**
- Added `cpSync('../../policies', 'dist/policies', { recursive: true })` to `apps/cli/esbuild.config.ts` — same pattern already used for `hooks/` and `templates/`
- Updated `resolvePackByName` in `apps/cli/src/policy-resolver.ts` to look in `dist/policies/` relative to the running binary (via `import.meta.url`), before falling back to the source tree
- Added `import { fileURLToPath } from 'node:url'` to enable the above
- Updated JSDoc comment to reflect the new 4-step search order

**How to verify:**
1. `pnpm build` — check that `apps/cli/dist/policies/essentials.yaml` exists
2. Create a temp dir, copy `dist/` there, run `echo '{"tool":"Bash","input":{"command":"echo hello"}}' | node dist/bin.js claude-hook pre` with an agentguard.yaml containing `pack: essentials` — no warning should appear

**Tier C scope check:**
- Files changed: 2 (limit: 5)
- Lines changed: ~18 (limit: 300)
- Breaking changes: None

---
*Tier C implementation by copilot-cli — AgentGuard three-tier governance*