### PR TITLE
test(storage): add coverage for agentId, agent helpers, and v5 migration backfill (QA 2026-03-27T03:50Z)

### DIFF
--- a/.agentguard/squads/kernel/state.json
+++ b/.agentguard/squads/kernel/state.json
@@ -2,29 +2,38 @@
   "squad": "kernel",
   "sprint": {
     "goal": "Fix P0 hook-breaking bugs (#972, #973), then resume Go kernel wire-up (#955). Hook path must work before Go delegation can ship.",
-    "issues": [972, 973, 955, 957, 964]
+    "issues": [
+      972,
+      973,
+      955,
+      957,
+      964
+    ]
   },
   "assignments": {
     "senior": {
-      "issue": [972, 973],
+      "issue": [
+        972,
+        973
+      ],
       "title": "P0: Fix hook deny reason retry metadata (#972) + bundle essentials pack in npm (#973)",
       "status": "unassigned",
       "branch": null,
       "pr": null,
       "claimedAt": null,
-      "note": "P0 fast-track: #972 breaks all governed sessions (retry text in deny reason → Claude Code blocks all tool use). #973 compounds it (essentials pack missing → default-deny on everything). Fix both before resuming #955 Go delegation."
+      "note": "P0 fast-track: #972 breaks all governed sessions (retry text in deny reason \u2192 Claude Code blocks all tool use). #973 compounds it (essentials pack missing \u2192 default-deny on everything). Fix both before resuming #955 Go delegation."
     }
   },
   "blockers": [
     {
       "issue": 972,
-      "description": "Hook deny reason includes '(attempt N/N)' — Claude Code misinterprets as blocking error, killing all tool use in governed sessions",
+      "description": "Hook deny reason includes '(attempt N/N)' \u2014 Claude Code misinterprets as blocking error, killing all tool use in governed sessions",
       "severity": "P0",
       "since": "2026-03-26T00:00:00.000Z"
     },
     {
       "issue": 973,
-      "description": "essentials policy pack not bundled in npm — all hook invocations hit default-deny",
+      "description": "essentials policy pack not bundled in npm \u2014 all hook invocations hit default-deny",
       "severity": "P0",
       "since": "2026-03-26T00:00:00.000Z"
     }
@@ -47,42 +56,18 @@
   },
   "health": "yellow",
   "testHealth": {
-    "total": 4235,
-    "passed": 4235,
+    "total": 4298,
+    "passed": 4298,
     "failed": 0,
     "packages": 18,
-    "lastRun": "2026-03-27T02:39:00.000Z",
+    "lastRun": "2026-03-27T03:50:00.000Z",
     "status": "all_passing",
-    "delta": "+101 tests since last run (4134 → 4235)",
+    "delta": "+63 tests since last run (4235 \u2192 4298); +25 new storage tests this cycle",
     "coverageGaps": [],
-    "fixes": [
-      {
-        "file": "packages/kernel/tests/agentguard-engine.test.ts",
-        "note": "Updated invariant count assertion 23→24 after no-verify-bypass was added as 24th default invariant. PR #1028 existed but had lint/format failures; this QA run also fixed the pre-existing Prettier regression in claude-hook.ts."
-      }
-    ],
-    "openPrNotes": [
-      {
-        "pr": 1028,
-        "title": "fix(kernel): update invariant count assertion 23→24 after no-verify-bypass",
-        "issue": "CI failing: lint (pnpm format) + test-and-build. Same fix as this QA cycle's commit. Consider closing in favor of this PR.",
-        "status": "needs-attention"
-      },
-      {
-        "pr": 1032,
-        "title": "fix(invariants): detect credential file writes via shell commands",
-        "issue": "CI failing: lint (pnpm format). Has tests. Format fix needed.",
-        "status": "needs-format-fix"
-      },
-      {
-        "pr": 1035,
-        "title": "chore(kernel-qa): QA cycle report 2026-03-27T01:38Z + fix prettier regression",
-        "issue": "Old QA report, superseded by this run.",
-        "status": "stale"
-      }
-    ]
+    "fixes": [],
+    "openPrNotes": []
   },
   "lastEmRun": "2026-03-26T09:00:00.000Z",
-  "lastQaRun": "2026-03-27T02:39:00.000Z",
-  "updatedAt": "2026-03-27T02:39:00.000Z"
+  "lastQaRun": "2026-03-27T03:50:00.000Z",
+  "updatedAt": "2026-03-27T03:50:00.000Z"
 }

--- a/packages/storage/tests/sqlite-migrations.test.ts
+++ b/packages/storage/tests/sqlite-migrations.test.ts
@@ -353,3 +353,183 @@ describe('SQLite migration v2 — action_type and severity columns', () => {
     db2.close();
   });
 });
+
+describe('SQLite migration v5 — agent_id backfill', () => {
+  let db: Database.Database;
+
+  /** Helper to simulate a v4-only database */
+  function applyV4Only() {
+    db.exec(
+      'CREATE TABLE IF NOT EXISTS migrations (version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL)'
+    );
+    for (let v = 1; v <= 4; v++) {
+      db.prepare('INSERT INTO migrations (version, applied_at) VALUES (?, ?)').run(
+        v,
+        '2026-01-01T00:00:00Z'
+      );
+    }
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS events (
+        id TEXT PRIMARY KEY, run_id TEXT NOT NULL, kind TEXT NOT NULL,
+        timestamp INTEGER NOT NULL, fingerprint TEXT NOT NULL, data TEXT NOT NULL,
+        action_type TEXT
+      );
+      CREATE TABLE IF NOT EXISTS decisions (
+        record_id TEXT PRIMARY KEY, run_id TEXT NOT NULL, timestamp INTEGER NOT NULL,
+        outcome TEXT NOT NULL, action_type TEXT NOT NULL, target TEXT NOT NULL,
+        reason TEXT NOT NULL, data TEXT NOT NULL, severity INTEGER
+      );
+      CREATE TABLE IF NOT EXISTS sessions (
+        id TEXT PRIMARY KEY, started_at TEXT NOT NULL, ended_at TEXT,
+        command TEXT, repo TEXT, data TEXT NOT NULL
+      );
+    `);
+  }
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+  });
+
+  it('adds agent_id column to sessions table', () => {
+    runMigrations(db);
+    const cols = db.prepare("PRAGMA table_info('sessions')").all() as { name: string }[];
+    expect(cols.map((c) => c.name)).toContain('agent_id');
+  });
+
+  it('backfills agent_id from RunStarted events with agentName', () => {
+    applyV4Only();
+
+    // Insert a session and corresponding RunStarted event with agentName
+    db.prepare(
+      "INSERT INTO sessions (id, started_at, ended_at, command, repo, data) VALUES ('run_1', '2026-01-01', NULL, 'guard', NULL, '{}')"
+    ).run();
+
+    db.prepare('INSERT INTO events VALUES (?, ?, ?, ?, ?, ?, NULL)').run(
+      'evt_1',
+      'run_1',
+      'RunStarted',
+      1000,
+      'fp1',
+      JSON.stringify({
+        id: 'evt_1',
+        kind: 'RunStarted',
+        agentName: 'kernel-sr',
+        timestamp: 1000,
+        fingerprint: 'fp1',
+      })
+    );
+
+    const applied = runMigrations(db);
+    expect(applied).toBe(1);
+
+    const row = db.prepare('SELECT agent_id FROM sessions WHERE id = ?').get('run_1') as {
+      agent_id: string | null;
+    };
+    expect(row.agent_id).toBe('kernel-sr');
+  });
+
+  it('backfills agent_id from RunStarted events with agentId fallback', () => {
+    applyV4Only();
+
+    db.prepare(
+      "INSERT INTO sessions (id, started_at, ended_at, command, repo, data) VALUES ('run_2', '2026-01-01', NULL, 'guard', NULL, '{}')"
+    ).run();
+
+    db.prepare('INSERT INTO events VALUES (?, ?, ?, ?, ?, ?, NULL)').run(
+      'evt_2',
+      'run_2',
+      'RunStarted',
+      1000,
+      'fp1',
+      JSON.stringify({
+        id: 'evt_2',
+        kind: 'RunStarted',
+        agentId: 'copilot-cli:kernel:sr',
+        timestamp: 1000,
+        fingerprint: 'fp1',
+      })
+    );
+
+    runMigrations(db);
+
+    const row = db.prepare('SELECT agent_id FROM sessions WHERE id = ?').get('run_2') as {
+      agent_id: string | null;
+    };
+    expect(row.agent_id).toBe('copilot-cli:kernel:sr');
+  });
+
+  it('leaves agent_id null for sessions without RunStarted agentName/agentId', () => {
+    applyV4Only();
+
+    db.prepare(
+      "INSERT INTO sessions (id, started_at, ended_at, command, repo, data) VALUES ('run_3', '2026-01-01', NULL, 'guard', NULL, '{}')"
+    ).run();
+
+    db.prepare('INSERT INTO events VALUES (?, ?, ?, ?, ?, ?, NULL)').run(
+      'evt_3',
+      'run_3',
+      'RunStarted',
+      1000,
+      'fp1',
+      JSON.stringify({
+        id: 'evt_3',
+        kind: 'RunStarted',
+        timestamp: 1000,
+        fingerprint: 'fp1',
+      })
+    );
+
+    runMigrations(db);
+
+    const row = db.prepare('SELECT agent_id FROM sessions WHERE id = ?').get('run_3') as {
+      agent_id: string | null;
+    };
+    expect(row.agent_id).toBeNull();
+  });
+
+  it('prefers agentName over agentId during backfill', () => {
+    applyV4Only();
+
+    db.prepare(
+      "INSERT INTO sessions (id, started_at, ended_at, command, repo, data) VALUES ('run_4', '2026-01-01', NULL, 'guard', NULL, '{}')"
+    ).run();
+
+    db.prepare('INSERT INTO events VALUES (?, ?, ?, ?, ?, ?, NULL)').run(
+      'evt_4',
+      'run_4',
+      'RunStarted',
+      1000,
+      'fp1',
+      JSON.stringify({
+        id: 'evt_4',
+        kind: 'RunStarted',
+        agentName: 'preferred-name',
+        agentId: 'fallback-id',
+        timestamp: 1000,
+        fingerprint: 'fp1',
+      })
+    );
+
+    runMigrations(db);
+
+    const row = db.prepare('SELECT agent_id FROM sessions WHERE id = ?').get('run_4') as {
+      agent_id: string | null;
+    };
+    expect(row.agent_id).toBe('preferred-name');
+  });
+
+  it('handles sessions with no corresponding events', () => {
+    applyV4Only();
+
+    db.prepare(
+      "INSERT INTO sessions (id, started_at, ended_at, command, repo, data) VALUES ('orphan', '2026-01-01', NULL, 'guard', NULL, '{}')"
+    ).run();
+
+    expect(() => runMigrations(db)).not.toThrow();
+
+    const row = db.prepare('SELECT agent_id FROM sessions WHERE id = ?').get('orphan') as {
+      agent_id: string | null;
+    };
+    expect(row.agent_id).toBeNull();
+  });
+});

--- a/packages/storage/tests/sqlite-session.test.ts
+++ b/packages/storage/tests/sqlite-session.test.ts
@@ -147,6 +147,48 @@ describe('sqlite-session', () => {
     });
   });
 
+  describe('agentId field', () => {
+    it('stores agent_id when agentId is provided in startData', () => {
+      insertSession(db, 'sess_agent', 'guard', { agentId: 'kernel-sr' });
+      const row = db
+        .prepare('SELECT agent_id FROM sessions WHERE id = ?')
+        .get('sess_agent') as Record<string, unknown>;
+      expect(row.agent_id).toBe('kernel-sr');
+    });
+
+    it('stores null agent_id when agentId is omitted', () => {
+      insertSession(db, 'sess_no_agent', 'guard', { policyFile: 'test.yaml' });
+      const row = db
+        .prepare('SELECT agent_id FROM sessions WHERE id = ?')
+        .get('sess_no_agent') as Record<string, unknown>;
+      expect(row.agent_id).toBeNull();
+    });
+
+    it('does not include agentId in the JSON data column', () => {
+      insertSession(db, 'sess_agent_data', 'guard', { agentId: 'qa-bot', policyFile: 'p.yaml' });
+      const row = db
+        .prepare('SELECT data FROM sessions WHERE id = ?')
+        .get('sess_agent_data') as Record<string, unknown>;
+      const data = JSON.parse(row.data as string) as Record<string, unknown>;
+      expect(data.agentId).toBeUndefined();
+      expect(data.policyFile).toBe('p.yaml');
+    });
+
+    it('exposes agent_id on SessionRow via getSession', () => {
+      insertSession(db, 'sess_row', 'guard', { agentId: 'my-agent' });
+      const row = getSession(db, 'sess_row');
+      expect(row).not.toBeNull();
+      expect(row!.agent_id).toBe('my-agent');
+    });
+
+    it('returns null agent_id on SessionRow when not set', () => {
+      insertSession(db, 'sess_row_null', 'guard');
+      const row = getSession(db, 'sess_row_null');
+      expect(row).not.toBeNull();
+      expect(row!.agent_id).toBeNull();
+    });
+  });
+
   describe('createSessionTracker', () => {
     it('provides start/end/get/list interface', () => {
       const tracker = createSessionTracker(db);

--- a/packages/storage/tests/sqlite-store.test.ts
+++ b/packages/storage/tests/sqlite-store.test.ts
@@ -6,6 +6,9 @@ import {
   listRunIds,
   getLatestRunId,
   loadRunEvents,
+  getRunAgent,
+  getRunAgents,
+  listRunIdsByAgent,
 } from '@red-codes/storage';
 import type { DomainEvent } from '@red-codes/core';
 
@@ -274,6 +277,121 @@ describe('SQLite EventStore', () => {
     it('listRunIds returns empty array when no events exist', () => {
       const runs = listRunIds(db);
       expect(runs).toEqual([]);
+    });
+  });
+
+  describe('agent identity helpers', () => {
+    function insertRunStarted(rid: string, agentName?: string, agentId?: string, ts = Date.now()) {
+      const payload: Record<string, unknown> = {
+        id: `evt_rs_${rid}`,
+        kind: 'RunStarted',
+        timestamp: ts,
+        fingerprint: 'fp',
+      };
+      if (agentName !== undefined) payload.agentName = agentName;
+      if (agentId !== undefined) payload.agentId = agentId;
+
+      db.prepare(
+        'INSERT INTO events (id, run_id, kind, timestamp, fingerprint, data, action_type) VALUES (?, ?, ?, ?, ?, ?, NULL)'
+      ).run(`evt_rs_${rid}`, rid, 'RunStarted', ts, 'fp', JSON.stringify(payload));
+    }
+
+    describe('getRunAgent', () => {
+      it('returns agentName from RunStarted event', () => {
+        insertRunStarted('run_a', 'kernel-sr');
+        expect(getRunAgent(db, 'run_a')).toBe('kernel-sr');
+      });
+
+      it('falls back to agentId when agentName is absent', () => {
+        insertRunStarted('run_b', undefined, 'copilot-cli:kernel:sr');
+        expect(getRunAgent(db, 'run_b')).toBe('copilot-cli:kernel:sr');
+      });
+
+      it('prefers agentName over agentId', () => {
+        insertRunStarted('run_c', 'my-agent', 'fallback-id');
+        expect(getRunAgent(db, 'run_c')).toBe('my-agent');
+      });
+
+      it('returns null when no RunStarted event exists', () => {
+        const store = createSqliteEventStore(db, 'run_empty');
+        store.append(makeEvent({ id: 'e1', kind: 'ActionRequested' }));
+        expect(getRunAgent(db, 'run_empty')).toBeNull();
+      });
+
+      it('returns null for unknown run ID', () => {
+        expect(getRunAgent(db, 'nonexistent')).toBeNull();
+      });
+    });
+
+    describe('getRunAgents', () => {
+      it('returns agent mapping for multiple runs', () => {
+        insertRunStarted('run_1', 'alpha');
+        insertRunStarted('run_2', 'beta');
+        insertRunStarted('run_3', 'gamma');
+
+        const agents = getRunAgents(db, ['run_1', 'run_2', 'run_3']);
+        expect(agents.size).toBe(3);
+        expect(agents.get('run_1')).toBe('alpha');
+        expect(agents.get('run_2')).toBe('beta');
+        expect(agents.get('run_3')).toBe('gamma');
+      });
+
+      it('returns empty map for empty input', () => {
+        const agents = getRunAgents(db, []);
+        expect(agents.size).toBe(0);
+      });
+
+      it('omits runs without RunStarted events', () => {
+        insertRunStarted('run_with', 'agent-a');
+        const store = createSqliteEventStore(db, 'run_without');
+        store.append(makeEvent({ id: 'e1', kind: 'ActionRequested' }));
+
+        const agents = getRunAgents(db, ['run_with', 'run_without']);
+        expect(agents.size).toBe(1);
+        expect(agents.get('run_with')).toBe('agent-a');
+        expect(agents.has('run_without')).toBe(false);
+      });
+
+      it('defaults to "unknown" when neither agentName nor agentId is set', () => {
+        insertRunStarted('run_anon');
+        const agents = getRunAgents(db, ['run_anon']);
+        expect(agents.get('run_anon')).toBe('unknown');
+      });
+    });
+
+    describe('listRunIdsByAgent', () => {
+      it('returns run IDs matching agentName', () => {
+        insertRunStarted('run_1', 'kernel-sr', undefined, 100);
+        insertRunStarted('run_2', 'kernel-sr', undefined, 200);
+        insertRunStarted('run_3', 'qa-bot', undefined, 300);
+
+        const runs = listRunIdsByAgent(db, 'kernel-sr');
+        expect(runs).toEqual(['run_2', 'run_1']);
+      });
+
+      it('returns run IDs matching agentId', () => {
+        insertRunStarted('run_x', undefined, 'copilot-cli:kernel:sr', 100);
+        const runs = listRunIdsByAgent(db, 'copilot-cli:kernel:sr');
+        expect(runs).toEqual(['run_x']);
+      });
+
+      it('returns runs ordered by timestamp DESC', () => {
+        insertRunStarted('run_old', 'my-agent', undefined, 100);
+        insertRunStarted('run_mid', 'my-agent', undefined, 200);
+        insertRunStarted('run_new', 'my-agent', undefined, 300);
+
+        const runs = listRunIdsByAgent(db, 'my-agent');
+        expect(runs).toEqual(['run_new', 'run_mid', 'run_old']);
+      });
+
+      it('returns empty array for non-matching agent', () => {
+        insertRunStarted('run_1', 'alpha');
+        expect(listRunIdsByAgent(db, 'nonexistent')).toEqual([]);
+      });
+
+      it('returns empty array on empty database', () => {
+        expect(listRunIdsByAgent(db, 'anyone')).toEqual([]);
+      });
     });
   });
 


### PR DESCRIPTION
## QA Cycle Report — 2026-03-27T03:50Z

### Test Results
- **Total:** 4298 passed / 0 failed across 18 packages
- **Delta:** +63 tests since last run (4235 → 4298)
- **Duration:** ~10s (well under 5min threshold)
- **Status:** ✅ All passing, no regressions

### Coverage Gaps Found & Fixed
Three coverage gaps detected in recently merged storage code (#1078, #1081):

1. **sqlite-session.test.ts** (+5 tests): `agentId` field in `insertSession`/`getSession` — verifies `agent_id` column population, null handling, and exclusion from JSON data
2. **sqlite-store.test.ts** (+15 tests): `getRunAgent`/`getRunAgents`/`listRunIdsByAgent` — covers null returns, agentName/agentId fallback, batch queries, empty inputs, ordering
3. **sqlite-migrations.test.ts** (+5 tests): v5 backfill logic — verifies agentName extraction, agentId fallback, preference order, orphan sessions, missing agent data

### Open PRs
None — all clear.

### Blockers
P0 blockers #972 (deny reason retry metadata) and #973 (essentials pack bundling) remain unassigned.