### PR TITLE
fix(ci): make CLI npm publish idempotent on duplicate release events

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -141,7 +141,15 @@ jobs:
 
       - name: Publish @red-codes/agentguard (CLI)
         working-directory: apps/cli
-        run: pnpm publish --provenance --access public --no-git-checks
+        run: |
+          OUTPUT=$(pnpm publish --provenance --access public --no-git-checks 2>&1) && echo "$OUTPUT" || {
+            echo "$OUTPUT"
+            if echo "$OUTPUT" | grep -q "cannot publish over the previously published"; then
+              echo "::notice::@red-codes/agentguard already published at this version, skipping"
+            else
+              exit 1
+            fi
+          }
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
## Summary

- The `Publish @red-codes/agentguard (CLI)` step in `publish.yml` was the only publish step **without** an E403-tolerance guard
- All 6 library package steps (`@red-codes/core`, `events`, `matchers`, `policy`, `invariants`, `kernel`) already use an `OUTPUT=$(...)` pattern to skip gracefully when a version is already published
- The CLI step ran `pnpm publish` naked, so any duplicate GitHub Release event caused a fatal 403 failure
- This is exactly what happened on 2026-03-29: version 2.10.2 was successfully published at 05:05:15, but a second release event at 05:06:32 caused run [23701956170](https://github.com/AgentGuardHQ/agent-guard/actions/runs/23701956170) to fail

## Root Cause Context (v2.10.2 Release Postmortem)

The full sequence of 5 CI failures on v2.10.2 today:

| Run | Time | Workflow | Category | Status |
|-----|------|----------|----------|--------|
| 23701803578 | 04:56 | Release Go Kernel | build — wrong Go module `agent-guard` vs `agentguard` in handler.go | ✅ fixed by #1315 |
| 23701803591 | 04:56 | Publish to npm | build — same Go module import bug in bundled kernel | ✅ fixed by #1315 |
| 23701893563 | 05:02 | Release Go Kernel | build — same (retry) | ✅ fixed by #1315 |
| 23701893570 | 05:02 | Publish to npm | build — same (retry) | ✅ fixed by #1315 |
| 23701956170 | 05:06 | Publish to npm | E403 duplicate publish — **this PR fixes** | 🔧 this PR |

## Fix

Wraps the CLI publish step in the same idempotent guard pattern used by all library packages:

```bash
OUTPUT=$(pnpm publish --provenance --access public --no-git-checks 2>&1) && echo "$OUTPUT" || {
  echo "$OUTPUT"
  if echo "$OUTPUT" | grep -q "cannot publish over the previously published"; then
    echo "::notice::@red-codes/agentguard already published at this version, skipping"
  else
    exit 1
  fi
}
```

## Test plan

- [ ] Verify the new step pattern matches the existing library publish steps in `publish.yml`
- [ ] Confirm no `${{ github.event.* }}` inputs are used (no injection risk)
- [ ] Next release: confirm CLI publish step tolerates a duplicate release event without failing

---
🤖 Automated triage by `triage-failing-ci-agent` (identity: `claude-code:opus:developer`) | 2026-03-29