### PR TITLE
fix(go): wildcard policy matching + bump to 2.10.0

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@red-codes/agentguard",
-  "version": "2.8.1",
+  "version": "2.10.0",
   "description": "Run AI agents without fear — CLI safety layer",
   "type": "module",
   "license": "Apache-2.0",

--- a/go/internal/engine/policy.go
+++ b/go/internal/engine/policy.go
@@ -132,10 +132,21 @@ func matchesRule(ctx action.ActionContext, rule *action.PolicyRule) bool {
 }
 
 // matchesAction checks if an action type matches any of the rule's action patterns.
+// Supports:
+//   - "*" wildcard (matches any action type)
+//   - Exact match: "git.push" matches "git.push"
+//   - Namespace wildcard: "git.*" matches "git.push", "git.commit" (but not "file.write")
 func matchesAction(actionType string, patterns action.StringOrSlice) bool {
 	for _, p := range patterns {
-		if p == actionType {
+		if p == "*" || p == actionType {
 			return true
+		}
+		// Namespace wildcard: e.g. "git.*" matches "git.push"
+		if strings.HasSuffix(p, ".*") {
+			namespace := p[:len(p)-2] // strip ".*"
+			if strings.HasPrefix(actionType, namespace+".") {
+				return true
+			}
 		}
 	}
 	return false


### PR DESCRIPTION
## Summary
- Fix critical bug: `matchesAction()` missing `"*"` wildcard and `"git.*"` namespace matching
- Without this, `action: "*"` allow rules never match → everything hits default-deny
- Bumps version to 2.10.0 for Go kernel release

## Test plan
- [x] All Go tests pass
- [x] `"*"` wildcard matches any action
- [x] `"git.*"` matches `"git.push"`, `"git.commit"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)