### PR TITLE
feat(ke-2): complete ActionContext adapter test coverage and ROADMAP

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -125,14 +125,14 @@ This sprint implements the architectural upgrades required for AgentGuard to fun
 - [x] ~~Produce machine-readable reason codes for all match results~~ — `packages/matchers/src/reason-codes.ts`
 - [x] ~~Benchmark: total evaluation p50 < 0.25ms~~ — benchmark suite in CI
 
-#### KE-2: Canonical Action Normalization (ActionContext)
+#### KE-2: Canonical Action Normalization (ActionContext) ✅ Done 2026-03-29
 
 > Formalize a vendor-neutral action representation that decouples the policy engine from provider-specific payloads.
 
-- [ ] Design `ActionContext` contract: actor identity (agent/session/worktree), action category, structured arguments
-- [ ] Build specialized adapter for Claude tool-calls → `ActionContext` mapping
-- [ ] Ensure policy engine consumes only normalized `ActionContext` (no provider-specific logic)
-- [ ] Benchmark: context normalization in 50–100µs
+- [x] ~~Design `ActionContext` contract: actor identity (agent/session/worktree), action category, structured arguments~~ — `packages/core/src/types.ts` (`ActionContext`, `ActorIdentity`, `ActionArguments`)
+- [x] ~~Build specialized adapter for Claude tool-calls → `ActionContext` mapping~~ — `packages/adapters/src/claude-code.ts` (`toActionContext`); Copilot CLI (`copilotToActionContext`); DeepAgents (`deepAgentsToActionContext`)
+- [x] ~~Ensure policy engine consumes only normalized `ActionContext` (no provider-specific logic)~~ — `packages/kernel/src/aab.ts` (`authorizeContext`, `normalizeToActionContext`); `packages/policy/src/evaluator.ts` accepts `ActionContext` directly
+- [x] ~~Benchmark: context normalization in 50–100µs~~ — p50 < 100µs verified in `packages/kernel/tests/action-context.test.ts`
 
 #### KE-3: Governance Event Envelope ✅ Done 2026-03-24
 
@@ -181,7 +181,8 @@ This sprint implements the architectural upgrades required for AgentGuard to fun
 
 > Ship the governance kernel to the world. Default-deny + KE-2 = production-grade enforcement.
 
-- [ ] Default-deny finalized + KE-2 ActionContext shipped
+- [x] ~~KE-2 ActionContext shipped~~ — ✅ Done 2026-03-29 — vendor-neutral normalization pipeline operational across Claude Code, Copilot CLI, and DeepAgents adapters
+- [ ] Default-deny finalized
 - [ ] **Stranger test validation** — Have someone with zero context install and configure AgentGuard from the README alone. Every friction point found is a v3.0 blocker. The individual governance experience (`npm install → agentguard claude-init → governance active`) must work flawlessly before anything else is promoted.
 - [ ] **User capture funnel** — Without this, installs vanish into the void:
   - README call-to-action: "Join early access / updates" link

--- a/packages/adapters/tests/copilot-cli-adapter.test.ts
+++ b/packages/adapters/tests/copilot-cli-adapter.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
   normalizeCopilotCliAction,
+  copilotToActionContext,
   formatCopilotHookResponse,
   resolveCopilotAgentIdentity,
 } from '@red-codes/adapters';
@@ -337,6 +338,101 @@ describe('Integration: Copilot CLI → Kernel', () => {
     const result = await kernel.propose(rawAction);
     expect(result.allowed).toBe(true);
     expect(result.decisionRecord?.action.agent).toMatch(/^copilot-cli:[a-z0-9]+$/);
+  });
+});
+
+describe('copilotToActionContext — KE-2 adapter mapping', () => {
+  it('converts a create tool payload to ActionContext', () => {
+    const payload: CopilotCliHookPayload = {
+      toolName: 'create',
+      toolArgs: JSON.stringify({ file_path: 'src/index.ts', content: 'hello' }),
+      sessionId: 'session-abc',
+    };
+
+    const ctx = copilotToActionContext(payload);
+
+    expect(ctx.action).toBe('file.write');
+    expect(ctx.actionClass).toBe('file');
+    expect(ctx.target).toBe('src/index.ts');
+    expect(ctx.source).toBe('copilot-cli');
+    expect(ctx.args.filePath).toBe('src/index.ts');
+    expect(ctx.args.content).toBe('hello');
+    expect(ctx.actor.agentId).toMatch(/^copilot-cli/);
+    expect(ctx.destructive).toBe(false);
+    expect(typeof ctx.normalizedAt).toBe('number');
+  });
+
+  it('converts a bash tool with git push to ActionContext', () => {
+    const payload: CopilotCliHookPayload = {
+      toolName: 'bash',
+      toolArgs: JSON.stringify({ command: 'git push origin feature-branch' }),
+    };
+
+    const ctx = copilotToActionContext(payload);
+
+    expect(ctx.action).toBe('git.push');
+    expect(ctx.actionClass).toBe('git');
+    expect(ctx.branch).toBe('feature-branch');
+    expect(ctx.args.branch).toBe('feature-branch');
+    expect(ctx.source).toBe('copilot-cli');
+  });
+
+  it('converts a destructive bash command to ActionContext', () => {
+    const payload: CopilotCliHookPayload = {
+      toolName: 'bash',
+      toolArgs: JSON.stringify({ command: 'rm -rf /tmp/data' }),
+    };
+
+    const ctx = copilotToActionContext(payload);
+
+    expect(ctx.destructive).toBe(true);
+    expect(ctx.actionClass).toBe('shell');
+    expect(ctx.source).toBe('copilot-cli');
+  });
+
+  it('converts a view tool payload (file.read)', () => {
+    const payload: CopilotCliHookPayload = {
+      toolName: 'view',
+      toolArgs: JSON.stringify({ file_path: 'README.md' }),
+    };
+
+    const ctx = copilotToActionContext(payload);
+
+    expect(ctx.action).toBe('file.read');
+    expect(ctx.actionClass).toBe('file');
+    expect(ctx.target).toBe('README.md');
+    expect(ctx.source).toBe('copilot-cli');
+  });
+
+  it('passes persona through to ActionContext', () => {
+    const payload: CopilotCliHookPayload = {
+      toolName: 'bash',
+      toolArgs: JSON.stringify({ command: 'npm test' }),
+    };
+
+    const ctx = copilotToActionContext(payload, { trustTier: 'elevated', role: 'ops' });
+
+    expect(ctx.persona).toEqual({ trustTier: 'elevated', role: 'ops' });
+    expect(ctx.actor.persona).toEqual({ trustTier: 'elevated', role: 'ops' });
+  });
+
+  it('produces NormalizedIntent-compatible output', () => {
+    const payload: CopilotCliHookPayload = {
+      toolName: 'create',
+      toolArgs: JSON.stringify({ file_path: 'test.ts', content: 'data' }),
+    };
+
+    const ctx = copilotToActionContext(payload);
+
+    expect(ctx).toHaveProperty('action');
+    expect(ctx).toHaveProperty('target');
+    expect(ctx).toHaveProperty('agent');
+    expect(ctx).toHaveProperty('destructive');
+    expect(ctx).toHaveProperty('actionClass');
+    expect(ctx).toHaveProperty('actor');
+    expect(ctx).toHaveProperty('args');
+    expect(ctx).toHaveProperty('source');
+    expect(ctx).toHaveProperty('normalizedAt');
   });
 });
 

--- a/packages/adapters/tests/deepagents-adapter.test.ts
+++ b/packages/adapters/tests/deepagents-adapter.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
   normalizeDeepAgentsAction,
+  deepAgentsToActionContext,
   formatDeepAgentsHookResponse,
   resolveDeepAgentsIdentity,
 } from '@red-codes/adapters';
@@ -323,5 +324,100 @@ describe('DeepAgents adapter integration', () => {
     const envelope = deepAgentsToEnvelope(event);
     expect(envelope.source).toBe('deepagents');
     expect(envelope.event).toBe(event);
+  });
+});
+
+describe('deepAgentsToActionContext — KE-2 adapter mapping', () => {
+  it('converts a write_file payload to ActionContext', () => {
+    const payload: DeepAgentsHookPayload = {
+      tool: 'write_file',
+      input: { path: 'src/index.ts', content: 'hello' },
+      sessionId: 'session-abc',
+    };
+
+    const ctx = deepAgentsToActionContext(payload);
+
+    expect(ctx.action).toBe('file.write');
+    expect(ctx.actionClass).toBe('file');
+    expect(ctx.target).toBe('src/index.ts');
+    expect(ctx.source).toBe('deepagents');
+    expect(ctx.args.filePath).toBe('src/index.ts');
+    expect(ctx.args.content).toBe('hello');
+    expect(ctx.actor.agentId).toMatch(/^deepagents/);
+    expect(ctx.destructive).toBe(false);
+    expect(typeof ctx.normalizedAt).toBe('number');
+  });
+
+  it('converts a run_shell payload with git push to ActionContext', () => {
+    const payload: DeepAgentsHookPayload = {
+      tool: 'run_shell',
+      input: { command: 'git push origin feature-branch' },
+    };
+
+    const ctx = deepAgentsToActionContext(payload);
+
+    expect(ctx.action).toBe('git.push');
+    expect(ctx.actionClass).toBe('git');
+    expect(ctx.branch).toBe('feature-branch');
+    expect(ctx.args.branch).toBe('feature-branch');
+    expect(ctx.source).toBe('deepagents');
+  });
+
+  it('converts a destructive shell command to ActionContext', () => {
+    const payload: DeepAgentsHookPayload = {
+      tool: 'run_shell',
+      input: { command: 'rm -rf /tmp/data' },
+    };
+
+    const ctx = deepAgentsToActionContext(payload);
+
+    expect(ctx.destructive).toBe(true);
+    expect(ctx.actionClass).toBe('shell');
+    expect(ctx.source).toBe('deepagents');
+  });
+
+  it('converts a read_file payload (file.read)', () => {
+    const payload: DeepAgentsHookPayload = {
+      tool: 'read_file',
+      input: { path: 'README.md' },
+    };
+
+    const ctx = deepAgentsToActionContext(payload);
+
+    expect(ctx.action).toBe('file.read');
+    expect(ctx.actionClass).toBe('file');
+    expect(ctx.target).toBe('README.md');
+    expect(ctx.source).toBe('deepagents');
+  });
+
+  it('passes persona through to ActionContext', () => {
+    const payload: DeepAgentsHookPayload = {
+      tool: 'run_shell',
+      input: { command: 'npm test' },
+    };
+
+    const ctx = deepAgentsToActionContext(payload, { trustTier: 'standard', role: 'developer' });
+
+    expect(ctx.persona).toEqual({ trustTier: 'standard', role: 'developer' });
+    expect(ctx.actor.persona).toEqual({ trustTier: 'standard', role: 'developer' });
+  });
+
+  it('produces NormalizedIntent-compatible output', () => {
+    const payload: DeepAgentsHookPayload = {
+      tool: 'write_file',
+      input: { path: 'test.ts', content: 'data' },
+    };
+
+    const ctx = deepAgentsToActionContext(payload);
+
+    expect(ctx).toHaveProperty('action');
+    expect(ctx).toHaveProperty('target');
+    expect(ctx).toHaveProperty('agent');
+    expect(ctx).toHaveProperty('destructive');
+    expect(ctx).toHaveProperty('actionClass');
+    expect(ctx).toHaveProperty('actor');
+    expect(ctx).toHaveProperty('args');
+    expect(ctx).toHaveProperty('source');
+    expect(ctx).toHaveProperty('normalizedAt');
   });
 });


### PR DESCRIPTION
## Summary
- Adds `copilotToActionContext` tests to `copilot-cli-adapter.test.ts` (6 new tests)
- Adds `deepAgentsToActionContext` tests to `deepagents-adapter.test.ts` (6 new tests)
- Updates `ROADMAP.md` to mark all KE-2 sub-tasks complete with file references
- Closes #917

## Changes
- `packages/adapters/tests/copilot-cli-adapter.test.ts` — added `copilotToActionContext — KE-2 adapter mapping` describe block with 6 tests covering file write, git push, destructive commands, file read, persona passthrough, and NormalizedIntent compatibility
- `packages/adapters/tests/deepagents-adapter.test.ts` — added `deepAgentsToActionContext — KE-2 adapter mapping` describe block with 6 tests covering the same cases for the DeepAgents adapter
- `ROADMAP.md` — checked off all 4 KE-2 sub-tasks with implementation file references; added KE-2 shipped entry to v3.0 milestone

## Test Plan
- [x] TypeScript build passes (`turbo build` — 18/18 tasks, all cached)
- [x] Vitest tests pass (`turbo test` — 36/36 tasks, 3,000+ tests across all packages)
- [x] ESLint clean on changed files
- [x] Prettier clean (`All matched files use Prettier code style!`)

## Risk Assessment

| Metric | Value |
|--------|-------|
| Risk level | low |
| Risk score | 5/100 |
| Blast radius | 0 (weighted) |
| Simulation result | allowed |

## Governance Report

| Metric | Count |
|--------|-------|
| Total events | 8 |
| Actions allowed | 0 |
| Actions denied | 1 |
| Policy denials | 1 |
| Invariant violations | 2 |
| Escalation events | 1 |
| Decision records | 3 |

<details>
<summary>Governance details</summary>

**Source**: `.agentguard/events/`, `logs/runtime-events.jsonl`

**Decision Records**: 3 total, 1 denial
**Escalation levels observed**: NORMAL only
**Pre-push simulation**: low risk, blast radius 0, policy: allowed (non-protected branch)

**Notable denials**:
- `git.push` to `main` denied by protected-branch invariant — this is correct governance; work was pushed to `agent/implementation/issue-917` instead
- `test-before-push` invariant flagged — tests were verified via turbo before push

</details>

---
*Identity: `claude-code:opus:developer` | Session: agentguard-autonomous-sdlc--coder-agent-823542*