### PR TITLE
fix(guard): graceful SQLite fallback when native bindings unavailable

### DIFF
--- a/apps/cli/src/commands/guard.ts
+++ b/apps/cli/src/commands/guard.ts
@@ -115,9 +115,20 @@ export async function guard(_args: string[], options: GuardOptions = {}): Promis
   // Generate run ID using seeded RNG so both sinks share it
   const runId = `run_${Date.now()}_${simpleHash(rng.random().toString())}`;
 
-  // Create sinks — use storage bundle
+  // Create sinks — use storage bundle with graceful fallback when SQLite is unavailable
+  // (e.g. native bindings missing in worktrees or on unsupported Node.js versions)
   const storeConfig = options.store ?? { backend: 'sqlite' as const };
-  const storage = await createStorageBundle(storeConfig);
+  let storage: Awaited<ReturnType<typeof createStorageBundle>>;
+  try {
+    storage = await createStorageBundle(storeConfig);
+  } catch (err) {
+    process.stderr.write(
+      `[agentguard] Warning: SQLite storage unavailable — falling back to no-op storage.\n` +
+        `  Cause: ${err instanceof Error ? err.message : String(err)}\n` +
+        `  Run with --no-sqlite to suppress this warning.\n`
+    );
+    storage = await createStorageBundle({ backend: 'none' });
+  }
   const eventSink = storage.createEventSink(runId);
   const decisionSink = storage.createDecisionSink(runId);
 

--- a/apps/cli/tests/cli-guard.test.ts
+++ b/apps/cli/tests/cli-guard.test.ts
@@ -122,3 +122,22 @@ describe('guard command kernel integration', () => {
     expect(result.allowed).toBe(false);
   });
 });
+
+describe('guard command storage fallback', () => {
+  it('no-op storage bundle is functional (fallback target)', async () => {
+    // Verify that the none-backend bundle (fallback target when SQLite fails)
+    // produces working sinks — this is what guard.ts falls back to on error.
+    const { createStorageBundle } = await import('@red-codes/storage');
+    const bundle = await createStorageBundle({ backend: 'none' });
+
+    const eventSink = bundle.createEventSink('run_test_123');
+    const decisionSink = bundle.createDecisionSink('run_test_123');
+
+    expect(bundle).toBeDefined();
+    expect(typeof eventSink.write).toBe('function');
+    expect(typeof decisionSink.write).toBe('function');
+    // No-op sinks should silently accept writes without throwing
+    expect(() => eventSink.write({ kind: 'ActionRequested' } as never)).not.toThrow();
+    expect(() => decisionSink.write({ kind: 'DecisionRecorded' } as never)).not.toThrow();
+  });
+});


### PR DESCRIPTION
Closes #1148

## Implementation Summary

**What changed:**
- In `guard.ts`, wrapped `createStorageBundle()` in try/catch — if SQLite bindings fail to load (e.g. `better-sqlite3` native module not built for current Node.js version in worktrees), the runtime now falls back to no-op storage and prints a descriptive warning instead of crashing
- Warning message tells users to run with `--no-sqlite` to suppress it
- Added test verifying the no-op storage bundle (the fallback target) is functional

**How to verify:**
1. In a worktree without rebuilt SQLite bindings, run `agentguard guard --dry-run`
2. Should now warn and continue instead of crashing with fatal error
3. Alternatively: set `AGENTGUARD_NO_SQLITE=1` to skip SQLite entirely

**Pattern alignment:**
The hook commands (`claude-hook`, `copilot-hook`, `deepagents-hook`) already used this graceful pattern. This brings `guard.ts` into alignment.

**Tier C scope check:**
- Files changed: 2 (limit: 5)
- Lines changed: ~32 (limit: 300)
- Breaking changes: None

---
*Tier C implementation by copilot-cli — AgentGuard three-tier governance*