### PR TITLE
fix(site): correct dashboard URLs and update swarm stats

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -369,7 +369,7 @@
         <a href="#invariants" class="text-muted hover:text-text transition-colors text-sm font-medium cursor-pointer">Invariants</a>
         <a href="#cli" class="text-muted hover:text-text transition-colors text-sm font-medium cursor-pointer">CLI</a>
         <a href="#swarm" class="text-muted hover:text-text transition-colors text-sm font-medium cursor-pointer">Swarm</a>
-        <a href="https://agentguard-cloud-dashboard.vercel.app" target="_blank" rel="noopener noreferrer" class="text-muted hover:text-text transition-colors text-sm font-medium cursor-pointer">Dashboard</a>
+        <a href="https://agentguard-cloud.vercel.app" target="_blank" rel="noopener noreferrer" class="text-muted hover:text-text transition-colors text-sm font-medium cursor-pointer">Dashboard</a>
         <a href="shellforge.html" class="text-muted hover:text-text transition-colors text-sm font-medium cursor-pointer">ShellForge</a>
         <a href="posts.html" class="text-muted hover:text-text transition-colors text-sm font-medium cursor-pointer">Newsletter</a>
         <a href="https://github.com/AgentGuardHQ/agentguard" target="_blank" rel="noopener noreferrer" class="text-muted hover:text-text transition-colors text-sm font-medium cursor-pointer">GitHub</a>
@@ -396,7 +396,7 @@
         <a href="#invariants" class="text-muted hover:text-text transition-colors text-sm font-medium cursor-pointer">Invariants</a>
         <a href="#cli" class="text-muted hover:text-text transition-colors text-sm font-medium cursor-pointer">CLI</a>
         <a href="#swarm" class="text-muted hover:text-text transition-colors text-sm font-medium cursor-pointer">Swarm</a>
-        <a href="https://agentguard-cloud-dashboard.vercel.app" target="_blank" rel="noopener noreferrer" class="text-muted hover:text-text transition-colors text-sm font-medium cursor-pointer">Dashboard</a>
+        <a href="https://agentguard-cloud.vercel.app" target="_blank" rel="noopener noreferrer" class="text-muted hover:text-text transition-colors text-sm font-medium cursor-pointer">Dashboard</a>
         <a href="shellforge.html" class="text-muted hover:text-text transition-colors text-sm font-medium cursor-pointer">ShellForge</a>
         <a href="posts.html" class="text-muted hover:text-text transition-colors text-sm font-medium cursor-pointer">Newsletter</a>
         <a href="https://github.com/AgentGuardHQ/agentguard" target="_blank" rel="noopener noreferrer" class="text-muted hover:text-text transition-colors text-sm font-medium cursor-pointer">GitHub</a>
@@ -1247,7 +1247,7 @@
             <div class="relative group">
               <pre class="bg-surface border border-surface-light rounded-xl p-5 font-mono text-sm overflow-x-auto"><code><span class="text-muted">$</span> <span class="text-text">aguard cloud login</span>
 <span class="text-muted"># Opens browser &rarr; GitHub or Google OAuth &rarr; CLI auto-configures</span>
-<span class="text-muted"># Visit: agentguard-cloud-dashboard.vercel.app</span></code></pre>
+<span class="text-muted"># Visit: agentguard-cloud.vercel.app</span></code></pre>
               <button class="copy-btn absolute top-3 right-3 text-muted hover:text-text p-2 rounded-lg hover:bg-surface-light transition-colors opacity-0 group-hover:opacity-100 cursor-pointer" data-code="aguard cloud login" aria-label="Copy to clipboard">
                 <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
               </button>
@@ -1296,8 +1296,8 @@
                 <p class="text-muted text-sm">Governance runs, violation timelines, analytics. Sign in with GitHub or Google.</p>
               </div>
             </div>
-            <a href="https://agentguard-cloud-dashboard.vercel.app" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-2 text-cta hover:text-cta-dark text-sm font-mono font-semibold transition-colors cursor-pointer">
-              agentguard-cloud-dashboard.vercel.app
+            <a href="https://agentguard-cloud.vercel.app" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-2 text-cta hover:text-cta-dark text-sm font-mono font-semibold transition-colors cursor-pointer">
+              agentguard-cloud.vercel.app
               <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><line x1="7" y1="17" x2="17" y2="7"/><polyline points="7 7 17 7 17 17"/></svg>
             </a>
           </div>
@@ -1680,18 +1680,18 @@ rules:
       <div class="max-w-7xl mx-auto px-6">
         <div class="text-center mb-6 reveal">
           <h2 id="swarm-heading" class="font-mono font-bold text-3xl sm:text-4xl mb-4">Agent Swarm</h2>
-          <p class="text-muted text-lg max-w-2xl mx-auto">Deploy a coordinated team of governed AI agents. 26 agents across 5 tiers, each with dedicated skills, schedules, and governance policies.</p>
+          <p class="text-muted text-lg max-w-2xl mx-auto">Deploy a coordinated team of governed AI agents — each with dedicated skills, schedules, and governance policies.</p>
         </div>
 
         <!-- Stats -->
         <div class="flex justify-center gap-8 mb-14 reveal">
           <div class="text-center">
-            <span class="block font-mono font-bold text-2xl text-cta">26</span>
+            <span class="block font-mono font-bold text-2xl text-cta">100+</span>
             <span class="text-muted text-xs uppercase tracking-wider">Agents</span>
           </div>
           <div class="text-center">
-            <span class="block font-mono font-bold text-2xl text-cta">5</span>
-            <span class="text-muted text-xs uppercase tracking-wider">Tiers</span>
+            <span class="block font-mono font-bold text-2xl text-cta">9</span>
+            <span class="text-muted text-xs uppercase tracking-wider">Squads</span>
           </div>
           <div class="text-center">
             <span class="block font-mono font-bold text-2xl text-cta">60+</span>
@@ -2185,7 +2185,7 @@ rules:
         <div>
           <h3 class="font-mono font-semibold text-text text-sm mb-4">Resources</h3>
           <ul class="space-y-2">
-            <li><a href="https://agentguard-cloud-dashboard.vercel.app" target="_blank" rel="noopener noreferrer" class="text-muted hover:text-text transition-colors text-sm cursor-pointer">Cloud Dashboard</a></li>
+            <li><a href="https://agentguard-cloud.vercel.app" target="_blank" rel="noopener noreferrer" class="text-muted hover:text-text transition-colors text-sm cursor-pointer">Cloud Dashboard</a></li>
             <li><a href="https://agentguard-cloud-office-sim.vercel.app" target="_blank" rel="noopener noreferrer" class="text-muted hover:text-text transition-colors text-sm cursor-pointer">Live Office</a></li>
             <li><a href="https://github.com/AgentGuardHQ/agentguard/blob/main/docs/unified-architecture.md" target="_blank" rel="noopener noreferrer" class="text-muted hover:text-text transition-colors text-sm cursor-pointer">Architecture Docs</a></li>
             <li><a href="https://github.com/AgentGuardHQ/agentguard/blob/main/docs/event-model.md" target="_blank" rel="noopener noreferrer" class="text-muted hover:text-text transition-colors text-sm cursor-pointer">Event Model</a></li>


### PR DESCRIPTION
## Summary

- Fixed all 6 references to `agentguard-cloud-dashboard.vercel.app` → `agentguard-cloud.vercel.app` (same bug as #1245)
- Updated swarm stats from stale "26 agents / 5 tiers" to "100+ agents / 9 squads"

## Test plan

- [ ] Verify site renders correctly on GitHub Pages after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)