### PR TITLE
fix: resolve Stop hook binary from workspace root in sub-repos

### DIFF
--- a/apps/cli/src/commands/claude-init.ts
+++ b/apps/cli/src/commands/claude-init.ts
@@ -14,6 +14,7 @@ import {
   WRITE_PERSONA,
   SESSION_PERSONA_CHECK,
   claudeHookWrapper,
+  claudeHookStopWrapper,
 } from '../templates/scripts.js';
 import { STARTER_SKILLS } from '../templates/skills.js';
 
@@ -339,7 +340,7 @@ export async function claudeInit(args: string[] = []): Promise<void> {
     hooks: [
       {
         type: 'command',
-        command: `${cli} claude-hook stop${storeSuffix}${dbPathSuffix}`,
+        command: `bash scripts/claude-hook-stop-wrapper.sh`,
         timeout: 15000,
         blocking: false,
       },
@@ -362,6 +363,10 @@ export async function claudeInit(args: string[] = []): Promise<void> {
     { name: 'write-persona.sh', content: WRITE_PERSONA },
     { name: 'session-persona-check.sh', content: SESSION_PERSONA_CHECK },
     { name: 'claude-hook-wrapper.sh', content: claudeHookWrapper(cli, storeSuffix, dbPathSuffix) },
+    {
+      name: 'claude-hook-stop-wrapper.sh',
+      content: claudeHookStopWrapper(cli, storeSuffix, dbPathSuffix),
+    },
   ];
 
   for (const { name, content } of scriptFiles) {
@@ -617,6 +622,7 @@ function removeHook(settingsPath: string, settingsLabel: string): void {
     'write-persona.sh',
     'session-persona-check.sh',
     'claude-hook-wrapper.sh',
+    'claude-hook-stop-wrapper.sh',
   ];
   for (const name of identityScripts) {
     const scriptPath = join(repoRoot, 'scripts', name);
@@ -1001,6 +1007,7 @@ function hasAgentGuardHook(settings: Settings): boolean {
 /** Wrapper scripts that hooks may reference. */
 const WRAPPER_SCRIPTS = [
   'scripts/claude-hook-wrapper.sh',
+  'scripts/claude-hook-stop-wrapper.sh',
   'scripts/session-persona-check.sh',
   'scripts/agent-identity-bridge.sh',
   'scripts/write-persona.sh',

--- a/apps/cli/src/templates/scripts.ts
+++ b/apps/cli/src/templates/scripts.ts
@@ -218,3 +218,47 @@ ${resolveBlock}
 exec \$AGENTGUARD_BIN claude-hook pre${storeSuffix}${dbPathSuffix}
 `;
 }
+
+export function claudeHookStopWrapper(
+  cliPrefix: string,
+  storeSuffix: string,
+  dbPathSuffix: string
+): string {
+  // For local dev (cliPrefix = "node apps/cli/dist/bin.js"), the binary is always resolvable.
+  // For installed package, resolve from workspace root to handle sub-repo CWD correctly.
+  const isLocal = cliPrefix.startsWith('node ');
+  const resolveBlock = isLocal
+    ? `AGENTGUARD_BIN="${cliPrefix}"`
+    : `# Resolve the agentguard binary from workspace root — not CWD — so sub-repos work
+AGENTGUARD_BIN=""
+if [ -x "\$AGENTGUARD_WORKSPACE/node_modules/.bin/agentguard" ]; then
+  AGENTGUARD_BIN="\$AGENTGUARD_WORKSPACE/node_modules/.bin/agentguard"
+elif command -v agentguard &>/dev/null; then
+  AGENTGUARD_BIN="agentguard"
+fi
+
+# Fail open — Stop is non-blocking, so silently exit if binary is missing
+if [ -z "\$AGENTGUARD_BIN" ]; then
+  exit 0
+fi`;
+
+  return `#!/usr/bin/env bash
+# claude-hook-stop-wrapper.sh — Resolves AgentGuard binary from workspace root for Stop hook.
+# Uses workspace root resolution so the hook works even when CWD is a sub-repo
+# that does not have its own node_modules/.bin/agentguard.
+
+# Resolve project root from git, then walk up if inside a worktree under .worktrees/
+_GIT_TOPLEVEL="\$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+_GIT_DIR="\$(git rev-parse --git-dir 2>/dev/null)"
+if [[ "\$_GIT_DIR" == *"/worktrees/"* ]] && [[ "\$_GIT_TOPLEVEL" == *"/.worktrees/"* ]]; then
+  AGENTGUARD_WORKSPACE="\${_GIT_TOPLEVEL%%/.worktrees/*}"
+else
+  AGENTGUARD_WORKSPACE="\$_GIT_TOPLEVEL"
+fi
+export AGENTGUARD_WORKSPACE
+
+${resolveBlock}
+
+exec \$AGENTGUARD_BIN claude-hook stop${storeSuffix}${dbPathSuffix}
+`;
+}

--- a/apps/cli/tests/cli-claude-init.test.ts
+++ b/apps/cli/tests/cli-claude-init.test.ts
@@ -52,6 +52,10 @@ vi.mock('../src/templates/scripts.js', () => ({
     (cli: string, store: string, dbPath: string) =>
       `#!/usr/bin/env bash\nexec ${cli} claude-hook pre${store}${dbPath}`
   ),
+  claudeHookStopWrapper: vi.fn(
+    (cli: string, store: string, dbPath: string) =>
+      `#!/usr/bin/env bash\nexec ${cli} claude-hook stop${store}${dbPath}`
+  ),
 }));
 
 vi.mock('../src/templates/skills.js', () => ({
@@ -64,7 +68,7 @@ vi.mock('../src/templates/skills.js', () => ({
 
 import { claudeInit } from '../src/commands/claude-init.js';
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
-import { claudeHookWrapper } from '../src/templates/scripts.js';
+import { claudeHookWrapper, claudeHookStopWrapper } from '../src/templates/scripts.js';
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -523,7 +527,7 @@ describe('claudeInit', () => {
         return p.includes('scripts/') || p.includes('scripts\\');
       });
 
-    // All 4 identity scripts should be written
+    // All 5 identity scripts should be written
     const scriptNames = scriptWrites.map((call) => {
       const p = call[0] as string;
       return p.split(/[/\\]/).pop();
@@ -532,7 +536,8 @@ describe('claudeInit', () => {
     expect(scriptNames).toContain('write-persona.sh');
     expect(scriptNames).toContain('session-persona-check.sh');
     expect(scriptNames).toContain('claude-hook-wrapper.sh');
-    expect(scriptWrites).toHaveLength(4);
+    expect(scriptNames).toContain('claude-hook-stop-wrapper.sh');
+    expect(scriptWrites).toHaveLength(5);
 
     // Every script path should end with .sh
     for (const call of scriptWrites) {
@@ -595,6 +600,31 @@ describe('claudeInit', () => {
     expect(written.hooks.PreToolUse[0].hooks[0].command).toContain('claude-hook-wrapper.sh');
   });
 
+  it('uses stop wrapper script for Stop hook (resolves binary from workspace root)', async () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    await claudeInit([]);
+
+    const written = writtenSettings();
+    // Stop hook must use the wrapper script, not an inline binary path,
+    // so binary resolution happens at runtime relative to workspace root (not CWD)
+    expect(written.hooks.Stop[0].hooks[0].command).toBe('bash scripts/claude-hook-stop-wrapper.sh');
+    expect(written.hooks.Stop[0].hooks[0].blocking).toBe(false);
+    expect(written.hooks.Stop[0].hooks[0].timeout).toBe(15000);
+  });
+
+  it('passes store suffix to claudeHookStopWrapper', async () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    await claudeInit(['--store', 'sqlite']);
+
+    expect(claudeHookStopWrapper).toHaveBeenCalledWith(
+      expect.any(String),
+      ' --store sqlite',
+      ''
+    );
+  });
+
   // --- Binary path resolution (#964) ---
 
   it('resolves ./node_modules/.bin/agentguard for project-level npm installs', async () => {
@@ -609,7 +639,7 @@ describe('claudeInit', () => {
     await claudeInit([]);
 
     const written = writtenSettings();
-    // PostToolUse, Stop, Notification hooks should use resolved binary path
+    // PostToolUse hook should use resolved binary path (Stop now uses a wrapper script)
     expect(written.hooks.PostToolUse[0].hooks[0].command).toContain(
       './node_modules/.bin/agentguard'
     );


### PR DESCRIPTION
Closes #1120

## Implementation Summary

**What changed:**
- Added `claudeHookStopWrapper()` template function in `apps/cli/src/templates/scripts.ts` that generates `scripts/claude-hook-stop-wrapper.sh` with proper workspace root resolution (same worktree/sub-repo detection logic as `claude-hook-wrapper.sh`)
- Changed the Stop hook command from inline `${cli} claude-hook stop...` to `bash scripts/claude-hook-stop-wrapper.sh` so binary resolution happens at runtime relative to workspace root, not CWD
- Installed `claude-hook-stop-wrapper.sh` alongside `claude-hook-wrapper.sh` during `claude-init`; removed during `--remove`
- Added `claude-hook-stop-wrapper.sh` to `WRAPPER_SCRIPTS` integrity list
- Updated tests: 5 scripts installed (was 4), added Stop hook wrapper tests

**How to verify:**
1. Run `agentguard claude-init` in a project with sub-repos
2. Check that `scripts/claude-hook-stop-wrapper.sh` is created
3. Work in a sub-repo (e.g., `shellforge/`) and end a Claude Code session
4. Stop hook fires without `No such file or directory` error

**Tier C scope check:**
- Files changed: 3 (limit: 5)
- Lines changed: ~86 (limit: 300)
- Breaking changes: None

---
*Tier C implementation by copilot-cli — AgentGuard three-tier governance*