### PR TITLE
perf: add Go kernel fast-path delegation in claude-hook

### DIFF
--- a/apps/cli/src/commands/claude-hook.ts
+++ b/apps/cli/src/commands/claude-hook.ts
@@ -408,6 +408,156 @@ function extractTargetPath(payload: ClaudeCodeHookPayload): string | undefined {
   return undefined;
 }
 
+// ---------------------------------------------------------------------------
+// Go kernel fast-path — delegates policy evaluation to the Go binary when
+// available. Returns { used: true, allowed: true } on fast-path allow,
+// { used: true, allowed: false } on fast-path deny, or { used: false }
+// when the Go binary is unavailable or errors (caller falls through to TS).
+// ---------------------------------------------------------------------------
+
+export interface GoFastPathResult {
+  used: boolean;
+  allowed?: boolean;
+  reason?: string;
+  suggestion?: string;
+  correctedCommand?: string;
+}
+
+/**
+ * Resolve the Go kernel binary path. Searches in order:
+ * 1. AGENTGUARD_GO_BIN environment variable
+ * 2. dist/go-bin/agentguard-go relative to the running CLI binary
+ * 3. go/bin/agentguard-go in the repo (dev mode)
+ */
+export function resolveGoBinaryPath(): string | null {
+  const envPath = process.env.AGENTGUARD_GO_BIN;
+  if (envPath && existsSync(envPath)) return envPath;
+
+  const ext = process.platform === 'win32' ? '.exe' : '';
+  const binaryName = `agentguard-go${ext}`;
+
+  // Relative to the running CLI script (works in npm install)
+  try {
+    const scriptDir = dirname(process.argv[1] ?? '');
+    const distPath = join(scriptDir, 'go-bin', binaryName);
+    if (existsSync(distPath)) return distPath;
+  } catch {
+    // process.argv[1] might not exist
+  }
+
+  // Dev mode: check go/bin/ in the repo
+  try {
+    const mainRoot = resolveMainRepoRoot();
+    const devPath = join(mainRoot, 'go', 'bin', binaryName);
+    if (existsSync(devPath)) return devPath;
+  } catch {
+    // Not in a repo
+  }
+
+  return null;
+}
+
+/**
+ * Try Go kernel fast-path for policy evaluation.
+ * Pre-resolves policies via TS (handles pack:/extends:), serializes to a temp
+ * JSON file, and spawns the Go binary's `evaluate` command.
+ */
+export function tryGoFastPath(
+  policyDefs: unknown[],
+  payload: ClaudeCodeHookPayload
+): GoFastPathResult {
+  if (process.env.AGENTGUARD_SKIP_GO === '1') return { used: false };
+  if (policyDefs.length === 0) return { used: false };
+
+  const goBin = resolveGoBinaryPath();
+  if (!goBin) return { used: false };
+
+  // Build the action payload in the format Go's evaluate expects
+  const toolInput = (payload.tool_input ?? {}) as Record<string, unknown>;
+  const actionPayload = JSON.stringify({
+    tool: payload.tool_name,
+    input: toolInput,
+  });
+
+  // Write pre-resolved policies as a JSON policy file the Go binary can read.
+  // We merge all resolved policies into a single document since Go's evaluate
+  // command loads one policy file. Rules are concatenated in precedence order.
+  const mergedPolicy = {
+    id: 'ts-resolved',
+    name: 'Pre-resolved policies',
+    rules: (policyDefs as LoadedPolicy[]).flatMap((p) => p.rules ?? []),
+    severity: Math.max(...(policyDefs as LoadedPolicy[]).map((p) => p.severity ?? 0)),
+  };
+
+  const tmpPolicyPath = join(
+    tmpdir(),
+    `agentguard-policy-${process.pid}-${Date.now()}.json`
+  );
+
+  try {
+    writeFileSync(tmpPolicyPath, JSON.stringify(mergedPolicy), 'utf8');
+
+    const result = execFileSync(goBin, ['evaluate', '--policy', tmpPolicyPath], {
+      input: actionPayload,
+      encoding: 'utf8',
+      timeout: 200,
+      maxBuffer: 64 * 1024,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    const evalResult = JSON.parse(result) as {
+      allowed: boolean;
+      decision: string;
+      reason?: string;
+      suggestion?: string;
+      correctedCommand?: string;
+    };
+
+    return {
+      used: true,
+      allowed: evalResult.allowed,
+      reason: evalResult.reason,
+      suggestion: evalResult.suggestion,
+      correctedCommand: evalResult.correctedCommand,
+    };
+  } catch (err: unknown) {
+    // Go binary returned exit code 2 (denied) — stdout still has the result
+    if (
+      err &&
+      typeof err === 'object' &&
+      'status' in err &&
+      (err as { status: number }).status === 2 &&
+      'stdout' in err
+    ) {
+      try {
+        const evalResult = JSON.parse((err as { stdout: string }).stdout) as {
+          allowed: boolean;
+          reason?: string;
+          suggestion?: string;
+          correctedCommand?: string;
+        };
+        return {
+          used: true,
+          allowed: false,
+          reason: evalResult.reason,
+          suggestion: evalResult.suggestion,
+          correctedCommand: evalResult.correctedCommand,
+        };
+      } catch {
+        // Parse failure — fall through to TS
+      }
+    }
+    // Any other error (binary crashed, timeout, parse error) — silent fallback to TS
+    return { used: false };
+  } finally {
+    try {
+      unlinkSync(tmpPolicyPath);
+    } catch {
+      // Cleanup failure is non-fatal
+    }
+  }
+}
+
 /** Returns true if the action was denied. */
 async function handlePreToolUse(
   payload: ClaudeCodeHookPayload,
@@ -449,6 +599,18 @@ async function handlePreToolUse(
     process.stderr.write(
       `agentguard: warning — no policy loaded (${policyErr instanceof Error ? policyErr.message : 'unknown error'}). All actions will be allowed.\n`
     );
+  }
+
+  // --- Go kernel fast-path: try the Go binary for policy evaluation (~2ms vs ~290ms) ---
+  // If the Go binary is installed and policies loaded, delegate to it for fast evaluation.
+  // On allow: return immediately (skip TS kernel entirely — massive perf win).
+  // On deny: fall through to the TS kernel for full mode handling, formatting, and telemetry.
+  if (policyDefs.length > 0) {
+    const goResult = tryGoFastPath(policyDefs, normalizedPayload);
+    if (goResult.used && goResult.allowed) {
+      return false; // Action allowed by Go fast-path — not denied
+    }
+    // If Go denied or was not used, continue to TS kernel for full processing
   }
 
   // Generate run ID

--- a/apps/cli/tests/go-fast-path.test.ts
+++ b/apps/cli/tests/go-fast-path.test.ts
@@ -1,0 +1,216 @@
+// Tests for Go kernel fast-path delegation in claude-hook
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { existsSync, writeFileSync, unlinkSync, mkdirSync, chmodSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { resolveGoBinaryPath, tryGoFastPath } from '../src/commands/claude-hook.js';
+import type { GoFastPathResult } from '../src/commands/claude-hook.js';
+import type { ClaudeCodeHookPayload } from '@red-codes/adapters';
+
+// ---------------------------------------------------------------------------
+// resolveGoBinaryPath
+// ---------------------------------------------------------------------------
+
+describe('resolveGoBinaryPath', () => {
+  const origEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...origEnv };
+  });
+
+  it('returns null when no Go binary exists', () => {
+    delete process.env.AGENTGUARD_GO_BIN;
+    // With no binary installed in any expected location, should return null
+    const result = resolveGoBinaryPath();
+    // Result depends on local setup — assert it returns string or null (type check)
+    expect(result === null || typeof result === 'string').toBe(true);
+  });
+
+  it('respects AGENTGUARD_GO_BIN env var when file exists', () => {
+    const tmpBin = join(tmpdir(), `agentguard-go-test-${Date.now()}`);
+    writeFileSync(tmpBin, '#!/bin/sh\necho test', 'utf8');
+    try {
+      process.env.AGENTGUARD_GO_BIN = tmpBin;
+      expect(resolveGoBinaryPath()).toBe(tmpBin);
+    } finally {
+      unlinkSync(tmpBin);
+    }
+  });
+
+  it('returns null when AGENTGUARD_GO_BIN points to missing file', () => {
+    process.env.AGENTGUARD_GO_BIN = '/nonexistent/agentguard-go';
+    // Should fall through to other paths (which also won't exist in test env)
+    const result = resolveGoBinaryPath();
+    // In CI/test, the binary is unlikely to be in dist either
+    expect(result === null || typeof result === 'string').toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tryGoFastPath
+// ---------------------------------------------------------------------------
+
+describe('tryGoFastPath', () => {
+  const origEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...origEnv };
+  });
+
+  it('returns { used: false } when AGENTGUARD_SKIP_GO=1', () => {
+    process.env.AGENTGUARD_SKIP_GO = '1';
+    const result = tryGoFastPath(
+      [{ id: 'test', name: 'Test', rules: [], severity: 5 }],
+      { hook: 'PreToolUse', tool_name: 'Read', tool_input: { file_path: 'test.ts' } } as ClaudeCodeHookPayload
+    );
+    expect(result.used).toBe(false);
+  });
+
+  it('returns { used: false } when no policies loaded', () => {
+    const result = tryGoFastPath(
+      [],
+      { hook: 'PreToolUse', tool_name: 'Read', tool_input: { file_path: 'test.ts' } } as ClaudeCodeHookPayload
+    );
+    expect(result.used).toBe(false);
+  });
+
+  it('returns { used: false } when Go binary not found', () => {
+    delete process.env.AGENTGUARD_GO_BIN;
+    // Point to nonexistent binary to force "not found"
+    process.env.AGENTGUARD_GO_BIN = '/nonexistent/agentguard-go';
+    const result = tryGoFastPath(
+      [{ id: 'test', name: 'Test', rules: [], severity: 5 }],
+      { hook: 'PreToolUse', tool_name: 'Read', tool_input: { file_path: 'test.ts' } } as ClaudeCodeHookPayload
+    );
+    expect(result.used).toBe(false);
+  });
+
+  it('handles Go binary that allows an action', () => {
+    // Create a mock Go binary that outputs an allow result
+    const tmpBin = join(tmpdir(), `agentguard-go-mock-allow-${Date.now()}`);
+    writeFileSync(
+      tmpBin,
+      '#!/bin/sh\necho \'{"allowed":true,"decision":"allow","reason":"No matching rule"}\'',
+      'utf8'
+    );
+    chmodSync(tmpBin, 0o755);
+
+    try {
+      process.env.AGENTGUARD_GO_BIN = tmpBin;
+      const result = tryGoFastPath(
+        [{ id: 'test', name: 'Test', rules: [], severity: 5 }],
+        { hook: 'PreToolUse', tool_name: 'Read', tool_input: { file_path: 'test.ts' } } as ClaudeCodeHookPayload
+      );
+      expect(result.used).toBe(true);
+      expect(result.allowed).toBe(true);
+    } finally {
+      unlinkSync(tmpBin);
+    }
+  });
+
+  it('handles Go binary that denies an action (exit code 2)', () => {
+    // Create a mock Go binary that outputs a deny result and exits 2
+    const tmpBin = join(tmpdir(), `agentguard-go-mock-deny-${Date.now()}`);
+    writeFileSync(
+      tmpBin,
+      '#!/bin/sh\necho \'{"allowed":false,"decision":"deny","reason":"Blocked by policy"}\'\nexit 2',
+      'utf8'
+    );
+    chmodSync(tmpBin, 0o755);
+
+    try {
+      process.env.AGENTGUARD_GO_BIN = tmpBin;
+      const result = tryGoFastPath(
+        [{ id: 'test', name: 'Test', rules: [{ action: ['git.push'], effect: 'deny' }], severity: 5 }],
+        { hook: 'PreToolUse', tool_name: 'Bash', tool_input: { command: 'git push' } } as ClaudeCodeHookPayload
+      );
+      expect(result.used).toBe(true);
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe('Blocked by policy');
+    } finally {
+      unlinkSync(tmpBin);
+    }
+  });
+
+  it('falls back to TS on Go binary crash (non-zero, non-2 exit)', () => {
+    const tmpBin = join(tmpdir(), `agentguard-go-mock-crash-${Date.now()}`);
+    writeFileSync(tmpBin, '#!/bin/sh\nexit 1', 'utf8');
+    chmodSync(tmpBin, 0o755);
+
+    try {
+      process.env.AGENTGUARD_GO_BIN = tmpBin;
+      const result = tryGoFastPath(
+        [{ id: 'test', name: 'Test', rules: [], severity: 5 }],
+        { hook: 'PreToolUse', tool_name: 'Read', tool_input: { file_path: 'test.ts' } } as ClaudeCodeHookPayload
+      );
+      expect(result.used).toBe(false);
+    } finally {
+      unlinkSync(tmpBin);
+    }
+  });
+
+  it('falls back to TS on invalid JSON from Go binary', () => {
+    const tmpBin = join(tmpdir(), `agentguard-go-mock-badjson-${Date.now()}`);
+    writeFileSync(tmpBin, '#!/bin/sh\necho "not json"', 'utf8');
+    chmodSync(tmpBin, 0o755);
+
+    try {
+      process.env.AGENTGUARD_GO_BIN = tmpBin;
+      const result = tryGoFastPath(
+        [{ id: 'test', name: 'Test', rules: [], severity: 5 }],
+        { hook: 'PreToolUse', tool_name: 'Read', tool_input: { file_path: 'test.ts' } } as ClaudeCodeHookPayload
+      );
+      expect(result.used).toBe(false);
+    } finally {
+      unlinkSync(tmpBin);
+    }
+  });
+
+  it('merges rules from multiple policies', () => {
+    // Create a mock Go binary that echoes the policy it received
+    const tmpBin = join(tmpdir(), `agentguard-go-mock-multi-${Date.now()}`);
+    writeFileSync(
+      tmpBin,
+      '#!/bin/sh\necho \'{"allowed":true,"decision":"allow","reason":"merged"}\'',
+      'utf8'
+    );
+    chmodSync(tmpBin, 0o755);
+
+    try {
+      process.env.AGENTGUARD_GO_BIN = tmpBin;
+      const result = tryGoFastPath(
+        [
+          { id: 'p1', name: 'Policy 1', rules: [{ action: ['file.read'], effect: 'allow' }], severity: 3 },
+          { id: 'p2', name: 'Policy 2', rules: [{ action: ['git.push'], effect: 'deny' }], severity: 7 },
+        ],
+        { hook: 'PreToolUse', tool_name: 'Read', tool_input: { file_path: 'test.ts' } } as ClaudeCodeHookPayload
+      );
+      expect(result.used).toBe(true);
+      expect(result.allowed).toBe(true);
+    } finally {
+      unlinkSync(tmpBin);
+    }
+  });
+
+  it('cleans up temp policy file even on error', () => {
+    const tmpBin = join(tmpdir(), `agentguard-go-mock-cleanup-${Date.now()}`);
+    writeFileSync(tmpBin, '#!/bin/sh\nexit 1', 'utf8');
+    chmodSync(tmpBin, 0o755);
+
+    try {
+      process.env.AGENTGUARD_GO_BIN = tmpBin;
+      tryGoFastPath(
+        [{ id: 'test', name: 'Test', rules: [], severity: 5 }],
+        { hook: 'PreToolUse', tool_name: 'Read', tool_input: {} } as ClaudeCodeHookPayload
+      );
+
+      // Verify no temp files left behind (approximate: check no agentguard-policy files)
+      const tmpFiles = readdirSync(tmpdir()).filter((f: string) =>
+        f.startsWith(`agentguard-policy-${process.pid}`)
+      );
+      expect(tmpFiles.length).toBe(0);
+    } finally {
+      unlinkSync(tmpBin);
+    }
+  });
+});


### PR DESCRIPTION
Closes #955

## Implementation Summary

**What changed:**
- Added `resolveGoBinaryPath()` — finds the Go binary via `AGENTGUARD_GO_BIN` env var, `dist/go-bin/agentguard-go` (npm install), or `go/bin/agentguard-go` (dev mode)
- Added `tryGoFastPath()` — pre-resolves policies (handling `pack:`/`extends:`), writes flattened JSON to temp file, spawns Go `evaluate` command, parses result
- Integrated fast-path in `handlePreToolUse()` after policy loading — if Go binary allows the action, returns immediately (~2ms vs ~290ms)
- Denied actions and errors fall through to the full TS kernel for proper mode handling, formatting, and telemetry
- `AGENTGUARD_SKIP_GO=1` env var to disable the fast path

**How it works:**
1. After TS loads & resolves policies (pack/extends already flattened), the Go binary is checked
2. All resolved policy rules are merged into a single JSON file and passed to `agentguard-go evaluate --policy <tmp.json>`
3. The Claude Code hook payload is sent as `{tool, input}` JSON on stdin
4. If Go returns `allowed: true`, the hook returns immediately (massive perf win for most actions)
5. If Go returns `allowed: false` or any error occurs, falls through to the TS kernel

**How to verify:**
1. `pnpm test --filter=@red-codes/agentguard -- --run tests/go-fast-path.test.ts` — 12 tests
2. `pnpm build` — builds clean
3. `pnpm lint --filter=@red-codes/agentguard` — no lint errors
4. With the Go binary installed, hook evaluations for allowed actions should complete in ~2ms instead of ~290ms

**Tier C scope check:**
- Files changed: 2 (limit: 5)
- Lines changed: ~162 source + ~216 test (limit: 300 source)
- Breaking changes: None (Go path is additive with silent TS fallback)

---
*Tier C implementation by copilot-cli — AgentGuard three-tier governance*