### PR TITLE
ci: add site-check.yml to unblock site-only PRs (closes #1267)

### DIFF
--- a/.github/workflows/site-check.yml
+++ b/.github/workflows/site-check.yml
@@ -1,0 +1,48 @@
+name: Site CI
+
+# Provides instant-pass lint and test-and-build status checks for site-only PRs.
+# size-check.yml has paths-ignore: ['site/**'] so those jobs never run for site
+# changes; branch protection requires them — this workflow satisfies the gate.
+#
+# Runs only when ALL changed files are in site/**. Mixed PRs (code + site) are
+# handled by size-check.yml's full CI, which takes precedence.
+
+on:
+  pull_request:
+    paths:
+      - 'site/**'
+
+jobs:
+  detect-site-only:
+    runs-on: ubuntu-latest
+    outputs:
+      site_only: ${{ steps.check.outputs.site_only }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+      - id: check
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          NON_SITE=$(git diff --name-only "$BASE_SHA"..."$HEAD_SHA" | grep -v '^site/' | grep -c . || echo 0)
+          if [ "$NON_SITE" = "0" ]; then
+            echo "site_only=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "site_only=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  lint:
+    needs: detect-site-only
+    if: needs.detect-site-only.outputs.site_only == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Site-only PR — code linting not required"
+
+  test-and-build:
+    needs: detect-site-only
+    if: needs.detect-site-only.outputs.site_only == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Site-only PR — build/test not required"


### PR DESCRIPTION
## Problem

`size-check.yml` has `paths-ignore: ['site/**']`, so `lint` and `test-and-build` jobs never run for site-only PRs. Branch protection requires both checks — this leaves site-only PRs permanently stuck requiring admin bypass.

## Solution

New `site-check.yml` workflow provides instant-pass `lint` and `test-and-build` checks for site-only PRs:

1. `detect-site-only` job diffs base..head and checks if ALL changed files are under `site/`
2. If site-only → `lint` and `test-and-build` jobs run immediately and pass
3. If mixed (code + site) → these jobs are skipped; `size-check.yml` handles the full CI

## Safety

- SHA values passed via `env:` (not interpolated in `run:`) to prevent injection
- Skip jobs guarded by the `detect-site-only` condition — won't bypass CI for code changes
- Pinned action SHA (same as existing `size-check.yml`)

## Test plan

- [ ] Open a site-only PR → `lint` and `test-and-build` both pass instantly
- [ ] Open a code-only PR → this workflow doesn't trigger, `size-check.yml` runs normally
- [ ] Open a mixed PR → `size-check.yml` runs full CI; this workflow's detect job runs but skip jobs don't fire (`site_only=false`)

Closes #1267

🤖 Generated with [Claude Code](https://claude.com/claude-code)