### PR TITLE
fix(site): update swarm stats — 26/5-tiers → 120/4-drivers

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -1685,18 +1685,18 @@ rules:
       <div class="max-w-7xl mx-auto px-6">
         <div class="text-center mb-6 reveal">
           <h2 id="swarm-heading" class="font-mono font-bold text-3xl sm:text-4xl mb-4">Agent Swarm</h2>
-          <p class="text-muted text-lg max-w-2xl mx-auto">Deploy a coordinated team of governed AI agents. 26 agents across 5 tiers, each with dedicated skills, schedules, and governance policies.</p>
+          <p class="text-muted text-lg max-w-2xl mx-auto">Deploy a coordinated team of governed AI agents. 120 agents across 4 governed drivers, each with dedicated skills, schedules, and governance policies.</p>
         </div>
 
         <!-- Stats -->
         <div class="flex justify-center gap-8 mb-14 reveal">
           <div class="text-center">
-            <span class="block font-mono font-bold text-2xl text-cta">26</span>
+            <span class="block font-mono font-bold text-2xl text-cta">120</span>
             <span class="text-muted text-xs uppercase tracking-wider">Agents</span>
           </div>
           <div class="text-center">
-            <span class="block font-mono font-bold text-2xl text-cta">5</span>
-            <span class="text-muted text-xs uppercase tracking-wider">Tiers</span>
+            <span class="block font-mono font-bold text-2xl text-cta">4</span>
+            <span class="text-muted text-xs uppercase tracking-wider">Drivers</span>
           </div>
           <div class="text-center">
             <span class="block font-mono font-bold text-2xl text-cta">60+</span>
@@ -1711,7 +1711,7 @@ rules:
         <!-- Architecture Diagram -->
         <div class="mb-14 reveal">
           <div class="max-w-4xl mx-auto bg-surface border border-surface-light rounded-xl p-4 sm:p-6">
-            <img src="assets/sdlc-swarm-control-plane.svg" alt="Autonomous SDLC Swarm — Control Plane architecture diagram showing 5 tiers of governed AI agents connected to a central control plane with recovery controller escalation states" class="w-full h-auto rounded-lg" loading="lazy"/>
+            <img src="assets/sdlc-swarm-control-plane.svg" alt="Autonomous SDLC Swarm — Control Plane architecture diagram showing governed AI agents across multiple drivers connected to a central control plane with recovery controller escalation states" class="w-full h-auto rounded-lg" loading="lazy"/>
           </div>
         </div>
 


### PR DESCRIPTION
Closes #1259

## Implementation Summary

**What changed:**
- Description text: "26 agents across 5 tiers" → "120 agents across 4 governed drivers"
- Stats widget: Agents `26` → `120`, Tiers `5` → Drivers `4`
- Image alt text: removed stale "5 tiers" claim

**How to verify:**
1. Open `site/index.html` and navigate to the `#swarm` section
2. Confirm the stats widget shows 120 agents and 4 Drivers
3. Cross-check against `.agentguard/swarm-state.json` — agentCount sum is 26+33+46+15=120 across 4 drivers

**Source of truth used:** `.agentguard/swarm-state.json` (lastUpdated: 2026-03-26T23:52:00Z)
- claude-code: 26 agents (tier A/B)
- codex: 33 agents (tier B)
- copilot: 46 agents (tier C)
- gemini: 15 agents (tier B)
- **Total: 120 agents across 4 drivers**

**Tier C scope check:**
- Files changed: 1 (limit: 5)
- Lines changed: ~10 (limit: 300)
- Breaking changes: None

---
*Tier C implementation by copilot-cli — AgentGuard three-tier governance*