### PR TITLE
fix(ci): add skip workflow for site-only PRs (closes #1267)

### DIFF
--- a/.github/workflows/ci-skip-site.yml
+++ b/.github/workflows/ci-skip-site.yml
@@ -1,0 +1,20 @@
+# Provides required status checks for PRs that only touch site/**
+# so branch protection doesn't block site-only changes.
+# See: https://github.com/AgentGuardHQ/agentguard/issues/1267
+name: CI
+
+on:
+  pull_request:
+    paths:
+      - 'site/**'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Skipping lint -- site-only change"
+
+  test-and-build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Skipping test-and-build -- site-only change"


### PR DESCRIPTION
## Summary
- Adds `ci-skip-site.yml` that provides passing `lint` and `test-and-build` jobs for PRs touching only `site/**`
- Unblocks all site squad PRs that were stuck due to branch protection requiring checks that never ran
- Closes #1267 (P0 blocker)

## How it works
- `size-check.yml` has `paths-ignore: site/**` — never triggers for site-only PRs
- `ci-skip-site.yml` has `paths: site/**` — triggers exactly when size-check doesn't
- Both use `name: CI` and provide jobs named `lint` and `test-and-build`
- For mixed PRs (site + source), both workflows trigger — real CI runs full checks

## Test plan
- [ ] Verify site-only PR gets the skip workflow checks
- [ ] Verify source-only PR still gets full CI
- [ ] Verify mixed PR gets both

🤖 Generated with [Claude Code](https://claude.com/claude-code)