### PR TITLE
feat(invariants): add no-verify-bypass invariant

### DIFF
--- a/packages/core/src/data/invariant-patterns.json
+++ b/packages/core/src/data/invariant-patterns.json
@@ -58,6 +58,7 @@
     { "id": "transitive-effect-analysis", "name": "Transitive Effect Analysis", "description": "Detects when an agent writes a script or config file whose contents would produce effects that would be denied if executed directly — closes the creative circumvention gap", "severity": 4 },
     { "id": "no-ide-socket-access", "name": "No IDE Socket Access", "description": "Blocks agent access to IDE inter-process communication sockets (VS Code, JetBrains, Cursor) — prevents governance escape via host IDE manipulation", "severity": 4 },
     { "id": "commit-scope-guard", "name": "Commit Scope Guard", "description": "All files in a git commit must have been written or modified by the current session — prevents accidental inclusion of pre-staged files", "severity": 4 },
-    { "id": "script-execution-tracking", "name": "Script Execution Tracking", "description": "Detects when a shell command executes a file written in the current session — prevents governance bypass via write-then-execute indirection", "severity": 4 }
+    { "id": "script-execution-tracking", "name": "Script Execution Tracking", "description": "Detects when a shell command executes a file written in the current session — prevents governance bypass via write-then-execute indirection", "severity": 4 },
+    { "id": "no-verify-bypass", "name": "No Verify Bypass", "description": "--no-verify flag on git push/commit is forbidden — prevents skipping pre-push/pre-commit hooks", "severity": 4 }
   ]
 }

--- a/packages/invariants/src/definitions.ts
+++ b/packages/invariants/src/definitions.ts
@@ -1760,4 +1760,37 @@ export const DEFAULT_INVARIANTS: AgentGuardInvariant[] = [
       };
     },
   },
+
+  {
+    id: 'no-verify-bypass',
+    name: 'No Verify Bypass',
+    description:
+      '--no-verify flag on git push/commit is forbidden — prevents skipping pre-push/pre-commit hooks',
+    severity: 4,
+    check(state) {
+      const command = (state.currentCommand || '').trim();
+      if (!command) {
+        return { holds: true, expected: 'No --no-verify flag', actual: 'No command' };
+      }
+
+      const isGitPushOrCommit = /\bgit\s+(?:push|commit)\b/.test(command);
+      if (!isGitPushOrCommit) {
+        return {
+          holds: true,
+          expected: 'No --no-verify flag',
+          actual: 'Not a git push/commit command',
+        };
+      }
+
+      const hasNoVerify = /(?:^|\s)--no-verify(?:\s|$)/.test(command);
+
+      return {
+        holds: !hasNoVerify,
+        expected: 'No --no-verify flag on git push/commit',
+        actual: hasNoVerify
+          ? `--no-verify bypass detected in: ${command.slice(0, 100)}`
+          : 'No --no-verify flag',
+      };
+    },
+  },
 ];

--- a/packages/invariants/tests/invariant-definitions.test.ts
+++ b/packages/invariants/tests/invariant-definitions.test.ts
@@ -2542,6 +2542,68 @@ describe('checkAllInvariants interaction tests', () => {
 });
 
 // ---------------------------------------------------------------------------
+// no-verify-bypass
+// ---------------------------------------------------------------------------
+
+describe('no-verify-bypass', () => {
+  const inv = findInvariant('no-verify-bypass');
+
+  it('holds when no command is set', () => {
+    const result = inv.check({});
+    expect(result.holds).toBe(true);
+  });
+
+  it('holds for normal git push', () => {
+    const result = inv.check({ currentCommand: 'git push origin main' });
+    expect(result.holds).toBe(true);
+  });
+
+  it('holds for normal git commit', () => {
+    const result = inv.check({ currentCommand: 'git commit -m "fix: stuff"' });
+    expect(result.holds).toBe(true);
+  });
+
+  it('fails for git push --no-verify', () => {
+    const result = inv.check({ currentCommand: 'git push --no-verify origin main' });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('--no-verify');
+  });
+
+  it('fails for git commit --no-verify', () => {
+    const result = inv.check({ currentCommand: 'git commit --no-verify -m "skip hooks"' });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('--no-verify');
+  });
+
+  it('fails for git push with --no-verify at end', () => {
+    const result = inv.check({ currentCommand: 'git push origin main --no-verify' });
+    expect(result.holds).toBe(false);
+  });
+
+  it('fails for git commit with --no-verify at end', () => {
+    const result = inv.check({
+      currentCommand: 'git commit -m "msg" --no-verify',
+    });
+    expect(result.holds).toBe(false);
+  });
+
+  it('holds for non-git commands containing --no-verify', () => {
+    const result = inv.check({ currentCommand: 'npm test --no-verify' });
+    expect(result.holds).toBe(true);
+  });
+
+  it('holds for git diff (not push/commit)', () => {
+    const result = inv.check({ currentCommand: 'git diff --no-verify' });
+    expect(result.holds).toBe(true);
+  });
+
+  it('holds for empty command string', () => {
+    const result = inv.check({ currentCommand: '' });
+    expect(result.holds).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // hasFileRedirect
 // ---------------------------------------------------------------------------
 

--- a/policies/engineering-standards/agentguard-pack.yaml
+++ b/policies/engineering-standards/agentguard-pack.yaml
@@ -34,6 +34,17 @@ rules:
     effect: deny
     reason: "Force push rewrites shared history — use revert instead"
 
+  # --- No --no-verify bypass — prevents skipping safety hooks ---
+  - action: shell.exec
+    effect: deny
+    target: "git push --no-verify"
+    reason: "--no-verify bypasses pre-push hooks — safety checks must not be skipped"
+
+  - action: shell.exec
+    effect: deny
+    target: "git commit --no-verify"
+    reason: "--no-verify bypasses pre-commit hooks — safety checks must not be skipped"
+
   # --- No destructive git operations ---
   - action: git.reset
     effect: deny

--- a/policies/essentials.yaml
+++ b/policies/essentials.yaml
@@ -9,6 +9,7 @@ severity: 4
 invariants:
   no-secret-exposure: enforce
   no-force-push: enforce
+  no-verify-bypass: enforce
   protected-branch: enforce
   no-credential-file-creation: enforce
   no-permission-escalation: enforce


### PR DESCRIPTION
Closes #702

## Implementation Summary

**What changed:**
- Added `no-verify-bypass` invariant (severity 4) to `packages/invariants/src/definitions.ts` — detects `--no-verify` flag on `git push` and `git commit` commands
- Registered invariant metadata in `packages/core/src/data/invariant-patterns.json`
- Enabled `no-verify-bypass: enforce` in `policies/essentials.yaml`
- Added explicit deny rules for `git push --no-verify` and `git commit --no-verify` to `policies/engineering-standards/agentguard-pack.yaml`
- Added 9 unit tests covering: normal commands, --no-verify at various positions, non-git commands, empty input

**How to verify:**
1. `pnpm build` — all 18 packages build clean
2. `pnpm test --filter=@red-codes/invariants` — all 577 tests pass
3. `pnpm lint --filter=@red-codes/invariants --filter=@red-codes/core` — no lint errors

**Tier C scope check:**
- Files changed: 5 (limit: 5)
- Lines changed: ~109 (limit: 300)
- Breaking changes: None

---
*Tier C implementation by copilot-cli — AgentGuard three-tier governance*