### PR TITLE
chore: bump version to 2.8.3

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@red-codes/agentguard",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "description": "Run AI agents without fear — CLI safety layer",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
Version bump for v2.8.3 release (guide mode fix + commit-scope-guard fail-open).