### PR TITLE
docs: sync site and docs with codebase counts

### DIFF
--- a/docs/autonomous-sdlc-methodology.md
+++ b/docs/autonomous-sdlc-methodology.md
@@ -7,7 +7,7 @@ AgentGuard — a 70,000-line, 20-package governed action runtime — was built i
 **Key metrics:**
 - 33,668 lines of production TypeScript, 39,160 lines of tests
 - 20 workspace packages, 3 applications (CLI, VS Code extension, telemetry server)
-- 142 test files, 17 invariants, 49 event types, 23 action types
+- 142 test files, 24 invariants, 47 event kinds, 41 action types
 - Equivalent to 240 story points / 6-8 months of traditional senior engineering
 - Delivered in <2 weeks by one person with an autonomous agent swarm
 

--- a/docs/hook-architecture.md
+++ b/docs/hook-architecture.md
@@ -107,7 +107,7 @@ AAB normalization (Bash → shell.exec or git.push, Write → file.write, etc.)
   ↓
 Policy evaluation (match rules from agentguard.yaml)
   ↓
-Invariant checks (17 built-in safety checks)
+Invariant checks (24 built-in safety checks)
   ↓
 Decision: ALLOW or DENY
   ↓

--- a/docs/owasp-agentic-top10-coverage.md
+++ b/docs/owasp-agentic-top10-coverage.md
@@ -1,6 +1,6 @@
 # OWASP Agentic Top 10 Coverage — AgentGuard
 
-> Audit date: 2026-03-25 | AgentGuard kernel: 22 invariants, 27 action types, 95+ command patterns
+> Audit date: 2026-03-25 | AgentGuard kernel: 24 invariants, 41 action types, 95+ command patterns
 
 ## Coverage Summary
 
@@ -49,7 +49,7 @@
 
 | Mechanism | Component | What It Does |
 |-----------|-----------|-------------|
-| Canonical action types | `packages/core/src/actions.ts` | 27 types across 9 classes with strict hierarchy |
+| Canonical action types | `packages/core/src/actions.ts` | 41 types across 10 classes with strict hierarchy |
 | Execution adapters | `packages/adapters/src/*.ts` | Separate handlers for file, shell, git, claude-code, copilot-cli |
 | Hook integrity | `packages/adapters/src/hook-integrity.ts` | Validates hook signatures and settings before execution |
 | Execution failure events | `ACTION_FAILED` event kind | All failures emit audit events |
@@ -220,7 +220,7 @@
 |----------|-----------|------------------------|
 | Prompt Injection | Moderate (detect + block destructive) | Claimed 10/10 |
 | Insecure Tool Impl | Strong (typed actions, adapters) | Claimed 10/10 |
-| Excessive Agency | Strong (22 invariants, escalation) | Claimed 10/10 |
+| Excessive Agency | Strong (24 invariants, escalation) | Claimed 10/10 |
 | Insecure Output | Weak (PII/secret detection only) | Claimed 10/10 |
 | Inadequate Sandboxing | Minimal (no OS isolation) | Claimed 10/10 |
 | Implicit Trust | Strong (crypto trust chain) | Claimed 10/10 |

--- a/docs/roadmap-overview.md
+++ b/docs/roadmap-overview.md
@@ -22,11 +22,11 @@ AgentGuard is the **mandatory execution control plane for AI agents** — the ru
 
 | Component | Status | Maturity |
 |-----------|--------|----------|
-| Governed action kernel (27 action types, 9 classes) | Implemented | Production |
+| Governed action kernel (41 action types, 10 classes) | Implemented | Production |
 | Action Authorization Boundary (AAB) | Implemented | Bypass vectors closed (3 fixed in v2.4.0) |
 | Policy evaluator (YAML/JSON, composition, packs) | Implemented | Production |
-| 21 built-in invariants | Implemented | Production |
-| Canonical event model (50+ event kinds) | Implemented | Production |
+| 24 built-in invariants | Implemented | Production |
+| Canonical event model (47 event kinds) | Implemented | Production |
 | Pre-execution simulation engine (3 simulators) | Implemented | Production |
 | Blast radius computation | Implemented | Production |
 | Escalation state machine (NORMAL → LOCKDOWN) | Implemented | Production |

--- a/docs/unified-architecture.md
+++ b/docs/unified-architecture.md
@@ -129,8 +129,8 @@ Pure domain logic with no environment dependencies.
 
 | Component | File | Responsibility |
 |-----------|------|----------------|
-| Canonical actions | `packages/core/src/actions.ts` | 23 action types, 8 classes |
-| Canonical events | `packages/events/src/schema.ts` | 50+ event kinds, factory, validation |
+| Canonical actions | `packages/core/src/actions.ts` | 41 action types, 10 classes |
+| Canonical events | `packages/events/src/schema.ts` | 47 event kinds, factory, validation |
 | Reference monitor | `packages/kernel/src/decision.ts` | Action authorization with decision trail |
 | Adapter registry | `packages/adapters/src/registry.ts` | Action class → handler mapping |
 | Event store | `packages/events/src/store.ts` | In-memory event persistence |

--- a/site/index.html
+++ b/site/index.html
@@ -771,7 +771,7 @@
             <div class="w-10 h-10 rounded-lg bg-cta/10 flex items-center justify-center mb-4">
               <svg class="w-5 h-5 text-cta" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
             </div>
-            <h3 class="font-mono font-semibold text-text mb-2">23 Safety Invariants</h3>
+            <h3 class="font-mono font-semibold text-text mb-2">24 Safety Invariants</h3>
             <p class="text-muted text-sm leading-relaxed">Secret detection, credential protection, branch guards, blast radius limits, lockfile integrity, script injection, CI/CD protection, network egress control, governance self-modification prevention. Always on.</p>
           </div>
 
@@ -1057,7 +1057,7 @@
     <section id="invariants" class="py-24" aria-labelledby="inv-heading">
       <div class="max-w-7xl mx-auto px-6">
         <div class="text-center mb-16 reveal">
-          <h2 id="inv-heading" class="font-mono font-bold text-3xl sm:text-4xl mb-4">23 Built-in Invariants</h2>
+          <h2 id="inv-heading" class="font-mono font-bold text-3xl sm:text-4xl mb-4">24 Built-in Invariants</h2>
           <p class="text-muted text-lg max-w-2xl mx-auto">Safety checks that run on every action. Zero configuration. Always on.</p>
         </div>
 
@@ -1185,6 +1185,11 @@
                 <td class="py-3 px-4 font-mono text-text">script-execution-tracking</td>
                 <td class="py-3 px-4"><span class="sev-high text-xs font-mono font-semibold px-2 py-0.5 rounded">HIGH</span></td>
                 <td class="py-3 px-4 text-muted">Prevents governance bypass via write-then-execute indirection</td>
+              </tr>
+              <tr>
+                <td class="py-3 px-4 font-mono text-text">no-verify-bypass</td>
+                <td class="py-3 px-4"><span class="sev-high text-xs font-mono font-semibold px-2 py-0.5 rounded">HIGH</span></td>
+                <td class="py-3 px-4 text-muted">Forbids --no-verify flag on git push/commit to prevent skipping hooks</td>
               </tr>
             </tbody>
           </table>
@@ -1578,7 +1583,7 @@ rules:
     <section id="cli" class="py-24" aria-labelledby="cli-heading">
       <div class="max-w-7xl mx-auto px-6">
         <div class="text-center mb-16 reveal">
-          <h2 id="cli-heading" class="font-mono font-bold text-3xl sm:text-4xl mb-4">30 CLI Commands</h2>
+          <h2 id="cli-heading" class="font-mono font-bold text-3xl sm:text-4xl mb-4">32 CLI Commands</h2>
           <p class="text-muted text-lg max-w-2xl mx-auto">Full lifecycle governance from your terminal.</p>
         </div>
 
@@ -1637,7 +1642,9 @@ rules:
             <h3 class="font-mono font-semibold text-cta text-xs uppercase tracking-wider mb-3">Setup &amp; Integration</h3>
             <ul class="space-y-2 text-sm font-mono">
               <li class="text-muted"><span class="text-text">claude-init</span> &mdash; Claude Code hooks</li>
+              <li class="text-muted"><span class="text-text">claude-hook</span> &mdash; Claude Code hook handler</li>
               <li class="text-muted"><span class="text-text">copilot-init</span> &mdash; GitHub Copilot hooks</li>
+              <li class="text-muted"><span class="text-text">copilot-hook</span> &mdash; Copilot hook handler</li>
               <li class="text-muted"><span class="text-text">cloud login</span> &mdash; Device code auth (browser OAuth)</li>
               <li class="text-muted"><span class="text-text">cloud events/runs</span> &mdash; Query cloud data</li>
               <li class="text-muted"><span class="text-text">auto-setup</span> &mdash; Auto-detect &amp; configure</li>


### PR DESCRIPTION
## Summary
- **Invariants**: Updated stale counts (17/21/22/23 → 24) across 5 docs and site; added missing `no-verify-bypass` to invariant table
- **Action types**: Updated stale counts (23/27 across 8/9 classes → 41 across 10 classes) in 4 docs
- **Event kinds**: Updated stale counts (49/50+ → 47) in 3 docs
- **CLI commands**: Updated site heading (30 → 32); added missing `claude-hook` and `copilot-hook` to CLI section

## Files changed
| File | Changes |
|------|---------|
| `site/index.html` | Invariant heading 23→24, CLI heading 30→32, added no-verify-bypass row, added claude-hook/copilot-hook |
| `docs/unified-architecture.md` | Actions 23/8→41/10, events 50+→47 |
| `docs/roadmap-overview.md` | Actions 27/9→41/10, invariants 21→24, events 50+→47 |
| `docs/owasp-agentic-top10-coverage.md` | Invariants 22→24, actions 27/9→41/10 |
| `docs/autonomous-sdlc-methodology.md` | Invariants 17→24, events 49→47, actions 23→41 |
| `docs/hook-architecture.md` | Invariants 17→24 |

## Test plan
- [ ] Verify site/index.html renders correctly (invariant table, CLI section)
- [ ] Confirm all numeric claims match `packages/invariants/src/definitions.ts` (24), `packages/core/src/data/actions.json` (41/10), `packages/events/src/schema.ts` (47), and `apps/cli/src/bin.ts` (32)

🤖 Generated with [Claude Code](https://claude.com/claude-code)