### PR TITLE
fix: Go module path matches repo name

### DIFF
--- a/go/cmd/agentguard/main.go
+++ b/go/cmd/agentguard/main.go
@@ -9,11 +9,11 @@ import (
 	"io"
 	"os"
 
-	"github.com/AgentGuardHQ/agent-guard/go/internal/action"
-	"github.com/AgentGuardHQ/agent-guard/go/internal/config"
-	"github.com/AgentGuardHQ/agent-guard/go/internal/engine"
-	"github.com/AgentGuardHQ/agent-guard/go/internal/kernel"
-	"github.com/AgentGuardHQ/agent-guard/go/pkg/hook"
+	"github.com/AgentGuardHQ/agentguard/go/internal/action"
+	"github.com/AgentGuardHQ/agentguard/go/internal/config"
+	"github.com/AgentGuardHQ/agentguard/go/internal/engine"
+	"github.com/AgentGuardHQ/agentguard/go/internal/kernel"
+	"github.com/AgentGuardHQ/agentguard/go/pkg/hook"
 )
 
 func main() {

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/AgentGuardHQ/agent-guard/go
+module github.com/AgentGuardHQ/agentguard/go
 
 go 1.18
 

--- a/go/internal/action/ast_test.go
+++ b/go/internal/action/ast_test.go
@@ -3,8 +3,8 @@ package action_test
 import (
 	"testing"
 
-	"github.com/AgentGuardHQ/agent-guard/go/internal/action"
-	"github.com/AgentGuardHQ/agent-guard/go/internal/config"
+	"github.com/AgentGuardHQ/agentguard/go/internal/action"
+	"github.com/AgentGuardHQ/agentguard/go/internal/config"
 )
 
 // ---- ParseShellCommand tests ----

--- a/go/internal/action/benchmark_test.go
+++ b/go/internal/action/benchmark_test.go
@@ -3,8 +3,8 @@ package action_test
 import (
 	"testing"
 
-	"github.com/AgentGuardHQ/agent-guard/go/internal/action"
-	"github.com/AgentGuardHQ/agent-guard/go/internal/config"
+	"github.com/AgentGuardHQ/agentguard/go/internal/action"
+	"github.com/AgentGuardHQ/agentguard/go/internal/config"
 )
 
 func setupNormalizer(b *testing.B) *action.Normalizer {

--- a/go/internal/action/normalize_test.go
+++ b/go/internal/action/normalize_test.go
@@ -3,8 +3,8 @@ package action_test
 import (
 	"testing"
 
-	"github.com/AgentGuardHQ/agent-guard/go/internal/action"
-	"github.com/AgentGuardHQ/agent-guard/go/internal/config"
+	"github.com/AgentGuardHQ/agentguard/go/internal/action"
+	"github.com/AgentGuardHQ/agentguard/go/internal/config"
 )
 
 func normalize(raw action.RawAction, source string) action.ActionContext {

--- a/go/internal/action/scanner_test.go
+++ b/go/internal/action/scanner_test.go
@@ -3,8 +3,8 @@ package action_test
 import (
 	"testing"
 
-	"github.com/AgentGuardHQ/agent-guard/go/internal/action"
-	"github.com/AgentGuardHQ/agent-guard/go/internal/config"
+	"github.com/AgentGuardHQ/agentguard/go/internal/action"
+	"github.com/AgentGuardHQ/agentguard/go/internal/config"
 )
 
 func newTestScanner() *action.Scanner {

--- a/go/internal/action/types_test.go
+++ b/go/internal/action/types_test.go
@@ -3,7 +3,7 @@ package action_test
 import (
 	"testing"
 
-	"github.com/AgentGuardHQ/agent-guard/go/internal/action"
+	"github.com/AgentGuardHQ/agentguard/go/internal/action"
 	"gopkg.in/yaml.v3"
 )
 

--- a/go/internal/blast/radius.go
+++ b/go/internal/blast/radius.go
@@ -10,7 +10,7 @@ import (
 	"math"
 	"strings"
 
-	"github.com/AgentGuardHQ/agent-guard/go/internal/action"
+	"github.com/AgentGuardHQ/agentguard/go/internal/action"
 )
 
 // Level constants for blast radius severity.

--- a/go/internal/blast/radius_test.go
+++ b/go/internal/blast/radius_test.go
@@ -3,8 +3,8 @@ package blast_test
 import (
 	"testing"
 
-	"github.com/AgentGuardHQ/agent-guard/go/internal/action"
-	"github.com/AgentGuardHQ/agent-guard/go/internal/blast"
+	"github.com/AgentGuardHQ/agentguard/go/internal/action"
+	"github.com/AgentGuardHQ/agentguard/go/internal/blast"
 )
 
 func TestFileReadHasLowBlastRadius(t *testing.T) {

--- a/go/internal/config/data.go
+++ b/go/internal/config/data.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"sync"
 
-	"github.com/AgentGuardHQ/agent-guard/go/internal/action"
+	"github.com/AgentGuardHQ/agentguard/go/internal/action"
 )
 
 //go:embed data/*.json

--- a/go/internal/config/data_test.go
+++ b/go/internal/config/data_test.go
@@ -3,7 +3,7 @@ package config_test
 import (
 	"testing"
 
-	"github.com/AgentGuardHQ/agent-guard/go/internal/config"
+	"github.com/AgentGuardHQ/agentguard/go/internal/config"
 )
 
 func TestToolActionMap(t *testing.T) {

--- a/go/internal/config/yaml.go
+++ b/go/internal/config/yaml.go
@@ -4,7 +4,7 @@ package config
 import (
 	"fmt"
 
-	"github.com/AgentGuardHQ/agent-guard/go/internal/action"
+	"github.com/AgentGuardHQ/agentguard/go/internal/action"
 	"gopkg.in/yaml.v3"
 )
 

--- a/go/internal/config/yaml_test.go
+++ b/go/internal/config/yaml_test.go
@@ -3,7 +3,7 @@ package config_test
 import (
 	"testing"
 
-	"github.com/AgentGuardHQ/agent-guard/go/internal/config"
+	"github.com/AgentGuardHQ/agentguard/go/internal/config"
 )
 
 func TestLoadYamlPolicy(t *testing.T) {

--- a/go/internal/decision/factory.go
+++ b/go/internal/decision/factory.go
@@ -5,7 +5,7 @@ import (
 	"encoding/hex"
 	"time"
 
-	"github.com/AgentGuardHQ/agent-guard/go/internal/action"
+	"github.com/AgentGuardHQ/agentguard/go/internal/action"
 )
 
 // generateID returns a unique decision record ID using crypto/rand.

--- a/go/internal/decision/store_test.go
+++ b/go/internal/decision/store_test.go
@@ -4,8 +4,8 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/AgentGuardHQ/agent-guard/go/internal/action"
-	"github.com/AgentGuardHQ/agent-guard/go/internal/decision"
+	"github.com/AgentGuardHQ/agentguard/go/internal/action"
+	"github.com/AgentGuardHQ/agentguard/go/internal/decision"
 )
 
 func makeDecision(dtype decision.DecisionType, sessionID string) decision.DecisionRecord {

--- a/go/internal/decision/types.go
+++ b/go/internal/decision/types.go
@@ -6,7 +6,7 @@ package decision
 import (
 	"time"
 
-	"github.com/AgentGuardHQ/agent-guard/go/internal/action"
+	"github.com/AgentGuardHQ/agentguard/go/internal/action"
 )
 
 // DecisionType classifies the outcome of a governance evaluation.

--- a/go/internal/decision/types_test.go
+++ b/go/internal/decision/types_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/AgentGuardHQ/agent-guard/go/internal/action"
-	"github.com/AgentGuardHQ/agent-guard/go/internal/decision"
+	"github.com/AgentGuardHQ/agentguard/go/internal/action"
+	"github.com/AgentGuardHQ/agentguard/go/internal/decision"
 )
 
 func TestNewAllowDecisionFields(t *testing.T) {

--- a/go/internal/engine/policy.go
+++ b/go/internal/engine/policy.go
@@ -4,7 +4,7 @@ package engine
 import (
 	"strings"
 
-	"github.com/AgentGuardHQ/agent-guard/go/internal/action"
+	"github.com/AgentGuardHQ/agentguard/go/internal/action"
 )
 
 // EvalOptions controls evaluation behavior.

--- a/go/internal/engine/policy_test.go
+++ b/go/internal/engine/policy_test.go
@@ -3,8 +3,8 @@ package engine_test
 import (
 	"testing"
 
-	"github.com/AgentGuardHQ/agent-guard/go/internal/action"
-	"github.com/AgentGuardHQ/agent-guard/go/internal/engine"
+	"github.com/AgentGuardHQ/agentguard/go/internal/action"
+	"github.com/AgentGuardHQ/agentguard/go/internal/engine"
 )
 
 func testPolicy() *action.LoadedPolicy {

--- a/go/internal/invariant/checker_test.go
+++ b/go/internal/invariant/checker_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/AgentGuardHQ/agent-guard/go/internal/action"
-	"github.com/AgentGuardHQ/agent-guard/go/internal/invariant"
+	"github.com/AgentGuardHQ/agentguard/go/internal/action"
+	"github.com/AgentGuardHQ/agentguard/go/internal/invariant"
 )
 
 // helper to build a minimal CheckContext for file-write scenarios.

--- a/go/internal/invariant/types.go
+++ b/go/internal/invariant/types.go
@@ -4,7 +4,7 @@
 package invariant
 
 import (
-	"github.com/AgentGuardHQ/agent-guard/go/internal/action"
+	"github.com/AgentGuardHQ/agentguard/go/internal/action"
 )
 
 // InvariantID uniquely identifies a built-in invariant.

--- a/go/internal/kernel/kernel.go
+++ b/go/internal/kernel/kernel.go
@@ -6,9 +6,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/AgentGuardHQ/agent-guard/go/internal/action"
-	"github.com/AgentGuardHQ/agent-guard/go/internal/config"
-	"github.com/AgentGuardHQ/agent-guard/go/internal/engine"
+	"github.com/AgentGuardHQ/agentguard/go/internal/action"
+	"github.com/AgentGuardHQ/agentguard/go/internal/config"
+	"github.com/AgentGuardHQ/agentguard/go/internal/engine"
 )
 
 // Kernel is the governed action kernel — the central orchestrator.

--- a/go/internal/kernel/kernel_test.go
+++ b/go/internal/kernel/kernel_test.go
@@ -5,8 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/AgentGuardHQ/agent-guard/go/internal/action"
-	"github.com/AgentGuardHQ/agent-guard/go/internal/kernel"
+	"github.com/AgentGuardHQ/agentguard/go/internal/action"
+	"github.com/AgentGuardHQ/agentguard/go/internal/kernel"
 )
 
 // writeTempPolicy writes YAML policy content to a temp file and returns the path.

--- a/go/internal/kernel/pipeline.go
+++ b/go/internal/kernel/pipeline.go
@@ -3,7 +3,7 @@ package kernel
 import (
 	"fmt"
 
-	"github.com/AgentGuardHQ/agent-guard/go/internal/action"
+	"github.com/AgentGuardHQ/agentguard/go/internal/action"
 )
 
 // StageFunc is a callback invoked for each pipeline stage after the kernel

--- a/go/internal/kernel/pipeline_test.go
+++ b/go/internal/kernel/pipeline_test.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/AgentGuardHQ/agent-guard/go/internal/action"
-	"github.com/AgentGuardHQ/agent-guard/go/internal/kernel"
+	"github.com/AgentGuardHQ/agentguard/go/internal/action"
+	"github.com/AgentGuardHQ/agentguard/go/internal/kernel"
 )
 
 func TestPipelineAllowedRunsStages(t *testing.T) {

--- a/go/internal/kernel/types.go
+++ b/go/internal/kernel/types.go
@@ -8,7 +8,7 @@ package kernel
 import (
 	"time"
 
-	"github.com/AgentGuardHQ/agent-guard/go/internal/action"
+	"github.com/AgentGuardHQ/agentguard/go/internal/action"
 )
 
 // KernelConfig holds the configuration for a Kernel instance.

--- a/go/internal/monitor/escalation_test.go
+++ b/go/internal/monitor/escalation_test.go
@@ -3,7 +3,7 @@ package monitor_test
 import (
 	"testing"
 
-	"github.com/AgentGuardHQ/agent-guard/go/internal/monitor"
+	"github.com/AgentGuardHQ/agentguard/go/internal/monitor"
 )
 
 func TestEscalationLevelString(t *testing.T) {

--- a/go/internal/shipper/batch.go
+++ b/go/internal/shipper/batch.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/AgentGuardHQ/agent-guard/go/internal/event"
+	"github.com/AgentGuardHQ/agentguard/go/internal/event"
 )
 
 // Batch accumulates events up to a max size or max age.

--- a/go/internal/shipper/pipeline.go
+++ b/go/internal/shipper/pipeline.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"sync"
 
-	"github.com/AgentGuardHQ/agent-guard/go/internal/event"
+	"github.com/AgentGuardHQ/agentguard/go/internal/event"
 )
 
 // FilterFunc decides whether an event should be shipped.

--- a/go/internal/shipper/shipper.go
+++ b/go/internal/shipper/shipper.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/AgentGuardHQ/agent-guard/go/internal/event"
+	"github.com/AgentGuardHQ/agentguard/go/internal/event"
 )
 
 // Shipper receives events from the EventBus and delivers them externally.

--- a/go/internal/shipper/shipper_test.go
+++ b/go/internal/shipper/shipper_test.go
@@ -16,8 +16,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/AgentGuardHQ/agent-guard/go/internal/event"
-	"github.com/AgentGuardHQ/agent-guard/go/internal/shipper"
+	"github.com/AgentGuardHQ/agentguard/go/internal/event"
+	"github.com/AgentGuardHQ/agentguard/go/internal/shipper"
 )
 
 func testEvent(kind event.Kind) event.Event {

--- a/go/internal/simulation/filesystem.go
+++ b/go/internal/simulation/filesystem.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/AgentGuardHQ/agent-guard/go/internal/action"
+	"github.com/AgentGuardHQ/agentguard/go/internal/action"
 )
 
 // sensitivePatterns are path substrings that indicate sensitive files.

--- a/go/internal/simulation/filesystem_test.go
+++ b/go/internal/simulation/filesystem_test.go
@@ -3,8 +3,8 @@ package simulation_test
 import (
 	"testing"
 
-	"github.com/AgentGuardHQ/agent-guard/go/internal/action"
-	"github.com/AgentGuardHQ/agent-guard/go/internal/simulation"
+	"github.com/AgentGuardHQ/agentguard/go/internal/action"
+	"github.com/AgentGuardHQ/agentguard/go/internal/simulation"
 )
 
 func TestFileReadNoImpact(t *testing.T) {

--- a/go/internal/simulation/forecast.go
+++ b/go/internal/simulation/forecast.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"strings"
 
-	"github.com/AgentGuardHQ/agent-guard/go/internal/action"
+	"github.com/AgentGuardHQ/agentguard/go/internal/action"
 )
 
 // Registry holds registered simulators and routes actions to them.

--- a/go/internal/simulation/forecast_test.go
+++ b/go/internal/simulation/forecast_test.go
@@ -3,8 +3,8 @@ package simulation_test
 import (
 	"testing"
 
-	"github.com/AgentGuardHQ/agent-guard/go/internal/action"
-	"github.com/AgentGuardHQ/agent-guard/go/internal/simulation"
+	"github.com/AgentGuardHQ/agentguard/go/internal/action"
+	"github.com/AgentGuardHQ/agentguard/go/internal/simulation"
 )
 
 func TestForecastAggregation(t *testing.T) {

--- a/go/internal/simulation/git.go
+++ b/go/internal/simulation/git.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/AgentGuardHQ/agent-guard/go/internal/action"
+	"github.com/AgentGuardHQ/agentguard/go/internal/action"
 )
 
 // protectedBranches are branch names that elevate git operation severity.

--- a/go/internal/simulation/git_test.go
+++ b/go/internal/simulation/git_test.go
@@ -3,8 +3,8 @@ package simulation_test
 import (
 	"testing"
 
-	"github.com/AgentGuardHQ/agent-guard/go/internal/action"
-	"github.com/AgentGuardHQ/agent-guard/go/internal/simulation"
+	"github.com/AgentGuardHQ/agentguard/go/internal/action"
+	"github.com/AgentGuardHQ/agentguard/go/internal/simulation"
 )
 
 func TestGitCommitLowImpact(t *testing.T) {

--- a/go/internal/simulation/package_sim.go
+++ b/go/internal/simulation/package_sim.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/AgentGuardHQ/agent-guard/go/internal/action"
+	"github.com/AgentGuardHQ/agentguard/go/internal/action"
 )
 
 // installPatterns match package install commands.

--- a/go/internal/simulation/package_sim_test.go
+++ b/go/internal/simulation/package_sim_test.go
@@ -3,8 +3,8 @@ package simulation_test
 import (
 	"testing"
 
-	"github.com/AgentGuardHQ/agent-guard/go/internal/action"
-	"github.com/AgentGuardHQ/agent-guard/go/internal/simulation"
+	"github.com/AgentGuardHQ/agentguard/go/internal/action"
+	"github.com/AgentGuardHQ/agentguard/go/internal/simulation"
 )
 
 func TestNpmInstallDependencyImpact(t *testing.T) {

--- a/go/internal/simulation/types.go
+++ b/go/internal/simulation/types.go
@@ -6,7 +6,7 @@
 package simulation
 
 import (
-	"github.com/AgentGuardHQ/agent-guard/go/internal/action"
+	"github.com/AgentGuardHQ/agentguard/go/internal/action"
 )
 
 // Impact severity constants.

--- a/go/pkg/hook/handler.go
+++ b/go/pkg/hook/handler.go
@@ -3,9 +3,9 @@ package hook
 import (
 	"os"
 
-	"github.com/AgentGuardHQ/agent-guard/go/internal/action"
-	"github.com/AgentGuardHQ/agent-guard/go/internal/config"
-	"github.com/AgentGuardHQ/agent-guard/go/internal/engine"
+	"github.com/AgentGuardHQ/agentguard/go/internal/action"
+	"github.com/AgentGuardHQ/agentguard/go/internal/config"
+	"github.com/AgentGuardHQ/agentguard/go/internal/engine"
 )
 
 // Handler evaluates hook requests against loaded policies.

--- a/go/pkg/hook/testutil_test.go
+++ b/go/pkg/hook/testutil_test.go
@@ -1,6 +1,6 @@
 package hook
 
-import "github.com/AgentGuardHQ/agent-guard/go/internal/action"
+import "github.com/AgentGuardHQ/agentguard/go/internal/action"
 
 // allowResult returns an EvalResult that allows the action.
 func allowResult() action.EvalResult {

--- a/go/pkg/signals/aggregator.go
+++ b/go/pkg/signals/aggregator.go
@@ -4,8 +4,8 @@ import (
 	"sort"
 	"time"
 
-	"github.com/AgentGuardHQ/agent-guard/go/internal/event"
-	"github.com/AgentGuardHQ/agent-guard/go/internal/monitor"
+	"github.com/AgentGuardHQ/agentguard/go/internal/event"
+	"github.com/AgentGuardHQ/agentguard/go/internal/monitor"
 )
 
 // Aggregator reads from an event store and produces governance intelligence signals.

--- a/go/pkg/signals/signals_test.go
+++ b/go/pkg/signals/signals_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/AgentGuardHQ/agent-guard/go/internal/event"
+	"github.com/AgentGuardHQ/agentguard/go/internal/event"
 )
 
 // --- Helpers ---


### PR DESCRIPTION
Module path `agent-guard/go` → `agentguard/go`. 44 files, all tests pass.
Enables Crush fork to `go get` the kernel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)