### PR TITLE
feat: init Codex, Copilot, and Gemini hook configs

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "agentguard codex-hook pre",
+            "command": "node apps/cli/dist/bin.js codex-hook pre",
             "statusMessage": "AgentGuard governance check"
           }
         ]
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "agentguard codex-hook post",
+            "command": "node apps/cli/dist/bin.js codex-hook post",
             "statusMessage": "AgentGuard error monitoring"
           }
         ]

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "agentguard gemini-hook pre"
+            "command": "node apps/cli/dist/bin.js gemini-hook pre"
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "agentguard gemini-hook post"
+            "command": "node apps/cli/dist/bin.js gemini-hook post"
           }
         ]
       }

--- a/.github/hooks/hooks.json
+++ b/.github/hooks/hooks.json
@@ -4,14 +4,14 @@
     "preToolUse": [
       {
         "type": "command",
-        "bash": "agentguard copilot-hook pre",
+        "bash": "node apps/cli/dist/bin.js copilot-hook pre",
         "timeoutSec": 30
       }
     ],
     "postToolUse": [
       {
         "type": "command",
-        "bash": "agentguard copilot-hook post",
+        "bash": "node apps/cli/dist/bin.js copilot-hook post",
         "timeoutSec": 10
       }
     ]

--- a/apps/cli/src/commands/claude-hook.ts
+++ b/apps/cli/src/commands/claude-hook.ts
@@ -468,6 +468,9 @@ async function handlePreToolUse(
     // Sink creation failure is non-fatal
   }
 
+  // Resolve agent identity early — used for both session tracking and cloud telemetry.
+  const agentId = resolveAgentIdentity();
+
   // Cloud telemetry — send governance events to the telemetry server so the
   // office-sim (and any dashboard) can visualize real agent activity.
   // Short-lived hook: we flush immediately after processing, not on an interval.
@@ -491,7 +494,7 @@ async function handlePreToolUse(
           identity?.server_url ??
           'https://telemetry.agentguard.dev',
         runId: cloudSessionId,
-        agentId: resolveAgentIdentity() ?? 'claude-code',
+        agentId: agentId ?? 'claude-code',
         installId: identity?.install_id,
         apiKey,
         flushIntervalMs: 0, // No interval — we flush manually before exit
@@ -566,6 +569,7 @@ async function handlePreToolUse(
   if (storage?.sessions) {
     storage.sessions.start(sessionKey, 'claude-hook', {
       storageBackend: storageConfig.backend,
+      agentId: agentId ?? undefined,
     });
   }
 

--- a/apps/cli/src/commands/codex-hook.ts
+++ b/apps/cli/src/commands/codex-hook.ts
@@ -228,6 +228,9 @@ async function handlePreToolUse(payload: CodexCliHookPayload, cliArgs: string[])
     // Sink creation failure is non-fatal
   }
 
+  // Resolve agent identity early — used for both session tracking and cloud telemetry.
+  const agentId = resolveAgentIdentity();
+
   // Cloud telemetry — send governance events to the telemetry server so the
   // dashboard can visualize Codex agent activity alongside Claude agent activity.
   // Short-lived hook: we flush immediately after processing, not on an interval.
@@ -249,7 +252,7 @@ async function handlePreToolUse(payload: CodexCliHookPayload, cliArgs: string[])
           identity?.server_url ??
           'https://telemetry.agentguard.dev',
         runId: cloudSessionId,
-        agentId: resolveAgentIdentity() ?? 'codex-cli',
+        agentId: agentId ?? 'codex-cli',
         installId: identity?.install_id,
         apiKey,
         flushIntervalMs: 0, // No interval — we flush manually before exit
@@ -317,6 +320,7 @@ async function handlePreToolUse(payload: CodexCliHookPayload, cliArgs: string[])
   if (storage?.sessions) {
     storage.sessions.start(sessionKey, 'codex-hook', {
       storageBackend: storageConfig.backend,
+      agentId: agentId ?? undefined,
     });
   }
 

--- a/apps/cli/src/commands/copilot-hook.ts
+++ b/apps/cli/src/commands/copilot-hook.ts
@@ -234,6 +234,9 @@ async function handlePreToolUse(
     // Sink creation failure is non-fatal
   }
 
+  // Resolve agent identity early — used for both session tracking and cloud telemetry.
+  const agentId = resolveAgentIdentity();
+
   // Cloud telemetry — send governance events to the telemetry server so the
   // dashboard can visualize Copilot agent activity alongside Claude agent activity.
   // Short-lived hook: we flush immediately after processing, not on an interval.
@@ -255,7 +258,7 @@ async function handlePreToolUse(
           identity?.server_url ??
           'https://telemetry.agentguard.dev',
         runId: cloudSessionId,
-        agentId: resolveAgentIdentity() ?? 'copilot-cli',
+        agentId: agentId ?? 'copilot-cli',
         installId: identity?.install_id,
         apiKey,
         flushIntervalMs: 0, // No interval — we flush manually before exit
@@ -323,6 +326,7 @@ async function handlePreToolUse(
   if (storage?.sessions) {
     storage.sessions.start(sessionKey, 'copilot-hook', {
       storageBackend: storageConfig.backend,
+      agentId: agentId ?? undefined,
     });
   }
 

--- a/apps/cli/src/commands/gemini-hook.ts
+++ b/apps/cli/src/commands/gemini-hook.ts
@@ -230,6 +230,9 @@ async function handleBeforeTool(
     // Sink creation failure is non-fatal
   }
 
+  // Resolve agent identity early — used for both session tracking and cloud telemetry.
+  const agentId = resolveAgentIdentity();
+
   // Cloud telemetry — send governance events to the telemetry server so the
   // dashboard can visualize Gemini agent activity alongside Claude agent activity.
   // Short-lived hook: we flush immediately after processing, not on an interval.
@@ -251,7 +254,7 @@ async function handleBeforeTool(
           identity?.server_url ??
           'https://telemetry.agentguard.dev',
         runId: cloudSessionId,
-        agentId: resolveAgentIdentity() ?? 'gemini-cli',
+        agentId: agentId ?? 'gemini-cli',
         installId: identity?.install_id,
         apiKey,
         flushIntervalMs: 0, // No interval — we flush manually before exit
@@ -319,6 +322,7 @@ async function handleBeforeTool(
   if (storage?.sessions) {
     storage.sessions.start(sessionKey, 'gemini-hook', {
       storageBackend: storageConfig.backend,
+      agentId: agentId ?? undefined,
     });
   }
 

--- a/packages/storage/src/migrations.ts
+++ b/packages/storage/src/migrations.ts
@@ -114,6 +114,14 @@ const MIGRATIONS: readonly Migration[] = [
       db.exec('CREATE INDEX IF NOT EXISTS idx_decisions_severity ON decisions (severity)');
     },
   },
+  {
+    version: 5,
+    description: 'Add agent_id to sessions for driver/agent identity tracking',
+    up(db) {
+      db.exec('ALTER TABLE sessions ADD COLUMN agent_id TEXT');
+      db.exec('CREATE INDEX IF NOT EXISTS idx_sessions_agent_id ON sessions (agent_id)');
+    },
+  },
 ];
 
 /**

--- a/packages/storage/src/sqlite-session.ts
+++ b/packages/storage/src/sqlite-session.ts
@@ -9,6 +9,7 @@ export interface SessionStartData {
   readonly dryRun?: boolean;
   readonly storageBackend?: string;
   readonly simulatorCount?: number;
+  readonly agentId?: string;
 }
 
 export interface SessionEndData {
@@ -39,10 +40,11 @@ export function insertSession(
   try {
     const now = new Date().toISOString();
     const repo = safeGetCwd();
+    const agentId = startData.agentId ?? null;
     const data = JSON.stringify({ ...startData, status: 'running' });
     db.prepare(
-      'INSERT OR IGNORE INTO sessions (id, started_at, ended_at, command, repo, data) VALUES (?, ?, NULL, ?, ?, ?)'
-    ).run(sessionId, now, command, repo, data);
+      'INSERT OR IGNORE INTO sessions (id, started_at, ended_at, command, repo, data, agent_id) VALUES (?, ?, NULL, ?, ?, ?, ?)'
+    ).run(sessionId, now, command, repo, data, agentId);
   } catch (err) {
     onError?.(err as Error);
   }

--- a/packages/storage/tests/sqlite-migrations.test.ts
+++ b/packages/storage/tests/sqlite-migrations.test.ts
@@ -14,7 +14,7 @@ describe('SQLite migrations', () => {
 
   it('creates all tables on first run', () => {
     const applied = runMigrations(db);
-    expect(applied).toBe(3);
+    expect(applied).toBe(4);
 
     const tables = db
       .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
@@ -48,20 +48,23 @@ describe('SQLite migrations', () => {
     // v2 indexes
     expect(names).toContain('idx_events_action_type');
     expect(names).toContain('idx_decisions_severity');
+
+    // v5 indexes
+    expect(names).toContain('idx_sessions_agent_id');
   });
 
   it('is idempotent — running twice applies nothing the second time', () => {
     const first = runMigrations(db);
     const second = runMigrations(db);
 
-    expect(first).toBe(3);
+    expect(first).toBe(4);
     expect(second).toBe(0);
   });
 
   it('tracks schema version', () => {
     expect(getSchemaVersion(db)).toBe(0);
     runMigrations(db);
-    expect(getSchemaVersion(db)).toBe(3);
+    expect(getSchemaVersion(db)).toBe(5);
   });
 
   it('enables WAL mode (on file-based databases)', () => {
@@ -114,8 +117,8 @@ describe('SQLite migrations', () => {
     expect(getSchemaVersion(db)).toBe(1);
 
     const applied = runMigrations(db);
-    expect(applied).toBe(2);
-    expect(getSchemaVersion(db)).toBe(3);
+    expect(applied).toBe(3);
+    expect(getSchemaVersion(db)).toBe(5);
 
     const indexes = db
       .prepare(
@@ -210,9 +213,9 @@ describe('SQLite migration v2 — action_type and severity columns', () => {
       JSON.stringify({ id: 'evt_2', kind: 'RunStarted', timestamp: 1001, fingerprint: 'fp2' })
     );
 
-    // Run v2+v3 migrations
+    // Run v2+v3+v5 migrations (v5 adds agent_id to sessions)
     const applied = runMigrations(db);
-    expect(applied).toBe(2);
+    expect(applied).toBe(3);
 
     const row1 = db.prepare('SELECT action_type FROM events WHERE id = ?').get('evt_1') as {
       action_type: string | null;


### PR DESCRIPTION
Adds governance hook configurations for all 3 new CLI drivers introduced in v2.8.0.

- `.codex/hooks.json` — Codex CLI PreToolUse/PostToolUse
- `.github/hooks/hooks.json` — Copilot CLI preToolUse/postToolUse  
- `.gemini/settings.json` — Gemini CLI BeforeTool/AfterTool

Claude hooks (`.claude/settings.json`) already existed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>