### PR TITLE
docs: sync documentation with v2.8.x codebase state

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -51,17 +51,18 @@ packages/
 ├── core/          @red-codes/core — Shared utilities (types, actions, hash, execution-log)
 ├── events/        @red-codes/events — Canonical event model (schema, bus, store)
 ├── policy/        @red-codes/policy — Policy system (composer, evaluator, loaders, pack loader)
-├── invariants/    @red-codes/invariants — Invariant system (21 built-in definitions, checker)
+├── invariants/    @red-codes/invariants — Invariant system (24 built-in definitions, checker)
 ├── invariant-data-protection/ @red-codes/invariant-data-protection — Data protection invariant plugin
 ├── matchers/      @red-codes/matchers — Structured matchers (Aho-Corasick, globs, hash sets)
 ├── kernel/        @red-codes/kernel — Governed action kernel (orchestrate, normalize, decide, escalate)
-├── adapters/      @red-codes/adapters — Execution adapters (file, shell, git, claude-code, copilot-cli)
+├── adapters/      @red-codes/adapters — Execution adapters (file, shell, git, claude-code, copilot-cli, codex-cli, gemini-cli)
 ├── storage/       @red-codes/storage — SQLite storage backend (opt-in)
 ├── telemetry/     @red-codes/telemetry — Runtime telemetry and logging
 ├── plugins/       @red-codes/plugins — Plugin ecosystem (discovery, registry, validation, sandboxing)
 ├── renderers/     @red-codes/renderers — Renderer plugin system (registry, TUI renderer)
 ├── sdk/           @red-codes/sdk — Agent SDK for programmatic governance integration
 ├── swarm/         @red-codes/swarm — Shareable agent swarm templates
+├── scheduler/     @red-codes/scheduler — Task scheduler, queue, lease manager, and worker orchestration
 └── telemetry-client/ @red-codes/telemetry-client — Telemetry client (identity, signing, queue, sender)
 
 apps/
@@ -117,7 +118,7 @@ The `claude-init` command provides an interactive wizard that generates a starte
 Agents declare their identity (role + driver) at the start of each governance session. If the `--agent-name` flag is not provided, an interactive prompt collects the identity.
 
 **Roles:** `developer`, `reviewer`, `ops`, `security`, `planner`
-**Drivers:** `human`, `claude-code`, `copilot`, `ci`
+**Drivers:** `human`, `claude-code`, `copilot`, `codex`, `gemini`, `ci`
 
 Identity serves three purposes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,84 @@
 # Changelog
 
+## 2.8.1 (2026-03-27)
+
+### Features
+
+* **Agent identity in all driver hooks** — All four hook drivers (Claude Code, Copilot CLI, Codex CLI, Gemini CLI) now resolve and pass agent identity into session tracking. Identity flows into SQLite session records for attribution and analytics.
+* **Session `agentId` tracking** — Migration v5 adds an `agent_id` column and index to the sessions table, enabling per-agent session queries and aggregation filters.
+* **`agentId` filter in aggregation queries** — Storage aggregation queries support filtering by `agentId` for agent-level analytics.
+* **Agent identity in `inspect` output** — `aguard inspect` now displays the resolved agent identity alongside run metadata.
+
+### Bug Fixes
+
+* **Init all driver hooks** — Re-initializing hooks via `agentguard *-init` commands now correctly re-writes hook configs for all four drivers.
+
+---
+
+## 2.8.0 (2026-03-26)
+
+### Features
+
+* **Codex CLI hook support** — New `agentguard codex-hook` and `agentguard codex-init` commands integrate AgentGuard governance into OpenAI Codex CLI workflows via PreToolUse/PostToolUse hooks. New adapter: `packages/adapters/src/codex-cli.ts`.
+* **Gemini CLI hook support** — New `agentguard gemini-hook` and `agentguard gemini-init` commands integrate AgentGuard governance into Google Gemini CLI workflows. New adapter: `packages/adapters/src/gemini-cli.ts`.
+* **Four-driver hook parity** — Claude Code, Copilot CLI, Codex CLI, and Gemini CLI all support the same PreToolUse/PostToolUse governance hook pattern with consistent block/allow/guide responses.
+
+---
+
+## 2.7.3 (2026-03-25)
+
+### Features
+
+* **Denial-retry-escalation invariant** — New invariant that detects and escalates repeated denial retries within a session (closes #908).
+* **Decisions index** — Added `action_type` index on the decisions table for faster filtered queries (closes #727).
+
+### Bug Fixes
+
+* **Path manipulation hardening** — Policy scope matching in `packages/matchers` is hardened against path traversal manipulation (closes #640).
+* **Credential pattern expansion** — Shell command stripping now catches additional AI/k8s/vault credential patterns (closes #639).
+* **CLI exports subpaths** — Added missing `bin` and `postinstall` subpaths to `apps/cli` package exports (closes missing export paths).
+
+---
+
+## 2.7.2 (2026-03-25)
+
+### Other
+
+* **CLI rename** — CLI binary renamed from `agentguard` to `aguard` (shorter alias). Documentation updated across 58 files.
+
+---
+
+## 2.7.1 (2026-03-25)
+
+### Bug Fixes
+
+* **Version bump** — Patch release to sync CLI version after 2.7.0 publish.
+
+---
+
+## 2.7.0 (2026-03-25)
+
+### Features
+
+* **`aguard` convenience package** — Registered `aguard` (and `aiguard`) as unscoped npm packages for shorter install and invocation: `npx aguard guard`.
+
+---
+
+## 2.6.0 (2026-03-25)
+
+### Features
+
+* **Go kernel** — Complete Go rewrite of the governance kernel ships as a static binary (`apps/cli/dist/go-bin/agentguard-go`). Delivered in phases: event system, invariant suite, hook protocol, decisions + escalation, blast radius engine, simulation, and full kernel orchestrator. Binary is distributed via GitHub Releases and downloaded via npm postinstall.
+* **Go kernel performance** — Single 3.2 MB static binary; hook evaluation < 3ms end-to-end (33× faster startup, ~100× faster hook evaluation vs Node.js kernel). Zero npm dependencies at runtime.
+* **Go kernel: AST shell parser** — Structural parsing of compound shell commands for normalization (KE-5).
+* **Go kernel: control plane signals API** — External governance intelligence API for consuming escalation state and decisions from outside the kernel process (KE-6).
+* **Go kernel: telemetry shipper** — Structured telemetry with stdout/file/HTTP sinks, correlation IDs, and performance span tracking (KE-4).
+* **Telemetry spans** — Structured spans, correlation IDs, and performance metrics added to Node.js telemetry pipeline.
+* **Write-then-execute bypass fix** — Invariants now correctly detect governance bypasses that write a file and immediately execute it in the same session (#862).
+* **Supply chain hardening** — All GitHub Actions workflow steps pinned to full SHA digests.
+
+---
+
 ## 2.5.0 (2026-03-25)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Install in 30 seconds. Your agents can't break what matters.</p>
 
 ---
 
-AI coding agents (Claude Code, GitHub Copilot, any MCP client) run autonomously — writing files, executing commands, pushing code. AgentGuard prevents them from doing catastrophic things: no accidental pushes to main, no credential leaks, no runaway destructive loops. 23 built-in safety checks, zero config required.
+AI coding agents (Claude Code, Codex CLI, GitHub Copilot CLI, Google Gemini CLI, OpenCode, and more) run autonomously — writing files, executing commands, pushing code. AgentGuard prevents them from doing catastrophic things: no accidental pushes to main, no credential leaks, no runaway destructive loops. 24 built-in safety checks, zero config required.
 
 **For individuals:** stop your AI from wrecking your machine or repo.
 **For teams:** run fleets of agents safely at scale, with audit trails that pass compliance.
@@ -97,7 +97,7 @@ agentguard guard --agent-name my-agent
 # Or omit --agent-name and an interactive prompt will ask for role + driver
 ```
 
-Identity consists of a **role** (`developer`, `reviewer`, `ops`, `security`, `ci`) and a **driver** (`human`, `claude-code`, `copilot`, `ci`). Identity flows to cloud telemetry for attribution, dashboard grouping, and persona-scoped policy rules.
+Identity consists of a **role** (`developer`, `reviewer`, `ops`, `security`, `ci`) and a **driver** (`human`, `claude-code`, `copilot`, `codex`, `gemini`, `ci`). Identity flows to cloud telemetry for attribution, dashboard grouping, and persona-scoped policy rules.
 
 ## What It Does
 
@@ -112,7 +112,7 @@ Identity consists of a **role** (`developer`, `reviewer`, `ops`, `security`, `ci
 | **Agent SDK** | Programmatic governance for custom integrations and RunManifest-driven workflows |
 | **Agent identity** | Declare agent role + driver for governance telemetry — automatic prompt or CLI flag |
 | **Pre-push hooks** | Branch protection enforcement via git pre-push hooks, configured from agentguard.yaml |
-| **Works with** | Claude Code, GitHub Copilot, any MCP client |
+| **Works with** | Claude Code, Codex CLI, GitHub Copilot CLI, Google Gemini CLI, OpenCode, any MCP client |
 
 ## Policy Format (YAML)
 
@@ -396,7 +396,9 @@ The Go kernel includes: action normalization with AST-based shell parsing, polic
 agentguard claude-init                    # Interactive wizard: mode + pack → creates policy + hooks
 agentguard claude-init --global           # Install hooks globally (~/.claude/settings.json)
 agentguard claude-init --mode guide --pack essentials  # Non-interactive setup
-agentguard claude-init                    # Also installs pre-push hooks for branch protection
+agentguard copilot-init                   # Set up GitHub Copilot CLI hook integration
+agentguard codex-init                     # Set up OpenAI Codex CLI hook integration
+agentguard gemini-init                    # Set up Google Gemini CLI hook integration
 agentguard init --template strict         # Scaffold policy from a template
 agentguard status                         # Show governance status
 

--- a/docs/hook-architecture.md
+++ b/docs/hook-architecture.md
@@ -1,4 +1,17 @@
-# Hook Architecture — How AgentGuard Integrates with Claude Code
+# Hook Architecture — How AgentGuard Integrates with AI Coding Agents
+
+## Supported Drivers
+
+AgentGuard supports four AI coding agent drivers via the same inline hook pattern:
+
+| Driver | Init command | Hook command | Config file |
+|--------|-------------|-------------|------------|
+| **Claude Code** | `agentguard claude-init` | `agentguard claude-hook pre\|post` | `.claude/settings.json` |
+| **GitHub Copilot CLI** | `agentguard copilot-init` | `agentguard copilot-hook pre\|post` | `.github/hooks/hooks.json` |
+| **OpenAI Codex CLI** | `agentguard codex-init` | `agentguard codex-hook pre\|post` | `.codex/hooks.json` |
+| **Google Gemini CLI** | `agentguard gemini-init` | `agentguard gemini-hook pre\|post` | `.gemini/settings.json` |
+
+All four drivers follow the same governance flow: the agent fires a `PreToolUse` hook before each tool call, AgentGuard evaluates the action against policy and invariants, and responds with an allow or block decision. Agent identity (role + driver) is resolved at session start and flows into all hook evaluations and telemetry.
 
 ## Design: Inline Hooks, Not a Daemon
 
@@ -187,8 +200,17 @@ echo '{"tool":"Bash","input":{"command":"git push origin main"}}' | agentguard c
 
 | File | Purpose |
 |------|---------|
-| `apps/cli/src/commands/claude-hook.ts` | Hook command (PreToolUse governance + PostToolUse monitoring) |
-| `apps/cli/src/commands/claude-init.ts` | Hook setup and teardown |
-| `packages/adapters/src/claude-code.ts` | Payload normalization and action mapping |
+| `apps/cli/src/commands/claude-hook.ts` | Claude Code hook command (PreToolUse governance + PostToolUse monitoring) |
+| `apps/cli/src/commands/claude-init.ts` | Claude Code hook setup and teardown |
+| `apps/cli/src/commands/copilot-hook.ts` | GitHub Copilot CLI hook command |
+| `apps/cli/src/commands/copilot-init.ts` | GitHub Copilot CLI hook setup |
+| `apps/cli/src/commands/codex-hook.ts` | OpenAI Codex CLI hook command |
+| `apps/cli/src/commands/codex-init.ts` | OpenAI Codex CLI hook setup |
+| `apps/cli/src/commands/gemini-hook.ts` | Google Gemini CLI hook command |
+| `apps/cli/src/commands/gemini-init.ts` | Google Gemini CLI hook setup |
+| `packages/adapters/src/claude-code.ts` | Claude Code payload normalization and action mapping |
+| `packages/adapters/src/copilot-cli.ts` | Copilot CLI payload normalization |
+| `packages/adapters/src/codex-cli.ts` | Codex CLI payload normalization |
+| `packages/adapters/src/gemini-cli.ts` | Gemini CLI payload normalization |
 | `packages/kernel/src/kernel.ts` | Governed action kernel (policy + invariant evaluation) |
 | `packages/kernel/src/aab.ts` | Action Authorization Boundary (tool → action type) |

--- a/docs/multi-framework-adapters.md
+++ b/docs/multi-framework-adapters.md
@@ -1,6 +1,19 @@
 # Multi-Framework Adapter System — AgentGuard
 
-This document describes the architecture for extending AgentGuard beyond Claude Code to support multiple AI agent frameworks.
+This document describes the architecture for integrating AgentGuard governance with multiple AI agent frameworks.
+
+## Status
+
+AgentGuard supports four hook-based driver adapters as of v2.8.0:
+
+| Driver | Adapter | Hook commands | Status |
+|--------|---------|---------------|--------|
+| **Claude Code** | `packages/adapters/src/claude-code.ts` | `agentguard claude-hook`, `claude-init` | ✅ Shipped |
+| **GitHub Copilot CLI** | `packages/adapters/src/copilot-cli.ts` | `agentguard copilot-hook`, `copilot-init` | ✅ Shipped |
+| **OpenAI Codex CLI** | `packages/adapters/src/codex-cli.ts` | `agentguard codex-hook`, `codex-init` | ✅ Shipped (v2.8.0) |
+| **Google Gemini CLI** | `packages/adapters/src/gemini-cli.ts` | `agentguard gemini-hook`, `gemini-init` | ✅ Shipped (v2.8.0) |
+
+The governance kernel is framework-agnostic — it accepts `RawAgentAction` objects and returns `GovernanceDecisionRecord` results. Each driver adapter translates its framework-specific PreToolUse/PostToolUse hook payload into the canonical `RawAgentAction` format.
 
 ## Context
 


### PR DESCRIPTION
## Documentation Sync — v2.8.x

**Agent identity:** claude-code:opus:ops

### Summary

Syncs documentation across README, ARCHITECTURE, CHANGELOG, and docs/ to reflect the v2.8.x codebase state.

### Changes

#### README.md
- Fix invariant count: **23 → 24** built-in safety checks in intro paragraph
- Update framework list: now includes Codex CLI, Gemini CLI, OpenCode
- Expand **drivers** list to include `codex` and `gemini`
- Update **"Works with"** table entry to list all 6 supported frameworks
- Add `codex-init`, `gemini-init`, `copilot-init` to CLI Reference (added in v2.8.0)

#### ARCHITECTURE.md
- Fix invariant count: **21 → 24** built-in definitions
- Expand adapters line to include `codex-cli` and `gemini-cli`
- Add `codex` and `gemini` to Drivers list
- Add `scheduler` package to package layout

#### CHANGELOG.md
- Add entries for **v2.6.0** through **v2.8.1** (was missing 6 versions)
- Documents: Go kernel rewrite, multi-driver hook support (Codex/Gemini), `aguard` rename, agent identity telemetry, supply chain hardening

#### docs/hook-architecture.md
- Updated title from "Claude Code" to "AI Coding Agents"
- Added driver support table listing all 4 drivers with init/hook commands
- Expanded Key Source Files to cover all 4 driver adapters

#### docs/multi-framework-adapters.md
- Added status table showing all 4 adapters are shipped (was describing only a plan)

### Why
Recent PRs (#1025 agent identity, v2.8.0 Codex/Gemini hooks, v2.7.x Go kernel + rename) introduced significant new capabilities that were not reflected in documentation.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>