### PR TITLE
fix(matchers): strip heredoc bodies before destructive pattern scanning

### DIFF
--- a/packages/matchers/src/command-scanner.ts
+++ b/packages/matchers/src/command-scanner.ts
@@ -83,6 +83,56 @@ function makePatternId(category: string, index: number): string {
   return `destructive:${category}:${index}`;
 }
 
+// ─── Heredoc stripping ──────────────────────────────────────────────────────
+
+/**
+ * Strip heredoc bodies from a shell command string before destructive pattern scanning.
+ *
+ * Heredoc bodies contain file content (not executable shell commands), so scanning
+ * them causes false positives when agents write reports or documents that mention
+ * blocked command patterns as examples.
+ *
+ * Given: `cat > /tmp/file.md << 'EOF'\nrm -rf would be bad\nEOF`
+ * Returns: `cat > /tmp/file.md << 'EOF'`
+ *
+ * Handles all heredoc forms: `<<`, `<<-`, `<< 'WORD'`, `<< "WORD"`, `<< WORD`.
+ */
+export function stripHeredocBodies(command: string): string {
+  if (!command.includes('<<')) return command;
+
+  const lines = command.split('\n');
+  const resultLines: string[] = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i]!;
+    // Match heredoc opener: <<[-] followed by optional whitespace and an optional-quoted delimiter
+    const heredocMatch = line.match(/<<-?\s*(['"]?)(\w+)\1/);
+    if (heredocMatch) {
+      resultLines.push(line);
+      const delimiter = heredocMatch[2]!;
+      i++;
+      // Skip lines until we find the closing delimiter (alone on a line, possibly with leading tabs for <<-)
+      while (i < lines.length) {
+        const bodyLine = lines[i]!;
+        // Closing delimiter may have leading whitespace (for <<-) stripped
+        if (bodyLine.trim() === delimiter) {
+          // Include the closing delimiter to preserve heredoc structure for downstream parsing
+          resultLines.push(bodyLine);
+          i++;
+          break;
+        }
+        i++;
+      }
+    } else {
+      resultLines.push(line);
+      i++;
+    }
+  }
+
+  return resultLines.join('\n');
+}
+
 // ─── CommandScanner ─────────────────────────────────────────────────────────
 
 /**
@@ -201,12 +251,16 @@ export class CommandScanner {
   scanDestructive(command: string): MatchResult[] {
     if (!command) return [];
 
+    // Strip heredoc bodies — they contain file content (not shell commands) and
+    // would cause false positives when agents write reports mentioning blocked patterns.
+    const scanTarget = stripHeredocBodies(command);
+
     const results: MatchResult[] = [];
     const seenPatterns = new Set<string>();
 
     // ─── Tier 1: Aho-Corasick keyword scan ────────────────────────────────
     if (this.keywordTrie) {
-      const emits = this.keywordTrie.parseText(command);
+      const emits = this.keywordTrie.parseText(scanTarget);
       for (const emit of emits) {
         const keyword = emit.keyword.toLowerCase();
         const entries = this.keywordEntries.get(keyword);
@@ -216,7 +270,7 @@ export class CommandScanner {
           if (seenPatterns.has(entry.patternId)) continue;
 
           // Verify with the original regex for word-boundary accuracy
-          if (entry.verifyRegex.test(command)) {
+          if (entry.verifyRegex.test(scanTarget)) {
             seenPatterns.add(entry.patternId);
             results.push({
               matched: true,
@@ -239,7 +293,7 @@ export class CommandScanner {
       for (const entry of entries) {
         if (seenPatterns.has(entry.patternId)) continue;
 
-        if (entry.verifyRegex.test(command)) {
+        if (entry.verifyRegex.test(scanTarget)) {
           seenPatterns.add(entry.patternId);
           results.push({
             matched: true,
@@ -258,7 +312,7 @@ export class CommandScanner {
     for (const entry of this.regexEntries) {
       if (seenPatterns.has(entry.patternId)) continue;
 
-      if (entry.regex.test(command)) {
+      if (entry.regex.test(scanTarget)) {
         seenPatterns.add(entry.patternId);
         results.push({
           matched: true,

--- a/packages/matchers/src/index.ts
+++ b/packages/matchers/src/index.ts
@@ -79,7 +79,7 @@ export {
 
 // ─── Matchers ────────────────────────────────────────────────────────────────
 
-export { CommandScanner } from './command-scanner.js';
+export { CommandScanner, stripHeredocBodies } from './command-scanner.js';
 export { PathMatcher } from './path-matcher.js';
 export type { PathPatternInput } from './path-matcher.js';
 export { PolicyMatcher } from './policy-matcher.js';

--- a/packages/matchers/tests/command-scanner.test.ts
+++ b/packages/matchers/tests/command-scanner.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { CommandScanner } from '../src/command-scanner.js';
+import { CommandScanner, stripHeredocBodies } from '../src/command-scanner.js';
 import type {
   DestructivePatternInput,
   GitActionPatternInput,
@@ -335,5 +335,65 @@ describe('CommandScanner', () => {
       expect(noGithub.scanGitAction('git push')).not.toBeNull();
       expect(noGithub.scanGithubAction('gh pr list')).toBeNull();
     });
+  });
+});
+
+// ─── stripHeredocBodies ───────────────────────────────────────────────────────
+
+describe('stripHeredocBodies', () => {
+  it('returns command unchanged when no heredoc present', () => {
+    expect(stripHeredocBodies('rm -rf /tmp/foo')).toBe('rm -rf /tmp/foo');
+    expect(stripHeredocBodies('cat file.txt')).toBe('cat file.txt');
+  });
+
+  it('strips heredoc body with single-quoted delimiter', () => {
+    const cmd = "cat > /tmp/file.md << 'EOF'\nrm -rf would be bad here\nEOF";
+    const result = stripHeredocBodies(cmd);
+    expect(result).toContain("cat > /tmp/file.md << 'EOF'");
+    expect(result).not.toContain('rm -rf would be bad here');
+    expect(result).toContain('EOF');
+  });
+
+  it('strips heredoc body with double-quoted delimiter', () => {
+    const cmd = 'cat > /tmp/file.md << "EOF"\nrm -rf would be bad\nEOF';
+    const result = stripHeredocBodies(cmd);
+    expect(result).not.toContain('rm -rf would be bad');
+  });
+
+  it('strips heredoc body with unquoted delimiter', () => {
+    const cmd = 'cat > /tmp/file.md << EOF\nrm -rf would be bad\nEOF';
+    const result = stripHeredocBodies(cmd);
+    expect(result).not.toContain('rm -rf would be bad');
+  });
+
+  it('strips heredoc body with <<- (tab-stripping) form', () => {
+    const cmd = 'cat > /tmp/file.md <<- EOF\n\trm -rf would be bad\n\tEOF';
+    const result = stripHeredocBodies(cmd);
+    expect(result).not.toContain('rm -rf would be bad');
+  });
+
+  it('allows destructive pattern detection on the command line itself', () => {
+    // The command portion before the heredoc is still scanned
+    const cmd = 'rm -rf /tmp/dir && cat > /tmp/file << EOF\nsafe content\nEOF';
+    const result = stripHeredocBodies(cmd);
+    expect(result).toContain('rm -rf /tmp/dir');
+  });
+
+  it('scanner does not fire on heredoc body content', () => {
+    const scanner = CommandScanner.create(
+      [{ pattern: '\\brm\\s+-rf\\b', description: 'Recursive force delete', riskLevel: 'critical', category: 'filesystem' }],
+      []
+    );
+    const cmd = "cat > /tmp/report.md << 'REPORT'\n## Analysis\nrm -rf is a dangerous command we block\nREPORT";
+    expect(scanner.isDestructive(cmd)).toBe(false);
+  });
+
+  it('scanner still detects destructive pattern in the command portion', () => {
+    const scanner = CommandScanner.create(
+      [{ pattern: '\\brm\\s+-rf\\b', description: 'Recursive force delete', riskLevel: 'critical', category: 'filesystem' }],
+      []
+    );
+    const cmd = 'rm -rf /tmp/dir';
+    expect(scanner.isDestructive(cmd)).toBe(true);
   });
 });


### PR DESCRIPTION
Closes #1119

## Implementation Summary

**What changed:**
- Added `stripHeredocBodies(command: string): string` function to `packages/matchers/src/command-scanner.ts` that removes heredoc body content from a command string before scanning
- Applied `stripHeredocBodies()` at the start of `scanDestructive()` so all three scanning tiers (Aho-Corasick, fallback regex, complex regex) operate on the command portion only
- Exported `stripHeredocBodies` from the package index for testability
- Added 8 tests covering all heredoc forms (`<<`, `<<-`, quoted/unquoted delimiters) and the false-positive scenario from the issue

**Root cause:** The `scanDestructive()` method scanned the entire command string passed to it, including heredoc body content. When agents wrote analysis reports via heredoc (e.g. `cat > /tmp/report.md << 'EOF'\n## Analysis\nrm -rf is a dangerous command...\nEOF`), the heredoc body triggered destructive pattern matches even though it contained document text, not shell commands.

**How to verify:**
1. Run `pnpm test --filter=@red-codes/matchers` — all 122 tests pass
2. Test the fixed case directly:
   ```typescript
   const cmd = "cat > /tmp/report.md << 'REPORT'\nrm -rf is a dangerous command we block\nREPORT";
   scanner.isDestructive(cmd); // → false (was true before fix)
   ```
3. Verify real destructive commands still trigger:
   ```typescript
   scanner.isDestructive('rm -rf /tmp/dir'); // → true ✅
   ```

**Tier C scope check:**
- Files changed: 3 (limit: 5)
- Lines changed: ~120 (limit: 300)
- Breaking changes: None — `scanDestructive()` public API unchanged; `stripHeredocBodies` is a new export

---
*Tier C implementation by copilot-cli — AgentGuard three-tier governance*