### PR TITLE
docs(site): sync site stats with codebase

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -776,7 +776,7 @@
             <div class="w-10 h-10 rounded-lg bg-danger/10 flex items-center justify-center mb-4">
               <svg class="w-5 h-5 text-danger" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
             </div>
-            <h3 class="font-mono font-semibold text-text mb-2">87 Destructive Patterns</h3>
+            <h3 class="font-mono font-semibold text-text mb-2">93 Destructive Patterns</h3>
             <p class="text-muted text-sm leading-relaxed">rm -rf, sudo, docker prune, DROP TABLE, pkill, systemctl&mdash;detected and classified by the AAB before execution.</p>
           </div>
 
@@ -813,7 +813,7 @@
               <svg class="w-5 h-5 text-cta" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 013 3L7 19l-4 1 1-4L16.5 3.5z"/></svg>
             </div>
             <h3 class="font-mono font-semibold text-text mb-2">Full Audit Trail</h3>
-            <p class="text-muted text-sm leading-relaxed">49 event kinds across JSONL or SQLite. Inspect, replay, export, diff, and attach evidence to PRs.</p>
+            <p class="text-muted text-sm leading-relaxed">47 event kinds across JSONL or SQLite. Inspect, replay, export, diff, and attach evidence to PRs.</p>
           </div>
 
           <!-- Card 7: Escalation System -->
@@ -939,7 +939,7 @@
             <div class="pipeline-arrow last flex-shrink-0">
               <div class="bg-surface border-2 border-cta rounded-lg px-4 py-4 text-center w-[110px]">
                 <div class="font-mono font-bold text-cta text-sm">Emit</div>
-                <div class="text-muted text-xs mt-1">49 event kinds</div>
+                <div class="text-muted text-xs mt-1">47 event kinds</div>
               </div>
             </div>
           </div>
@@ -1574,7 +1574,7 @@ rules:
     <section id="cli" class="py-24" aria-labelledby="cli-heading">
       <div class="max-w-7xl mx-auto px-6">
         <div class="text-center mb-16 reveal">
-          <h2 id="cli-heading" class="font-mono font-bold text-3xl sm:text-4xl mb-4">29 CLI Commands</h2>
+          <h2 id="cli-heading" class="font-mono font-bold text-3xl sm:text-4xl mb-4">30 CLI Commands</h2>
           <p class="text-muted text-lg max-w-2xl mx-auto">Full lifecycle governance from your terminal.</p>
         </div>
 
@@ -1589,6 +1589,7 @@ rules:
               <li class="text-muted"><span class="text-text">analytics</span> &mdash; Violation patterns</li>
               <li class="text-muted"><span class="text-text">status</span> &mdash; Governance session status</li>
               <li class="text-muted"><span class="text-text">audit-verify</span> &mdash; Audit chain integrity</li>
+              <li class="text-muted"><span class="text-text">team-report</span> &mdash; Team-level observability</li>
             </ul>
           </div>
 
@@ -1638,6 +1639,8 @@ rules:
               <li class="text-muted"><span class="text-text">auto-setup</span> &mdash; Auto-detect &amp; configure</li>
               <li class="text-muted"><span class="text-text">config</span> &mdash; Show/get/set config</li>
               <li class="text-muted"><span class="text-text">init</span> &mdash; Scaffold extensions</li>
+              <li class="text-muted"><span class="text-text">trust</span> &mdash; Policy &amp; hook trust</li>
+              <li class="text-muted"><span class="text-text">telemetry</span> &mdash; Manage telemetry</li>
               <li class="text-muted"><span class="text-text">demo</span> &mdash; Interactive showcase</li>
             </ul>
           </div>


### PR DESCRIPTION
## Summary
- **CLI Commands**: 29 → 30 — added missing `trust`, `team-report`, `telemetry` commands to the CLI section
- **Destructive Patterns**: 87 → 93 — synced with `packages/core/src/data/destructive-patterns.json`
- **Event Kinds**: 49 → 47 — synced with `packages/events/src/schema.ts` (47 `EventKind` constants)

## Known remaining drift (requires section redesign)
The **Swarm section** shows "26 agents across 5 tiers" with 5 conceptual tier cards (Core, Governance, Ops, Quality, Marketing). The actual squad manifest (`.agentguard/squad-manifest.yaml`) now has **49 agents across 8 squads** with a rank-based structure (director, em, product-lead, architect, senior, junior, qa). Updating the stat numbers alone would conflict with the tier cards and architecture diagram — a full section redesign is needed.

## Verified as accurate (no changes needed)
- Invariants: 23 ✓
- Action types: 41 across 10 classes ✓
- Policy packs: 8 ✓

## Test plan
- [ ] Verify site renders correctly at `site/index.html`
- [ ] Confirm CLI section heading reads "30 CLI Commands"
- [ ] Confirm `trust`, `team-report`, `telemetry` appear in the CLI command listing
- [ ] Confirm "93 Destructive Patterns" in Features section
- [ ] Confirm "47 event kinds" in Features and Architecture sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)