### PR TITLE
fix(site): remove placeholder demo video section from landing page

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -545,30 +545,7 @@
       </div>
     </section>
 
-    <!-- ============================================ -->
-    <!-- DEMO VIDEO                                    -->
-    <!-- ============================================ -->
-    <section id="demo" class="py-24 border-b border-surface-light" aria-labelledby="demo-heading">
-      <div class="max-w-4xl mx-auto px-6">
-        <div class="text-center mb-12 reveal">
-          <h2 id="demo-heading" class="font-mono font-bold text-3xl sm:text-4xl mb-4">See It In Action</h2>
-          <p class="text-muted text-lg max-w-2xl mx-auto">Install, configure a policy, run a governed session, and view the Cloud dashboard &mdash; in 30 seconds.</p>
-        </div>
-
-        <div class="reveal">
-          <div class="relative bg-surface border border-surface-light rounded-xl overflow-hidden aspect-video flex items-center justify-center glow-green" id="demo-video-container">
-            <!-- Placeholder: replace with video embed when recorded -->
-            <div class="text-center p-8">
-              <div class="w-16 h-16 rounded-full bg-cta/10 flex items-center justify-center mx-auto mb-4">
-                <svg class="w-8 h-8 text-cta" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><polygon points="5 3 19 12 5 21 5 3"/></svg>
-              </div>
-              <p class="font-mono text-muted text-sm">Demo video coming soon</p>
-              <p class="text-muted text-xs mt-2">npm install &rarr; agentguard.yaml &rarr; governed session &rarr; Cloud dashboard</p>
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
+    <!-- Demo video section: hidden until recorded (see #1007) -->
 
     <!-- ============================================ -->
     <!-- WHAT IT PREVENTS                             -->


### PR DESCRIPTION
Closes #1007

## Implementation Summary

**What changed:**
- Removed the "See It In Action" demo video section from `site/index.html` that displayed a "Demo video coming soon" placeholder
- Left an HTML comment marking the spot so it's easy to restore when a real video is recorded

**Why:**
The placeholder signals the product isn't ready, which works against the launch narrative. Per the issue, option 2 (remove until video is ready) is the safest approach.

**How to verify:**
1. Open `site/index.html` in a browser
2. Confirm the "Demo video coming soon" placeholder is gone
3. Confirm the page flows from the "How It Works" section directly to "What AgentGuard Prevents"

**Tier C scope check:**
- Files changed: 1 (limit: 5)
- Lines changed: ~25 (limit: 300)
- Breaking changes: None

---
*Tier C implementation by copilot-cli — AgentGuard three-tier governance*