### PR TITLE
feat: promote Live Office as hero marketing asset in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ AI coding agents (Claude Code, Codex CLI, GitHub Copilot CLI, Google Gemini CLI,
 **For individuals:** stop your AI from wrecking your machine or repo.
 **For teams:** run fleets of agents safely at scale, with audit trails that pass compliance.
 
+> **See it live** — We run 100+ autonomous AI agents building AgentGuard itself, governed 24/7.
+> Every deny, every escalation, every code review — visible in real time.
+> **[Watch the live swarm &rarr;](https://agentguard-cloud-office-sim.vercel.app)**
+
 ## Quick Start
 
 ```bash
@@ -80,19 +84,19 @@ agentguard claude-init --mode guide --pack essentials
 > **[agentguard-cloud-dashboard.vercel.app/onboarding](https://agentguard-cloud-dashboard.vercel.app/onboarding)**
 > · [GitHub Discussions](https://github.com/AgentGuardHQ/agentguard/discussions) — ask questions, share setups
 
-## Cloud Dashboard
+## Cloud Dashboard & Live Office
 
 Connect to the AgentGuard Cloud for team governance, real-time telemetry, and multi-tenant management:
 
 ```bash
-agentguard cloud login
-# Opens browser → authenticate with GitHub or Google → CLI auto-configures
+npm install -g @red-codes/agentguard   # Install AgentGuard
+agentguard cloud login                  # Opens browser → authenticate → CLI auto-configures
 ```
 
 | Link | Description |
 |------|-------------|
-| [agentguard-cloud-dashboard.vercel.app](https://agentguard-cloud-dashboard.vercel.app) | Team dashboard — runs, violations, analytics |
-| [agentguard-cloud-office-sim.vercel.app](https://agentguard-cloud-office-sim.vercel.app) | Live Office — 2D visualization of agent activity |
+| **[Live Office](https://agentguard-cloud-office-sim.vercel.app)** | **Watch our 100+ agent swarm build software 24/7** — real-time governance visualization |
+| [Dashboard](https://agentguard-cloud-dashboard.vercel.app) | Team dashboard — runs, violations, analytics |
 
 ## Agent Identity
 
@@ -114,7 +118,7 @@ Identity consists of a **role** (`developer`, `reviewer`, `ops`, `security`, `ci
 | **47 event kinds** | Full lifecycle telemetry: `ActionRequested → ActionAllowed/Denied → ActionExecuted` |
 | **Real-time cloud dashboard** | Telemetry streams to your team dashboard; opt-in, anonymous by default |
 | **Multi-tenant** | Team workspaces, GitHub/Google OAuth, SSO-ready |
-| **Live Office visualization** | 2D view of agents working in real time — share a link with your team |
+| **Live Office visualization** | [24/7 live view](https://agentguard-cloud-office-sim.vercel.app) of our actual 100+ agent swarm — watch AI build software under governance |
 | **Agent SDK** | Programmatic governance for custom integrations and RunManifest-driven workflows |
 | **Agent identity** | Declare agent role + driver for governance telemetry — automatic prompt or CLI flag |
 | **Pre-push hooks** | Branch protection enforcement via git pre-push hooks, configured from agentguard.yaml |
@@ -503,7 +507,7 @@ agentguard cloud login     # Connect after you have an API key
 | Resource | URL |
 |----------|-----|
 | Dashboard | [agentguard-cloud-dashboard.vercel.app](https://agentguard-cloud-dashboard.vercel.app) |
-| Live Office | [agentguard-cloud-office-sim.vercel.app](https://agentguard-cloud-office-sim.vercel.app) |
+| **Live Office** | **[agentguard-cloud-office-sim.vercel.app](https://agentguard-cloud-office-sim.vercel.app)** — watch our swarm build software 24/7 |
 | Website | [agentguardhq.github.io/agentguard](https://agentguardhq.github.io/agentguard/) |
 | Docs | [docs/](docs/) |
 | Architecture | [docs/unified-architecture.md](docs/unified-architecture.md) |


### PR DESCRIPTION
## Summary
- Add prominent "See it live" callout after intro with direct link to the office-sim — this is the first thing someone reads after the badges
- Update "What It Does" table row from generic "2D view" to "24/7 live view of our actual 100+ agent swarm"
- Rename section to "Cloud Dashboard & Live Office", reorder links so Live Office is first
- Bold Live Office in the Links table with description

The office sim is our most compelling proof point — a 24/7 live view of a real agent swarm building software under governance. It was buried in a links table at line 506. Now it's front and center.

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm all links point to correct URLs
- [ ] Check that the callout block renders as a blockquote

🤖 Generated with [Claude Code](https://claude.com/claude-code)