### PR TITLE
docs: fix stale invariant count 23→24 across README, ROADMAP, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Install in 30 seconds. Your agents can't break what matters.</p>
 
 ---
 
-AI coding agents (Claude Code, GitHub Copilot, any MCP client) run autonomously — writing files, executing commands, pushing code. AgentGuard prevents them from doing catastrophic things: no accidental pushes to main, no credential leaks, no runaway destructive loops. 23 built-in safety checks, zero config required.
+AI coding agents (Claude Code, GitHub Copilot, any MCP client) run autonomously — writing files, executing commands, pushing code. AgentGuard prevents them from doing catastrophic things: no accidental pushes to main, no credential leaks, no runaway destructive loops. 24 built-in safety checks, zero config required.
 
 **For individuals:** stop your AI from wrecking your machine or repo.
 **For teams:** run fleets of agents safely at scale, with audit trails that pass compliance.
@@ -48,7 +48,7 @@ The `claude-init` wizard walks you through setup interactively:
 
   Enable a policy pack?
     ❯ 1) essentials — secrets, force push, protected branches, credentials
-      2) strict — all 23 invariants enforced
+      2) strict — all 24 invariants enforced
       3) none — monitor only, configure later
 ```
 
@@ -104,7 +104,7 @@ Identity consists of a **role** (`developer`, `reviewer`, `ops`, `security`, `pl
 | Capability | Details |
 |------------|---------|
 | **Policy enforcement** | YAML rules with deny / allow / escalate — drop `agentguard.yaml` in your repo |
-| **23 built-in invariants** | Secret exposure, protected branches, blast radius, path traversal, CI/CD config, package script injection, and more |
+| **24 built-in invariants** | Secret exposure, protected branches, blast radius, path traversal, CI/CD config, package script injection, and more |
 | **47 event kinds** | Full lifecycle telemetry: `ActionRequested → ActionAllowed/Denied → ActionExecuted` |
 | **Real-time cloud dashboard** | Telemetry streams to your team dashboard; opt-in, anonymous by default |
 | **Multi-tenant** | Team workspaces, GitHub/Google OAuth, SSO-ready |
@@ -290,7 +290,7 @@ rules:
 
 ## Built-in Invariants
 
-23 safety invariants run on every action evaluation:
+24 safety invariants run on every action evaluation:
 
 | Invariant | Severity | What it blocks |
 |-----------|----------|----------------|
@@ -317,6 +317,7 @@ rules:
 | `test-before-push` | Medium | Requires tests to pass before push |
 | `recursive-operation-guard` | Low | `find -exec`, `xargs` with write/delete |
 | `lockfile-integrity` | Low | `package.json` changes without lockfile sync |
+| `no-verify-bypass` | High | `--no-verify` flag on git push/commit (prevents skipping hooks) |
 
 ## Architecture
 
@@ -327,7 +328,7 @@ Agent tool call
 AgentGuard Kernel
   1. Normalize   — map tool call to canonical action type
   2. Evaluate    — match policy rules (deny / allow / escalate)
-  3. Check       — run 23 built-in invariants
+  3. Check       — run 24 built-in invariants
   4. Execute     — run action via adapter (file, shell, git)
   5. Emit        — 47 event kinds → SQLite audit trail + cloud telemetry
 ```
@@ -371,7 +372,7 @@ For teams running agent fleets, governance becomes invisible. Agents get 8% more
 
 **Zero-dependency deployment** — the Go kernel is a single static binary. No `node_modules`, no `pnpm install`, no bootstrap deadlocks. Drop it in a worktree and it works. This is critical for CI/CD and fleet scenarios where agents spin up fresh environments.
 
-The Go kernel includes: action normalization with AST-based shell parsing, policy evaluation, 23 invariants, escalation state machine, blast radius engine, telemetry shipper (stdout/file/HTTP), and a control plane signals API. It ships automatically via `npm install` — a postinstall script downloads the prebuilt binary for your platform.
+The Go kernel includes: action normalization with AST-based shell parsing, policy evaluation, 24 invariants, escalation state machine, blast radius engine, telemetry shipper (stdout/file/HTTP), and a control plane signals API. It ships automatically via `npm install` — a postinstall script downloads the prebuilt binary for your platform.
 
 ## For Teams and Enterprise
 
@@ -469,7 +470,7 @@ extends:
 | `engineering-standards` | Balanced dev-friendly guardrails: test-before-push, format checks, safe deps |
 | `ci-safe` | Strict CI/CD pipeline protection |
 | `enterprise` | Full enterprise governance |
-| `strict` | Maximum restriction — all 23 invariants enforced |
+| `strict` | Maximum restriction — all 24 invariants enforced |
 | `open-source` | OSS contribution-friendly defaults |
 
 ## Community & Updates

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,7 +27,7 @@ AgentGuard is the **Execution Control Plane for autonomous AI agents** — the i
 | Governed action kernel (41 action types, 10 classes) | Implemented | Production |
 | Action Authorization Boundary (AAB) | Implemented | Bypass vectors closed (3 fixed in v2.4.0) |
 | Policy evaluator (YAML/JSON, composition, packs) | Implemented | Production |
-| 23 built-in invariants | Implemented | Production |
+| 24 built-in invariants | Implemented | Production |
 | Canonical event model (47 event kinds) | Implemented | Production |
 | Pre-execution simulation engine (3 simulators) | Implemented | Production |
 | Blast radius computation | Implemented | Production |

--- a/docs/autonomous-sdlc-architecture.md
+++ b/docs/autonomous-sdlc-architecture.md
@@ -81,7 +81,7 @@ Agents cannot perform anything outside this set. That gives deterministic govern
 
 ### Mapping to AgentGuard's Action Types
 
-AgentGuard already defines 23 canonical action types across 8 classes (`src/core/actions.ts:27-51`). The 5 SDLC syscalls are a higher-level abstraction over these implementation-level types:
+AgentGuard already defines 41 canonical action types across 10 classes (`packages/core/src/data/actions.json`). The 5 SDLC syscalls are a higher-level abstraction over these implementation-level types:
 
 | Syscall | AgentGuard Action Types |
 |---------|------------------------|

--- a/docs/owasp-agentic-top10-coverage.md
+++ b/docs/owasp-agentic-top10-coverage.md
@@ -180,7 +180,7 @@
 
 | Mechanism | Component | What It Does |
 |-----------|-----------|-------------|
-| 38+ event kinds | `packages/events/src/schema.ts` | Governance, reference monitor, decision, simulation, integrity, heartbeat |
+| 47 event kinds | `packages/events/src/schema.ts` | Governance, reference monitor, decision, simulation, integrity, heartbeat |
 | SQLite persistence | `packages/storage/src/sqlite-sink.ts` | All events sunk to indexed database with migrations |
 | Policy traces | `PolicyTraceRecorded` event | Logs all rules checked, conditions evaluated, outcomes |
 | Heartbeat monitoring | `packages/kernel/src/heartbeat.ts` | `HeartbeatEmitted`, `HeartbeatMissed`, `AgentUnresponsive` |

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -258,7 +258,7 @@ rules:
 
 ### 3. Invariant Plugins
 
-Invariant plugins add custom safety checks evaluated before every action. AgentGuard ships 23 built-in invariants; plugins extend this with domain-specific checks.
+Invariant plugins add custom safety checks evaluated before every action. AgentGuard ships 24 built-in invariants; plugins extend this with domain-specific checks.
 
 **Integration point:** `packages/invariants/src/` — implement the `AgentGuardInvariant` interface.
 


### PR DESCRIPTION
## Summary

Fixes stale invariant count (**23 → 24**) across all user-facing documentation. The 24th invariant (`no-verify-bypass`) was added to the kernel but documentation was never updated.

### Changes

| File | Fix |
|------|-----|
| **README.md** | Update 7 count references (23→24); add `no-verify-bypass` row to invariant table |
| **ROADMAP.md** | Update invariant count in status table |
| **docs/plugin-api.md** | Update invariant count |
| **docs/autonomous-sdlc-architecture.md** | Fix very stale action type count (23/8 classes → 41/10 classes) + file path |
| **docs/owasp-agentic-top10-coverage.md** | Fix stale event kind count (38+ → 47) |

### Verification

Counts verified against source of truth:
- Invariants: 24 entries in `DEFAULT_INVARIANTS[]` (`packages/invariants/src/definitions.ts`)
- Action types: 41 in `packages/core/src/data/actions.json`
- Event kinds: 47 exported `EventKind` constants (`packages/events/src/schema.ts`)

Docs-only change — no code modified.

agent: `claude-code:opus:site:builder`