### PR TITLE
chore: bump version to 2.8.2

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@red-codes/agentguard",
-  "version": "2.7.3",
+  "version": "2.8.2",
   "description": "Run AI agents without fear — CLI safety layer",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
Version bump for release — includes fix for read-only tool default-deny (#1114).

🤖 Generated with [Claude Code](https://claude.com/claude-code)