### PR TITLE
docs: sync documentation with codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,7 +173,7 @@ apps/
 │   ├── session-store.ts        # Session management
 │   ├── file-event-store.ts     # File-based event persistence
 │   ├── evidence-summary.ts     # Evidence summary generator for PR reports
-│   └── commands/               # guard, inspect, replay, export, import, simulate, ci-check, plugin, policy (validate, suggest, verify), claude-hook, claude-init, copilot-hook, copilot-init, deepagents-hook, deepagents-init, cloud, init, diff, evidence-pr, traces, session-viewer, status, analytics, auto-setup, config, audit-verify, demo, adoption, learn, migrate, trust, team-report
+│   └── commands/               # guard, inspect, replay, export, import, simulate, ci-check, plugin, policy (validate, suggest, verify), claude-hook, claude-init, copilot-hook, copilot-init, goose-init, cloud, init, diff, evidence-pr, traces, session-viewer, status, analytics, auto-setup, config, audit-verify, demo, adoption, learn, migrate, trust, team-report
 ├── mcp-server/src/             # @red-codes/mcp-server — MCP governance server
 │   ├── index.ts                # Entry point
 │   ├── server.ts               # MCP server implementation
@@ -187,7 +187,7 @@ apps/
 
 # TS test files (vitest) distributed across packages/ and apps/ directories
 policy/                     # Policy configuration (JSON: action_rules, capabilities)
-policies/                   # Policy packs (YAML: ci-safe, engineering-standards, enterprise, hipaa, open-source, soc2, strict)
+policies/                   # Policy packs (YAML: ci-safe, engineering-standards, enterprise, essentials, hipaa, open-source, soc2, strict)
 docs/                       # System documentation (architecture, event model, specs)
 hooks/                      # Git hooks (post-commit, post-merge)
 examples/                   # Example governance scenarios and error demos
@@ -229,7 +229,7 @@ The kernel loop is the core of AgentGuard. Every agent action passes through it:
 1. Agent proposes action (Claude Code tool call → `RawAgentAction`)
 2. AAB normalizes intent (tool → action type, detect git/destructive commands)
 3. Policy evaluator matches rules (deny/allow with scopes, branches, limits)
-4. Invariant checker verifies system state (21 defaults)
+4. Invariant checker verifies system state (24 invariants)
 5. If allowed: execute via adapter (file/shell/git handlers)
 6. Emit lifecycle events: `ACTION_REQUESTED` → `ACTION_ALLOWED/DENIED` → `ACTION_EXECUTED/FAILED`
 7. Sink all events to SQLite for audit trail
@@ -293,8 +293,7 @@ Each workspace package maps to a single architectural concept:
 - `agentguard cloud login|signup|connect|status|events|runs|summary|disconnect` — Cloud governance analytics
 - `agentguard copilot-hook` — Handle GitHub Copilot PreToolUse/PostToolUse hook events
 - `agentguard copilot-init` — Set up GitHub Copilot hook integration
-- `agentguard deepagents-hook` — Handle DeepAgents (LangChain) PreToolUse/PostToolUse hook events
-- `agentguard deepagents-init` — Set up DeepAgents hook integration (generates Python middleware)
+- `agentguard goose-init` — Set up Goose hook integration
 - `agentguard team-report` — Team-level governance observability across agents
 - `agentguard telemetry [on|off|status]` — Manage anonymous telemetry settings
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Identity consists of a **role** (`developer`, `reviewer`, `ops`, `security`, `ci
 |------------|---------|
 | **Policy enforcement** | YAML rules with deny / allow / escalate — drop `agentguard.yaml` in your repo |
 | **24 built-in invariants** | Secret exposure, protected branches, blast radius, path traversal, CI/CD config, package script injection, and more |
-| **47 event kinds** | Full lifecycle telemetry: `ActionRequested → ActionAllowed/Denied → ActionExecuted` |
+| **48 event kinds** | Full lifecycle telemetry: `ActionRequested → ActionAllowed/Denied → ActionExecuted` |
 | **Real-time cloud dashboard** | Telemetry streams to your team dashboard; opt-in, anonymous by default |
 | **Multi-tenant** | Team workspaces, GitHub/Google OAuth, SSO-ready |
 | **Live Office visualization** | 2D view of agents working in real time — share a link with your team |
@@ -403,7 +403,6 @@ agentguard claude-init                    # Interactive wizard: mode + pack → 
 agentguard claude-init --global           # Install hooks globally (~/.claude/settings.json)
 agentguard claude-init --mode guide --pack essentials  # Non-interactive setup
 agentguard copilot-init                   # Set up GitHub Copilot CLI hook integration
-agentguard deepagents-init                # Set up DeepAgents (.deepagents/agentguard_middleware.py) middleware
 agentguard init --template strict         # Scaffold policy from a template
 agentguard status                         # Show governance status
 


### PR DESCRIPTION
## What drifted

| File | Drift | Fix |
|------|-------|-----|
| `README.md` | "47 event kinds" — schema.ts defines 48 (`UnknownCommandWarn` + `IdeSocketAccessBlocked`) | Updated to 48 |
| `README.md` | `agentguard deepagents-init` in CLI reference — no command file or switch case exists | Removed |
| `CLAUDE.md` | Kernel loop step 4: "21 defaults" — source defines 24 invariants | Updated to 24 |
| `CLAUDE.md` | `commands/` directory comment listed `deepagents-hook, deepagents-init` (removed) and omitted `goose-init` (added) | Replaced |
| `CLAUDE.md` | `policies/` comment omitted `essentials` pack (`policies/essentials.yaml` exists) | Added |
| `CLAUDE.md` | CLI Commands section documented `deepagents-hook` and `deepagents-init` — no source files exist | Removed, added `goose-init` |

## Verification

Each fix was verified against the actual source code:
- Event count: manually counted all `export const ... EventKind` declarations in `packages/events/src/schema.ts` (48)
- Invariant count: `id:` fields in `packages/invariants/src/definitions.ts` (24)
- Commands: `switch (command)` cases in `apps/cli/src/bin.ts` — no `deepagents-hook/init` case, `goose-init` case present
- Policy packs: `ls policies/` — `essentials.yaml` present, others in subdirs
- Command files: `apps/cli/src/commands/deepagents*.ts` — no files; `goose-init.ts` — exists

## Dogfood note

AgentGuard governance hook blocked writes initially because `apps/cli/dist/bin.js` was not built in the worktree. The bootstrap exemption (`pnpm build` pattern) correctly allowed self-bootstrapping. No governance issues encountered after kernel was built.

---
*Created by copilot-docs-sync — AgentGuard Copilot swarm*