### PR TITLE
feat: add agent identity to agentguard inspect output

### DIFF
--- a/apps/cli/src/commands/inspect.ts
+++ b/apps/cli/src/commands/inspect.ts
@@ -33,38 +33,60 @@ async function openSqliteDb(storageConfig?: StorageConfig) {
 export async function inspect(args: string[], storageConfig?: StorageConfig): Promise<void> {
   const showDecisions = args.includes('--decisions');
   const showTraces = args.includes('--traces');
+  const agentIdx = args.indexOf('--agent');
+  const agentFilter = agentIdx !== -1 ? args[agentIdx + 1] : undefined;
   const filteredArgs = args.filter(
-    (a) =>
-      a !== '--decisions' && a !== '--traces' && a !== '--store' && a !== 'sqlite' && a !== 'jsonl'
+    (a, i) =>
+      a !== '--decisions' &&
+      a !== '--traces' &&
+      a !== '--agent' &&
+      a !== '--store' &&
+      a !== 'sqlite' &&
+      a !== 'jsonl' &&
+      (agentIdx === -1 || i !== agentIdx + 1)
   );
   const targetArg = filteredArgs[0];
 
   if (!targetArg || targetArg === '--list') {
     const storage = await openSqliteDb(storageConfig);
     if (!storage) return;
-    const { listRunIds } = await import('@red-codes/storage');
+    const { listRunIds, listRunIdsByAgent, getRunAgents, loadRunEvents } = await import(
+      '@red-codes/storage'
+    );
     const db = storage.db as import('better-sqlite3').Database;
-    const runs = listRunIds(db);
-    storage.close();
+    const runs = agentFilter ? listRunIdsByAgent(db, agentFilter) : listRunIds(db);
 
     if (runs.length === 0) {
-      process.stderr.write('\n  \x1b[2mNo runs recorded yet.\x1b[0m\n');
-      process.stderr.write('  Run \x1b[1magentguard guard\x1b[0m to start recording.\n\n');
+      if (agentFilter) {
+        process.stderr.write(
+          `\n  \x1b[2mNo runs found for agent: ${agentFilter}\x1b[0m\n\n`
+        );
+      } else {
+        process.stderr.write('\n  \x1b[2mNo runs recorded yet.\x1b[0m\n');
+        process.stderr.write('  Run \x1b[1magentguard guard\x1b[0m to start recording.\n\n');
+      }
+      storage.close();
       return;
     }
 
-    process.stderr.write('\n  \x1b[1mRecorded Runs\x1b[0m\n');
+    const displayRuns = runs.slice(0, 20);
+    const agentMap = getRunAgents(db, displayRuns);
+
+    const header = agentFilter
+      ? `\x1b[1mRecorded Runs\x1b[0m \x1b[2m(agent: ${agentFilter})\x1b[0m`
+      : '\x1b[1mRecorded Runs\x1b[0m';
+    process.stderr.write(`\n  ${header}\n`);
     process.stderr.write(`  ${'\x1b[2m'}${'─'.repeat(50)}${'\x1b[0m'}\n`);
 
-    const storage2 = await openSqliteDb(storageConfig);
-    if (!storage2) return;
-    const { loadRunEvents } = await import('@red-codes/storage');
-    const db2 = storage2.db as import('better-sqlite3').Database;
-    for (const id of runs.slice(0, 20)) {
-      const events = loadRunEvents(db2, id);
-      process.stderr.write(`  ${id}  ${'\x1b[2m'}(${events.length} events)${'\x1b[0m'}\n`);
+    for (const id of displayRuns) {
+      const evts = loadRunEvents(db, id);
+      const agent = agentMap.get(id);
+      const agentLabel = agent ? `  \x1b[36m${agent}\x1b[0m` : '';
+      process.stderr.write(
+        `  ${id}${agentLabel}  ${'\x1b[2m'}(${evts.length} events)${'\x1b[0m'}\n`
+      );
     }
-    storage2.close();
+    storage.close();
 
     process.stderr.write('\n');
     return;
@@ -91,18 +113,21 @@ export async function inspect(args: string[], storageConfig?: StorageConfig): Pr
   // Load events
   const storage = await openSqliteDb(storageConfig);
   if (!storage) return;
-  const { loadRunEvents, loadRunDecisions } = await import('@red-codes/storage');
+  const { loadRunEvents, loadRunDecisions, getRunAgent } = await import('@red-codes/storage');
   const db = storage.db as import('better-sqlite3').Database;
   const eventList = loadRunEvents(db, targetRunId);
+  const agent = getRunAgent(db, targetRunId);
 
   if (eventList.length === 0) {
     process.stderr.write(`  \x1b[31mError:\x1b[0m No events found for run: ${targetRunId}\n`);
   }
 
+  const agentLine = agent ? `  \x1b[1mAgent:\x1b[0m ${agent}\n` : '';
+
   // Show decision records if --decisions flag is present
   if (showDecisions) {
     const decisions = loadRunDecisions(db, targetRunId);
-    process.stderr.write(`\n  \x1b[1mRun:\x1b[0m ${targetRunId}\n`);
+    process.stderr.write(`\n  \x1b[1mRun:\x1b[0m ${targetRunId}\n${agentLine}`);
     if (decisions.length > 0) {
       process.stderr.write(renderDecisionTable(decisions));
     } else {
@@ -113,7 +138,7 @@ export async function inspect(args: string[], storageConfig?: StorageConfig): Pr
   storage.close();
 
   if (!showDecisions) {
-    process.stderr.write(`\n  \x1b[1mRun:\x1b[0m ${targetRunId}\n`);
+    process.stderr.write(`\n  \x1b[1mRun:\x1b[0m ${targetRunId}\n${agentLine}`);
   }
 
   // Show policy evaluation traces if --traces flag is present

--- a/apps/cli/tests/cli-inspect.test.ts
+++ b/apps/cli/tests/cli-inspect.test.ts
@@ -92,6 +92,61 @@ describe('inspect', () => {
     expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('Recorded Runs'));
   });
 
+  it('shows agent name in --list when RunStarted has agentName', async () => {
+    seedEvents('run_001', [
+      makeActionEvent('RunStarted', { agentName: 'kernel-sr' }),
+      makeActionEvent('ActionAllowed'),
+    ]);
+
+    await inspect(['--list'], storageConfig);
+
+    expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('kernel-sr'));
+  });
+
+  it('shows agent identity in run detail view', async () => {
+    seedEvents('run_001', [
+      makeActionEvent('RunStarted', { agentName: 'cloud-em' }),
+      makeActionEvent('ActionAllowed'),
+      makeActionEvent('ActionExecuted'),
+    ]);
+
+    await inspect(['run_001'], storageConfig);
+
+    expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('Agent:'));
+    expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('cloud-em'));
+  });
+
+  it('filters runs by --agent flag', async () => {
+    seedEvents('run_001', [
+      makeActionEvent('RunStarted', { agentName: 'kernel-sr' }),
+      makeActionEvent('ActionAllowed'),
+    ]);
+    seedEvents('run_002', [
+      makeActionEvent('RunStarted', { agentName: 'cloud-em', timestamp: 2000 }),
+      makeActionEvent('ActionAllowed', { timestamp: 2001 }),
+    ]);
+
+    await inspect(['--list', '--agent', 'kernel-sr'], storageConfig);
+
+    expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('kernel-sr'));
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      expect.stringContaining('agent: kernel-sr')
+    );
+  });
+
+  it('shows no runs message when --agent filter has no matches', async () => {
+    seedEvents('run_001', [
+      makeActionEvent('RunStarted', { agentName: 'kernel-sr' }),
+      makeActionEvent('ActionAllowed'),
+    ]);
+
+    await inspect(['--list', '--agent', 'nonexistent'], storageConfig);
+
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      expect.stringContaining('No runs found for agent: nonexistent')
+    );
+  });
+
   it('loads specific run by ID', async () => {
     seedEvents('run_001', [makeActionEvent('ActionAllowed'), makeActionEvent('ActionExecuted')]);
 

--- a/packages/storage/src/sqlite-store.ts
+++ b/packages/storage/src/sqlite-store.ts
@@ -214,6 +214,55 @@ export function queryEventsByKindAcrossRuns(
   }));
 }
 
+/** Resolve agent identity for a run from its RunStarted event */
+export function getRunAgent(db: Database.Database, runId: string): string | null {
+  const row = db
+    .prepare(
+      `SELECT COALESCE(
+        json_extract(data, '$.agentName'),
+        json_extract(data, '$.agentId'),
+        NULL
+      ) as agent FROM events WHERE run_id = ? AND kind = 'RunStarted' LIMIT 1`
+    )
+    .get(runId) as { agent: string | null } | undefined;
+  return row?.agent ?? null;
+}
+
+/** Resolve agent identity for multiple runs in a single query */
+export function getRunAgents(
+  db: Database.Database,
+  runIds: string[]
+): Map<string, string> {
+  if (runIds.length === 0) return new Map();
+  const placeholders = runIds.map(() => '?').join(', ');
+  const rows = db
+    .prepare(
+      `SELECT run_id, COALESCE(
+        json_extract(data, '$.agentName'),
+        json_extract(data, '$.agentId'),
+        'unknown'
+      ) as agent FROM events WHERE run_id IN (${placeholders}) AND kind = 'RunStarted'`
+    )
+    .all(...runIds) as Array<{ run_id: string; agent: string }>;
+  const result = new Map<string, string>();
+  for (const row of rows) {
+    result.set(row.run_id, row.agent);
+  }
+  return result;
+}
+
+/** List run IDs that belong to a specific agent */
+export function listRunIdsByAgent(db: Database.Database, agentName: string): string[] {
+  const rows = db
+    .prepare(
+      `SELECT run_id FROM events WHERE kind = 'RunStarted' AND (
+        json_extract(data, '$.agentName') = ? OR json_extract(data, '$.agentId') = ?
+      ) ORDER BY timestamp DESC`
+    )
+    .all(agentName, agentName) as { run_id: string }[];
+  return rows.map((r) => r.run_id);
+}
+
 /** Extract run_id from event metadata if present */
 function extractRunId(event: DomainEvent): string | undefined {
   const meta = event.metadata as Record<string, unknown> | undefined;


### PR DESCRIPTION
Closes #1030

## Implementation Summary

**What changed:**
- `inspect --list` now shows the agent name (from RunStarted event) next to each run ID in cyan
- `inspect --agent <name>` filters the run list to only runs belonging to that agent
- Run detail view (`inspect <runId>`, `inspect --last`) now shows an `Agent:` line in the header
- Added 3 new storage helpers: `getRunAgent()`, `getRunAgents()`, `listRunIdsByAgent()` — following the same RunStarted JSON extraction pattern used by `agentSummaries()`
- 4 new tests covering agent display in list, detail view, agent filtering, and no-match messaging

**How to verify:**
1. Run `pnpm build && pnpm test --filter=@red-codes/agentguard -- tests/cli-inspect.test.ts`
2. All 17 inspect tests pass (13 original + 4 new)
3. Storage tests: `pnpm test --filter=@red-codes/storage` — 200 tests pass

**Tier C scope check:**
- Files changed: 3 (limit: 5)
- Lines changed: ~148 (limit: 300)
- Breaking changes: None

---
*Tier C implementation by copilot-cli — AgentGuard three-tier governance*