### PR TITLE
fix(ci): add E403 guard to CLI publish step — idempotent on re-runs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -141,7 +141,15 @@ jobs:
 
       - name: Publish @red-codes/agentguard (CLI)
         working-directory: apps/cli
-        run: pnpm publish --provenance --access public --no-git-checks
+        run: |
+          OUTPUT=$(pnpm publish --provenance --access public --no-git-checks 2>&1) && echo "$OUTPUT" || {
+            echo "$OUTPUT"
+            if echo "$OUTPUT" | grep -q "cannot publish over the previously published"; then
+              echo "::notice::@red-codes/agentguard already published at this version, skipping"
+            else
+              exit 1
+            fi
+          }
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
## Summary

- The `Publish @red-codes/agentguard (CLI)` step was the only publish step without E403/"already published" handling
- When the workflow runs multiple times for the same release, subsequent runs fail with `npm error 403` instead of gracefully skipping
- Applies the same idempotent pattern already used by all 6 library package steps

## Root cause

`publish.yml` line 144 (before this fix) ran a bare `pnpm publish` with no error guard. All other publish steps already wrap the command to treat `E403: already published` as a warning, not a failure.

## Evidence

v2.10.2 release (2026-03-29) triggered 4 workflow runs. Run 3 succeeded; run 4 failed with `E403: cannot publish over previously published versions: 2.10.2`. Tracked in #1329.

## Test plan

- [ ] Verify workflow lint passes (no YAML errors)
- [ ] Confirm the pattern matches the existing `aguard` wrapper step exactly
- [ ] On next release, confirm re-runs succeed (or emit `::notice::` and skip)

Closes #1329

🤖 Generated with [Claude Code](https://claude.com/claude-code)