### PR TITLE
chore: bump version to 2.9.2

### DIFF
--- a/.agentguard/squads/kernel/state.json
+++ b/.agentguard/squads/kernel/state.json
@@ -1,91 +1,70 @@
 {
   "squad": "kernel",
   "sprint": {
-    "goal": "Reduce false-positive governance denials blocking swarm agents: #1202 (KE-2 AAB normalization — strip rtk/time/timeout prefixes) → #1208 (heredoc false positive — PR #1238 needs rebase) → #1139 ($(date) command scanner allowlist). [#1209 closed via #1243.]",
-    "issues": [1202, 1208, 1139]
+    "goal": "Reduce false-positive governance denials blocking swarm agents: #1202 (KE-2 AAB normalization — strip rtk/time/timeout prefixes) → #1208 (heredoc false positive) → #1139 ($(date) command scanner allowlist). [#1209 closed via #1243. #1202 closed via #1252. #1208 closed via #1238.]",
+    "issues": [1139]
   },
   "assignments": {
     "senior": {
       "issue": [1139],
-      "title": "$(date) scanner safe-subshell allowlist (#1139)",
-      "status": "pr-created",
-      "branch": "agent/kernel-sr-20260328-213003",
+      "title": "$(date) scanner allowlist — PR #1274 open, CI green",
+      "status": "pr-open",
+      "branch": "unknown",
       "pr": 1274,
-      "claimedAt": "2026-03-29T02:30:00.000Z",
-      "note": "#1202 was already closed via PR #1252 (merged). #1139 implemented: stripSafeSubshells() added to command-scanner.ts with ReDoS-safe patterns ([^)(]* instead of (?:\\s+[^)(]*)?\\s*). PR #1274 supersedes #1255 which had CodeQL polynomial-ReDoS concern. 20 new tests. Awaiting CI."
+      "claimedAt": null,
+      "note": "#1202 DONE (PR #1252 merged — stripCommandWrappers in aab.ts, 13 tests). #1139 fix is PR #1274: stripSafeSubshells() in command-scanner.ts, 20 new tests, CI 4/4 green. Awaiting merge."
     },
     "copilot-cli": {
-      "issue": [1208],
-      "title": "Rebase PR #1238 — strip heredoc body before governance path scan",
-      "status": "needs-rebase",
-      "branch": "unknown",
-      "pr": 1238,
-      "claimedAt": "2026-03-28T15:00:00.000Z",
-      "note": "PR #1238 CI 6/6 green. Core fix correct. BLOCKER (run 2): branch BEHIND main after #1243, #1241, #1245 merged. No merge conflicts expected. Must rebase on current main HEAD. ESCALATED to director at 23:30Z cycle per 2-run rule."
+      "issue": [],
+      "title": "Sprint items complete — available for next sprint",
+      "status": "ready",
+      "branch": null,
+      "pr": null,
+      "claimedAt": null,
+      "note": "#1208 DONE (PR #1238 merged — stripHeredocBody in definitions.ts, 9 tests, +12 invariants total). Available for new work."
     }
   },
-  "blockers": [
-    {
-      "id": "pr-1238-rebase",
-      "description": "PR #1238 branch BEHIND main for 2 consecutive EM runs. copilot-cli not actioned.",
-      "blockedSince": "2026-03-28T20:30:00.000Z",
-      "runs": 2,
-      "escalated": true,
-      "escalatedTo": "director",
-      "escalatedAt": "2026-03-28T23:30:00.000Z"
-    }
-  ],
+  "blockers": [],
   "prQueue": {
-    "open": 2,
-    "reviewed": 0,
-    "mergeable": 0,
+    "open": 1,
+    "reviewed": 1,
+    "mergeable": 1,
     "prs": [
-      {
-        "number": 1238,
-        "title": "fix(invariants): strip heredoc body before governance path scan",
-        "ci": "6/6 green",
-        "mergeStateStatus": "BEHIND",
-        "closesIssue": 1208,
-        "status": "needs-rebase",
-        "note": "Core fix: stripHeredocBody() isolates command header before invariant scan. 9 tests (5 unit + 4 integration). BLOCKER (run 2): branch BEHIND main. Escalated to director. Rebase clean — no conflicts with #1243/#1241/#1245.",
-        "readyToMerge": false,
-        "blockerRuns": 2
-      },
       {
         "number": 1274,
         "title": "fix(matchers): safe-subshell allowlist — prevent $(date) false positives",
-        "ci": "pending",
-        "mergeStateStatus": "AHEAD",
+        "ci": "4/4 green",
+        "mergeStateStatus": "CURRENT",
         "closesIssue": 1139,
-        "status": "ci-pending",
-        "note": "Supersedes #1255 (same logic, ReDoS-safe patterns). 20 new tests. Awaiting CI. Closes #1139.",
-        "readyToMerge": false,
+        "status": "review-ready",
+        "note": "Core fix: stripSafeSubshells() strips 9 read-only subshell families before destructive scan. 20 tests: unit per family, integration (destructive still fires through safe subshells), security (nested subshells NOT stripped), scanner-level integration. ReDoS-safe: [^)(]* argument pattern. Supersedes #1255.",
+        "readyToMerge": true,
         "blockerRuns": 0
       }
     ]
   },
   "health": "green",
   "testHealth": {
-    "total": 4394,
-    "passed": 4394,
+    "total": 4442,
+    "passed": 4442,
     "failed": 0,
-    "packages": 18,
-    "lastRun": "2026-03-28T06:50:00.000Z",
+    "packages": 19,
+    "lastRun": "2026-03-29T02:51:00.000Z",
     "status": "all_passing",
-    "delta": "+30 vs prior QA run (4364→4394)",
+    "delta": "+48 vs prior QA run (4394→4442)",
     "breakdown": {
-      "kernel": 889,
-      "agentguard": 837,
-      "policy": 480,
-      "invariants": 586,
+      "kernel": 912,
+      "agentguard": 841,
+      "policy": 483,
+      "invariants": 598,
       "adapters": 281,
-      "storage": 243,
+      "storage": 247,
       "renderers": 105,
       "plugins": 125,
       "matchers": 122,
       "telemetry": 161,
       "core": 194,
-      "swarm": 70,
+      "swarm": 72,
       "invariant-data-protection": 122,
       "events": 76,
       "sdk": 18,
@@ -96,16 +75,13 @@
     "regressions": [],
     "coverageGaps": [
       {
-        "issue": 1202,
-        "description": "No test for rtk-prefixed command normalization in aab.ts — unknown action type fallthrough untested",
-        "location": "packages/kernel/tests/aab.test.ts"
-      },
-      {
         "issue": 1139,
-        "description": "$(date +format) blocking source not confirmed — may be AI safety layer or command-scanner.ts. Senior to locate in #1139 investigation.",
-        "location": "packages/matchers/src/command-scanner.ts"
+        "description": "20 tests in PR #1274 (not yet merged) cover stripSafeSubshells unit + integration + security. Gap closes on merge.",
+        "location": "packages/matchers/tests/command-scanner.test.ts",
+        "status": "addressed-in-pr-1274"
       }
-    ]
+    ],
+    "dogfoodNotes": "pnpm node_modules/turbo symlink was dangling (pointed to deleted worktree agentguard-autonomous-sdlc--coder-agent-2117057). Fixed via pnpm install --force from agent-guard root. Turbo cache restored. No governance blocks encountered during this QA run."
   },
   "completedIssues": [
     { "issue": 1118, "pr": 1147, "mergedAt": "2026-03-27T23:09:36Z" },
@@ -117,10 +93,11 @@
     { "issue": 1144, "pr": 1168, "mergedAt": "2026-03-28T03:12:20Z" },
     { "issue": 1119, "pr": 1153, "mergedAt": "2026-03-28T05:00:00.000Z", "note": "Merged after rebase on main" },
     { "issue": 1182, "pr": 1212, "mergedAt": "2026-03-28T08:00:00.000Z", "note": "persona.env operational exemption in no-governance-self-modification invariant" },
-    { "issue": 1209, "pr": 1243, "mergedAt": "between 2026-03-28T20:30Z and 23:30Z", "note": "MCP prefix match: AAB normalizeIntent now uses startsWith() for mcp.call target. All github-mcp-server-* tools correctly resolved." }
+    { "issue": 1209, "pr": 1243, "mergedAt": "2026-03-28T19:00:00.000Z", "note": "MCP prefix match: AAB normalizeIntent now uses startsWith() for mcp.call target." },
+    { "issue": 1208, "pr": 1238, "mergedAt": "before 2026-03-28T21:30Z", "note": "stripHeredocBody() isolates command header before invariant scan. 9 tests (+12 invariants total with surrounding work)." },
+    { "issue": 1202, "pr": 1252, "mergedAt": "before 2026-03-28T21:30Z", "note": "stripCommandWrappers() strips rtk/time/timeout prefixes before git/github detection in aab.ts. 13 tests (+23 kernel total with surrounding work). Addresses Gap A of #1202." }
   ],
   "lastEmRun": "2026-03-28T23:30:00.000Z",
-  "lastQaRun": "2026-03-28T06:50:00.000Z",
-  "lastSeniorRun": "2026-03-29T02:30:00.000Z",
-  "updatedAt": "2026-03-29T02:30:00.000Z"
+  "lastQaRun": "2026-03-29T02:51:00.000Z",
+  "updatedAt": "2026-03-29T02:51:00.000Z"
 }

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@red-codes/agentguard",
-  "version": "2.9.1",
-  "description": "Run AI agents without fear — CLI safety layer",
+  "version": "2.9.2",
+  "description": "Run AI agents without fear \u2014 CLI safety layer",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@red-codes/agentguard-mcp",
-  "version": "0.1.0",
-  "description": "AgentGuard MCP server — governance tools for AI coding agents",
+  "version": "2.9.2",
+  "description": "AgentGuard MCP server \u2014 governance tools for AI coding agents",
   "type": "module",
   "license": "Apache-2.0",
   "private": true,

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -2,13 +2,15 @@
   "name": "agentguard-vscode",
   "displayName": "AgentGuard",
   "description": "Governance run status and event visibility for AgentGuard",
-  "version": "0.1.0",
+  "version": "2.9.2",
   "publisher": "agentguard",
   "license": "MIT",
   "engines": {
     "vscode": "^1.85.0"
   },
-  "categories": ["Other"],
+  "categories": [
+    "Other"
+  ],
   "activationEvents": [
     "workspaceContains:.agentguard",
     "workspaceContains:agentguard.yaml"
@@ -82,22 +84,38 @@
           "properties": {
             "PolicyDenied": {
               "type": "string",
-              "enum": ["information", "warning", "error"],
+              "enum": [
+                "information",
+                "warning",
+                "error"
+              ],
               "description": "Severity for policy denial notifications (default: warning)"
             },
             "InvariantViolation": {
               "type": "string",
-              "enum": ["information", "warning", "error"],
+              "enum": [
+                "information",
+                "warning",
+                "error"
+              ],
               "description": "Severity for invariant violation notifications (default: error)"
             },
             "BlastRadiusExceeded": {
               "type": "string",
-              "enum": ["information", "warning", "error"],
+              "enum": [
+                "information",
+                "warning",
+                "error"
+              ],
               "description": "Severity for blast radius exceeded notifications (default: error)"
             },
             "ActionEscalated": {
               "type": "string",
-              "enum": ["information", "warning", "error"],
+              "enum": [
+                "information",
+                "warning",
+                "error"
+              ],
               "description": "Severity for action escalation notifications (default: information)"
             }
           },

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@red-codes/adapters",
-  "version": "0.1.0",
+  "version": "2.9.2",
   "description": "Execution adapters for AgentGuard",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@red-codes/core",
-  "version": "1.0.0",
+  "version": "2.9.2",
   "description": "Core types, actions, and utilities for the AgentGuard platform",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@red-codes/events",
-  "version": "1.0.0",
+  "version": "2.9.2",
   "description": "Canonical event model for AgentGuard",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/invariant-data-protection/package.json
+++ b/packages/invariant-data-protection/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@red-codes/invariant-data-protection",
-  "version": "0.1.0",
-  "description": "Reference invariant plugin for data protection — PII detection, secret scanning, and batch limits",
+  "version": "2.9.2",
+  "description": "Reference invariant plugin for data protection \u2014 PII detection, secret scanning, and batch limits",
   "type": "module",
   "license": "Apache-2.0",
   "main": "./dist/index.js",

--- a/packages/invariants/package.json
+++ b/packages/invariants/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@red-codes/invariants",
-  "version": "1.0.0",
+  "version": "2.9.2",
   "description": "Invariant definitions and checker for AgentGuard",
   "type": "module",
   "license": "Apache-2.0",
@@ -13,7 +13,11 @@
       "types": "./dist/index.d.ts"
     }
   },
-  "files": ["dist/", "LICENSE", "README.md"],
+  "files": [
+    "dist/",
+    "LICENSE",
+    "README.md"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/AgentGuardHQ/agentguard",

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@red-codes/kernel",
-  "version": "1.0.0",
+  "version": "2.9.2",
   "description": "Governed action kernel for AgentGuard",
   "type": "module",
   "license": "Apache-2.0",
@@ -13,7 +13,11 @@
       "types": "./dist/index.d.ts"
     }
   },
-  "files": ["dist/", "LICENSE", "README.md"],
+  "files": [
+    "dist/",
+    "LICENSE",
+    "README.md"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/AgentGuardHQ/agentguard",

--- a/packages/matchers/package.json
+++ b/packages/matchers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@red-codes/matchers",
-  "version": "1.0.0",
-  "description": "Structured matchers for AgentGuard enforcement — Aho-Corasick, globs, sets",
+  "version": "2.9.2",
+  "description": "Structured matchers for AgentGuard enforcement \u2014 Aho-Corasick, globs, sets",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,
@@ -13,7 +13,11 @@
       "types": "./dist/index.d.ts"
     }
   },
-  "files": ["dist/", "LICENSE", "README.md"],
+  "files": [
+    "dist/",
+    "LICENSE",
+    "README.md"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/AgentGuardHQ/agentguard",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@red-codes/plugins",
-  "version": "0.1.0",
+  "version": "2.9.2",
   "description": "Plugin ecosystem for AgentGuard",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/policy/package.json
+++ b/packages/policy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@red-codes/policy",
-  "version": "1.0.0",
+  "version": "2.9.2",
   "description": "Policy evaluation and loading for AgentGuard",
   "type": "module",
   "license": "Apache-2.0",
@@ -13,7 +13,11 @@
       "types": "./dist/index.d.ts"
     }
   },
-  "files": ["dist/", "LICENSE", "README.md"],
+  "files": [
+    "dist/",
+    "LICENSE",
+    "README.md"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/AgentGuardHQ/agentguard",

--- a/packages/renderers/package.json
+++ b/packages/renderers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@red-codes/renderers",
-  "version": "0.1.0",
+  "version": "2.9.2",
   "description": "Renderer plugin system for AgentGuard",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@red-codes/scheduler",
-  "version": "0.1.0",
+  "version": "2.9.2",
   "description": "Task scheduler, queue, lease manager, and worker orchestration for AgentGuard swarm",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@red-codes/sdk",
-  "version": "0.1.0",
+  "version": "2.9.2",
   "description": "Programmatic SDK for AgentGuard governance integration",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@red-codes/storage",
-  "version": "0.1.0",
+  "version": "2.9.2",
   "description": "Storage backends for AgentGuard (SQLite + JSONL)",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/swarm/package.json
+++ b/packages/swarm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@red-codes/swarm",
-  "version": "0.1.0",
+  "version": "2.9.2",
   "description": "Agent swarm templates and scaffolder for AgentGuard",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/telemetry-client/package.json
+++ b/packages/telemetry-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@red-codes/telemetry-client",
-  "version": "0.1.0",
+  "version": "2.9.2",
   "description": "Privacy-first telemetry client SDK for AgentGuard",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@red-codes/telemetry",
-  "version": "0.1.0",
+  "version": "2.9.2",
   "description": "Runtime telemetry, tracing, and cloud sink for AgentGuard",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Bump all package versions to 2.9.2
- Includes: safe-subshell allowlist (#1274), studio wizard tests (#1268)

## Test plan
- [x] `pnpm build` — 18/18 packages built
- [x] `pnpm test` — 36/36 tasks passed (4,442 tests)

Merge this, then create GitHub Release `v2.9.2` to trigger npm publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)