### PR TITLE
feat(telemetry): add driverType field to AgentEvent wire format

### DIFF
--- a/packages/telemetry/src/cloud-sink.ts
+++ b/packages/telemetry/src/cloud-sink.ts
@@ -21,7 +21,7 @@ import type {
 import { anonymizeEvent } from './anonymize.js';
 import { createAgentEventQueue } from './agent-event-queue.js';
 import { createAgentEventSender } from './agent-event-sender.js';
-import { mapDomainEventToAgentEvent, mapDecisionToAgentEvent } from './event-mapper.js';
+import { mapDomainEventToAgentEvent, mapDecisionToAgentEvent, parseDriverType } from './event-mapper.js';
 import type { AgentEvent } from './event-mapper.js';
 import type { AgentEventQueue } from './agent-event-queue.js';
 import type { AgentEventSender } from './agent-event-sender.js';
@@ -119,10 +119,14 @@ export async function createCloudSinks(config: CloudSinkConfig): Promise<CloudSi
   }
 
   function prepareEvent(agentEvent: AgentEvent): AgentEvent {
+    const resolvedAgentId = agentEvent.agentId === 'unknown' ? agentId : agentEvent.agentId;
+    const resolvedDriverType =
+      agentEvent.driverType ?? parseDriverType(resolvedAgentId) ?? parseDriverType(agentId);
     const prepared: AgentEvent = {
       ...agentEvent,
       sessionId: runId,
-      agentId: agentEvent.agentId === 'unknown' ? agentId : agentEvent.agentId,
+      agentId: resolvedAgentId,
+      ...(resolvedDriverType !== undefined ? { driverType: resolvedDriverType } : {}),
       ...(parentSessionId ? { parentSessionId } : {}),
     };
     if (isAnonymous) {

--- a/packages/telemetry/src/event-mapper.ts
+++ b/packages/telemetry/src/event-mapper.ts
@@ -16,6 +16,7 @@ import type {
 export interface AgentEvent {
   eventId?: string;
   agentId: string;
+  driverType?: string;
   timestamp?: string;
   eventType:
     | 'tool_call'
@@ -33,6 +34,21 @@ export interface AgentEvent {
   policyVersion?: string;
   sessionId?: string;
   parentSessionId?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Driver type extraction from composite agentId
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse `driverType` from a composite agentId string.
+ * Format: `<driver>:<agentName>` (e.g. `claude-code:kernel-qa`).
+ * Returns undefined if the agentId has no driver prefix.
+ */
+export function parseDriverType(agentId: string): string | undefined {
+  const colonIndex = agentId.indexOf(':');
+  if (colonIndex <= 0) return undefined;
+  return agentId.slice(0, colonIndex);
 }
 
 // ---------------------------------------------------------------------------
@@ -177,9 +193,12 @@ export function mapDomainEventToAgentEvent(event: DomainEvent): AgentEvent {
 
   const riskLevel = resolveRiskLevel(simulationRiskLevel, escalationLevel);
 
+  const driverType = parseDriverType(agentId);
+
   const agentEvent: AgentEvent = {
     eventId: randomUUID(),
     agentId,
+    ...(driverType !== undefined ? { driverType } : {}),
     timestamp: new Date(event.timestamp).toISOString(),
     eventType,
     action: actionType,
@@ -217,9 +236,13 @@ export function mapDecisionToAgentEvent(record: GovernanceDecisionRecord): Agent
   const escalationLevel = record.monitor?.escalationLevel;
   const riskLevel = resolveRiskLevel(simulationRiskLevel, escalationLevel);
 
+  const agentId = record.action.agent;
+  const driverType = parseDriverType(agentId);
+
   const agentEvent: AgentEvent = {
     eventId: randomUUID(),
-    agentId: record.action.agent,
+    agentId,
+    ...(driverType !== undefined ? { driverType } : {}),
     timestamp: new Date(record.timestamp).toISOString(),
     eventType: 'decision',
     action: record.action.type,

--- a/packages/telemetry/tests/event-mapper.test.ts
+++ b/packages/telemetry/tests/event-mapper.test.ts
@@ -5,6 +5,7 @@ import {
   mapDomainEventToAgentEvent,
   mapDecisionToAgentEvent,
   mapEnvelopeToAgentEvent,
+  parseDriverType,
 } from '../src/event-mapper.js';
 
 // ---------------------------------------------------------------------------
@@ -960,5 +961,93 @@ describe('mapEnvelopeToAgentEvent', () => {
     expect(claudeResult.policyVersion).toBe(copilotResult.policyVersion);
     expect(claudeResult.metadata?.source).toBe('claude-code');
     expect(copilotResult.metadata?.source).toBe('copilot-cli');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseDriverType
+// ---------------------------------------------------------------------------
+
+describe('parseDriverType', () => {
+  it('parses driver from composite agentId', () => {
+    expect(parseDriverType('claude-code:kernel-qa')).toBe('claude-code');
+    expect(parseDriverType('copilot-cli:cloud-em')).toBe('copilot-cli');
+    expect(parseDriverType('codex-cli:studio-sr')).toBe('codex-cli');
+    expect(parseDriverType('gemini-cli:ops-agent')).toBe('gemini-cli');
+  });
+
+  it('returns undefined for legacy agentIds without driver prefix', () => {
+    expect(parseDriverType('kernel-sr')).toBeUndefined();
+    expect(parseDriverType('unknown')).toBeUndefined();
+  });
+
+  it('returns undefined for empty string', () => {
+    expect(parseDriverType('')).toBeUndefined();
+  });
+
+  it('handles agentId starting with colon as no driver', () => {
+    expect(parseDriverType(':missing-driver')).toBeUndefined();
+  });
+
+  it('handles multiple colons — only splits on first', () => {
+    expect(parseDriverType('claude-code:cloud:em')).toBe('claude-code');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// driverType propagation
+// ---------------------------------------------------------------------------
+
+describe('mapDomainEventToAgentEvent — driverType', () => {
+  it('sets driverType for composite agentId', () => {
+    const event = makeDomainEvent({
+      kind: 'ActionRequested',
+      actionType: 'file.write',
+      target: '/src/app.ts',
+      agentId: 'claude-code:kernel-qa',
+    });
+    const result = mapDomainEventToAgentEvent(event);
+    expect(result.driverType).toBe('claude-code');
+    expect(result.agentId).toBe('claude-code:kernel-qa');
+  });
+
+  it('omits driverType for legacy agentId without driver prefix', () => {
+    const event = makeDomainEvent({
+      kind: 'ActionRequested',
+      actionType: 'file.write',
+      target: '/src/app.ts',
+      agentId: 'kernel-sr',
+    });
+    const result = mapDomainEventToAgentEvent(event);
+    expect(result.driverType).toBeUndefined();
+  });
+});
+
+describe('mapDecisionToAgentEvent — driverType', () => {
+  it('sets driverType for composite agentId in decision record', () => {
+    const record = makeDecisionRecord({
+      action: {
+        type: 'git.push',
+        target: 'main',
+        agent: 'copilot-cli:cloud-em',
+        destructive: false,
+      },
+    });
+    const result = mapDecisionToAgentEvent(record);
+    expect(result.driverType).toBe('copilot-cli');
+    expect(result.agentId).toBe('copilot-cli:cloud-em');
+  });
+
+  it('omits driverType for legacy agentId in decision record', () => {
+    const record = makeDecisionRecord({
+      action: {
+        type: 'git.push',
+        target: 'main',
+        agent: 'cloud-em',
+        destructive: false,
+      },
+    });
+    const result = mapDecisionToAgentEvent(record);
+    expect(result.driverType).toBeUndefined();
   });
 });


### PR DESCRIPTION
Closes #1031

## Implementation Summary

**What changed:**
- Added optional `driverType?: string` field to the `AgentEvent` interface in `event-mapper.ts`
- Added exported `parseDriverType(agentId)` helper that extracts driver from composite `<driver>:<agentName>` format
- `mapDomainEventToAgentEvent` and `mapDecisionToAgentEvent` now populate `driverType` automatically
- `prepareEvent` in `cloud-sink.ts` derives `driverType` from the composite agentId when not already set (fallback to session-level `agentId` if event agentId is 'unknown')
- Backward compatible: legacy agentIds without `:` prefix leave `driverType` undefined

**How to verify:**
1. `pnpm test --filter=@red-codes/telemetry` — all 146 tests pass
2. Composite agentId like `claude-code:kernel-qa` produces `driverType: 'claude-code'` in emitted events
3. Legacy agentId like `kernel-sr` produces no `driverType` field (backward compat)

**Tier C scope check:**
- Files changed: 3 (limit: 5)
- Lines changed: ~119 (limit: 300)
- Breaking changes: None (additive optional field)

---
*Tier C implementation by copilot-cli — AgentGuard three-tier governance*