### PR TITLE
fix: bump aguard wrapper to 2.9.2

### DIFF
--- a/npm-wrapper/aguard/package.json
+++ b/npm-wrapper/aguard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aguard",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "description": "Agent Guard — run AI agents without fear. Installs @red-codes/agentguard.",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Missed in version bump. Publish workflow requires wrapper version to match CLI.