### PR TITLE
docs: sync documentation with codebase state

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -55,7 +55,7 @@ packages/
 ├── invariant-data-protection/ @red-codes/invariant-data-protection — Data protection invariant plugin
 ├── matchers/      @red-codes/matchers — Structured matchers (Aho-Corasick, globs, hash sets)
 ├── kernel/        @red-codes/kernel — Governed action kernel (orchestrate, normalize, decide, escalate)
-├── adapters/      @red-codes/adapters — Execution adapters (file, shell, git, claude-code, copilot-cli, codex-cli, gemini-cli)
+├── adapters/      @red-codes/adapters — Execution adapters (file, shell, git, claude-code, copilot-cli, deepagents)
 ├── storage/       @red-codes/storage — SQLite storage backend (opt-in)
 ├── telemetry/     @red-codes/telemetry — Runtime telemetry and logging
 ├── plugins/       @red-codes/plugins — Plugin ecosystem (discovery, registry, validation, sandboxing)
@@ -118,7 +118,7 @@ The `claude-init` command provides an interactive wizard that generates a starte
 Agents declare their identity (role + driver) at the start of each governance session. If the `--agent-name` flag is not provided, an interactive prompt collects the identity.
 
 **Roles:** `developer`, `reviewer`, `ops`, `security`, `planner`
-**Drivers:** `human`, `claude-code`, `copilot`, `codex`, `gemini`, `ci`
+**Drivers:** `human`, `claude-code`, `copilot`, `opencode`, `ci`
 
 Identity serves three purposes:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,7 +173,7 @@ apps/
 │   ├── session-store.ts        # Session management
 │   ├── file-event-store.ts     # File-based event persistence
 │   ├── evidence-summary.ts     # Evidence summary generator for PR reports
-│   └── commands/               # guard, inspect, replay, export, import, simulate, ci-check, plugin, policy (validate, suggest, verify), claude-hook, claude-init, copilot-hook, copilot-init, cloud, init, diff, evidence-pr, traces, session-viewer, status, analytics, auto-setup, config, audit-verify, demo, adoption, learn, migrate, trust
+│   └── commands/               # guard, inspect, replay, export, import, simulate, ci-check, plugin, policy (validate, suggest, verify), claude-hook, claude-init, copilot-hook, copilot-init, deepagents-hook, deepagents-init, cloud, init, diff, evidence-pr, traces, session-viewer, status, analytics, auto-setup, config, audit-verify, demo, adoption, learn, migrate, trust, team-report
 ├── mcp-server/src/             # @red-codes/mcp-server — MCP governance server
 │   ├── index.ts                # Entry point
 │   ├── server.ts               # MCP server implementation
@@ -293,6 +293,8 @@ Each workspace package maps to a single architectural concept:
 - `agentguard cloud login|signup|connect|status|events|runs|summary|disconnect` — Cloud governance analytics
 - `agentguard copilot-hook` — Handle GitHub Copilot PreToolUse/PostToolUse hook events
 - `agentguard copilot-init` — Set up GitHub Copilot hook integration
+- `agentguard deepagents-hook` — Handle DeepAgents (LangChain) PreToolUse/PostToolUse hook events
+- `agentguard deepagents-init` — Set up DeepAgents hook integration (generates Python middleware)
 - `agentguard team-report` — Team-level governance observability across agents
 - `agentguard telemetry [on|off|status]` — Manage anonymous telemetry settings
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ agentguard guard --agent-name my-agent
 # Or omit --agent-name and an interactive prompt will ask for role + driver
 ```
 
-Identity consists of a **role** (`developer`, `reviewer`, `ops`, `security`, `ci`) and a **driver** (`human`, `claude-code`, `copilot`, `codex`, `gemini`, `opencode`, `deepagents`, `ci`). Identity flows to cloud telemetry for attribution, dashboard grouping, and persona-scoped policy rules.
+Identity consists of a **role** (`developer`, `reviewer`, `ops`, `security`, `ci`) and a **driver** (`human`, `claude-code`, `copilot`, `opencode`, `ci`). Identity flows to cloud telemetry for attribution, dashboard grouping, and persona-scoped policy rules.
 
 ## What It Does
 
@@ -397,9 +397,6 @@ agentguard claude-init                    # Interactive wizard: mode + pack → 
 agentguard claude-init --global           # Install hooks globally (~/.claude/settings.json)
 agentguard claude-init --mode guide --pack essentials  # Non-interactive setup
 agentguard copilot-init                   # Set up GitHub Copilot CLI hook integration
-agentguard codex-init                     # Set up OpenAI Codex CLI hook integration
-agentguard gemini-init                    # Set up Google Gemini CLI hook integration
-agentguard opencode-init                  # Set up OpenCode (.opencode/plugins/agentguard.ts) hook integration
 agentguard deepagents-init                # Set up DeepAgents (.deepagents/agentguard_middleware.py) middleware
 agentguard init --template strict         # Scaffold policy from a template
 agentguard status                         # Show governance status

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -251,8 +251,8 @@ Depends on: KE-2 (ActionContext provides vendor-neutral normalization).
 - [x] ~~Agent SDK for programmatic governance integration~~ — ✅ Done 2026-03-21 (v2.3.0)
 - [ ] Generic MCP adapter for any MCP-compatible tool
 - [x] ~~OpenCode driver support~~ — ✅ Done 2026-03-26 (v2.7.x) — `opencode` registered as supported agent driver (PR #1019)
-- [x] ~~Codex CLI adapter (PreToolUse/PostToolUse)~~ — ✅ Done 2026-03-27 (v2.8.0) — `agentguard codex-hook` + `agentguard codex-init` (PR #1024)
-- [x] ~~Gemini CLI adapter (BeforeTool/AfterTool)~~ — ✅ Done 2026-03-27 (v2.8.0) — `agentguard gemini-hook` + `agentguard gemini-init` (PR #1024)
+- [ ] Codex CLI adapter (PreToolUse/PostToolUse) — `agentguard codex-hook` + `agentguard codex-init`
+- [ ] Gemini CLI adapter (BeforeTool/AfterTool) — `agentguard gemini-hook` + `agentguard gemini-init`
 - [ ] **Runtime sandbox adapters** — Optional modules that enrich governance with sandbox metadata. Integrate, don't depend:
   - `@agentguard/runtime-nemoclaw` — NVIDIA NemoClaw adapter: detect sandbox environment, map sandbox permissions → governance rules, fuse behavioral telemetry (AgentGuard) with system constraints (NemoClaw) for full-stack audit trail. Enterprise credibility multiplier — "contained + governed" covers prevent/detect/contain/audit. **Not a dependency** — kernel remains runtime-independent.
   - Future: Docker/Podman, Firecracker, Bubblewrap adapters via same pattern


### PR DESCRIPTION
## Summary

Automated documentation sync detected drift between codebase and docs. This PR fixes factual inaccuracies across 4 documentation files.

## Drift Found & Fixed

### ARCHITECTURE.md
- **Adapters list wrong**: Listed `codex-cli, gemini-cli` as adapters — these files do not exist in `packages/adapters/src/`. Actual adapter is `deepagents.ts`. Fixed to list `deepagents`.
- **Drivers list wrong**: Listed `codex`, `gemini` as drivers — these are not in the actual `Driver` type in `apps/cli/src/identity.ts` (which has `human | claude-code | copilot | opencode | ci`). Fixed to remove `codex` and `gemini`, add `opencode`.

### CLAUDE.md
- **Commands directory comment incomplete**: Missing `deepagents-hook`, `deepagents-init`, `team-report` from the `commands/` inline listing.
- **CLI commands section incomplete**: Missing `agentguard deepagents-hook` and `agentguard deepagents-init` entries (both exist in `apps/cli/src/commands/` and handled in `bin.ts`).

### README.md
- **Driver list wrong**: Listed `codex`, `gemini`, `deepagents` as valid drivers — these are not in `VALID_DRIVERS` in `identity.ts`. Fixed to match actual supported drivers.
- **Non-existent commands**: `agentguard codex-init`, `agentguard gemini-init`, `agentguard opencode-init` do not exist in the CLI (no case statements in `bin.ts`, no command files). Removed from Quick Start.

### ROADMAP.md
- **Codex/Gemini adapters incorrectly marked done**: Lines 254–255 marked Codex CLI and Gemini CLI adapters as `[x]` done at v2.8.0 (PR #1024), but `packages/adapters/src/codex-cli.ts` and `gemini-cli.ts` do not exist in the codebase. Reverted to `[ ]` pending.

## Document Contradictions Flagged

- ROADMAP.md (lines 254–255) and ARCHITECTURE.md (adapters list, line 58) both claimed codex/gemini adapters were shipped — but neither the adapter source files nor the CLI command files exist. These are now corrected consistently across both files.
- README.md and ARCHITECTURE.md both had inconsistent driver lists. Now both match `apps/cli/src/identity.ts`.

## Changes

- `ARCHITECTURE.md` — corrected adapter list + driver list
- `CLAUDE.md` — added deepagents-hook, deepagents-init, team-report to commands listing
- `README.md` — fixed driver list, removed 3 non-existent init commands
- `ROADMAP.md` — reverted codex/gemini adapter items to pending

## Source

Auto-generated by the **Scheduled Docs Sync** skill.
Agent identity: `copilot-cli:copilot:ops` (copilot-docs-sync)

---
*Run: 2026-03-28T06:06:00Z*