### PR TITLE
fix(site): update invariant count (23→24) and CLI commands (29→32)

### DIFF
--- a/.agentguard/squads/site/em-report.json
+++ b/.agentguard/squads/site/em-report.json
@@ -1,0 +1,51 @@
+{
+  "squad": "site",
+  "timestamp": "2026-03-26T20:40:00.000Z",
+  "health": "green",
+  "summary": "Site healthy. Fixed invariant count drift (23→24) and CLI commands count (29→32) after recent codebase changes. No open issues or PRs. OG image and meta tags intact after recent PR #1011 fix.",
+  "siteBuild": {
+    "status": "pass",
+    "notes": "Static site structure valid: index.html, posts.html, posts.json, sitemap.xml, robots.txt, og-image.png all present and well-formed."
+  },
+  "contentFreshness": {
+    "status": "fixed",
+    "drift": [
+      {
+        "claim": "invariants count",
+        "was": 23,
+        "now": 24,
+        "cause": "PR #1002 added no-verify-bypass invariant",
+        "fixed": true
+      },
+      {
+        "claim": "CLI commands count",
+        "was": 29,
+        "now": 32,
+        "cause": "New commands added since last site sync",
+        "fixed": true
+      }
+    ],
+    "verified": [
+      "93 destructive patterns — matches codebase",
+      "47 event kinds — matches codebase",
+      "41 action types — matches codebase"
+    ]
+  },
+  "prQueue": {
+    "open": 0,
+    "reviewed": 0,
+    "merged": [
+      "#1015 — marketing EM report",
+      "#1011 — OG image PNG + social meta tags",
+      "#1009 — site stats sync",
+      "#1005 — stale numeric claims fix"
+    ]
+  },
+  "blockers": [],
+  "escalations": [],
+  "governanceDenials": 0,
+  "nextActions": [
+    "Open PR for invariant + CLI command count fix",
+    "Monitor for further invariant additions that cause site drift"
+  ]
+}

--- a/.agentguard/squads/site/state.json
+++ b/.agentguard/squads/site/state.json
@@ -1,15 +1,15 @@
 {
   "squad": "site",
   "sprint": {
-    "goal": "",
+    "goal": "Keep site numeric claims in sync with codebase",
     "issues": []
   },
   "assignments": {},
   "blockers": [],
   "prQueue": {
-    "open": 0,
+    "open": 1,
     "reviewed": 0,
     "mergeable": 0
   },
-  "updatedAt": "2026-03-25T00:00:00.000Z"
+  "updatedAt": "2026-03-26T20:40:00.000Z"
 }

--- a/site/index.html
+++ b/site/index.html
@@ -5,11 +5,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="google-site-verification" content="OeJuCct5Y8LRHQB95DkF5Y9hwUvZIvtYrpKy16x3o28" />
   <title>AgentGuard — Run AI Agents Without Fear</title>
-  <meta name="description" content="AgentGuard — default-deny governance for AI coding agents. 23 invariants, four enforcement modes, tamper-evident audit trail. Install in 30 seconds.">
+  <meta name="description" content="AgentGuard — default-deny governance for AI coding agents. 24 invariants, four enforcement modes, tamper-evident audit trail. Install in 30 seconds.">
 
   <!-- OpenGraph -->
   <meta property="og:title" content="AgentGuard — Run AI Agents Without Fear">
-  <meta property="og:description" content="Default-deny governance for AI coding agents. 23 invariants, four enforcement modes (monitor, educate, guide, enforce), tamper-evident audit trail. Install in 30 seconds.">
+  <meta property="og:description" content="Default-deny governance for AI coding agents. 24 invariants, four enforcement modes (monitor, educate, guide, enforce), tamper-evident audit trail. Install in 30 seconds.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://agentguardhq.github.io/agentguard/">
   <meta property="og:image" content="https://agentguardhq.github.io/agentguard/og-image.png">
@@ -32,7 +32,7 @@
     "name": "AgentGuard",
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "Windows, macOS, Linux",
-    "description": "AgentGuard — default-deny governance for AI coding agents. 23 invariants, four enforcement modes, tamper-evident audit trail.",
+    "description": "AgentGuard — default-deny governance for AI coding agents. 24 invariants, four enforcement modes, tamper-evident audit trail.",
     "url": "https://agentguardhq.github.io/agentguard/",
     "offers": {
       "@type": "Offer",
@@ -435,7 +435,7 @@
             Run AI Agents <span class="text-cta">Without Fear</span>
           </h1>
           <p class="text-muted text-lg leading-relaxed mb-8 max-w-xl">
-            Your AI agents can't push to main, leak credentials, or destroy your repo. 23 built-in safety checks block catastrophic actions before they execute. Install in 30 seconds. Sleep at night.
+            Your AI agents can't push to main, leak credentials, or destroy your repo. 24 built-in safety checks block catastrophic actions before they execute. Install in 30 seconds. Sleep at night.
           </p>
           <div class="flex flex-wrap gap-4">
             <a href="#quickstart" class="bg-cta hover:bg-cta-dark text-bg font-semibold px-6 py-3 rounded-lg transition-colors text-sm inline-flex items-center gap-2 cursor-pointer">
@@ -492,11 +492,11 @@
             <div class="text-muted text-sm mt-1">Action Types</div>
           </div>
           <div class="reveal">
-            <div class="font-mono font-bold text-3xl sm:text-4xl text-text counter" data-target="23">0</div>
+            <div class="font-mono font-bold text-3xl sm:text-4xl text-text counter" data-target="24">0</div>
             <div class="text-muted text-sm mt-1">Invariants</div>
           </div>
           <div class="reveal">
-            <div class="font-mono font-bold text-3xl sm:text-4xl text-text counter" data-target="29">0</div>
+            <div class="font-mono font-bold text-3xl sm:text-4xl text-text counter" data-target="32">0</div>
             <div class="text-muted text-sm mt-1">CLI Commands</div>
           </div>
         </div>
@@ -539,7 +539,7 @@
               <svg class="w-5 h-5 text-info" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><polyline points="9 12 11 14 15 10"/></svg>
             </div>
             <h3 class="font-mono font-semibold text-text mb-2">Production-Grade Kernel</h3>
-            <p class="text-muted text-sm leading-relaxed">Sub-millisecond evaluation latency. 23 invariants, 93 destructive patterns, tamper-evident audit chain. The reference monitor architecture enterprises require for autonomous agent deployment.</p>
+            <p class="text-muted text-sm leading-relaxed">Sub-millisecond evaluation latency. 24 invariants, 93 destructive patterns, tamper-evident audit chain. The reference monitor architecture enterprises require for autonomous agent deployment.</p>
           </div>
         </div>
       </div>
@@ -708,7 +708,7 @@
             </li>
             <li class="flex items-start gap-3">
               <svg class="w-5 h-5 text-cta mt-0.5 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
-              <span>23 built-in invariants + 93 destructive patterns detected <strong class="text-text">automatically</strong></span>
+              <span>24 built-in invariants + 93 destructive patterns detected <strong class="text-text">automatically</strong></span>
             </li>
             <li class="flex items-start gap-3">
               <svg class="w-5 h-5 text-cta mt-0.5 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
@@ -2310,7 +2310,7 @@ rules:
       // ---- Terminal Typing Animation ----
       var terminalLines = [
         { text: '  AgentGuard Runtime Active', cls: 'text-cta', delay: 0 },
-        { text: '  policy: agentguard.yaml | invariants: 23 | patterns: 93', cls: 'text-muted', delay: 0 },
+        { text: '  policy: agentguard.yaml | invariants: 24 | patterns: 93', cls: 'text-muted', delay: 0 },
         { text: '', cls: '', delay: 300 },
         { text: '  \u2713 file.write  src/auth/service.ts', cls: 'text-cta', delay: 0 },
         { text: '  \u2713 shell.exec  npm test', cls: 'text-cta', delay: 0 },


### PR DESCRIPTION
## Summary
- **Invariants**: 23 → 24 (drifted after #1002 added `no-verify-bypass`)
- **CLI Commands**: 29 → 32 (new commands added since last site sync)
- Updated all occurrences: meta tags, OG tags, JSON-LD, hero text, counters, feature card, terminal demo
- Verified remaining claims match codebase: 93 destructive patterns, 47 event kinds, 41 action types

## Test plan
- [ ] Verify site renders correctly with updated counters
- [ ] Check meta tags show "24 invariants" in page source
- [ ] Confirm OG preview shows correct description

🤖 Generated with [Claude Code](https://claude.com/claude-code)