### PR TITLE
feat(site): add user capture funnel — 4 early access touchpoints (closes #938)

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -446,6 +446,10 @@
               <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
               View on GitHub
             </a>
+            <a href="https://agentguard-cloud-dashboard.vercel.app/signup" target="_blank" rel="noopener noreferrer" class="border border-cta/40 hover:border-cta text-cta font-semibold px-6 py-3 rounded-lg transition-colors text-sm inline-flex items-center gap-2 cursor-pointer">
+              <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
+              Get Early Access
+            </a>
           </div>
         </div>
 
@@ -1248,6 +1252,19 @@
                 <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
               </button>
             </div>
+          </div>
+
+          <!-- Early Access CTA -->
+          <div class="reveal mt-10 bg-surface border border-cta/20 rounded-xl p-6 text-center" style="transition-delay: 300ms">
+            <div class="flex items-center justify-center gap-2 mb-2">
+              <svg class="w-5 h-5 text-cta" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M22 11.08V12a10 10 0 11-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
+              <span class="font-mono text-cta text-sm font-semibold">Next step</span>
+            </div>
+            <p class="text-muted text-sm mb-4">Get cloud governance telemetry, team dashboards, and release updates.</p>
+            <a href="https://agentguard-cloud-dashboard.vercel.app/signup" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-2 bg-cta hover:bg-cta-dark text-bg font-semibold px-5 py-2.5 rounded-lg transition-colors text-sm cursor-pointer">
+              <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
+              Sign Up for Early Access
+            </a>
           </div>
         </div>
       </div>
@@ -2095,6 +2112,57 @@ rules:
       </div>
     </section>
 
+    <!-- ============================================ -->
+    <!-- EARLY ACCESS / USER CAPTURE                  -->
+    <!-- ============================================ -->
+    <section id="early-access" class="py-24 bg-gradient-to-b from-transparent via-cta/[0.03] to-transparent" aria-labelledby="early-access-heading">
+      <div class="max-w-3xl mx-auto px-6">
+        <div class="reveal text-center mb-10">
+          <p class="font-mono text-cta text-sm font-semibold tracking-wider uppercase mb-4">Stay in the Loop</p>
+          <h2 id="early-access-heading" class="font-mono font-bold text-3xl sm:text-4xl mb-4">Get Early Access</h2>
+          <p class="text-muted text-lg max-w-xl mx-auto">
+            Cloud dashboard, team governance analytics, and real-time agent telemetry are launching soon.
+            Sign up to be first in line.
+          </p>
+        </div>
+
+        <div class="reveal flex flex-col sm:flex-row items-center justify-center gap-4 mb-10">
+          <a href="https://agentguard-cloud-dashboard.vercel.app/signup" target="_blank" rel="noopener noreferrer" class="bg-cta hover:bg-cta-dark text-bg font-semibold px-8 py-3.5 rounded-lg transition-colors text-sm inline-flex items-center gap-2 cursor-pointer w-full sm:w-auto justify-center">
+            <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
+            Sign Up for Early Access
+          </a>
+          <a href="https://github.com/AgentGuardHQ/agentguard/discussions" target="_blank" rel="noopener noreferrer" class="border border-surface-light hover:border-muted text-text font-semibold px-8 py-3.5 rounded-lg transition-colors text-sm inline-flex items-center gap-2 cursor-pointer w-full sm:w-auto justify-center">
+            <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/></svg>
+            Join Discussions
+          </a>
+        </div>
+
+        <div class="reveal grid sm:grid-cols-3 gap-6">
+          <div class="bg-surface border border-surface-light rounded-xl p-5 text-center">
+            <div class="w-10 h-10 mx-auto mb-3 rounded-lg bg-cta/10 flex items-center justify-center">
+              <svg class="w-5 h-5 text-cta" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18"/><path d="M9 21V9"/></svg>
+            </div>
+            <p class="font-mono text-text text-sm font-semibold mb-1">Cloud Dashboard</p>
+            <p class="text-muted text-xs">Multi-tenant governance telemetry with GitHub & Google OAuth.</p>
+          </div>
+          <div class="bg-surface border border-surface-light rounded-xl p-5 text-center">
+            <div class="w-10 h-10 mx-auto mb-3 rounded-lg bg-cta/10 flex items-center justify-center">
+              <svg class="w-5 h-5 text-cta" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87"/><path d="M16 3.13a4 4 0 010 7.75"/></svg>
+            </div>
+            <p class="font-mono text-text text-sm font-semibold mb-1">Team Analytics</p>
+            <p class="text-muted text-xs">Cross-agent governance reports and violation pattern insights.</p>
+          </div>
+          <div class="bg-surface border border-surface-light rounded-xl p-5 text-center">
+            <div class="w-10 h-10 mx-auto mb-3 rounded-lg bg-cta/10 flex items-center justify-center">
+              <svg class="w-5 h-5 text-cta" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
+            </div>
+            <p class="font-mono text-text text-sm font-semibold mb-1">Live Telemetry</p>
+            <p class="text-muted text-xs">Real-time agent activity streams and office visualization.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
   </main>
 
   <!-- ============================================ -->
@@ -2153,6 +2221,7 @@ rules:
             <li><a href="https://github.com/AgentGuardHQ/agentguard/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer" class="text-muted hover:text-text transition-colors text-sm cursor-pointer">Contributing</a></li>
             <li><a href="https://github.com/AgentGuardHQ/agentguard/issues" target="_blank" rel="noopener noreferrer" class="text-muted hover:text-text transition-colors text-sm cursor-pointer">Issues</a></li>
             <li><a href="https://github.com/AgentGuardHQ/agentguard/discussions" target="_blank" rel="noopener noreferrer" class="text-muted hover:text-text transition-colors text-sm cursor-pointer">Discussions</a></li>
+            <li><a href="https://agentguard-cloud-dashboard.vercel.app/signup" target="_blank" rel="noopener noreferrer" class="text-cta hover:text-cta-dark transition-colors text-sm font-semibold cursor-pointer">Early Access ↗</a></li>
           </ul>
         </div>
       </div>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://agentguardhq.github.io/agentguard/</loc>
-    <lastmod>2026-03-26</lastmod>
+    <lastmod>2026-03-27</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
## Summary

Adds a user capture funnel to the landing page — the **v3.0 release blocker** from #938.

### 4 Capture Touchpoints

| Location | Type | CTA |
|----------|------|-----|
| **Hero section** | Button (green outline) | "Get Early Access" |
| **After Quick Start step 04** | Banner with pitch | "Sign Up for Early Access" |
| **Dedicated section** (before footer) | Full section with 3 feature cards | "Sign Up for Early Access" + "Join Discussions" |
| **Footer** (Community column) | Highlighted link | "Early Access ↗" |

### Design Details

- All CTAs link to the cloud dashboard signup (`agentguard-cloud-dashboard.vercel.app/signup`)
- GitHub Discussions linked as secondary CTA in dedicated section
- Follows existing Tailwind/design system conventions (green CTA colors, `font-mono` headings, surface cards)
- Responsive: buttons stack vertically on mobile, cards use `sm:grid-cols-3`
- 3 feature cards highlight what's coming: Cloud Dashboard, Team Analytics, Live Telemetry
- Sitemap lastmod updated to 2026-03-27

### Files Changed

- `site/index.html` — 4 new capture points (+69 lines)
- `site/sitemap.xml` — lastmod date update

Closes #938