### PR TITLE
fix(site): update stale numeric claims to match codebase

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,11 +24,11 @@ AgentGuard is the **Execution Control Plane for autonomous AI agents** — the i
 
 | Component | Status | Maturity |
 |-----------|--------|----------|
-| Governed action kernel (27 action types, 9 classes) | Implemented | Production |
+| Governed action kernel (41 action types, 10 classes) | Implemented | Production |
 | Action Authorization Boundary (AAB) | Implemented | Bypass vectors closed (3 fixed in v2.4.0) |
 | Policy evaluator (YAML/JSON, composition, packs) | Implemented | Production |
-| 22 built-in invariants | Implemented | Production |
-| Canonical event model (50+ event kinds) | Implemented | Production |
+| 23 built-in invariants | Implemented | Production |
+| Canonical event model (47 event kinds) | Implemented | Production |
 | Pre-execution simulation engine (3 simulators) | Implemented | Production |
 | Blast radius computation | Implemented | Production |
 | Escalation state machine (NORMAL → LOCKDOWN) | Implemented | Production |
@@ -73,7 +73,7 @@ This is the architectural hinge that transforms AgentGuard from advisory interce
 
 - [x] ~~Default-deny unknown actions~~ — ✅ Done 2026-03-24 — Evaluator defaults to `defaultDeny: true`; all 8 policy packs + starter policy updated with explicit allow rules for safe actions
 - [x] ~~Deny actions with no registered adapter~~ — Emit `ActionDenied` instead of silently skipping
-- [x] ~~Expand destructive command patterns~~ — 87 patterns (sudo, pkill, docker, systemctl, DB commands, etc.)
+- [x] ~~Expand destructive command patterns~~ — 93 patterns (sudo, pkill, docker, systemctl, DB commands, etc.)
 - [x] ~~Governance self-modification invariant~~ — Agents cannot modify `agentguard.yaml` or policies/
 - [x] ~~Path traversal prevention in file adapter~~ — ✅ Done 2026-03-21 (v2.3.0)
 - [x] ~~Enforce PAUSE and ROLLBACK~~ — ✅ Done 2026-03-18 (PRs #475, #617 — enforced kernel behaviors, not just metadata labels)

--- a/site/index.html
+++ b/site/index.html
@@ -476,7 +476,7 @@
             <div class="text-muted text-sm mt-1">Tests</div>
           </div>
           <div class="reveal">
-            <div class="font-mono font-bold text-3xl sm:text-4xl text-text counter" data-target="87">0</div>
+            <div class="font-mono font-bold text-3xl sm:text-4xl text-text counter" data-target="93">0</div>
             <div class="text-muted text-sm mt-1">Destructive Patterns</div>
           </div>
           <div class="reveal">
@@ -535,7 +535,7 @@
               <svg class="w-5 h-5 text-info" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><polyline points="9 12 11 14 15 10"/></svg>
             </div>
             <h3 class="font-mono font-semibold text-text mb-2">Production-Grade Kernel</h3>
-            <p class="text-muted text-sm leading-relaxed">Sub-millisecond evaluation latency. 23 invariants, 87 destructive patterns, tamper-evident audit chain. The reference monitor architecture enterprises require for autonomous agent deployment.</p>
+            <p class="text-muted text-sm leading-relaxed">Sub-millisecond evaluation latency. 23 invariants, 93 destructive patterns, tamper-evident audit chain. The reference monitor architecture enterprises require for autonomous agent deployment.</p>
           </div>
         </div>
       </div>
@@ -704,7 +704,7 @@
             </li>
             <li class="flex items-start gap-3">
               <svg class="w-5 h-5 text-cta mt-0.5 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
-              <span>23 built-in invariants + 87 destructive patterns detected <strong class="text-text">automatically</strong></span>
+              <span>23 built-in invariants + 93 destructive patterns detected <strong class="text-text">automatically</strong></span>
             </li>
             <li class="flex items-start gap-3">
               <svg class="w-5 h-5 text-cta mt-0.5 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
@@ -771,12 +771,12 @@
             <p class="text-muted text-sm leading-relaxed">Secret detection, credential protection, branch guards, blast radius limits, lockfile integrity, script injection, CI/CD protection, network egress control, governance self-modification prevention. Always on.</p>
           </div>
 
-          <!-- Card 2: 87 Destructive Patterns -->
+          <!-- Card 2: 93 Destructive Patterns -->
           <div class="reveal bg-surface border border-surface-light rounded-xl p-6 card-lift cursor-pointer">
             <div class="w-10 h-10 rounded-lg bg-danger/10 flex items-center justify-center mb-4">
               <svg class="w-5 h-5 text-danger" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
             </div>
-            <h3 class="font-mono font-semibold text-text mb-2">87 Destructive Patterns</h3>
+            <h3 class="font-mono font-semibold text-text mb-2">93 Destructive Patterns</h3>
             <p class="text-muted text-sm leading-relaxed">rm -rf, sudo, docker prune, DROP TABLE, pkill, systemctl&mdash;detected and classified by the AAB before execution.</p>
           </div>
 
@@ -813,7 +813,7 @@
               <svg class="w-5 h-5 text-cta" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 013 3L7 19l-4 1 1-4L16.5 3.5z"/></svg>
             </div>
             <h3 class="font-mono font-semibold text-text mb-2">Full Audit Trail</h3>
-            <p class="text-muted text-sm leading-relaxed">49 event kinds across JSONL or SQLite. Inspect, replay, export, diff, and attach evidence to PRs.</p>
+            <p class="text-muted text-sm leading-relaxed">47 event kinds across JSONL or SQLite. Inspect, replay, export, diff, and attach evidence to PRs.</p>
           </div>
 
           <!-- Card 7: Escalation System -->
@@ -939,7 +939,7 @@
             <div class="pipeline-arrow last flex-shrink-0">
               <div class="bg-surface border-2 border-cta rounded-lg px-4 py-4 text-center w-[110px]">
                 <div class="font-mono font-bold text-cta text-sm">Emit</div>
-                <div class="text-muted text-xs mt-1">49 event kinds</div>
+                <div class="text-muted text-xs mt-1">47 event kinds</div>
               </div>
             </div>
           </div>
@@ -2303,7 +2303,7 @@ rules:
       // ---- Terminal Typing Animation ----
       var terminalLines = [
         { text: '  AgentGuard Runtime Active', cls: 'text-cta', delay: 0 },
-        { text: '  policy: agentguard.yaml | invariants: 23 | patterns: 87', cls: 'text-muted', delay: 0 },
+        { text: '  policy: agentguard.yaml | invariants: 23 | patterns: 93', cls: 'text-muted', delay: 0 },
         { text: '', cls: '', delay: 300 },
         { text: '  \u2713 file.write  src/auth/service.ts', cls: 'text-cta', delay: 0 },
         { text: '  \u2713 shell.exec  npm test', cls: 'text-cta', delay: 0 },


### PR DESCRIPTION
## Summary
- **Destructive patterns**: 87 → 93 across landing page (stats bar, feature cards, terminal animation, solution section)
- **Event kinds**: 49 → 47 in features card and architecture pipeline diagram (stats bar was already correct at 47)
- **ROADMAP.md**: Updated invariant count (22 → 23), action types (27/9 → 41/10 classes), event kinds (50+ → 47), destructive patterns (87 → 93)

All numbers verified against source:
- `packages/core/src/data/destructive-patterns.json` → 93 patterns
- `packages/events/src/schema.ts` → 47 exported EventKind constants
- `packages/invariants/src/definitions.ts` → 23 invariant definitions
- `packages/core/src/data/actions.json` → 41 types across 10 classes

## Test plan
- [ ] Verify landing page stats bar shows updated numbers (93 patterns, 47 events)
- [ ] Verify features section and architecture diagram show 47 event kinds
- [ ] Verify ROADMAP current state table matches codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

`source:marketing-launch-agent`