### PR TITLE
fix(dx): cold-start install works without claude-init

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,20 @@ jobs:
 
       - run: pnpm turbo test
 
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+
+      - name: Build Go kernel binaries (shipped in npm package)
+        working-directory: go
+        run: |
+          mkdir -p ../apps/cli/dist/go-bin
+          GOOS=linux GOARCH=amd64 go build -o ../apps/cli/dist/go-bin/agentguard-go-linux-amd64 ./cmd/agentguard/
+          GOOS=darwin GOARCH=arm64 go build -o ../apps/cli/dist/go-bin/agentguard-go-darwin-arm64 ./cmd/agentguard/
+          GOOS=darwin GOARCH=amd64 go build -o ../apps/cli/dist/go-bin/agentguard-go-darwin-amd64 ./cmd/agentguard/
+          GOOS=windows GOARCH=amd64 go build -o ../apps/cli/dist/go-bin/agentguard-go-windows-amd64.exe ./cmd/agentguard/
+          ls -la ../apps/cli/dist/go-bin/
+
       - name: Verify CLI version matches tag
         working-directory: apps/cli
         run: |

--- a/apps/cli/scripts/install-go-kernel.js
+++ b/apps/cli/scripts/install-go-kernel.js
@@ -88,14 +88,28 @@ async function main() {
     return;
   }
 
-  const binaryName = `agentguard-${suffix}`;
-  const url = `https://github.com/${REPO}/releases/download/${version}/${binaryName}`;
-  const dest = join(BIN_DIR, process.platform === 'win32' ? 'agentguard-go.exe' : 'agentguard-go');
+  const destName = process.platform === 'win32' ? 'agentguard-go.exe' : 'agentguard-go';
+  const dest = join(BIN_DIR, destName);
 
   if (existsSync(dest)) {
     console.log('[agentguard] Go kernel binary already exists');
     return;
   }
+
+  // Check for platform-specific binary shipped in npm package (built by CI)
+  const shippedName = `agentguard-go-${suffix}`;
+  const shippedPath = join(BIN_DIR, shippedName);
+  if (existsSync(shippedPath)) {
+    // Rename shipped binary to the expected name
+    const { renameSync } = await import('node:fs');
+    renameSync(shippedPath, dest);
+    if (process.platform !== 'win32') chmodSync(dest, 0o755);
+    console.log(`[agentguard] Go kernel installed (${suffix}) — ~100x faster hook evaluation`);
+    return;
+  }
+
+  const binaryName = `agentguard-${suffix}`;
+  const url = `https://github.com/${REPO}/releases/download/${version}/${binaryName}`;
 
   console.log(`[agentguard] Downloading Go kernel (${suffix})...`);
 

--- a/apps/cli/src/postinstall.ts
+++ b/apps/cli/src/postinstall.ts
@@ -467,6 +467,22 @@ function main(): void {
   const copilotResult = writeCopilotCliHooks(projectRoot);
   const policyResult = writeStarterPolicy(projectRoot);
 
+  // Create default identity so the identity wizard doesn't block first tool call.
+  // Users can customize later with `npx agentguard claude-init`.
+  const identityPath = join(projectRoot, '.agentguard-identity');
+  if (!existsSync(identityPath)) {
+    writeFileSync(identityPath, 'claude-code:unknown:developer\n', 'utf8');
+  }
+
+  // Create .agentguard/ directory tree for governance state
+  const agDir = join(projectRoot, '.agentguard');
+  for (const sub of ['events', 'decisions', 'lessons']) {
+    const dir = join(agDir, sub);
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+  }
+
   printSummary(claudeResult, copilotResult, policyResult, projectRoot);
 }
 

--- a/apps/cli/src/templates/scripts.ts
+++ b/apps/cli/src/templates/scripts.ts
@@ -243,6 +243,9 @@ ${bootstrapToolPatterns}
   # Not a bootstrap command — fail closed
   echo '{"decision":"block","reason":"AgentGuard kernel binary not found — governance cannot evaluate this action. Run: pnpm install && pnpm build"}'
   exit 0
+else
+  # Binary found — save stdin for the hook (consumed by bootstrap check above only when binary missing)
+  _AG_STDIN="\$(cat)"
 fi`;
 
   return `#!/usr/bin/env bash
@@ -264,7 +267,7 @@ fi
 
 ${resolveBlock}
 
-# Pass through to the actual hook
-exec \$AGENTGUARD_BIN claude-hook pre${storeSuffix}${dbPathSuffix}
+# Pass through to the actual hook — pipe saved stdin from the else branch above
+printf '%s' "\$_AG_STDIN" | exec \$AGENTGUARD_BIN claude-hook pre${storeSuffix}${dbPathSuffix}
 `;
 }


### PR DESCRIPTION
Postinstall creates default identity + dirs, wrapper preserves stdin, CI ships Go binaries for all platforms