### PR TITLE
test(copilot-init): binary path resolution tests — parity with claude-init (#964)

### DIFF
--- a/apps/cli/tests/cli-copilot-init.test.ts
+++ b/apps/cli/tests/cli-copilot-init.test.ts
@@ -1,5 +1,6 @@
 // Tests for copilot-init CLI command
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { join } from 'node:path';
 
 vi.mock('node:fs', () => ({
   readFileSync: vi.fn(),
@@ -173,5 +174,46 @@ describe('copilotInit', () => {
     const config = writtenHooksConfig();
     const preHook = config.hooks.preToolUse[0];
     expect(preHook.bash).toContain('--store sqlite');
+  });
+
+  // --- Binary path resolution (#964) ---
+
+  it('resolves ./node_modules/.bin/agentguard for project-level npm installs', async () => {
+    vi.mocked(existsSync).mockImplementation((p: unknown) => {
+      const path = String(p);
+      // npm-installed: node_modules/.bin/agentguard exists, but NOT the dev marker
+      if (path.includes(join('node_modules', '.bin', 'agentguard'))) return true;
+      return false;
+    });
+
+    await copilotInit([]);
+
+    const config = writtenHooksConfig();
+    expect(config.hooks.preToolUse[0].bash).toContain('./node_modules/.bin/agentguard');
+    expect(config.hooks.preToolUse[0].bash).toContain('copilot-hook pre');
+  });
+
+  it('uses bare agentguard for --global even when node_modules/.bin exists', async () => {
+    vi.mocked(existsSync).mockImplementation((p: unknown) => {
+      const path = String(p);
+      if (path.includes(join('node_modules', '.bin', 'agentguard'))) return true;
+      return false;
+    });
+
+    await copilotInit(['--global']);
+
+    const config = writtenHooksConfig();
+    expect(config.hooks.preToolUse[0].bash).not.toContain('node_modules');
+    expect(config.hooks.preToolUse[0].bash).toContain('agentguard copilot-hook pre');
+  });
+
+  it('falls back to bare agentguard when node_modules/.bin does not exist', async () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    await copilotInit([]);
+
+    const config = writtenHooksConfig();
+    expect(config.hooks.preToolUse[0].bash).not.toContain('node_modules');
+    expect(config.hooks.preToolUse[0].bash).toContain('agentguard copilot-hook pre');
   });
 });


### PR DESCRIPTION
## Summary
- PR #969 fixed `resolveCliPrefix()` in both `claude-init.ts` and `copilot-init.ts` but only shipped tests for `claude-init`
- Adds 3 symmetric tests to `cli-copilot-init.test.ts` covering the `resolveBinary()` paths:
  - npm-install: `./node_modules/.bin/agentguard` is used when the binary exists locally
  - `--global` bypass: bare `agentguard` is used even when `node_modules/.bin` exists
  - Bare fallback: bare `agentguard` when no local binary is present

## Test plan
- [x] `pnpm test --filter=@red-codes/agentguard` — 949/949 passing (946 → +3 new)
- [x] All 3 new tests verify the `bash` field in `preToolUse` hook config

🤖 Generated with [Claude Code](https://claude.com/claude-code)