### PR TITLE
fix(site): update stale counts and add OpenCode driver

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -736,6 +736,11 @@
             <svg class="w-6 h-6 text-text" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
             <span class="font-mono text-text text-sm font-medium">GitHub Copilot</span>
           </div>
+          <!-- OpenCode -->
+          <div class="reveal flex items-center gap-2.5 opacity-70 hover:opacity-100 transition-opacity">
+            <svg class="w-6 h-6 text-text" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>
+            <span class="font-mono text-text text-sm font-medium">OpenCode</span>
+          </div>
           <!-- VS Code -->
           <div class="reveal flex items-center gap-2.5 opacity-70 hover:opacity-100 transition-opacity">
             <svg class="w-6 h-6 text-text" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
@@ -771,7 +776,7 @@
             <div class="w-10 h-10 rounded-lg bg-cta/10 flex items-center justify-center mb-4">
               <svg class="w-5 h-5 text-cta" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
             </div>
-            <h3 class="font-mono font-semibold text-text mb-2">23 Safety Invariants</h3>
+            <h3 class="font-mono font-semibold text-text mb-2">24 Safety Invariants</h3>
             <p class="text-muted text-sm leading-relaxed">Secret detection, credential protection, branch guards, blast radius limits, lockfile integrity, script injection, CI/CD protection, network egress control, governance self-modification prevention. Always on.</p>
           </div>
 
@@ -844,7 +849,7 @@
               <svg class="w-5 h-5 text-info" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M20 21v-2a4 4 0 00-4-4H8a4 4 0 00-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
             </div>
             <h3 class="font-mono font-semibold text-text mb-2">Agent Identity</h3>
-            <p class="text-muted text-sm leading-relaxed">Declare agent role (developer, reviewer, ops, security) and driver (human, claude-code, copilot, ci). Identity flows to telemetry, persona-scoped policies, and cloud dashboard.</p>
+            <p class="text-muted text-sm leading-relaxed">Declare agent role (developer, reviewer, ops, security) and driver (human, claude-code, copilot, opencode, ci). Identity flows to telemetry, persona-scoped policies, and cloud dashboard.</p>
           </div>
 
 
@@ -919,7 +924,7 @@
             <div class="pipeline-arrow flex-shrink-0">
               <div class="bg-surface border-2 border-warning rounded-lg px-4 py-4 text-center w-[110px]">
                 <div class="font-mono font-bold text-warning text-sm">Invariants</div>
-                <div class="text-muted text-xs mt-1">23 safety checks</div>
+                <div class="text-muted text-xs mt-1">24 safety checks</div>
               </div>
             </div>
 
@@ -1046,7 +1051,7 @@
               </tbody>
             </table>
           </div>
-          <p class="text-muted/70 text-xs mt-4">Agents get 8% more productive time per session. Ships automatically via <code class="text-text/60">npm install</code> &mdash; a postinstall script downloads the prebuilt binary for your platform. Works with both Claude Code and GitHub Copilot hooks.</p>
+          <p class="text-muted/70 text-xs mt-4">Agents get 8% more productive time per session. Ships automatically via <code class="text-text/60">npm install</code> &mdash; a postinstall script downloads the prebuilt binary for your platform. Works with Claude Code, GitHub Copilot, and OpenCode hooks.</p>
         </div>
       </div>
     </section>
@@ -1057,7 +1062,7 @@
     <section id="invariants" class="py-24" aria-labelledby="inv-heading">
       <div class="max-w-7xl mx-auto px-6">
         <div class="text-center mb-16 reveal">
-          <h2 id="inv-heading" class="font-mono font-bold text-3xl sm:text-4xl mb-4">23 Built-in Invariants</h2>
+          <h2 id="inv-heading" class="font-mono font-bold text-3xl sm:text-4xl mb-4">24 Built-in Invariants</h2>
           <p class="text-muted text-lg max-w-2xl mx-auto">Safety checks that run on every action. Zero configuration. Always on.</p>
         </div>
 
@@ -1185,6 +1190,11 @@
                 <td class="py-3 px-4 font-mono text-text">script-execution-tracking</td>
                 <td class="py-3 px-4"><span class="sev-high text-xs font-mono font-semibold px-2 py-0.5 rounded">HIGH</span></td>
                 <td class="py-3 px-4 text-muted">Prevents governance bypass via write-then-execute indirection</td>
+              </tr>
+              <tr>
+                <td class="py-3 px-4 font-mono text-text">no-verify-bypass</td>
+                <td class="py-3 px-4"><span class="sev-high text-xs font-mono font-semibold px-2 py-0.5 rounded">HIGH</span></td>
+                <td class="py-3 px-4 text-muted">Forbids --no-verify flag on git push/commit to prevent skipping hooks</td>
               </tr>
             </tbody>
           </table>
@@ -1578,7 +1588,7 @@ rules:
     <section id="cli" class="py-24" aria-labelledby="cli-heading">
       <div class="max-w-7xl mx-auto px-6">
         <div class="text-center mb-16 reveal">
-          <h2 id="cli-heading" class="font-mono font-bold text-3xl sm:text-4xl mb-4">30 CLI Commands</h2>
+          <h2 id="cli-heading" class="font-mono font-bold text-3xl sm:text-4xl mb-4">32 CLI Commands</h2>
           <p class="text-muted text-lg max-w-2xl mx-auto">Full lifecycle governance from your terminal.</p>
         </div>
 
@@ -1872,6 +1882,19 @@ rules:
             <div class="flex flex-wrap gap-2">
               <span class="text-xs font-mono text-muted bg-surface-light/50 px-2 py-1 rounded">preToolUse</span>
               <span class="text-xs font-mono text-muted bg-surface-light/50 px-2 py-1 rounded">postToolUse</span>
+            </div>
+          </div>
+
+          <!-- OpenCode -->
+          <div class="reveal bg-surface border border-surface-light rounded-xl p-8 card-lift cursor-pointer">
+            <div class="w-12 h-12 rounded-xl bg-cta/10 flex items-center justify-center mb-5">
+              <svg class="w-6 h-6 text-cta" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>
+            </div>
+            <h3 class="font-mono font-bold text-text text-lg mb-2">OpenCode</h3>
+            <p class="text-muted text-sm leading-relaxed mb-4">Full governance support for OpenCode CLI. Auto-detected via <code class="text-xs text-cta">OPENCODE_HOME</code> environment variable. Same policies, same invariants, same audit trail.</p>
+            <div class="flex flex-wrap gap-2">
+              <span class="text-xs font-mono text-muted bg-surface-light/50 px-2 py-1 rounded">Auto-detected</span>
+              <span class="text-xs font-mono text-muted bg-surface-light/50 px-2 py-1 rounded">Hook integration</span>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- Update invariant count from 23 → 24 in features card, architecture pipeline, and invariants section heading; add missing `no-verify-bypass` invariant row to the table
- Update CLI commands count from 30 → 32 in CLI section heading (stats bar was already correct)
- Add OpenCode as a supported integration: "Works with" bar, Integrations section card, Agent Identity driver list, and Go Kernel performance footnote

## Context
Recent commits added a 24th invariant (`no-verify-bypass`) and the OpenCode driver (#1014), but the site content was not updated to reflect these additions. The stats bar counters (24 invariants, 32 CLI commands) were already correct from a prior fix, but inline references and section headings were stale.

## Test plan
- [ ] Verify `site/index.html` renders correctly in a browser
- [ ] Confirm invariant table shows 24 rows
- [ ] Confirm OpenCode appears in "Works with", Integrations, and Agent Identity sections
- [ ] Confirm CLI section heading says "32 CLI Commands"

🤖 Generated with [Claude Code](https://claude.com/claude-code)