### PR TITLE
fix(bootstrap): pnpm install --force to avoid interactive Y/n prompt

### DIFF
--- a/scripts/claude-hook-wrapper.sh
+++ b/scripts/claude-hook-wrapper.sh
@@ -46,6 +46,9 @@ if [ -z "$AGENTGUARD_BIN" ]; then
     *'"command":"yarn build'* ) BOOTSTRAP_SAFE=1 ;;
     *'"command":"npx turbo build'* ) BOOTSTRAP_SAFE=1 ;;
     *'"command":"pnpm turbo build'* ) BOOTSTRAP_SAFE=1 ;;
+    # pnpm install --force bypasses the interactive "remove modules?" prompt that
+    # appears when node_modules exists but the lockfile has changed (AgentGuardHQ/agent-guard#1331)
+    *'"command":"pnpm install --force'* ) BOOTSTRAP_SAFE=1 ;;
   esac
 
   # Check if this is a read-only tool (safe regardless of kernel state)
@@ -69,12 +72,12 @@ if [ -z "$AGENTGUARD_BIN" ]; then
 
   if [ "$BOOTSTRAP_SAFE" -eq 1 ]; then
     # Allow through — emit a warning so the agent knows governance is not active
-    echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","additionalContext":"[AgentGuard bootstrap] Kernel binary not found — allowing bootstrap/read-only action. Run pnpm install && pnpm build to enable full governance."}}'
+    echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","additionalContext":"[AgentGuard bootstrap] Kernel binary not found — allowing bootstrap/read-only action. Run: (1) pnpm install --force  (2) pnpm build  to enable full governance. Use --force to skip the interactive Y/n prompt."}}'
     exit 0
   fi
 
   # Not a bootstrap command — fail closed
-  echo '{"decision":"block","reason":"AgentGuard kernel binary not found — governance cannot evaluate this action. Run: pnpm install && pnpm build"}'
+  echo '{"decision":"block","reason":"AgentGuard kernel binary not found — governance cannot evaluate this action. Bootstrap steps: (1) pnpm install --force  (2) pnpm build"}'
   exit 0
 fi
 


### PR DESCRIPTION
Closes #1331

## Implementation Summary

**What changed:**
- Added explicit `pnpm install --force` case to the bootstrap-safe allowlist in `scripts/claude-hook-wrapper.sh` (already matched by the `pnpm install` prefix pattern, but now self-documenting with an inline issue reference)
- Updated the bootstrap guidance message (bootstrap-allowed path) to recommend numbered steps: `(1) pnpm install --force  (2) pnpm build` — run separately rather than with `&&`, which is itself blocked by the chaining-operator security check in the same script
- Updated the fail-closed message to use the same numbered-steps format

**Root cause of the double bug:**
The original messages told agents to run `pnpm install && pnpm build` — but the same chaining-operator check in this script would block that exact command. The fix removes the self-contradicting guidance and promotes `--force` which skips pnpm's interactive "remove modules?" prompt.

**How to verify:**
1. Simulate a stale-modules state: have `node_modules/` present but `apps/cli/dist/bin.js` absent
2. Confirm `pnpm install --force` is allowed through the bootstrap exemption
3. Confirm the bootstrap context message now reads `(1) pnpm install --force  (2) pnpm build`
4. Confirm `pnpm install --force` does not hang on the Y/n prompt

**Tier C scope check:**
- Files changed: 1 (limit: 5)
- Lines changed: ~7 (limit: 300)
- Breaking changes: None

---
*Tier C implementation by copilot-cli — AgentGuard three-tier governance*