### PR TITLE
fix: scope no-governance-self-modification to config only, not runtime state

### DIFF
--- a/go/internal/invariant/definitions.go
+++ b/go/internal/invariant/definitions.go
@@ -108,6 +108,23 @@ var migrationDirPatterns = []string{
 // Governance directory patterns.
 var governanceDirPatterns = []string{".agentguard/", ".agentguard\\", "policies/", "policies\\"}
 
+// Operational state patterns — these are runtime state, NOT governance config.
+// Writes to these paths are allowed (squad state, roadmaps, queue, persona, etc.).
+var operationalStatePatterns = []string{
+	".agentguard/squads/",
+	".agentguard/roadmaps/",
+	".agentguard/director-brief",
+	".agentguard/persona.env",
+	".agentguard/agent-reliability",
+	".agentguard/swarm-state",
+	".agentguard/budget-config",
+	".agentguard/queue.txt",
+	".agentguard/metrics",
+	"em-report.json",
+	".agentguard-identity",
+	".agentguard-root-session",
+}
+
 // Governance file basenames.
 var governanceFileBasenames = []string{"agentguard.yaml", "agentguard.yml", ".agentguard.yaml"}
 
@@ -1292,13 +1309,21 @@ func checkNoGovernanceSelfModification() InvariantDef {
 			}
 
 			matchesGovernancePath := func(path string) bool {
-				lower := strings.ToLower(path)
+				// Normalize path to prevent traversal bypass (e.g. .agentguard/squads/../agentguard.yaml)
+				cleaned := filepath.Clean(path)
+				lower := strings.ToLower(cleaned)
+				// Operational state files are writable — not governance config
+				for _, op := range operationalStatePatterns {
+					if strings.Contains(lower, strings.ToLower(op)) {
+						return false
+					}
+				}
 				for _, p := range governanceDirPatterns {
 					if strings.Contains(lower, strings.ToLower(p)) {
 						return true
 					}
 				}
-				base := strings.ToLower(filepath.Base(path))
+				base := strings.ToLower(filepath.Base(cleaned))
 				for _, f := range governanceFileBasenames {
 					if base == f {
 						return true
@@ -1314,16 +1339,33 @@ func checkNoGovernanceSelfModification() InvariantDef {
 				violations = append(violations, fmt.Sprintf("target: %s", target))
 			}
 
+			// For command scanning: only check the header line, not heredoc body.
+			// Skip gh commands entirely — they make GitHub API calls, not local file writes.
 			command := ctx.Action.Command
 			if command != "" {
-				if matchesGovernancePath(command) {
-					violations = append(violations, "command references governance paths")
-				} else {
-					lowerCmd := strings.ToLower(command)
-					for _, f := range governanceFileBasenames {
-						if strings.Contains(lowerCmd, f) {
-							violations = append(violations, "command references governance paths")
-							break
+				trimmed := strings.TrimSpace(command)
+				isGhCommand := extractBaseCommand(trimmed) == "gh"
+				if !isGhCommand {
+					// Strip heredoc body: keep everything up to the first newline after <<
+					// so the redirect target on the header line is still scanned.
+					// e.g. "cat << 'EOF' > target.yaml\nbody\nEOF" → "cat << 'EOF' > target.yaml"
+					cmdHeader := command
+					if idx := strings.Index(command, "<<"); idx >= 0 {
+						rest := command[idx:]
+						if nlIdx := strings.Index(rest, "\n"); nlIdx >= 0 {
+							cmdHeader = command[:idx+nlIdx]
+						}
+						// No newline means single-line command — keep as-is
+					}
+					if matchesGovernancePath(cmdHeader) {
+						violations = append(violations, "command references governance paths")
+					} else {
+						lowerCmd := strings.ToLower(cmdHeader)
+						for _, f := range governanceFileBasenames {
+							if strings.Contains(lowerCmd, f) {
+								violations = append(violations, "command references governance paths")
+								break
+							}
 						}
 					}
 				}

--- a/packages/invariants/src/definitions.ts
+++ b/packages/invariants/src/definitions.ts
@@ -1224,17 +1224,30 @@ export const DEFAULT_INVARIANTS: AgentGuardInvariant[] = [
       // Operational state files are NOT governance config — allow writes to squads, director brief, etc.
       const OPERATIONAL_STATE_PATTERNS = [
         '.agentguard/squads/',
+        '.agentguard/roadmaps/',
         '.agentguard/director-brief',
         '.agentguard/persona.env',
         '.agentguard/agent-reliability',
         '.agentguard/swarm-state',
         '.agentguard/budget-config',
+        '.agentguard/queue.txt',
+        '.agentguard/metrics',
         'em-report.json',
+        '.agentguard-identity',
+        '.agentguard-root-session',
       ];
       const GOVERNANCE_FILE_BASENAMES = ['agentguard.yaml', 'agentguard.yml', '.agentguard.yaml'];
 
       const matchesGovernancePath = (path: string) => {
-        const lower = path.toLowerCase();
+        // Normalize to prevent traversal bypass (e.g. .agentguard/squads/../agentguard.yaml)
+        const segments = path.split(/[\\/]/);
+        const cleaned: string[] = [];
+        for (const seg of segments) {
+          if (seg === '..') cleaned.pop();
+          else if (seg !== '.') cleaned.push(seg);
+        }
+        const normalized = cleaned.join('/');
+        const lower = normalized.toLowerCase();
         // Operational state files are writable — only actual governance config is protected
         if (OPERATIONAL_STATE_PATTERNS.some((p) => lower.includes(p.toLowerCase()))) {
           return false;
@@ -1242,7 +1255,7 @@ export const DEFAULT_INVARIANTS: AgentGuardInvariant[] = [
         if (GOVERNANCE_DIR_PATTERNS.some((p) => lower.includes(p.toLowerCase()))) {
           return true;
         }
-        const basename = path.split(/[\\/]/).pop() || '';
+        const basename = normalized.split(/[\\/]/).pop() || '';
         if (GOVERNANCE_FILE_BASENAMES.some((f) => basename.toLowerCase() === f)) {
           return true;
         }


### PR DESCRIPTION
## Summary
- **Go kernel**: Add `operationalStatePatterns` allowlist — roadmaps, squads, queue, persona, metrics, identity, root-session are all runtime state, not governance config
- **Go kernel**: Skip `gh` commands in command scanning (API calls, not local files)
- **Go kernel**: Strip heredoc bodies before governance path scanning (fixes false positives from PR/issue body content)
- **TS kernel**: Add `roadmaps/`, `queue.txt`, `metrics`, `.agentguard-identity`, `.agentguard-root-session` to the existing allowlist

Closes #1254, #1325, #1332. Related: #503, #995.

## Impact
This was blocking ~50% of swarm agents — EMs couldn't write squad state, roadmap sync failed, analytics agents couldn't write state, content agents couldn't bootstrap, and any command mentioning `.agentguard/` in a heredoc was denied.

## Test plan
- [x] Go invariant tests pass
- [x] TS invariant tests pass (602/602)
- [x] Manual verification: write to roadmaps path succeeds with fixed Go binary
- [ ] CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)