### PR TITLE
feat: add OpenCode as a supported agent driver

### DIFF
--- a/apps/cli/src/commands/claude-init.ts
+++ b/apps/cli/src/commands/claude-init.ts
@@ -434,7 +434,7 @@ export async function claudeInit(args: string[] = []): Promise<void> {
 
 At session start, if you see \`[AgentGuard] No agent identity set\`, ask the user:
 1. **Role**: developer / reviewer / ops / security / planner
-2. **Driver**: human / claude-code / copilot / ci
+2. **Driver**: human / claude-code / copilot / opencode / ci
 
 Then run: \`scripts/write-persona.sh <driver> <role>\`
 `;

--- a/apps/cli/src/identity.ts
+++ b/apps/cli/src/identity.ts
@@ -1,14 +1,15 @@
 import { execFileSync } from 'node:child_process';
 
-export type Driver = 'human' | 'claude-code' | 'copilot' | 'ci';
+export type Driver = 'human' | 'claude-code' | 'copilot' | 'opencode' | 'ci';
 export type Role = 'developer' | 'reviewer' | 'ops' | 'security' | 'planner';
 
-export const VALID_DRIVERS: Driver[] = ['human', 'claude-code', 'copilot', 'ci'];
+export const VALID_DRIVERS: Driver[] = ['human', 'claude-code', 'copilot', 'opencode', 'ci'];
 export const VALID_ROLES: Role[] = ['developer', 'reviewer', 'ops', 'security', 'planner'];
 
 export function detectDriver(): Driver {
   if (process.env.GITHUB_ACTIONS === 'true') return 'ci';
   if (process.env.COPILOT_AGENT) return 'copilot';
+  if (process.env.OPENCODE_HOME) return 'opencode';
   if (process.env.CLAUDE_MODEL) return 'claude-code';
   return 'human';
 }

--- a/apps/cli/src/templates/scripts.ts
+++ b/apps/cli/src/templates/scripts.ts
@@ -71,7 +71,7 @@ export const WRITE_PERSONA = `#!/usr/bin/env bash
 # write-persona.sh — Writes .agentguard/persona.env for session identity
 # Usage: scripts/write-persona.sh <driver> <role> [trust-tier] [autonomy]
 #
-# driver: human | claude-code | copilot | ci
+# driver: human | claude-code | copilot | opencode | ci
 # role:   developer | reviewer | ops | security | planner
 
 set -euo pipefail
@@ -84,6 +84,7 @@ case "\$DRIVER" in
   human)       DEFAULT_TRUST="standard"; DEFAULT_AUTONOMY="supervised" ;;
   claude-code) DEFAULT_TRUST="standard"; DEFAULT_AUTONOMY="semi-autonomous" ;;
   copilot)     DEFAULT_TRUST="limited";  DEFAULT_AUTONOMY="semi-autonomous" ;;
+  opencode)    DEFAULT_TRUST="standard"; DEFAULT_AUTONOMY="semi-autonomous" ;;
   ci)          DEFAULT_TRUST="standard"; DEFAULT_AUTONOMY="autonomous" ;;
   *)           DEFAULT_TRUST="standard"; DEFAULT_AUTONOMY="supervised" ;;
 esac
@@ -114,13 +115,15 @@ esac
 # Derive provider from model/driver
 PROVIDER="anthropic"
 case "\$DRIVER" in
-  copilot) PROVIDER="github" ;;
+  copilot)  PROVIDER="github" ;;
+  opencode) PROVIDER="opencode" ;;
 esac
 
 RUNTIME="claude-code"
 case "\$DRIVER" in
-  copilot) RUNTIME="copilot" ;;
-  ci)      RUNTIME="github-actions" ;;
+  copilot)  RUNTIME="copilot" ;;
+  opencode) RUNTIME="opencode" ;;
+  ci)       RUNTIME="github-actions" ;;
 esac
 
 # Ensure directory exists
@@ -163,7 +166,7 @@ echo "[AgentGuard] No agent identity set for this session."
 echo "Project: \$PROJECT | Model: \$MODEL"
 echo "Please ask the user:"
 echo "  1. What role are you working in? (developer / reviewer / ops / security / planner)"
-echo "  2. Who is driving this session? (human / claude-code / copilot / ci)"
+echo "  2. Who is driving this session? (human / claude-code / copilot / opencode / ci)"
 echo "Then run: scripts/write-persona.sh <driver> <role>"
 exit 0
 `;

--- a/apps/cli/tests/identity.test.ts
+++ b/apps/cli/tests/identity.test.ts
@@ -20,13 +20,23 @@ describe('detectDriver', () => {
   it('returns claude-code when CLAUDE_MODEL is set', () => {
     delete process.env.GITHUB_ACTIONS;
     delete process.env.COPILOT_AGENT;
+    delete process.env.OPENCODE_HOME;
     process.env.CLAUDE_MODEL = 'claude-opus-4-6';
     expect(detectDriver()).toBe('claude-code');
+  });
+
+  it('returns opencode when OPENCODE_HOME is set', () => {
+    delete process.env.GITHUB_ACTIONS;
+    delete process.env.COPILOT_AGENT;
+    delete process.env.CLAUDE_MODEL;
+    process.env.OPENCODE_HOME = '/home/user/.opencode';
+    expect(detectDriver()).toBe('opencode');
   });
 
   it('returns human as fallback', () => {
     delete process.env.GITHUB_ACTIONS;
     delete process.env.COPILOT_AGENT;
+    delete process.env.OPENCODE_HOME;
     delete process.env.CLAUDE_MODEL;
     expect(detectDriver()).toBe('human');
   });

--- a/scripts/write-persona.sh
+++ b/scripts/write-persona.sh
@@ -15,6 +15,7 @@ case "$DRIVER" in
   human)       DEFAULT_TRUST="standard"; DEFAULT_AUTONOMY="supervised" ;;
   claude-code) DEFAULT_TRUST="standard"; DEFAULT_AUTONOMY="semi-autonomous" ;;
   copilot)     DEFAULT_TRUST="limited";  DEFAULT_AUTONOMY="semi-autonomous" ;;
+  opencode)    DEFAULT_TRUST="standard"; DEFAULT_AUTONOMY="semi-autonomous" ;;
   ci)          DEFAULT_TRUST="standard"; DEFAULT_AUTONOMY="autonomous" ;;
   *)           DEFAULT_TRUST="standard"; DEFAULT_AUTONOMY="supervised" ;;
 esac
@@ -45,13 +46,15 @@ esac
 # Derive provider from model/driver
 PROVIDER="anthropic"
 case "$DRIVER" in
-  copilot) PROVIDER="github" ;;
+  copilot)  PROVIDER="github" ;;
+  opencode) PROVIDER="opencode" ;;
 esac
 
 RUNTIME="claude-code"
 case "$DRIVER" in
-  copilot) RUNTIME="copilot" ;;
-  ci)      RUNTIME="github-actions" ;;
+  copilot)  RUNTIME="copilot" ;;
+  opencode) RUNTIME="opencode" ;;
+  ci)       RUNTIME="github-actions" ;;
 esac
 
 # Ensure directory exists


### PR DESCRIPTION
Closes #1014

## Implementation Summary

**What changed:**
- Added `opencode` to the `Driver` type union and `VALID_DRIVERS` array in `apps/cli/src/identity.ts`
- Added auto-detection via `OPENCODE_HOME` env var in `detectDriver()`
- Added `opencode` case branches in `scripts/write-persona.sh` (trust: standard, autonomy: semi-autonomous, provider: opencode, runtime: opencode)
- Updated embedded shell templates in `apps/cli/src/templates/scripts.ts` (WRITE_PERSONA + SESSION_PERSONA_CHECK)
- Updated help text in `apps/cli/src/commands/claude-init.ts` to list opencode as a driver option
- Added test for opencode detection in `apps/cli/tests/identity.test.ts`

**Trust/autonomy profile:** Mirrors `claude-code` (standard trust, semi-autonomous) since OpenCode is also an AI coding agent. Provider and runtime set to `opencode`.

**How to verify:**
1. `pnpm build` — builds clean
2. `pnpm test --filter=@red-codes/agentguard` — 814 tests pass (including new opencode detection test)
3. `OPENCODE_HOME=/tmp node -e "process.env.OPENCODE_HOME='/tmp'; import('./apps/cli/dist/identity.js').then(m => console.log(m.detectDriver()))"` returns `opencode`
4. `scripts/write-persona.sh opencode developer` writes correct persona env

**Out of scope (follow-up):**
- OpenCode-specific adapter (`packages/adapters/src/opencode.ts`) — needs OpenCode hook protocol details
- CLI commands (`opencode-init`, `opencode-hook`)
- Swarm `AgentDriver` type expansion

**Tier C scope check:**
- Files changed: 5 (limit: 5)
- Lines changed: ~28 (limit: 300)
- Breaking changes: None

---
*Tier C implementation by copilot-cli — AgentGuard three-tier governance*