### PR TITLE
fix(invariants): tighten no-governance-self-modification to allow operational .agentguard/ paths

### DIFF
--- a/packages/invariants/src/definitions.ts
+++ b/packages/invariants/src/definitions.ts
@@ -1196,7 +1196,26 @@ export const DEFAULT_INVARIANTS: AgentGuardInvariant[] = [
       const GOVERNANCE_DIR_PATTERNS = ['.agentguard/', '.agentguard\\', 'policies/', 'policies\\'];
       const GOVERNANCE_FILE_BASENAMES = ['agentguard.yaml', 'agentguard.yml', '.agentguard.yaml'];
 
+      // Operational subdirectories under .agentguard/ that agents legitimately write to.
+      // These are runtime artifacts, not governance configuration files.
+      const AGENTGUARD_OPERATIONAL_PREFIXES = [
+        '.agentguard/persona.env',
+        '.agentguard\\persona.env',
+        '.agentguard/squads/',
+        '.agentguard\\squads\\',
+        '.agentguard/sessions/',
+        '.agentguard\\sessions\\',
+      ];
+
+      const isOperationalPath = (path: string) => {
+        const lower = path.toLowerCase();
+        return AGENTGUARD_OPERATIONAL_PREFIXES.some((p) => lower.startsWith(p.toLowerCase()));
+      };
+
       const matchesGovernancePath = (path: string) => {
+        if (isOperationalPath(path)) {
+          return false;
+        }
         const lower = path.toLowerCase();
         if (GOVERNANCE_DIR_PATTERNS.some((p) => lower.includes(p.toLowerCase()))) {
           return true;
@@ -1212,10 +1231,19 @@ export const DEFAULT_INVARIANTS: AgentGuardInvariant[] = [
       const targetViolation = target !== '' && matchesGovernancePath(target);
 
       const command = state.currentCommand || '';
+      // Strip quoted string arguments, then tokenize and check each path-like token individually.
+      // This correctly applies the operational path allowlist to redirect targets
+      // (e.g., `echo ... > .agentguard/persona.env`) and prevents false positives
+      // when governance paths appear only inside quoted flag values
+      // (e.g., `gh issue create --body "...mentions .agentguard/..."`).
+      const commandForPatternCheck = command.replace(/"[^"]*"|'[^']*'/g, '""');
+      const commandTokens = commandForPatternCheck.split(/\s+/);
       const commandViolation =
         command !== '' &&
-        (matchesGovernancePath(command) ||
-          GOVERNANCE_FILE_BASENAMES.some((f) => command.toLowerCase().includes(f)));
+        commandTokens.some((token) => {
+          const pathToken = token.replace(/^[><|&]+/, '');
+          return matchesGovernancePath(pathToken);
+        });
 
       const governanceFiles = (state.modifiedFiles || []).filter((f) => matchesGovernancePath(f));
 

--- a/packages/invariants/tests/invariant-definitions.test.ts
+++ b/packages/invariants/tests/invariant-definitions.test.ts
@@ -1409,34 +1409,53 @@ describe('no-governance-self-modification', () => {
     expect(result.actual).toContain('modified');
   });
 
-  // Acceptance tests for #1182: agent-identity-bridge chicken-and-egg
+  // Acceptance tests for #1182 / #1201: operational .agentguard/ paths must not be blocked.
   // persona.env is the identity bootstrap file written by scripts/agent-identity-bridge.sh.
   // It lives under .agentguard/ but is NOT a governance config file — it's a runtime identity
-  // file required for governance telemetry enrichment. Blocking it creates a chicken-and-egg
-  // where governance requires identity, but governance blocks setting identity.
-  // TODO(#1182): remove .skip once no-governance-self-modification adds persona.env allowlist.
-  it.skip('holds when writing .agentguard/persona.env (identity bootstrap — not governance config)', () => {
+  // file required for governance telemetry enrichment.
+  it('holds when writing .agentguard/persona.env (identity bootstrap — not governance config)', () => {
     const result = inv.check({ currentTarget: '.agentguard/persona.env' });
     expect(result.holds).toBe(true);
   });
 
-  it.skip('holds when shell command writes .agentguard/persona.env via redirect', () => {
+  it('holds when shell command writes .agentguard/persona.env via redirect', () => {
     const result = inv.check({
       currentCommand: 'echo "AGENTGUARD_AGENT_ROLE=developer" > .agentguard/persona.env',
     });
     expect(result.holds).toBe(true);
   });
 
-  it.skip('holds when modifiedFiles contains only .agentguard/persona.env', () => {
+  it('holds when modifiedFiles contains only .agentguard/persona.env', () => {
     const result = inv.check({ modifiedFiles: ['.agentguard/persona.env'] });
     expect(result.holds).toBe(true);
   });
 
-  // Verify current (pre-fix) behavior so regressions in the fix are caught
-  it('currently blocks .agentguard/persona.env writes (pre-#1182-fix behavior)', () => {
-    const result = inv.check({ currentTarget: '.agentguard/persona.env' });
-    // This SHOULD become holds:true after #1182 is fixed — update alongside the fix
+  it('holds when writing squad coordination state (.agentguard/squads/)**', () => {
+    const result = inv.check({ currentTarget: '.agentguard/squads/cloud/state.json' });
+    expect(result.holds).toBe(true);
+  });
+
+  it('holds when modifiedFiles contains .agentguard/squads/ path', () => {
+    const result = inv.check({ modifiedFiles: ['.agentguard/squads/office-sim/state.json'] });
+    expect(result.holds).toBe(true);
+  });
+
+  it('holds when writing session artifact (.agentguard/sessions/)**', () => {
+    const result = inv.check({ currentTarget: '.agentguard/sessions/run-123/summary.json' });
+    expect(result.holds).toBe(true);
+  });
+
+  it('still blocks writes to other .agentguard/ subdirectories (e.g. events/)', () => {
+    const result = inv.check({ currentTarget: '.agentguard/events/run-123.jsonl' });
     expect(result.holds).toBe(false);
+  });
+
+  it('holds when gh issue create command body mentions .agentguard/ paths (false-positive fix)', () => {
+    const result = inv.check({
+      currentCommand:
+        'gh issue create --title "test" --body "Found issue in .agentguard/persona.env path"',
+    });
+    expect(result.holds).toBe(true);
   });
 });
 


### PR DESCRIPTION
Closes #1201

## Implementation Summary

**What changed:**
- Added `AGENTGUARD_OPERATIONAL_PREFIXES` allowlist to the `no-governance-self-modification` invariant — paths that match are exempted from the governance path check
- Allowlisted operational paths: `.agentguard/persona.env`, `.agentguard/squads/**`, `.agentguard/sessions/**`
- Fixed false-positive in command scanning: quoted string argument values are now stripped before checking commands for governance path patterns, preventing `gh issue create --body "...mentions .agentguard/..."` from triggering a block
- Switched from whole-command string match to per-token matching, so the operational path allowlist correctly applies to redirect targets (e.g., `echo ... > .agentguard/persona.env`)
- Removed `.skip` from 3 acceptance tests added by #1198 for issue #1182; added 5 new tests covering squads/, sessions/, and the false-positive fix
- Removed pre-fix regression guard test that expected `holds: false` for `persona.env`

**How to verify:**
1. `pnpm test --filter=@red-codes/invariants` — all 594 tests pass
2. Check that `.agentguard/persona.env` write now returns `holds: true`
3. Check that `.agentguard/events/` write still returns `holds: false`
4. Confirm `gh issue create --body "...mentions .agentguard/..."` no longer triggers a violation

**Tier C scope check:**
- Files changed: 2 (limit: 5)
- Lines changed: ~60 (limit: 300)
- Breaking changes: None

---
*Tier C implementation by copilot-cli — AgentGuard three-tier governance*
