### PR TITLE
chore: bump to 2.10.3

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@red-codes/agentguard",
-  "version": "2.10.2",
+  "version": "2.10.3",
   "description": "Run AI agents without fear — CLI safety layer",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary
Version bump to 2.10.3 including the governance self-modification invariant fix (#1351).

Merge this, then create a GitHub release to trigger npm publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)