### PR TITLE
feat: Go evaluator wildcard matching — unblocks 3ms fast-path (#955)

### DIFF
--- a/go/internal/engine/policy.go
+++ b/go/internal/engine/policy.go
@@ -132,9 +132,10 @@ func matchesRule(ctx action.ActionContext, rule *action.PolicyRule) bool {
 }
 
 // matchesAction checks if an action type matches any of the rule's action patterns.
+// Supports exact match and "*" wildcard (matches any action type).
 func matchesAction(actionType string, patterns action.StringOrSlice) bool {
 	for _, p := range patterns {
-		if p == actionType {
+		if p == "*" || p == actionType {
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary
One-line fix: `matchesAction()` now handles `"*"` wildcard in policy rules. Without this, catch-all allow rules (`action: "*"`) were treated as literals, making the Go fast-path deny everything and fall back to TS.

## Performance
| Path | Latency | Notes |
|------|---------|-------|
| Go fast-path (after fix) | **3ms** | Policy evaluation only |
| TS fallback | 78-290ms | Full pipeline: policy + invariants + telemetry |

At 17,000+ daily hook invocations, this saves ~22 minutes of overhead.

## Test plan
- [x] All Go tests pass (14 packages)
- [x] Read → allow, git commit → allow, git push main → deny, .env write → deny, rm -rf → deny
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)