### PR TITLE
docs: sync documentation with codebase state

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -51,7 +51,7 @@ packages/
 ├── core/          @red-codes/core — Shared utilities (types, actions, hash, execution-log)
 ├── events/        @red-codes/events — Canonical event model (schema, bus, store)
 ├── policy/        @red-codes/policy — Policy system (composer, evaluator, loaders, pack loader)
-├── invariants/    @red-codes/invariants — Invariant system (21 built-in definitions, checker)
+├── invariants/    @red-codes/invariants — Invariant system (24 built-in definitions, checker)
 ├── invariant-data-protection/ @red-codes/invariant-data-protection — Data protection invariant plugin
 ├── matchers/      @red-codes/matchers — Structured matchers (Aho-Corasick, globs, hash sets)
 ├── kernel/        @red-codes/kernel — Governed action kernel (orchestrate, normalize, decide, escalate)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ The system has one architectural spine: the **canonical event model**. All syste
 
 **Key characteristics:**
 - Governed action kernel: propose → normalize → evaluate → execute → emit
-- 23 built-in invariants (secret exposure, protected branches, blast radius, test-before-push, no force push, no skill modification, no scheduled task modification, credential file creation, package script injection, lockfile integrity, recursive operation guard, large file write, CI/CD config modification, permission escalation, governance self-modification, container config modification, environment variable modification, network egress, destructive migration, transitive effect analysis, IDE socket access, commit scope guard, script execution tracking)
+- 24 built-in invariants (secret exposure, protected branches, blast radius, test-before-push, no force push, no skill modification, no scheduled task modification, credential file creation, package script injection, lockfile integrity, recursive operation guard, large file write, CI/CD config modification, permission escalation, governance self-modification, container config modification, environment variable modification, network egress, destructive migration, transitive effect analysis, IDE socket access, commit scope guard, script execution tracking, no-verify bypass)
 - YAML/JSON policy format with pattern matching, scopes, and branch conditions
 - Escalation tracking: NORMAL → ELEVATED → HIGH → LOCKDOWN
 - SQLite event persistence for audit trail and replay (JSONL export still supported)
@@ -43,7 +43,7 @@ This is a **pnpm monorepo** orchestrated by **Turbo**. Workspace packages live i
 packages/
 ├── core/src/                   # @red-codes/core — Shared utilities
 │   ├── types.ts                # Shared TypeScript type definitions (includes RunManifest)
-│   ├── actions.ts              # 27 canonical action types across 9 classes
+│   ├── actions.ts              # 41 canonical action types across 10 classes
 │   ├── governance-data.ts      # Governance data loader (typed access to shared JSON data)
 │   ├── data/                   # JSON governance data (actions, blast-radius, destructive-patterns, escalation, git-action-patterns, invariant-patterns, tool-action-map)
 │   ├── hash.ts                 # Content hashing utilities
@@ -73,7 +73,7 @@ packages/
 │   ├── policy-trust.ts         # Policy trust verification
 │   └── yaml-loader.ts          # YAML policy parser
 ├── invariants/src/             # @red-codes/invariants — Invariant system
-│   ├── definitions.ts          # 23 built-in invariant definitions
+│   ├── definitions.ts          # 24 built-in invariant definitions
 │   └── checker.ts              # Invariant evaluation engine
 ├── matchers/src/               # @red-codes/matchers — Structured matchers (KE-1)
 │   ├── path-matcher.ts         # Glob-based path matching (picomatch)
@@ -317,10 +317,11 @@ The canonical event model is the architectural spine. Event kinds defined in `pa
 - **Environmental Enforcement**: `IdeSocketAccessBlocked`
 
 ### Action Classes & Types
-27 canonical action types across 9 classes, defined in `packages/core/src/actions.ts`:
+41 canonical action types across 10 classes, defined in `packages/core/src/actions.ts`:
 - **file**: `file.read`, `file.write`, `file.delete`, `file.move`
 - **test**: `test.run`, `test.run.unit`, `test.run.integration`
-- **git**: `git.diff`, `git.commit`, `git.push`, `git.branch.create`, `git.branch.delete`, `git.checkout`, `git.reset`, `git.merge`, `git.worktree.add`, `git.worktree.remove`, `git.worktree.list`
+- **git**: `git.diff`, `git.commit`, `git.push`, `git.force-push`, `git.branch.create`, `git.branch.delete`, `git.checkout`, `git.reset`, `git.merge`, `git.worktree.add`, `git.worktree.remove`, `git.worktree.list`
+- **github**: `github.pr.list`, `github.pr.create`, `github.pr.merge`, `github.pr.close`, `github.pr.view`, `github.pr.checks`, `github.issue.list`, `github.issue.create`, `github.issue.close`, `github.release.create`, `github.run.list`, `github.run.view`, `github.api`
 - **shell**: `shell.exec`
 - **npm**: `npm.install`, `npm.script.run`, `npm.publish`
 - **http**: `http.request`

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Install in 30 seconds. Your agents can't break what matters.</p>
 
 ---
 
-AI coding agents (Claude Code, GitHub Copilot, any MCP client) run autonomously — writing files, executing commands, pushing code. AgentGuard prevents them from doing catastrophic things: no accidental pushes to main, no credential leaks, no runaway destructive loops. 23 built-in safety checks, zero config required.
+AI coding agents (Claude Code, GitHub Copilot, any MCP client) run autonomously — writing files, executing commands, pushing code. AgentGuard prevents them from doing catastrophic things: no accidental pushes to main, no credential leaks, no runaway destructive loops. 24 built-in safety checks, zero config required.
 
 **For individuals:** stop your AI from wrecking your machine or repo.
 **For teams:** run fleets of agents safely at scale, with audit trails that pass compliance.
@@ -48,7 +48,7 @@ The `claude-init` wizard walks you through setup interactively:
 
   Enable a policy pack?
     ❯ 1) essentials — secrets, force push, protected branches, credentials
-      2) strict — all 23 invariants enforced
+      2) strict — all 24 invariants enforced
       3) none — monitor only, configure later
 ```
 
@@ -104,7 +104,7 @@ Identity consists of a **role** (`developer`, `reviewer`, `ops`, `security`, `pl
 | Capability | Details |
 |------------|---------|
 | **Policy enforcement** | YAML rules with deny / allow / escalate — drop `agentguard.yaml` in your repo |
-| **23 built-in invariants** | Secret exposure, protected branches, blast radius, path traversal, CI/CD config, package script injection, and more |
+| **24 built-in invariants** | Secret exposure, protected branches, blast radius, path traversal, CI/CD config, package script injection, and more |
 | **47 event kinds** | Full lifecycle telemetry: `ActionRequested → ActionAllowed/Denied → ActionExecuted` |
 | **Real-time cloud dashboard** | Telemetry streams to your team dashboard; opt-in, anonymous by default |
 | **Multi-tenant** | Team workspaces, GitHub/Google OAuth, SSO-ready |
@@ -290,7 +290,7 @@ rules:
 
 ## Built-in Invariants
 
-23 safety invariants run on every action evaluation:
+24 safety invariants run on every action evaluation:
 
 | Invariant | Severity | What it blocks |
 |-----------|----------|----------------|
@@ -309,6 +309,7 @@ rules:
 | `no-ide-socket-access` | High | VS Code IPC socket files |
 | `commit-scope-guard` | High | Staged files not written by the current session |
 | `script-execution-tracking` | High | Shell commands executing session-written scripts (write-then-execute bypass) |
+| `no-verify-bypass` | High | `--no-verify` flag on git push/commit (skips pre-push/pre-commit hooks) |
 | `blast-radius-limit` | Medium | Caps file modification count per action (default: 20) |
 | `no-container-config-modification` | Medium | Dockerfile, docker-compose.yml |
 | `no-env-var-modification` | Medium | Shell profile and env var files |
@@ -327,7 +328,7 @@ Agent tool call
 AgentGuard Kernel
   1. Normalize   — map tool call to canonical action type
   2. Evaluate    — match policy rules (deny / allow / escalate)
-  3. Check       — run 23 built-in invariants
+  3. Check       — run 24 built-in invariants
   4. Execute     — run action via adapter (file, shell, git)
   5. Emit        — 47 event kinds → SQLite audit trail + cloud telemetry
 ```
@@ -371,7 +372,7 @@ For teams running agent fleets, governance becomes invisible. Agents get 8% more
 
 **Zero-dependency deployment** — the Go kernel is a single static binary. No `node_modules`, no `pnpm install`, no bootstrap deadlocks. Drop it in a worktree and it works. This is critical for CI/CD and fleet scenarios where agents spin up fresh environments.
 
-The Go kernel includes: action normalization with AST-based shell parsing, policy evaluation, 23 invariants, escalation state machine, blast radius engine, telemetry shipper (stdout/file/HTTP), and a control plane signals API. It ships automatically via `npm install` — a postinstall script downloads the prebuilt binary for your platform.
+The Go kernel includes: action normalization with AST-based shell parsing, policy evaluation, 24 invariants, escalation state machine, blast radius engine, telemetry shipper (stdout/file/HTTP), and a control plane signals API. It ships automatically via `npm install` — a postinstall script downloads the prebuilt binary for your platform.
 
 ## For Teams and Enterprise
 
@@ -469,7 +470,7 @@ extends:
 | `engineering-standards` | Balanced dev-friendly guardrails: test-before-push, format checks, safe deps |
 | `ci-safe` | Strict CI/CD pipeline protection |
 | `enterprise` | Full enterprise governance |
-| `strict` | Maximum restriction — all 23 invariants enforced |
+| `strict` | Maximum restriction — all 24 invariants enforced |
 | `open-source` | OSS contribution-friendly defaults |
 
 ## Community & Updates

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,7 +27,7 @@ AgentGuard is the **Execution Control Plane for autonomous AI agents** — the i
 | Governed action kernel (41 action types, 10 classes) | Implemented | Production |
 | Action Authorization Boundary (AAB) | Implemented | Bypass vectors closed (3 fixed in v2.4.0) |
 | Policy evaluator (YAML/JSON, composition, packs) | Implemented | Production |
-| 23 built-in invariants | Implemented | Production |
+| 24 built-in invariants | Implemented | Production |
 | Canonical event model (47 event kinds) | Implemented | Production |
 | Pre-execution simulation engine (3 simulators) | Implemented | Production |
 | Blast radius computation | Implemented | Production |


### PR DESCRIPTION
## Summary

Automated documentation sync detected drift between codebase and docs.

### Drift Detected

**Invariant count stale (23 -> 24):**
- The `no-verify-bypass` invariant was added to `packages/invariants/src/definitions.ts` as the 24th built-in invariant, but all documentation still referenced 23.

**Action type count stale (27 -> 41, 9 classes -> 10 classes):**
- `packages/core/src/data/actions.json` contains 41 action types across 10 classes (added `github` class with 13 PR/issue/release/run types, and `git.force-push`). CLAUDE.md still listed 27 types across 9 classes without the `github` class.

**ARCHITECTURE.md invariant count severely stale (21 -> 24):**
- Package description said '21 built-in definitions' -- actual count is 24.

## Changes

- **README.md**: Updated invariant count (23->24) in 5 places; added `no-verify-bypass` row to invariant table; updated architecture diagram; updated strict policy pack description
- **CLAUDE.md**: Updated invariant count (23->24) in 3 places; updated action type count (27->41, 9->10 classes); added `github` action class with all 13 types; added `git.force-push` to git list; added `no-verify-bypass` to invariant list
- **ARCHITECTURE.md**: Fixed invariant system description (21->24 built-in definitions)
- **ROADMAP.md**: Updated feature table entry (23->24 built-in invariants)

## Contradictions Flagged

- ROADMAP.md already had '41 action types, 10 classes' correct but still said '23 built-in invariants' -- now fixed.
- ARCHITECTURE.md was most out of date (21 invariants vs actual 24).

## Source

Auto-generated by the **Scheduled Docs Sync** skill.
Agent identity: `documentation-maintainer-agent` (copilot-cli:copilot:ops)

---
*Run: 2026-03-27T02:46:52Z*