### PR TITLE
fix: add aguard bin alias to @red-codes/agentguard and update hook resolvers

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -8,7 +8,8 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {
-    "agentguard": "./dist/bin.js"
+    "agentguard": "./dist/bin.js",
+    "aguard": "./dist/bin.js"
   },
   "files": [
     "dist/",

--- a/apps/cli/src/commands/claude-init.ts
+++ b/apps/cli/src/commands/claude-init.ts
@@ -38,6 +38,10 @@ function resolveCliPrefix(isGlobal: boolean): { cli: string; isLocal: boolean } 
     if (existsSync(nmBin)) {
       return { cli: './node_modules/.bin/agentguard', isLocal: false };
     }
+    const nmBinAguard = join(mainRoot, 'node_modules', '.bin', 'aguard');
+    if (existsSync(nmBinAguard)) {
+      return { cli: './node_modules/.bin/aguard', isLocal: false };
+    }
   }
   return { cli: 'agentguard', isLocal: false };
 }

--- a/apps/cli/src/commands/copilot-init.ts
+++ b/apps/cli/src/commands/copilot-init.ts
@@ -25,6 +25,10 @@ function resolveCliPrefix(isGlobal: boolean): { cli: string; isLocal: boolean } 
     if (existsSync(nmBin)) {
       return { cli: './node_modules/.bin/agentguard', isLocal: false };
     }
+    const nmBinAguard = join(mainRoot, 'node_modules', '.bin', 'aguard');
+    if (existsSync(nmBinAguard)) {
+      return { cli: './node_modules/.bin/aguard', isLocal: false };
+    }
   }
   return { cli: 'agentguard', isLocal: false };
 }


### PR DESCRIPTION
Closes #971

## Implementation Summary

**What changed:**
- Added `"aguard": "./dist/bin.js"` to the `bin` field in `apps/cli/package.json` — `@red-codes/agentguard` now exposes both `agentguard` and `aguard` binaries
- Updated `resolveCliPrefix()` in `claude-init.ts` to fall back to `./node_modules/.bin/aguard` when `agentguard` is not found in node_modules
- Updated `resolveCliPrefix()` in `copilot-init.ts` with the same fallback

**How to verify:**
1. `npm install -g @red-codes/agentguard` — both `agentguard` and `aguard` commands should work
2. In a project with `@red-codes/agentguard` as a local dependency, run `agentguard claude-init` — it resolves `./node_modules/.bin/agentguard` first, then `./node_modules/.bin/aguard` as fallback
3. Existing hooks referencing `agentguard` continue to work unchanged

**Tier C scope check:**
- Files changed: 3 (limit: 5)
- Lines changed: ~10 (limit: 300)
- Breaking changes: None

---
*Tier C implementation by copilot-cli — AgentGuard three-tier governance*