### PR TITLE
fix(ci): port ci-skip-site.yml to main (unblocks #1293, closes #1297)

### DIFF
--- a/.github/workflows/ci-skip-site.yml
+++ b/.github/workflows/ci-skip-site.yml
@@ -1,0 +1,20 @@
+# Provides required status checks for PRs that only touch site/**
+# so branch protection doesn't block site-only changes.
+# See: https://github.com/AgentGuardHQ/agentguard/issues/1267
+name: CI
+
+on:
+  pull_request:
+    paths:
+      - 'site/**'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Skipping lint -- site-only change"
+
+  test-and-build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Skipping test-and-build -- site-only change"


### PR DESCRIPTION
## Summary
- Ports `ci-skip-site.yml` from `master` to `main` — the file was merged in PR #1296 but targeted `master` (not `main`)
- Unblocks PR #1293 (site AAB action types fix) which targets `main`
- Closes #1297 (main/master divergence — this file specifically)

## Context
PR #1296 fixed the CI infrastructure issue (#1267) by adding `ci-skip-site.yml`, but it was opened against `master`. Since the repo's default branch is `main` and most new PRs target `main`, the fix wasn't effective for them.

## Test plan
- [ ] After merge, verify PR #1293 gets `lint` and `test-and-build` checks from the skip workflow
- [ ] Verify source-code PRs still get full CI from `size-check.yml`
- [ ] Verify mixed PRs (site + source) get both workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)