### PR TITLE
docs: sync documentation with codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,7 +173,7 @@ apps/
 │   ├── session-store.ts        # Session management
 │   ├── file-event-store.ts     # File-based event persistence
 │   ├── evidence-summary.ts     # Evidence summary generator for PR reports
-│   └── commands/               # guard, inspect, replay, export, import, simulate, ci-check, plugin, policy (validate, suggest, verify), claude-hook, claude-init, copilot-hook, copilot-init, cloud, init, diff, evidence-pr, traces, session-viewer, status, analytics, auto-setup, config, audit-verify, demo, adoption, learn, migrate, trust
+│   └── commands/               # guard, inspect, replay, export, import, simulate, ci-check, plugin, policy (validate, suggest, verify), claude-hook, claude-init, copilot-hook, copilot-init, deepagents-hook, deepagents-init, cloud, init, diff, evidence-pr, traces, session-viewer, status, analytics, auto-setup, config, audit-verify, demo, adoption, learn, migrate, trust, team-report, telemetry
 ├── mcp-server/src/             # @red-codes/mcp-server — MCP governance server
 │   ├── index.ts                # Entry point
 │   ├── server.ts               # MCP server implementation
@@ -293,6 +293,8 @@ Each workspace package maps to a single architectural concept:
 - `agentguard cloud login|signup|connect|status|events|runs|summary|disconnect` — Cloud governance analytics
 - `agentguard copilot-hook` — Handle GitHub Copilot PreToolUse/PostToolUse hook events
 - `agentguard copilot-init` — Set up GitHub Copilot hook integration
+- `agentguard deepagents-init` — Set up DeepAgents (LangChain) hook integration
+- `agentguard deepagents-hook` — DeepAgents hook handler (internal)
 - `agentguard team-report` — Team-level governance observability across agents
 - `agentguard telemetry [on|off|status]` — Manage anonymous telemetry settings
 

--- a/README.md
+++ b/README.md
@@ -397,10 +397,7 @@ agentguard claude-init                    # Interactive wizard: mode + pack → 
 agentguard claude-init --global           # Install hooks globally (~/.claude/settings.json)
 agentguard claude-init --mode guide --pack essentials  # Non-interactive setup
 agentguard copilot-init                   # Set up GitHub Copilot CLI hook integration
-agentguard codex-init                     # Set up OpenAI Codex CLI hook integration
-agentguard gemini-init                    # Set up Google Gemini CLI hook integration
-agentguard opencode-init                  # Set up OpenCode (.opencode/plugins/agentguard.ts) hook integration
-agentguard deepagents-init                # Set up DeepAgents (.deepagents/agentguard_middleware.py) middleware
+agentguard deepagents-init                # Set up DeepAgents (LangChain) hook integration
 agentguard init --template strict         # Scaffold policy from a template
 agentguard status                         # Show governance status
 


### PR DESCRIPTION
## What drifted

### CLAUDE.md — Missing DeepAgents commands
- **CLI commands list** was missing `deepagents-init` and `deepagents-hook` (both exist in `apps/cli/src/bin.ts` and `apps/cli/src/commands/`)
- **Commands directory listing** was missing `deepagents-hook`, `deepagents-init`, `team-report`, and `telemetry`

### README.md — Phantom setup commands
- Removed `codex-init`, `gemini-init`, and `opencode-init` from the setup example code block — none of these exist in `bin.ts` or `apps/cli/src/commands/`

## Verification
- CLI commands verified via `grep "case '" apps/cli/src/bin.ts`
- Command files verified via `ls apps/cli/src/commands/`
- Only documentation files modified

---
*Created by copilot-docs-sync — AgentGuard Copilot swarm*