### PR TITLE
feat(kernel): unknown command warn+audit — Option A default-deny (#179)

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -218,6 +218,8 @@ export type EventKind =
   | 'IntentDriftDetected'
   // Capability Validation
   | 'CapabilityValidated'
+  // Unknown Command Warning (Option A default-deny)
+  | 'UnknownCommandWarn'
   // Environmental Enforcement
   // TODO(issue-225): Reserved for future direct emission; currently InvariantViolation is emitted instead.
   | 'IdeSocketAccessBlocked';

--- a/packages/events/src/schema.ts
+++ b/packages/events/src/schema.ts
@@ -92,6 +92,9 @@ export const INTENT_DRIFT_DETECTED: EventKind = 'IntentDriftDetected';
 // Capability Validation
 export const CAPABILITY_VALIDATED: EventKind = 'CapabilityValidated';
 
+// Unknown Command Warning (Option A default-deny: warn+audit, not hard-deny)
+export const UNKNOWN_COMMAND_WARN: EventKind = 'UnknownCommandWarn';
+
 // Environmental Enforcement
 // TODO(issue-225): Reserved for future direct emission from the shell adapter when IDE
 // context variables are stripped. Currently the kernel emits InvariantViolation when the
@@ -186,6 +189,10 @@ const EVENT_SCHEMAS: Record<string, EventSchema> = {
   [SIMULATION_COMPLETED]: {
     required: ['simulatorId', 'riskLevel', 'blastRadius'],
     optional: ['predictedChanges', 'durationMs', 'metadata'],
+  },
+  [UNKNOWN_COMMAND_WARN]: {
+    required: ['actionType', 'target', 'command'],
+    optional: ['agentId', 'agentRole', 'riskLevel', 'metadata'],
   },
   [PIPELINE_STARTED]: {
     required: ['runId', 'task'],

--- a/packages/kernel/src/aab.ts
+++ b/packages/kernel/src/aab.ts
@@ -281,6 +281,11 @@ export function normalizeIntent(rawAction: RawAgentAction | null): NormalizedInt
     }
   }
 
+  // Tag unknown shell commands: shell.exec that didn't match any git/github pattern
+  // and isn't explicitly destructive. These get warn+audit (Option A default-deny).
+  const isUnknownCommand =
+    action === 'shell.exec' && rawAction.command && !isDestructiveCommand(rawAction.command);
+
   return {
     action,
     target,
@@ -293,7 +298,10 @@ export function normalizeIntent(rawAction: RawAgentAction | null): NormalizedInt
         : undefined),
     command: rawAction.command || undefined,
     filesAffected: rawAction.filesAffected || undefined,
-    metadata: rawAction.metadata || undefined,
+    metadata: {
+      ...rawAction.metadata,
+      ...(isUnknownCommand ? { unknownCommand: true } : {}),
+    },
     persona: rawAction.persona || undefined,
     // Destructive detection scans the FULL command (including quotes) because
     // destructive SQL inside quotes (e.g. psql -c 'DROP TABLE') is still dangerous.

--- a/packages/kernel/src/kernel.ts
+++ b/packages/kernel/src/kernel.ts
@@ -39,6 +39,7 @@ import {
   ACTION_ESCALATED,
   ACTION_EXECUTED,
   ACTION_FAILED,
+  UNKNOWN_COMMAND_WARN,
   DECISION_RECORDED,
   SIMULATION_COMPLETED,
   INTENT_DRIFT_DETECTED,
@@ -1429,6 +1430,28 @@ export function createKernel(config: KernelConfig = {}): Kernel {
           metadata: { runId },
         });
         allEvents.push(allowedEvent);
+
+        // 5b-ii. Unknown command warning (Option A default-deny: warn+audit, not hard-deny).
+        // Emits when a shell.exec command didn't match any known git/github/destructive pattern.
+        // The action is still allowed — this is telemetry for the cloud dashboard.
+        if (ctx.metadata?.unknownCommand) {
+          const unknownWarnEvent = createEvent(UNKNOWN_COMMAND_WARN, {
+            actionType: decision.intent.action,
+            target: decision.intent.target,
+            command: ctx.command || decision.intent.target,
+            agentId: ctx.agent,
+            agentRole,
+            riskLevel: 'medium',
+            metadata: {
+              runId,
+              tag: 'unknown-command',
+              decision: 'allow',
+              source: ctx.source,
+            },
+          });
+          allEvents.push(unknownWarnEvent);
+          sinkEvent(unknownWarnEvent);
+        }
 
         // 5c. Intent drift check (advisory — does not block execution)
         let intentDrift: IntentDriftResult | undefined;


### PR DESCRIPTION
## Summary
- When a `shell.exec` command doesn't match any known git/github/destructive pattern, emit an `UnknownCommandWarn` event with `decision: allow` and `tag: unknown-command`
- The action is **still allowed** — this is telemetry for the cloud dashboard, not a hard deny
- 4 files changed across core, events, kernel packages
- Closes AgentGuardHQ/agentguard-workspace#179

### Changes
| File | What |
|------|------|
| `packages/core/src/types.ts` | Add `UnknownCommandWarn` to `EventKind` union |
| `packages/events/src/schema.ts` | Add `UNKNOWN_COMMAND_WARN` event kind + schema |
| `packages/kernel/src/aab.ts` | Tag unknown shell.exec commands in `normalizeIntent` |
| `packages/kernel/src/kernel.ts` | Emit `UnknownCommandWarn` after `ACTION_ALLOWED` |

### Demo story
Attendees see that AgentGuard is aware of ALL commands — not just explicit deny rules. Unknown commands get tracked, tagged, and surfaced in the cloud dashboard without breaking the "commands work normally" flow.

## Test plan
- [x] `pnpm build` — 18/18 packages built clean
- [x] `pnpm test` — 36/36 tasks passed (4,442+ tests)
- [ ] E2E: run unknown command through Copilot CLI adapter, verify event in cloud dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)