### PR TITLE
docs: sync documentation with codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,7 +187,7 @@ apps/
 
 # TS test files (vitest) distributed across packages/ and apps/ directories
 policy/                     # Policy configuration (JSON: action_rules, capabilities)
-policies/                   # Policy packs (YAML: ci-safe, engineering-standards, enterprise, hipaa, open-source, soc2, strict)
+policies/                   # Policy packs (dirs: ci-safe, engineering-standards, enterprise, hipaa, open-source, soc2, strict; YAML: essentials, readybench)
 docs/                       # System documentation (architecture, event model, specs)
 hooks/                      # Git hooks (post-commit, post-merge)
 examples/                   # Example governance scenarios and error demos
@@ -196,7 +196,7 @@ paper/                      # White paper (agentguard-whitepaper.md, diagrams, r
 scripts/                    # Build and utility scripts
 site/                       # GitHub Pages static site
 spec/                       # Feature specifications and templates
-templates/                  # Policy templates (ci-only, development, permissive, strict)
+templates/                  # Policy templates (ci-only, ci-safe, development, enterprise, permissive, strict; manifest variants: ci-only, full-dev, read-only-audit)
 ```
 
 ## Development Commands

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Install in 30 seconds. Your agents can't break what matters.</p>
 
 ---
 
-AI coding agents (Claude Code, GitHub Copilot, any MCP client) run autonomously — writing files, executing commands, pushing code. AgentGuard prevents them from doing catastrophic things: no accidental pushes to main, no credential leaks, no runaway destructive loops. 23 built-in safety checks, zero config required.
+AI coding agents (Claude Code, GitHub Copilot, any MCP client) run autonomously — writing files, executing commands, pushing code. AgentGuard prevents them from doing catastrophic things: no accidental pushes to main, no credential leaks, no runaway destructive loops. 24 built-in safety checks, zero config required.
 
 **For individuals:** stop your AI from wrecking your machine or repo.
 **For teams:** run fleets of agents safely at scale, with audit trails that pass compliance.


### PR DESCRIPTION
## What drifted

- **README.md line 17**: Invariant count was stale at `23` — corrected to `24` (all other references in README already said 24; the `no-verify-bypass` invariant was added earlier but this line was missed)
- **CLAUDE.md `policies/` entry**: Description said `(YAML: ci-safe, ...)` but the packs are actually subdirectories; also two new standalone YAML pack files (`essentials.yaml`, `readybench.yaml`) were not listed
- **CLAUDE.md `templates/` entry**: Missing `ci-safe.yaml`, `enterprise.yaml`, and the three `manifest-*.yaml` variants added to the templates directory

## Verification

Each fix was verified against the actual source:
- Invariant count: `awk '/^export const DEFAULT_INVARIANTS/,0' packages/invariants/src/definitions.ts | grep -c 'name:'` → 24
- Policies directory: `ls -la policies/` shows dirs + 2 YAML files
- Templates directory: `ls templates/` shows 9 files

---
*Created by copilot-docs-sync — AgentGuard Copilot swarm*