### PR TITLE
fix(invariants): detect credential file writes via shell commands

### DIFF
--- a/packages/invariants/src/definitions.ts
+++ b/packages/invariants/src/definitions.ts
@@ -500,6 +500,15 @@ export function isCredentialPath(filePath: string): boolean {
   return false;
 }
 
+/** Checks whether a shell command references a well-known credential file path.
+ * Splits the command into tokens and checks each against `isCredentialPath`. */
+export function shellCommandReferencesCredentialFile(command: string): boolean {
+  if (!command) return false;
+  // Split on whitespace, then strip surrounding quotes from each token
+  const tokens = command.split(/\s+/).map((t) => t.replace(/^['"]|['"]$/g, ''));
+  return tokens.some((token) => token !== '' && isCredentialPath(token));
+}
+
 /** Shell command patterns that indicate network egress (case-insensitive). */
 const NETWORK_COMMAND_PATTERNS: RegExp[] = [
   /\bcurl\b/,
@@ -755,9 +764,25 @@ export const DEFAULT_INVARIANTS: AgentGuardInvariant[] = [
     severity: 5,
     check(state) {
       const actionType = state.currentActionType || '';
-      const writingActions = ['file.write', 'file.move'];
 
-      // Only applies to write/move actions — reading credential files is allowed
+      // Read-only action types are always allowed
+      if (READ_ONLY_ACTIONS.includes(actionType)) {
+        return { holds: true, expected: 'N/A', actual: `Action type ${actionType} is read-only` };
+      }
+
+      // For shell.exec, skip read-only commands (cat, grep, ls, etc.)
+      if (actionType === 'shell.exec') {
+        const command = (state.currentCommand || '').trim();
+        const baseCmd = extractBaseCommand(command);
+        if (READ_ONLY_CMDS.includes(baseCmd) && !hasFileRedirect(command)) {
+          return { holds: true, expected: 'N/A', actual: 'Read-only shell command' };
+        }
+      }
+
+      // Actions that can modify credential files
+      const writingActions = ['file.write', 'file.move', 'shell.exec'];
+
+      // Non-writing actions are allowed (e.g. file.read, file.delete)
       if (actionType !== '' && !writingActions.includes(actionType)) {
         return {
           holds: true,
@@ -767,16 +792,35 @@ export const DEFAULT_INVARIANTS: AgentGuardInvariant[] = [
       }
 
       const target = state.currentTarget || '';
-      if (target === '') {
-        return { holds: true, expected: 'N/A', actual: 'No target specified' };
+      const command = state.currentCommand || '';
+
+      // Check target path against credential patterns
+      const targetViolation = target !== '' && isCredentialPath(target);
+
+      // For shell.exec, also check if command arguments reference credential files
+      const commandViolation =
+        actionType === 'shell.exec' &&
+        command !== '' &&
+        shellCommandReferencesCredentialFile(command);
+
+      const holds = !targetViolation && !commandViolation;
+
+      if (holds) {
+        return {
+          holds: true,
+          expected: 'No creation or modification of credential files',
+          actual: 'No credential files affected',
+        };
       }
 
-      const violation = isCredentialPath(target);
+      const violations: string[] = [];
+      if (targetViolation) violations.push(`target: ${target}`);
+      if (commandViolation) violations.push('command references credential files');
 
       return {
-        holds: !violation,
+        holds: false,
         expected: 'No creation or modification of credential files',
-        actual: violation ? `Credential file targeted: ${target}` : 'No credential files affected',
+        actual: `Credential file targeted (${violations.join('; ')})`,
       };
     },
   },

--- a/packages/invariants/tests/invariant-definitions.test.ts
+++ b/packages/invariants/tests/invariant-definitions.test.ts
@@ -643,6 +643,80 @@ describe('no-credential-file-creation', () => {
     });
     expect(result.holds).toBe(false);
   });
+
+  // Shell bypass tests (issue #618)
+  it('fails when shell.exec runs sed -i targeting .env file', () => {
+    const result = inv.check({
+      currentActionType: 'shell.exec',
+      currentCommand: "sed -i 's/old/new/' .env",
+    });
+    expect(result.holds).toBe(false);
+    expect(result.actual).toContain('command references credential files');
+  });
+
+  it('fails when shell.exec runs tee targeting .env.local', () => {
+    const result = inv.check({
+      currentActionType: 'shell.exec',
+      currentCommand: 'tee .env.local',
+    });
+    expect(result.holds).toBe(false);
+  });
+
+  it('fails when shell.exec redirects output to .npmrc', () => {
+    const result = inv.check({
+      currentActionType: 'shell.exec',
+      currentCommand: 'echo "//registry:_authToken=tok" > .npmrc',
+    });
+    expect(result.holds).toBe(false);
+  });
+
+  it('fails when shell.exec copies to SSH key path', () => {
+    const result = inv.check({
+      currentActionType: 'shell.exec',
+      currentCommand: 'cp /tmp/key ~/.ssh/id_rsa',
+    });
+    expect(result.holds).toBe(false);
+  });
+
+  it('fails when shell.exec writes to AWS credentials', () => {
+    const result = inv.check({
+      currentActionType: 'shell.exec',
+      currentCommand: 'echo "[default]" >> ~/.aws/credentials',
+    });
+    expect(result.holds).toBe(false);
+  });
+
+  it('holds when shell.exec reads credential file with cat (read-only)', () => {
+    const result = inv.check({
+      currentActionType: 'shell.exec',
+      currentCommand: 'cat .env',
+    });
+    expect(result.holds).toBe(true);
+  });
+
+  it('holds when shell.exec greps credential file (read-only)', () => {
+    const result = inv.check({
+      currentActionType: 'shell.exec',
+      currentCommand: 'grep SECRET .env',
+    });
+    expect(result.holds).toBe(true);
+  });
+
+  it('holds when shell.exec runs command with no credential file references', () => {
+    const result = inv.check({
+      currentActionType: 'shell.exec',
+      currentCommand: 'echo hello > output.txt',
+    });
+    expect(result.holds).toBe(true);
+  });
+
+  it('fails when cat redirects to credential file', () => {
+    const result = inv.check({
+      currentActionType: 'shell.exec',
+      currentCommand: 'cat /tmp/stolen > .env',
+    });
+    expect(result.holds).toBe(false);
+  });
 });
 
 describe('no-package-script-injection', () => {


### PR DESCRIPTION
Closes #618

## Implementation Summary

**What changed:**
- Enhanced the `no-credential-file-creation` invariant to also inspect `shell.exec` actions
- Added `shellCommandReferencesCredentialFile()` helper that tokenizes shell commands and checks each argument against credential path matchers
- Read-only shell commands (`cat`, `grep`, `ls`, etc.) remain exempt unless they use file redirects (`>`)
- Shell commands like `sed -i .env`, `tee .npmrc`, `cp key ~/.ssh/id_rsa`, and `echo tok >> .env` are now blocked

**How to verify:**
1. `pnpm build --filter=@red-codes/invariants`
2. `pnpm test --filter=@red-codes/invariants` — all 586 tests pass
3. New tests cover: `sed -i`, `tee`, redirect to `.npmrc`, `cp` to SSH path, `echo >>` to AWS credentials, read-only exemptions (`cat .env`, `grep .env`), non-credential commands, and redirect-based bypass (`cat > .env`)

**Tier C scope check:**
- Files changed: 2 (limit: 5)
- Lines changed: ~125 (limit: 300)
- Breaking changes: None

---
*Tier C implementation by copilot-cli — AgentGuard three-tier governance*