### PR TITLE
docs: sync invariant count (23→24), add opencode driver, expand hook architecture docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -51,7 +51,7 @@ packages/
 ├── core/          @red-codes/core — Shared utilities (types, actions, hash, execution-log)
 ├── events/        @red-codes/events — Canonical event model (schema, bus, store)
 ├── policy/        @red-codes/policy — Policy system (composer, evaluator, loaders, pack loader)
-├── invariants/    @red-codes/invariants — Invariant system (21 built-in definitions, checker)
+├── invariants/    @red-codes/invariants — Invariant system (24 built-in definitions, checker)
 ├── invariant-data-protection/ @red-codes/invariant-data-protection — Data protection invariant plugin
 ├── matchers/      @red-codes/matchers — Structured matchers (Aho-Corasick, globs, hash sets)
 ├── kernel/        @red-codes/kernel — Governed action kernel (orchestrate, normalize, decide, escalate)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ The system has one architectural spine: the **canonical event model**. All syste
 
 **Key characteristics:**
 - Governed action kernel: propose → normalize → evaluate → execute → emit
-- 23 built-in invariants (secret exposure, protected branches, blast radius, test-before-push, no force push, no skill modification, no scheduled task modification, credential file creation, package script injection, lockfile integrity, recursive operation guard, large file write, CI/CD config modification, permission escalation, governance self-modification, container config modification, environment variable modification, network egress, destructive migration, transitive effect analysis, IDE socket access, commit scope guard, script execution tracking)
+- 24 built-in invariants (secret exposure, protected branches, blast radius, test-before-push, no force push, no skill modification, no scheduled task modification, credential file creation, package script injection, lockfile integrity, recursive operation guard, large file write, CI/CD config modification, permission escalation, governance self-modification, container config modification, environment variable modification, network egress, destructive migration, transitive effect analysis, IDE socket access, commit scope guard, script execution tracking, no-verify bypass)
 - YAML/JSON policy format with pattern matching, scopes, and branch conditions
 - Escalation tracking: NORMAL → ELEVATED → HIGH → LOCKDOWN
 - SQLite event persistence for audit trail and replay (JSONL export still supported)
@@ -73,7 +73,7 @@ packages/
 │   ├── policy-trust.ts         # Policy trust verification
 │   └── yaml-loader.ts          # YAML policy parser
 ├── invariants/src/             # @red-codes/invariants — Invariant system
-│   ├── definitions.ts          # 23 built-in invariant definitions
+│   ├── definitions.ts          # 24 built-in invariant definitions
 │   └── checker.ts              # Invariant evaluation engine
 ├── matchers/src/               # @red-codes/matchers — Structured matchers (KE-1)
 │   ├── path-matcher.ts         # Glob-based path matching (picomatch)
@@ -389,6 +389,6 @@ pnpm test --filter=@red-codes/kernel  # Test a single package
 
 At session start, if you see `[AgentGuard] No agent identity set`, ask the user:
 1. **Role**: developer / reviewer / ops / security / planner
-2. **Driver**: human / claude-code / copilot / ci
+2. **Driver**: human / claude-code / copilot / opencode / ci
 
 Then run: `scripts/write-persona.sh <driver> <role>`

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Install in 30 seconds. Your agents can't break what matters.</p>
 
 ---
 
-AI coding agents (Claude Code, GitHub Copilot, any MCP client) run autonomously — writing files, executing commands, pushing code. AgentGuard prevents them from doing catastrophic things: no accidental pushes to main, no credential leaks, no runaway destructive loops. 23 built-in safety checks, zero config required.
+AI coding agents (Claude Code, GitHub Copilot, any MCP client) run autonomously — writing files, executing commands, pushing code. AgentGuard prevents them from doing catastrophic things: no accidental pushes to main, no credential leaks, no runaway destructive loops. 24 built-in safety checks, zero config required.
 
 **For individuals:** stop your AI from wrecking your machine or repo.
 **For teams:** run fleets of agents safely at scale, with audit trails that pass compliance.
@@ -48,7 +48,7 @@ The `claude-init` wizard walks you through setup interactively:
 
   Enable a policy pack?
     ❯ 1) essentials — secrets, force push, protected branches, credentials
-      2) strict — all 23 invariants enforced
+      2) strict — all 24 invariants enforced
       3) none — monitor only, configure later
 ```
 
@@ -97,14 +97,14 @@ agentguard guard --agent-name my-agent
 # Or omit --agent-name and an interactive prompt will ask for role + driver
 ```
 
-Identity consists of a **role** (`developer`, `reviewer`, `ops`, `security`, `planner`) and a **driver** (`human`, `claude-code`, `copilot`, `ci`). Identity flows to cloud telemetry for attribution, dashboard grouping, and persona-scoped policy rules.
+Identity consists of a **role** (`developer`, `reviewer`, `ops`, `security`, `planner`) and a **driver** (`human`, `claude-code`, `copilot`, `opencode`, `ci`). Identity flows to cloud telemetry for attribution, dashboard grouping, and persona-scoped policy rules.
 
 ## What It Does
 
 | Capability | Details |
 |------------|---------|
 | **Policy enforcement** | YAML rules with deny / allow / escalate — drop `agentguard.yaml` in your repo |
-| **23 built-in invariants** | Secret exposure, protected branches, blast radius, path traversal, CI/CD config, package script injection, and more |
+| **24 built-in invariants** | Secret exposure, protected branches, blast radius, path traversal, CI/CD config, package script injection, hook bypass prevention, and more |
 | **47 event kinds** | Full lifecycle telemetry: `ActionRequested → ActionAllowed/Denied → ActionExecuted` |
 | **Real-time cloud dashboard** | Telemetry streams to your team dashboard; opt-in, anonymous by default |
 | **Multi-tenant** | Team workspaces, GitHub/Google OAuth, SSO-ready |
@@ -290,7 +290,7 @@ rules:
 
 ## Built-in Invariants
 
-23 safety invariants run on every action evaluation:
+24 safety invariants run on every action evaluation:
 
 | Invariant | Severity | What it blocks |
 |-----------|----------|----------------|
@@ -317,6 +317,7 @@ rules:
 | `test-before-push` | Medium | Requires tests to pass before push |
 | `recursive-operation-guard` | Low | `find -exec`, `xargs` with write/delete |
 | `lockfile-integrity` | Low | `package.json` changes without lockfile sync |
+| `no-verify-bypass` | High | `--no-verify` flag on `git push`/`git commit` (prevents hook bypass) |
 
 ## Architecture
 
@@ -327,7 +328,7 @@ Agent tool call
 AgentGuard Kernel
   1. Normalize   — map tool call to canonical action type
   2. Evaluate    — match policy rules (deny / allow / escalate)
-  3. Check       — run 23 built-in invariants
+  3. Check       — run 24 built-in invariants
   4. Execute     — run action via adapter (file, shell, git)
   5. Emit        — 47 event kinds → SQLite audit trail + cloud telemetry
 ```
@@ -371,7 +372,7 @@ For teams running agent fleets, governance becomes invisible. Agents get 8% more
 
 **Zero-dependency deployment** — the Go kernel is a single static binary. No `node_modules`, no `pnpm install`, no bootstrap deadlocks. Drop it in a worktree and it works. This is critical for CI/CD and fleet scenarios where agents spin up fresh environments.
 
-The Go kernel includes: action normalization with AST-based shell parsing, policy evaluation, 23 invariants, escalation state machine, blast radius engine, telemetry shipper (stdout/file/HTTP), and a control plane signals API. It ships automatically via `npm install` — a postinstall script downloads the prebuilt binary for your platform.
+The Go kernel includes: action normalization with AST-based shell parsing, policy evaluation, 24 invariants, escalation state machine, blast radius engine, telemetry shipper (stdout/file/HTTP), and a control plane signals API. It ships automatically via `npm install` — a postinstall script downloads the prebuilt binary for your platform.
 
 ## For Teams and Enterprise
 
@@ -469,7 +470,7 @@ extends:
 | `engineering-standards` | Balanced dev-friendly guardrails: test-before-push, format checks, safe deps |
 | `ci-safe` | Strict CI/CD pipeline protection |
 | `enterprise` | Full enterprise governance |
-| `strict` | Maximum restriction — all 23 invariants enforced |
+| `strict` | Maximum restriction — all 24 invariants enforced |
 | `open-source` | OSS contribution-friendly defaults |
 
 ## Community & Updates

--- a/docs/hook-architecture.md
+++ b/docs/hook-architecture.md
@@ -1,4 +1,17 @@
-# Hook Architecture — How AgentGuard Integrates with Claude Code
+# Hook Architecture — How AgentGuard Integrates with AI Coding Agents
+
+## Supported Agents
+
+AgentGuard currently integrates with two AI coding agent runtimes via inline hooks:
+
+| Agent | Init Command | Hook Command | Hook Config | Fail Mode |
+|-------|-------------|--------------|-------------|-----------|
+| **Claude Code** | `agentguard claude-init` | `agentguard claude-hook pre\|post` | `.claude/settings.json` | Fail-closed |
+| **GitHub Copilot CLI** | `agentguard copilot-init` | `agentguard copilot-hook pre\|post` | `.github/hooks/hooks.json` | Fail-open |
+
+**OpenCode** (`opencode.ai`) is supported as an agent driver for identity and persona attribution (auto-detected via `OPENCODE_HOME`) but does not yet have its own hook integration.
+
+---
 
 ## Design: Inline Hooks, Not a Daemon
 
@@ -94,6 +107,30 @@ Options:
 - `agentguard claude-init --store sqlite` — use SQLite storage backend
 - `agentguard claude-init --remove` — uninstall hooks
 
+### Copilot CLI Hook Configuration
+
+Running `agentguard copilot-init` writes this to `.github/hooks/hooks.json`:
+
+```json
+{
+  "version": 1,
+  "hooks": {
+    "preToolUse": {
+      "type": "command",
+      "bash": "agentguard copilot-hook pre",
+      "timeoutSec": 10
+    },
+    "postToolUse": {
+      "type": "command",
+      "bash": "agentguard copilot-hook post",
+      "timeoutSec": 10
+    }
+  }
+}
+```
+
+The Copilot CLI adapter normalizes Copilot-specific tool payloads into `RawAgentAction` objects before passing them to the governance kernel. Copilot hooks are **fail-open** — if the hook errors, Copilot continues normally.
+
 ## How PreToolUse Governance Works
 
 Each PreToolUse invocation runs through this sequence:
@@ -187,8 +224,11 @@ echo '{"tool":"Bash","input":{"command":"git push origin main"}}' | agentguard c
 
 | File | Purpose |
 |------|---------|
-| `apps/cli/src/commands/claude-hook.ts` | Hook command (PreToolUse governance + PostToolUse monitoring) |
-| `apps/cli/src/commands/claude-init.ts` | Hook setup and teardown |
-| `packages/adapters/src/claude-code.ts` | Payload normalization and action mapping |
+| `apps/cli/src/commands/claude-hook.ts` | Claude Code hook command (PreToolUse governance + PostToolUse monitoring) |
+| `apps/cli/src/commands/claude-init.ts` | Claude Code hook setup and teardown |
+| `apps/cli/src/commands/copilot-hook.ts` | Copilot CLI hook command (preToolUse governance + postToolUse monitoring) |
+| `apps/cli/src/commands/copilot-init.ts` | Copilot CLI hook setup and teardown |
+| `packages/adapters/src/claude-code.ts` | Claude Code payload normalization and action mapping |
+| `packages/adapters/src/copilot-cli.ts` | Copilot CLI payload normalization and action mapping |
 | `packages/kernel/src/kernel.ts` | Governed action kernel (policy + invariant evaluation) |
 | `packages/kernel/src/aab.ts` | Action Authorization Boundary (tool → action type) |

--- a/docs/multi-framework-adapters.md
+++ b/docs/multi-framework-adapters.md
@@ -2,11 +2,20 @@
 
 This document describes the architecture for extending AgentGuard beyond Claude Code to support multiple AI agent frameworks.
 
+## Current State
+
+AgentGuard supports two framework adapters with full hook integration:
+
+| Framework | Adapter | Init Command | Hook Command | Status |
+|-----------|---------|-------------|--------------|--------|
+| **Claude Code** | `packages/adapters/src/claude-code.ts` | `claude-init` | `claude-hook pre\|post` | ✅ Shipped |
+| **GitHub Copilot CLI** | `packages/adapters/src/copilot-cli.ts` | `copilot-init` | `copilot-hook pre\|post` | ✅ Shipped |
+
+The governance kernel is framework-agnostic. It accepts `RawAgentAction` objects and returns `GovernanceDecisionRecord` results. Each adapter is responsible only for translating framework-specific payloads into this canonical format.
+
 ## Context
 
-AgentGuard currently supports a single framework adapter: Claude Code (`src/adapters/claude-code.ts`). The adapter registry (`src/adapters/registry.ts`) maps action classes to execution handlers, but the ingestion side — translating framework-specific payloads into `RawAgentAction` — is tightly coupled to Claude Code's PreToolUse/PostToolUse hook pattern.
-
-The governance kernel is already framework-agnostic. It accepts `RawAgentAction` objects and returns `GovernanceDecisionRecord` results. The gap is in the translation layer: each framework has a different mechanism for tool invocation, and each needs a bridge to the kernel.
+The adapter registry (`packages/adapters/src/registry.ts`) maps action classes to execution handlers. The ingestion side — translating framework-specific payloads into `RawAgentAction` — is handled by per-framework adapters. Each framework has a different mechanism for tool invocation, and each needs a bridge to the kernel.
 
 ## FrameworkAdapter Interface
 
@@ -43,13 +52,13 @@ src/adapters/
 
 ## Adapter Priority & Complexity
 
-| Framework | Priority | Complexity | Integration Mechanism |
-|-----------|----------|------------|----------------------|
-| MCP (Model Context Protocol) | P0 | Medium | Intercept `call_tool` requests; MCP tools map naturally to `RawAgentAction` |
-| LangChain / LangGraph | P0 | Medium | Wrap `BaseTool.invoke()` with governance middleware |
-| OpenAI Agents SDK | P1 | Medium | Function calling interception via middleware |
-| AutoGen | P1 | Medium | Agent message interception |
-| Copilot CLI | P2 | Low | Hook-based pattern similar to Claude Code |
+| Framework | Priority | Complexity | Integration Mechanism | Status |
+|-----------|----------|------------|----------------------|--------|
+| Copilot CLI | — | Low | Hook-based pattern similar to Claude Code | ✅ Shipped |
+| MCP (Model Context Protocol) | P0 | Medium | Intercept `call_tool` requests; MCP tools map naturally to `RawAgentAction` | Planned |
+| LangChain / LangGraph | P0 | Medium | Wrap `BaseTool.invoke()` with governance middleware | Planned |
+| OpenAI Agents SDK | P1 | Medium | Function calling interception via middleware | Planned |
+| AutoGen | P1 | Medium | Agent message interception | Planned |
 
 ## Adapter Details
 


### PR DESCRIPTION
## Summary

Documentation drift fix — syncing docs with recent code changes merged to main.

**Identity:** claude-code:opus:ops (agentguard-autonomous-sdlc--documentation-maintainer-agent)

### Changes

#### Invariant count: 23 → 24
The `no-verify-bypass` invariant was added in PR #1002 but documentation still showed 23 everywhere.

- `README.md`: updated all 6 occurrences of "23 invariants" → 24
- `README.md`: added `no-verify-bypass` to the invariants table (High severity — blocks `--no-verify` flag on `git push`/`git commit`)
- `ARCHITECTURE.md`: fixed package description from "21 built-in definitions" → 24
- `CLAUDE.md`: updated count and added no-verify bypass to the invariant list

#### OpenCode driver
OpenCode was added as a supported agent driver in PR #1019, but docs still listed only `human`, `claude-code`, `copilot`, `ci`.

- `README.md`: added `opencode` to the supported driver list
- `CLAUDE.md`: added `opencode` to the Agent Identity driver list

#### Hook architecture docs
`docs/hook-architecture.md` only described Claude Code hooks despite Copilot CLI hooks being shipped.

- Broadened title from "How AgentGuard Integrates with Claude Code" to "How AgentGuard Integrates with AI Coding Agents"
- Added supported agents overview table at the top
- Added Copilot CLI hook configuration section with JSON config example
- Updated Key Source Files table with copilot adapter files

#### Multi-framework adapters docs
`docs/multi-framework-adapters.md` described Copilot CLI as P2/planned when it is actually shipped.

- Updated Context section to reflect 2 shipped adapters (Claude Code + Copilot CLI)
- Updated priority table with shipped/planned status column

### Code Changes Referenced
- `feat(invariants): add no-verify-bypass invariant` — PR #1002
- `feat: add OpenCode as a supported agent driver` — PR #1019
- `test: add coverage for copilot-hook and copilot-init` — PR #992 (confirming Copilot CLI is shipped)