### PR TITLE
fix: increase Go fast-path execFileSync timeout from 200ms to 500ms

### DIFF
--- a/apps/cli/src/commands/claude-hook.ts
+++ b/apps/cli/src/commands/claude-hook.ts
@@ -513,7 +513,7 @@ export function tryGoFastPath(
     const result = execFileSync(goBin, ['evaluate', '--policy', tmpPolicyPath], {
       input: actionPayload,
       encoding: 'utf8',
-      timeout: 200,
+      timeout: 500,
       maxBuffer: 64 * 1024,
       stdio: ['pipe', 'pipe', 'pipe'],
     });


### PR DESCRIPTION
Closes #1142

## Implementation Summary

**What changed:**
- Increased the `execFileSync` timeout in `tryGoFastPath` from 200ms to 500ms in `apps/cli/src/commands/claude-hook.ts`

**How to verify:**
1. Run `pnpm test --filter=@red-codes/agentguard -- go-fast-path` — all 12 tests pass
2. The previously flaky tests (`handles Go binary that allows an action`, `merges rules from multiple policies`) now have sufficient headroom in slow CI environments

**Tier C scope check:**
- Files changed: 1 (limit: 5)
- Lines changed: ~1 (limit: 300)
- Breaking changes: None

---
*Tier C implementation by copilot-cli — AgentGuard three-tier governance*