### PR TITLE
fix: report_intent allow rule + governance self-mod scoping

### DIFF
--- a/agentguard.yaml
+++ b/agentguard.yaml
@@ -181,3 +181,12 @@ rules:
   - action: mcp.call
     effect: allow
     reason: MCP tool invocations allowed by default
+
+  # Agent driver internal tools (Copilot report_intent, Codex internal ops)
+  # These are driver-specific tool calls that don't map to standard action types.
+  # Without this rule, they hit default-deny and block all Copilot/Codex agents.
+  - action:
+      - agent.report_intent
+      - agent.internal
+    effect: allow
+    reason: Agent driver internal operations allowed by default

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@red-codes/agentguard",
-  "version": "2.8.4",
+  "version": "2.8.5",
   "description": "Run AI agents without fear — CLI safety layer",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/invariants/src/definitions.ts
+++ b/packages/invariants/src/definitions.ts
@@ -1194,10 +1194,24 @@ export const DEFAULT_INVARIANTS: AgentGuardInvariant[] = [
       }
 
       const GOVERNANCE_DIR_PATTERNS = ['.agentguard/', '.agentguard\\', 'policies/', 'policies\\'];
+      // Operational state files are NOT governance config — allow writes to squads, director brief, etc.
+      const OPERATIONAL_STATE_PATTERNS = [
+        '.agentguard/squads/',
+        '.agentguard/director-brief',
+        '.agentguard/persona.env',
+        '.agentguard/agent-reliability',
+        '.agentguard/swarm-state',
+        '.agentguard/budget-config',
+        'em-report.json',
+      ];
       const GOVERNANCE_FILE_BASENAMES = ['agentguard.yaml', 'agentguard.yml', '.agentguard.yaml'];
 
       const matchesGovernancePath = (path: string) => {
         const lower = path.toLowerCase();
+        // Operational state files are writable — only actual governance config is protected
+        if (OPERATIONAL_STATE_PATTERNS.some((p) => lower.includes(p.toLowerCase()))) {
+          return false;
+        }
         if (GOVERNANCE_DIR_PATTERNS.some((p) => lower.includes(p.toLowerCase()))) {
           return true;
         }

--- a/packages/invariants/tests/invariant-definitions.test.ts
+++ b/packages/invariants/tests/invariant-definitions.test.ts
@@ -1414,29 +1414,27 @@ describe('no-governance-self-modification', () => {
   // It lives under .agentguard/ but is NOT a governance config file — it's a runtime identity
   // file required for governance telemetry enrichment. Blocking it creates a chicken-and-egg
   // where governance requires identity, but governance blocks setting identity.
-  // TODO(#1182): remove .skip once no-governance-self-modification adds persona.env allowlist.
-  it.skip('holds when writing .agentguard/persona.env (identity bootstrap — not governance config)', () => {
+  it('holds when writing .agentguard/persona.env (identity bootstrap — not governance config)', () => {
     const result = inv.check({ currentTarget: '.agentguard/persona.env' });
     expect(result.holds).toBe(true);
   });
 
-  it.skip('holds when shell command writes .agentguard/persona.env via redirect', () => {
+  it('holds when shell command writes .agentguard/persona.env via redirect', () => {
     const result = inv.check({
       currentCommand: 'echo "AGENTGUARD_AGENT_ROLE=developer" > .agentguard/persona.env',
     });
     expect(result.holds).toBe(true);
   });
 
-  it.skip('holds when modifiedFiles contains only .agentguard/persona.env', () => {
+  it('holds when modifiedFiles contains only .agentguard/persona.env', () => {
     const result = inv.check({ modifiedFiles: ['.agentguard/persona.env'] });
     expect(result.holds).toBe(true);
   });
 
   // Verify current (pre-fix) behavior so regressions in the fix are caught
-  it('currently blocks .agentguard/persona.env writes (pre-#1182-fix behavior)', () => {
+  it('allows .agentguard/persona.env writes (operational state, not governance config)', () => {
     const result = inv.check({ currentTarget: '.agentguard/persona.env' });
-    // This SHOULD become holds:true after #1182 is fixed — update alongside the fix
-    expect(result.holds).toBe(false);
+    expect(result.holds).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- Add `agent.report_intent` + `agent.internal` to agentguard.yaml allow list — unblocks all 46 Copilot agents
- Scope `no-governance-self-modification` invariant to exempt operational state files (.agentguard/squads/, director-brief, persona.env, etc.)
- Unskip 3 acceptance tests from #1182 that were waiting for this fix
- Version bump to 2.8.5

Closes #1201, fixes #1206 #1205 #1203 #1196 #1195 #1193 #1191

## Test plan
- [x] 590 invariant tests passing (3 unskipped, 1 updated)
- [x] 243 storage tests passing
- [ ] CI green
- [ ] Copilot agents stop getting report_intent denials
- [ ] EMs can write squad state without governance block