### PR TITLE
style: fix pre-existing Prettier violations blocking CI lint gate

### DIFF
--- a/apps/cli/src/commands/inspect.ts
+++ b/apps/cli/src/commands/inspect.ts
@@ -50,17 +50,14 @@ export async function inspect(args: string[], storageConfig?: StorageConfig): Pr
   if (!targetArg || targetArg === '--list') {
     const storage = await openSqliteDb(storageConfig);
     if (!storage) return;
-    const { listRunIds, listRunIdsByAgent, getRunAgents, loadRunEvents } = await import(
-      '@red-codes/storage'
-    );
+    const { listRunIds, listRunIdsByAgent, getRunAgents, loadRunEvents } =
+      await import('@red-codes/storage');
     const db = storage.db as import('better-sqlite3').Database;
     const runs = agentFilter ? listRunIdsByAgent(db, agentFilter) : listRunIds(db);
 
     if (runs.length === 0) {
       if (agentFilter) {
-        process.stderr.write(
-          `\n  \x1b[2mNo runs found for agent: ${agentFilter}\x1b[0m\n\n`
-        );
+        process.stderr.write(`\n  \x1b[2mNo runs found for agent: ${agentFilter}\x1b[0m\n\n`);
       } else {
         process.stderr.write('\n  \x1b[2mNo runs recorded yet.\x1b[0m\n');
         process.stderr.write('  Run \x1b[1magentguard guard\x1b[0m to start recording.\n\n');

--- a/packages/storage/src/aggregation-queries.ts
+++ b/packages/storage/src/aggregation-queries.ts
@@ -96,9 +96,7 @@ function buildTimeConditions(
     conditions.push(buildRunIdSubquery(filter.sessionLimit));
   }
   if (filter?.agentId !== undefined) {
-    conditions.push(
-      `${table}.run_id IN (SELECT id FROM sessions WHERE agent_id = ?)`
-    );
+    conditions.push(`${table}.run_id IN (SELECT id FROM sessions WHERE agent_id = ?)`);
     params.push(filter.agentId);
   }
 

--- a/packages/storage/src/migrations.ts
+++ b/packages/storage/src/migrations.ts
@@ -125,7 +125,8 @@ const MIGRATIONS: readonly Migration[] = [
 
   {
     version: 5,
-    description: 'Add agent_id column to sessions table with index; backfill from RunStarted events',
+    description:
+      'Add agent_id column to sessions table with index; backfill from RunStarted events',
     up(db) {
       db.exec('ALTER TABLE sessions ADD COLUMN agent_id TEXT');
       db.exec('CREATE INDEX IF NOT EXISTS idx_sessions_agent_id ON sessions (agent_id)');
@@ -141,7 +142,9 @@ const MIGRATIONS: readonly Migration[] = [
         )
         .all() as Array<{ run_id: string; agent: string }>;
 
-      const update = db.prepare('UPDATE sessions SET agent_id = ? WHERE id = ? AND agent_id IS NULL');
+      const update = db.prepare(
+        'UPDATE sessions SET agent_id = ? WHERE id = ? AND agent_id IS NULL'
+      );
       for (const row of rows) {
         update.run(row.agent, row.run_id);
       }

--- a/packages/storage/src/sqlite-store.ts
+++ b/packages/storage/src/sqlite-store.ts
@@ -229,10 +229,7 @@ export function getRunAgent(db: Database.Database, runId: string): string | null
 }
 
 /** Resolve agent identity for multiple runs in a single query */
-export function getRunAgents(
-  db: Database.Database,
-  runIds: string[]
-): Map<string, string> {
+export function getRunAgents(db: Database.Database, runIds: string[]): Map<string, string> {
   if (runIds.length === 0) return new Map();
   const placeholders = runIds.map(() => '?').join(', ');
   const rows = db

--- a/packages/telemetry/src/cloud-sink.ts
+++ b/packages/telemetry/src/cloud-sink.ts
@@ -21,7 +21,11 @@ import type {
 import { anonymizeEvent } from './anonymize.js';
 import { createAgentEventQueue } from './agent-event-queue.js';
 import { createAgentEventSender } from './agent-event-sender.js';
-import { mapDomainEventToAgentEvent, mapDecisionToAgentEvent, parseDriverType } from './event-mapper.js';
+import {
+  mapDomainEventToAgentEvent,
+  mapDecisionToAgentEvent,
+  parseDriverType,
+} from './event-mapper.js';
 import type { AgentEvent } from './event-mapper.js';
 import type { AgentEventQueue } from './agent-event-queue.js';
 import type { AgentEventSender } from './agent-event-sender.js';


### PR DESCRIPTION
## Summary

- 5 files had Prettier formatting violations predating recent PRs, causing the `pnpm format` lint check to fail across all open PRs
- This is a pure formatting fix with no functional changes
- Unblocks lint gate for: #1137, #1135, #1134, #1126, #1109, #1090

**Files fixed:**
- `packages/storage/src/migrations.ts`
- `packages/storage/src/aggregation-queries.ts`
- `packages/storage/src/sqlite-store.ts`
- `packages/telemetry/src/cloud-sink.ts`
- `apps/cli/src/commands/inspect.ts`

## Test plan
- [ ] CI lint check passes (`pnpm format` returns clean)
- [ ] No functional changes — formatting only

🤖 HQ EM run 2026-03-27T21:18Z