### PR TITLE
fix(site): sync test counter 2637→4195 + site EM report 2026-03-27T20:40Z

### DIFF
--- a/.agentguard/squads/site/em-report.json
+++ b/.agentguard/squads/site/em-report.json
@@ -1,51 +1,81 @@
 {
   "squad": "site",
-  "timestamp": "2026-03-26T20:40:00.000Z",
-  "health": "green",
-  "summary": "Site healthy. Fixed invariant count drift (23→24) and CLI commands count (29→32) after recent codebase changes. No open issues or PRs. OG image and meta tags intact after recent PR #1011 fix.",
+  "timestamp": "2026-03-27T20:40:00.000Z",
+  "health": "yellow",
+  "summary": "Test counter drifted 2637→4195 (+1558 tests). Fixed in this cycle. All other numeric claims verified accurate. Merge queue blocked by pre-existing Prettier lint failures in engineering files. Escalated to engineering squad.",
   "siteBuild": {
     "status": "pass",
-    "notes": "Static site structure valid: index.html, posts.html, posts.json, sitemap.xml, robots.txt, og-image.png all present and well-formed."
+    "notes": "Static site valid. All assets present: index.html, posts.html, posts.json, sitemap.xml, robots.txt, og-image.png. OpenCode + DeepAgents logos added (PR from main branch)."
   },
   "contentFreshness": {
     "status": "fixed",
     "drift": [
       {
-        "claim": "invariants count",
-        "was": 23,
-        "now": 24,
-        "cause": "PR #1002 added no-verify-bypass invariant",
-        "fixed": true
-      },
-      {
-        "claim": "CLI commands count",
-        "was": 29,
-        "now": 32,
-        "cause": "New commands added since last site sync",
+        "claim": "tests count",
+        "was": 2637,
+        "now": 4195,
+        "cause": "1558 new tests added since last site sync (PR #1117 target was stale at 4161)",
         "fixed": true
       }
     ],
     "verified": [
-      "93 destructive patterns — matches codebase",
-      "47 event kinds — matches codebase",
-      "41 action types — matches codebase"
+      "93 destructive patterns — matches packages/core/src/data/destructive-patterns.json (93 items)",
+      "47 event kinds — matches packages/events/src/schema.ts (47 EventKind exports)",
+      "41 action types — matches packages/core/src/data/actions.json (types array len=41)",
+      "10 action classes — matches packages/core/src/data/actions.json (classes array len=10)",
+      "24 invariants — matches packages/invariants/src/definitions.ts",
+      "32 CLI commands — matches apps/cli/src/commands/ (32 files)",
+      "93 destructive patterns — verified",
+      "8 built-in policy packs — verified"
     ]
   },
   "prQueue": {
-    "open": 0,
-    "reviewed": 0,
-    "merged": [
-      "#1015 — marketing EM report",
-      "#1011 — OG image PNG + social meta tags",
-      "#1009 — site stats sync",
-      "#1005 — stale numeric claims fix"
+    "open": 2,
+    "reviewed": 2,
+    "mergeable": 0,
+    "details": [
+      {
+        "pr": 1117,
+        "title": "fix(site): sync test count 2637→4161",
+        "status": "superseded",
+        "action": "close — stale count (4161 vs actual 4195); blocked by lint+test-and-build failures",
+        "blocker": "pre-existing Prettier lint in packages/storage + apps/cli"
+      },
+      {
+        "pr": 1134,
+        "title": "chore(marketing-em): EM cycle — site fix + OWASP blog draft",
+        "status": "4/5 checks pass",
+        "action": "waiting on lint fix to merge",
+        "blocker": "pre-existing Prettier lint in packages/storage + apps/cli (engineering squad)",
+        "note": "Contains correct 2637→4195 fix but mixed with marketing content"
+      }
     ]
   },
-  "blockers": [],
-  "escalations": [],
+  "blockers": [
+    {
+      "id": "lint-formatter",
+      "description": "Pre-existing Prettier formatting failures in packages/storage and apps/cli block all PRs from merging",
+      "severity": "medium",
+      "owner": "engineering",
+      "action": "Run pnpm format:fix on packages/storage/src/aggregation-queries.ts, packages/storage/src/migrations.ts, packages/storage/src/sqlite-store.ts, apps/cli/src/commands/inspect.ts",
+      "impact": "Blocks entire merge queue including site counter fix"
+    }
+  ],
+  "escalations": [
+    "Lint failure blocking merge queue — needs engineering squad attention (pnpm format:fix)"
+  ],
   "governanceDenials": 0,
+  "dogfoodIssues": [
+    {
+      "issue": 1008,
+      "description": "site-builder agent denied despite explicit allow rules in policy — false positive default-deny",
+      "status": "open",
+      "owner": "engineering"
+    }
+  ],
   "nextActions": [
-    "Open PR for invariant + CLI command count fix",
-    "Monitor for further invariant additions that cause site drift"
+    "Close PR #1117 (superseded by correct 4195 count)",
+    "Engineering squad to run pnpm format:fix to unblock merge queue",
+    "This cycle's PR: site counter fix 2637→4195 + OpenCode/DeepAgents logos"
   ]
 }

--- a/.agentguard/squads/site/state.json
+++ b/.agentguard/squads/site/state.json
@@ -4,12 +4,30 @@
     "goal": "Keep site numeric claims in sync with codebase",
     "issues": []
   },
-  "assignments": {},
-  "blockers": [],
-  "prQueue": {
-    "open": 1,
-    "reviewed": 0,
-    "mergeable": 0
+  "assignments": {
+    "site-em": {
+      "cycle": "2026-03-27T20:40:00.000Z",
+      "completed": [
+        "Verified all numeric claims (93 patterns, 47 events, 41 actions, 24 invariants, 32 commands)",
+        "Fixed test counter 2637→4195 in site/index.html + terminal animation",
+        "Reviewed PR queue: #1117 superseded, #1134 blocked by lint",
+        "Escalated lint blocker to engineering squad"
+      ]
+    }
   },
-  "updatedAt": "2026-03-26T20:40:00.000Z"
+  "blockers": [
+    {
+      "id": "lint-formatter",
+      "description": "Pre-existing Prettier failures in packages/storage + apps/cli blocking all PR merges",
+      "owner": "engineering",
+      "since": "2026-03-27"
+    }
+  ],
+  "prQueue": {
+    "open": 2,
+    "reviewed": 2,
+    "mergeable": 0,
+    "thisRun": "agent/site-em-20260327-204002"
+  },
+  "updatedAt": "2026-03-27T20:40:00.000Z"
 }

--- a/site/index.html
+++ b/site/index.html
@@ -480,7 +480,7 @@
       <div class="max-w-7xl mx-auto px-6">
         <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-8 text-center reveal-stagger">
           <div class="reveal">
-            <div class="font-mono font-bold text-3xl sm:text-4xl text-text counter" data-target="2637">0</div>
+            <div class="font-mono font-bold text-3xl sm:text-4xl text-text counter" data-target="4195">0</div>
             <div class="text-muted text-sm mt-1">Tests</div>
           </div>
           <div class="reveal">
@@ -2381,7 +2381,7 @@ rules:
         { text: '  \u26A0 invariant  protected-branch violated', cls: 'text-warning', delay: 0 },
         { text: '', cls: '', delay: 600 },
         { text: '  \u2713 file.write  src/utils/hash.ts', cls: 'text-cta', delay: 0 },
-        { text: '  \u2713 test.run    vitest (2,637 passed)', cls: 'text-cta', delay: 0 },
+        { text: '  \u2713 test.run    vitest (4,195 passed)', cls: 'text-cta', delay: 0 },
         { text: '  \u2713 git.commit  "feat: add hash utility"', cls: 'text-cta', delay: 0 },
         { text: '  \u2717 file.write  .env \u2192 DENIED (no-secret-exposure)', cls: 'text-danger', delay: 0 },
         { text: '  \u2717 shell.exec  rm -rf / \u2192 DENIED (destructive)', cls: 'text-danger', delay: 0 },


### PR DESCRIPTION
## Summary

- **fix(site)**: Test counter updated `2637 → 4195` (grep-verified: `grep -rh "^\s*it(" --include="*.test.ts" . --exclude-dir=node_modules --exclude-dir=dist | wc -l` → 4195)
- **fix(site)**: Terminal animation updated to match (`vitest (4,195 passed)`)
- **chore**: Squad state + EM health report updated (health=yellow, lint escalated)
- Supersedes PR #1117 (stale count: had 4161 vs actual 4195)

## Numeric Claims Audit (all verified this cycle)

| Claim | Site | Codebase | Status |
|-------|------|----------|--------|
| Tests | ~~2637~~ **4195** | 4195 (it() count) | ✅ Fixed |
| Destructive Patterns | 93 | 93 (destructive-patterns.json) | ✅ Accurate |
| Event Kinds | 47 | 47 (EventKind exports) | ✅ Accurate |
| Action Types | 41 | 41 (actions.json types array) | ✅ Accurate |
| Invariants | 24 | 24 (definitions.ts) | ✅ Accurate |
| CLI Commands | 32 | 32 (commands/ files) | ✅ Accurate |

## Blocker (escalated to engineering)

Pre-existing Prettier lint failures in `packages/storage` and `apps/cli` are blocking the entire merge queue. This PR will also fail lint — this is not a site-introduced issue.

**Engineering action needed**: `pnpm format:fix` on:
- `packages/storage/src/aggregation-queries.ts`
- `packages/storage/src/migrations.ts`
- `packages/storage/src/sqlite-store.ts`
- `apps/cli/src/commands/inspect.ts`

## Test plan
- [ ] Verify counter animates to 4,195 on site load
- [ ] Confirm terminal animation shows `vitest (4,195 passed)`
- [ ] Confirm no other numeric claims changed

🤖 Site EM agent — claude-code:site:em (2026-03-27T20:40Z)