### PR TITLE
docs: sync documentation with codebase — invariant count 23→24, add no-verify-bypass

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ The system has one architectural spine: the **canonical event model**. All syste
 
 **Key characteristics:**
 - Governed action kernel: propose → normalize → evaluate → execute → emit
-- 23 built-in invariants (secret exposure, protected branches, blast radius, test-before-push, no force push, no skill modification, no scheduled task modification, credential file creation, package script injection, lockfile integrity, recursive operation guard, large file write, CI/CD config modification, permission escalation, governance self-modification, container config modification, environment variable modification, network egress, destructive migration, transitive effect analysis, IDE socket access, commit scope guard, script execution tracking)
+- 24 built-in invariants (secret exposure, protected branches, blast radius, test-before-push, no force push, no skill modification, no scheduled task modification, credential file creation, package script injection, lockfile integrity, recursive operation guard, large file write, CI/CD config modification, permission escalation, governance self-modification, container config modification, environment variable modification, network egress, destructive migration, transitive effect analysis, IDE socket access, commit scope guard, script execution tracking, no-verify bypass)
 - YAML/JSON policy format with pattern matching, scopes, and branch conditions
 - Escalation tracking: NORMAL → ELEVATED → HIGH → LOCKDOWN
 - SQLite event persistence for audit trail and replay (JSONL export still supported)
@@ -73,7 +73,7 @@ packages/
 │   ├── policy-trust.ts         # Policy trust verification
 │   └── yaml-loader.ts          # YAML policy parser
 ├── invariants/src/             # @red-codes/invariants — Invariant system
-│   ├── definitions.ts          # 23 built-in invariant definitions
+│   ├── definitions.ts          # 24 built-in invariant definitions
 │   └── checker.ts              # Invariant evaluation engine
 ├── matchers/src/               # @red-codes/matchers — Structured matchers (KE-1)
 │   ├── path-matcher.ts         # Glob-based path matching (picomatch)
@@ -187,7 +187,7 @@ apps/
 
 # TS test files (vitest) distributed across packages/ and apps/ directories
 policy/                     # Policy configuration (JSON: action_rules, capabilities)
-policies/                   # Policy packs (YAML: ci-safe, engineering-standards, enterprise, hipaa, open-source, soc2, strict)
+policies/                   # Policy packs (ci-safe, engineering-standards, enterprise, hipaa, open-source, soc2, strict as subdirs; essentials.yaml and readybench.yaml as flat files)
 docs/                       # System documentation (architecture, event model, specs)
 hooks/                      # Git hooks (post-commit, post-merge)
 examples/                   # Example governance scenarios and error demos

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Install in 30 seconds. Your agents can't break what matters.</p>
 
 ---
 
-AI coding agents (Claude Code, GitHub Copilot, any MCP client) run autonomously — writing files, executing commands, pushing code. AgentGuard prevents them from doing catastrophic things: no accidental pushes to main, no credential leaks, no runaway destructive loops. 23 built-in safety checks, zero config required.
+AI coding agents (Claude Code, GitHub Copilot, any MCP client) run autonomously — writing files, executing commands, pushing code. AgentGuard prevents them from doing catastrophic things: no accidental pushes to main, no credential leaks, no runaway destructive loops. 24 built-in safety checks, zero config required.
 
 **For individuals:** stop your AI from wrecking your machine or repo.
 **For teams:** run fleets of agents safely at scale, with audit trails that pass compliance.
@@ -48,7 +48,7 @@ The `claude-init` wizard walks you through setup interactively:
 
   Enable a policy pack?
     ❯ 1) essentials — secrets, force push, protected branches, credentials
-      2) strict — all 23 invariants enforced
+      2) strict — all 24 invariants enforced
       3) none — monitor only, configure later
 ```
 
@@ -104,7 +104,7 @@ Identity consists of a **role** (`developer`, `reviewer`, `ops`, `security`, `pl
 | Capability | Details |
 |------------|---------|
 | **Policy enforcement** | YAML rules with deny / allow / escalate — drop `agentguard.yaml` in your repo |
-| **23 built-in invariants** | Secret exposure, protected branches, blast radius, path traversal, CI/CD config, package script injection, and more |
+| **24 built-in invariants** | Secret exposure, protected branches, blast radius, path traversal, CI/CD config, package script injection, and more |
 | **47 event kinds** | Full lifecycle telemetry: `ActionRequested → ActionAllowed/Denied → ActionExecuted` |
 | **Real-time cloud dashboard** | Telemetry streams to your team dashboard; opt-in, anonymous by default |
 | **Multi-tenant** | Team workspaces, GitHub/Google OAuth, SSO-ready |
@@ -290,7 +290,7 @@ rules:
 
 ## Built-in Invariants
 
-23 safety invariants run on every action evaluation:
+24 safety invariants run on every action evaluation:
 
 | Invariant | Severity | What it blocks |
 |-----------|----------|----------------|
@@ -317,6 +317,7 @@ rules:
 | `test-before-push` | Medium | Requires tests to pass before push |
 | `recursive-operation-guard` | Low | `find -exec`, `xargs` with write/delete |
 | `lockfile-integrity` | Low | `package.json` changes without lockfile sync |
+| `no-verify-bypass` | Medium | `git push/commit --no-verify` skipping pre-push/pre-commit hooks |
 
 ## Architecture
 
@@ -327,7 +328,7 @@ Agent tool call
 AgentGuard Kernel
   1. Normalize   — map tool call to canonical action type
   2. Evaluate    — match policy rules (deny / allow / escalate)
-  3. Check       — run 23 built-in invariants
+  3. Check       — run 24 built-in invariants
   4. Execute     — run action via adapter (file, shell, git)
   5. Emit        — 47 event kinds → SQLite audit trail + cloud telemetry
 ```
@@ -371,7 +372,7 @@ For teams running agent fleets, governance becomes invisible. Agents get 8% more
 
 **Zero-dependency deployment** — the Go kernel is a single static binary. No `node_modules`, no `pnpm install`, no bootstrap deadlocks. Drop it in a worktree and it works. This is critical for CI/CD and fleet scenarios where agents spin up fresh environments.
 
-The Go kernel includes: action normalization with AST-based shell parsing, policy evaluation, 23 invariants, escalation state machine, blast radius engine, telemetry shipper (stdout/file/HTTP), and a control plane signals API. It ships automatically via `npm install` — a postinstall script downloads the prebuilt binary for your platform.
+The Go kernel includes: action normalization with AST-based shell parsing, policy evaluation, 24 invariants, escalation state machine, blast radius engine, telemetry shipper (stdout/file/HTTP), and a control plane signals API. It ships automatically via `npm install` — a postinstall script downloads the prebuilt binary for your platform.
 
 ## For Teams and Enterprise
 
@@ -469,7 +470,7 @@ extends:
 | `engineering-standards` | Balanced dev-friendly guardrails: test-before-push, format checks, safe deps |
 | `ci-safe` | Strict CI/CD pipeline protection |
 | `enterprise` | Full enterprise governance |
-| `strict` | Maximum restriction — all 23 invariants enforced |
+| `strict` | Maximum restriction — all 24 invariants enforced |
 | `open-source` | OSS contribution-friendly defaults |
 
 ## Community & Updates


### PR DESCRIPTION
## What drifted

### Invariant count: 23 → 24
The `no-verify-bypass` invariant was added as the 24th built-in invariant but docs still said 23.

**README.md fixes:**
- Updated all 6 occurrences of "23" to "24" in invariant-related contexts (hero text, feature table, invariant section header, architecture diagram, Go kernel description, policy packs table)
- Added `no-verify-bypass` row to the Built-in Invariants table (blocks `git push/commit --no-verify` to prevent hook bypass)

**CLAUDE.md fixes:**
- Updated invariant count from 23 to 24 in the key characteristics list
- Added `no-verify bypass` to the invariant names list
- Updated `definitions.ts` comment from 23 to 24 built-in invariant definitions
- Updated `policies/` directory description to include `essentials.yaml` and `readybench.yaml` flat files alongside the subdirectory packs

## Verification
Each fix was verified against `packages/invariants/src/definitions.ts` — the `DEFAULT_INVARIANTS` array exports 24 invariant objects (lines 548–end), with `no-verify-bypass` as the last entry at line 1765.

---
*Created by copilot-docs-sync — AgentGuard Copilot swarm*