### PR TITLE
fix(site): replace placeholder blog post URLs in posts.json

### DIFF
--- a/site/posts.json
+++ b/site/posts.json
@@ -1,24 +1,10 @@
 {
   "posts": [
     {
-      "title": "Why AI Agents Need Governance Before They Need More Power",
-      "date": "2026-03-14",
+      "title": "AI Doesn't Break Systems. Unchecked Actions Do.",
+      "date": "2026-03-22",
       "excerpt": "Most AI coding agents execute with zero oversight. They can delete files, push to main, and expose secrets — all in a single tool call. Here's why governance at the execution layer changes everything.",
-      "url": "https://linkedin.com/posts/example-1",
-      "image": null
-    },
-    {
-      "title": "21 Safety Invariants Every AI Agent Should Respect",
-      "date": "2026-03-07",
-      "excerpt": "We built 21 invariants into AgentGuard that catch destructive patterns before they execute. From secret exposure to force-push protection, here's what they are and why they matter.",
-      "url": "https://linkedin.com/posts/example-2",
-      "image": null
-    },
-    {
-      "title": "The Governed Action Kernel: How AgentGuard Makes Every AI Action Auditable",
-      "date": "2026-02-28",
-      "excerpt": "Every action an AI agent takes passes through a 7-stage pipeline: propose, normalize, evaluate, simulate, execute, emit, persist. This is how we built a deterministic governance layer.",
-      "url": "https://linkedin.com/posts/example-3",
+      "url": "https://www.linkedin.com/pulse/ai-doesnt-break-systems-unchecked-actions-do-jared-pleva-recrc/",
       "image": null
     }
   ]

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -2,13 +2,13 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://agentguardhq.github.io/agentguard/</loc>
-    <lastmod>2026-03-21</lastmod>
+    <lastmod>2026-03-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://agentguardhq.github.io/agentguard/posts.html</loc>
-    <lastmod>2026-03-21</lastmod>
+    <lastmod>2026-03-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>


### PR DESCRIPTION
Closes #930

## Implementation Summary

**What changed:**
- Replaced 3 placeholder LinkedIn URLs (`example-1/2/3`) in `site/posts.json` with the real published article URL already present in `posts.html`
- Removed the two posts that have no published counterparts (keeping only the one real article)
- Also updated `site/sitemap.xml` lastmod dates from `2026-03-21` to `2026-03-26` (also fixes #932)

**How to verify:**
1. Check `site/posts.json` — no longer contains `example-1/2/3` placeholder URLs
2. The remaining entry URL matches the article card in `site/posts.html`
3. `site/sitemap.xml` reflects current date

**Tier C scope check:**
- Files changed: 2 (limit: 5)
- Lines changed: ~14 (limit: 300)
- Breaking changes: None

---
*Tier C implementation by copilot-cli — AgentGuard three-tier governance*