### PR TITLE
docs: add OpenCode and DeepAgents framework support to README and site

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Install in 30 seconds. Your agents can't break what matters.</p>
 
 ---
 
-AI coding agents (Claude Code, Codex CLI, GitHub Copilot CLI, Google Gemini CLI, OpenCode, and more) run autonomously — writing files, executing commands, pushing code. AgentGuard prevents them from doing catastrophic things: no accidental pushes to main, no credential leaks, no runaway destructive loops. 24 built-in safety checks, zero config required.
+AI coding agents (Claude Code, Codex CLI, GitHub Copilot CLI, Google Gemini CLI, OpenCode, DeepAgents, and more) run autonomously — writing files, executing commands, pushing code. AgentGuard prevents them from doing catastrophic things: no accidental pushes to main, no credential leaks, no runaway destructive loops. 24 built-in safety checks, zero config required.
 
 **For individuals:** stop your AI from wrecking your machine or repo.
 **For teams:** run fleets of agents safely at scale, with audit trails that pass compliance.
@@ -97,7 +97,7 @@ agentguard guard --agent-name my-agent
 # Or omit --agent-name and an interactive prompt will ask for role + driver
 ```
 
-Identity consists of a **role** (`developer`, `reviewer`, `ops`, `security`, `ci`) and a **driver** (`human`, `claude-code`, `copilot`, `codex`, `gemini`, `ci`). Identity flows to cloud telemetry for attribution, dashboard grouping, and persona-scoped policy rules.
+Identity consists of a **role** (`developer`, `reviewer`, `ops`, `security`, `ci`) and a **driver** (`human`, `claude-code`, `copilot`, `codex`, `gemini`, `opencode`, `deepagents`, `ci`). Identity flows to cloud telemetry for attribution, dashboard grouping, and persona-scoped policy rules.
 
 ## What It Does
 
@@ -112,7 +112,7 @@ Identity consists of a **role** (`developer`, `reviewer`, `ops`, `security`, `ci
 | **Agent SDK** | Programmatic governance for custom integrations and RunManifest-driven workflows |
 | **Agent identity** | Declare agent role + driver for governance telemetry — automatic prompt or CLI flag |
 | **Pre-push hooks** | Branch protection enforcement via git pre-push hooks, configured from agentguard.yaml |
-| **Works with** | Claude Code, Codex CLI, GitHub Copilot CLI, Google Gemini CLI, OpenCode, any MCP client |
+| **Works with** | Claude Code, Codex CLI, GitHub Copilot CLI, Google Gemini CLI, OpenCode, DeepAgents (LangChain), any MCP client |
 
 ## Policy Format (YAML)
 
@@ -399,6 +399,8 @@ agentguard claude-init --mode guide --pack essentials  # Non-interactive setup
 agentguard copilot-init                   # Set up GitHub Copilot CLI hook integration
 agentguard codex-init                     # Set up OpenAI Codex CLI hook integration
 agentguard gemini-init                    # Set up Google Gemini CLI hook integration
+agentguard opencode-init                  # Set up OpenCode (.opencode/plugins/agentguard.ts) hook integration
+agentguard deepagents-init                # Set up DeepAgents (.deepagents/agentguard_middleware.py) middleware
 agentguard init --template strict         # Scaffold policy from a template
 agentguard status                         # Show governance status
 

--- a/site/index.html
+++ b/site/index.html
@@ -732,6 +732,16 @@
             <svg class="w-6 h-6 text-text" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
             <span class="font-mono text-text text-sm font-medium">MCP Server</span>
           </div>
+          <!-- OpenCode -->
+          <div class="reveal flex items-center gap-2.5 opacity-70 hover:opacity-100 transition-opacity">
+            <svg class="w-6 h-6 text-text" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M8 12h8M12 8v8"/></svg>
+            <span class="font-mono text-text text-sm font-medium">OpenCode</span>
+          </div>
+          <!-- DeepAgents -->
+          <div class="reveal flex items-center gap-2.5 opacity-70 hover:opacity-100 transition-opacity">
+            <svg class="w-6 h-6 text-text" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M21 16V8a2 2 0 00-1-1.73l-7-4a2 2 0 00-2 0l-7 4A2 2 0 003 8v8a2 2 0 001 1.73l7 4a2 2 0 002 0l7-4A2 2 0 0021 16z"/></svg>
+            <span class="font-mono text-text text-sm font-medium">DeepAgents</span>
+          </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
Closes #1057

## Implementation Summary

**What changed:**
- `README.md`: Added DeepAgents to intro paragraph and 'Works with' table alongside other supported frameworks
- `README.md`: Added `opencode` and `deepagents` to identity driver list in Agent Identity section
- `README.md`: Added `agentguard opencode-init` and `agentguard deepagents-init` commands to CLI Reference setup section
- `site/index.html`: Added OpenCode and DeepAgents entries to 'Works with' social proof section with appropriate SVG icons

**How to verify:**
1. Open README.md — search for 'opencode-init' and 'deepagents-init' in CLI Reference
2. Open site/index.html locally — verify OpenCode and DeepAgents appear in the 'Works with' section
3. Confirm no stale '4 frameworks' references exist (none found; there were no explicit count badges)

**Note:** This PR depends on #1109 (OpenCode adapter) and #1126 (DeepAgents adapter) being merged first for the features to be live.

**Tier C scope check:**
- Files changed: 2 (limit: 5)
- Lines changed: ~15 (limit: 300)
- Breaking changes: None — documentation only

---
*Tier C implementation by copilot-cli — AgentGuard three-tier governance*