### PR TITLE
docs: fix stale adapter references in hook-architecture and multi-framework-adapters

### DIFF
--- a/docs/hook-architecture.md
+++ b/docs/hook-architecture.md
@@ -2,16 +2,15 @@
 
 ## Supported Drivers
 
-AgentGuard supports four AI coding agent drivers via the same inline hook pattern:
+AgentGuard supports three AI coding agent drivers via the same inline hook pattern, plus a Python middleware adapter for LangChain DeepAgents:
 
 | Driver | Init command | Hook command | Config file |
 |--------|-------------|-------------|------------|
 | **Claude Code** | `agentguard claude-init` | `agentguard claude-hook pre\|post` | `.claude/settings.json` |
 | **GitHub Copilot CLI** | `agentguard copilot-init` | `agentguard copilot-hook pre\|post` | `.github/hooks/hooks.json` |
-| **OpenAI Codex CLI** | `agentguard codex-init` | `agentguard codex-hook pre\|post` | `.codex/hooks.json` |
-| **Google Gemini CLI** | `agentguard gemini-init` | `agentguard gemini-hook pre\|post` | `.gemini/settings.json` |
+| **LangChain DeepAgents** | `agentguard deepagents-init` | `agentguard deepagents-hook pre\|post` | `.deepagents/agentguard_middleware.py` |
 
-All four drivers follow the same governance flow: the agent fires a `PreToolUse` hook before each tool call, AgentGuard evaluates the action against policy and invariants, and responds with an allow or block decision. Agent identity (role + driver) is resolved at session start and flows into all hook evaluations and telemetry.
+All drivers follow the same governance flow: the agent fires a `PreToolUse`-equivalent hook before each tool call, AgentGuard evaluates the action against policy and invariants, and responds with an allow or block decision. Agent identity (role + driver) is resolved at session start and flows into all hook evaluations and telemetry.
 
 ## Design: Inline Hooks, Not a Daemon
 
@@ -204,13 +203,10 @@ echo '{"tool":"Bash","input":{"command":"git push origin main"}}' | agentguard c
 | `apps/cli/src/commands/claude-init.ts` | Claude Code hook setup and teardown |
 | `apps/cli/src/commands/copilot-hook.ts` | GitHub Copilot CLI hook command |
 | `apps/cli/src/commands/copilot-init.ts` | GitHub Copilot CLI hook setup |
-| `apps/cli/src/commands/codex-hook.ts` | OpenAI Codex CLI hook command |
-| `apps/cli/src/commands/codex-init.ts` | OpenAI Codex CLI hook setup |
-| `apps/cli/src/commands/gemini-hook.ts` | Google Gemini CLI hook command |
-| `apps/cli/src/commands/gemini-init.ts` | Google Gemini CLI hook setup |
+| `apps/cli/src/commands/deepagents-hook.ts` | LangChain DeepAgents hook command |
+| `apps/cli/src/commands/deepagents-init.ts` | LangChain DeepAgents middleware setup (generates Python shim) |
 | `packages/adapters/src/claude-code.ts` | Claude Code payload normalization and action mapping |
 | `packages/adapters/src/copilot-cli.ts` | Copilot CLI payload normalization |
-| `packages/adapters/src/codex-cli.ts` | Codex CLI payload normalization |
-| `packages/adapters/src/gemini-cli.ts` | Gemini CLI payload normalization |
+| `packages/adapters/src/deepagents.ts` | DeepAgents payload normalization and Python tool mapping |
 | `packages/kernel/src/kernel.ts` | Governed action kernel (policy + invariant evaluation) |
 | `packages/kernel/src/aab.ts` | Action Authorization Boundary (tool → action type) |

--- a/docs/multi-framework-adapters.md
+++ b/docs/multi-framework-adapters.md
@@ -4,14 +4,15 @@ This document describes the architecture for integrating AgentGuard governance w
 
 ## Status
 
-AgentGuard supports four hook-based driver adapters as of v2.8.0:
+AgentGuard supports three hook-based driver adapters plus a Python middleware adapter for LangChain DeepAgents:
 
 | Driver | Adapter | Hook commands | Status |
 |--------|---------|---------------|--------|
 | **Claude Code** | `packages/adapters/src/claude-code.ts` | `agentguard claude-hook`, `claude-init` | ✅ Shipped |
 | **GitHub Copilot CLI** | `packages/adapters/src/copilot-cli.ts` | `agentguard copilot-hook`, `copilot-init` | ✅ Shipped |
-| **OpenAI Codex CLI** | `packages/adapters/src/codex-cli.ts` | `agentguard codex-hook`, `codex-init` | ✅ Shipped (v2.8.0) |
-| **Google Gemini CLI** | `packages/adapters/src/gemini-cli.ts` | `agentguard gemini-hook`, `gemini-init` | ✅ Shipped (v2.8.0) |
+| **LangChain DeepAgents** | `packages/adapters/src/deepagents.ts` | `agentguard deepagents-hook`, `deepagents-init` | ✅ Shipped (v2.8.x) |
+| **OpenAI Codex CLI** | — | `agentguard codex-hook`, `codex-init` | 🗓 Planned |
+| **Google Gemini CLI** | — | `agentguard gemini-hook`, `gemini-init` | 🗓 Planned |
 
 The governance kernel is framework-agnostic — it accepts `RawAgentAction` objects and returns `GovernanceDecisionRecord` results. Each driver adapter translates its framework-specific PreToolUse/PostToolUse hook payload into the canonical `RawAgentAction` format.
 
@@ -38,21 +39,22 @@ FrameworkAdapter {
 - `translateResult` converts kernel decisions back to framework-specific responses (e.g., Claude Code expects `{ decision: 'allow' | 'block' }`)
 - `install()` / `uninstall()` handle framework-specific setup (hook registration, middleware injection, config file updates)
 
-## Target Directory Structure
+## Current Directory Structure
 
 ```
-src/adapters/
-├── registry.ts              # Existing action class → handler registry
-├── framework.ts             # FrameworkAdapter interface definition
-├── framework-registry.ts    # Framework adapter registry
-├── claude-code.ts           # Existing Claude Code adapter
-└── frameworks/
-    ├── mcp.ts               # MCP (Model Context Protocol)
-    ├── langchain.ts         # LangChain / LangGraph
-    ├── openai-agents.ts     # OpenAI Agents SDK
-    ├── autogen.ts           # AutoGen
-    └── copilot-cli.ts       # Copilot CLI
+packages/adapters/src/
+├── registry.ts              # Action class → handler registry
+├── claude-code.ts           # Claude Code adapter (PreToolUse/PostToolUse hooks)
+├── copilot-cli.ts           # GitHub Copilot CLI adapter (meta-tool mapping included)
+├── deepagents.ts            # LangChain DeepAgents adapter (Python middleware bridge)
+├── file.ts                  # File action handler
+├── git.ts                   # Git action handler
+├── hook-integrity.ts        # Hook integrity verification
+├── index.ts                 # Module exports
+└── shell.ts                 # Shell action handler
 ```
+
+Future planned adapters (MCP generic adapter, OpenAI Codex CLI, Google Gemini CLI, AutoGen, OpenAI Agents SDK) will follow the same `translateToRawAction` / `translateResult` pattern.
 
 ## Adapter Priority & Complexity
 


### PR DESCRIPTION
## Summary

**Agent:** claude-code:opus:ops
**Identity:** agentguard-autonomous-sdlc--documentation-maintainer-agent

Removes references to Codex CLI and Gemini CLI adapters that were marked as "✅ Shipped" but have no corresponding adapter files (`packages/adapters/src/codex-cli.ts`, `gemini-cli.ts`) or CLI commands (`codex-hook`, `gemini-init`, etc.) in the codebase.

Adds LangChain DeepAgents (`packages/adapters/src/deepagents.ts`) which was shipped in v2.8.x via PR #1126 with `agentguard deepagents-hook` and `deepagents-init` commands.

## Files Changed

### `docs/hook-architecture.md`
- Replace Codex CLI and Gemini CLI rows with LangChain DeepAgents in Supported Drivers table
- Update Key Source Files table to point to actual files (`deepagents-hook.ts`, `deepagents-init.ts`, `deepagents.ts`)

### `docs/multi-framework-adapters.md`
- Replace Codex/Gemini (falsely "✅ Shipped") with DeepAgents ("✅ Shipped v2.8.x")
- Mark Codex CLI and Gemini CLI as "🗓 Planned" (matches ROADMAP)
- Replace stale "Target Directory Structure" with "Current Directory Structure" reflecting actual `packages/adapters/src/` contents
- Add note about future planned adapters

## Verification

Actual adapter files confirmed: `claude-code.ts`, `copilot-cli.ts`, `deepagents.ts`, `file.ts`, `git.ts`, `hook-integrity.ts`, `index.ts`, `registry.ts`, `shell.ts`

No `codex-cli.ts` or `gemini-cli.ts` exist. No `codex-hook`, `gemini-hook`, `codex-init`, or `gemini-init` commands exist.

---
*Docs-only change — no source code modified.*