### PR TITLE
fix(bootstrap): harden SessionStart install + build detection (#1341, #1322)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -32,13 +32,13 @@
           },
           {
             "type": "command",
-            "command": "test -d node_modules || pnpm install --frozen-lockfile",
+            "command": "test -f node_modules/.modules.yaml || pnpm install --force",
             "timeout": 120000,
             "blocking": true
           },
           {
             "type": "command",
-            "command": "test -f apps/cli/dist/bin.js || pnpm build",
+            "command": "test -f apps/cli/dist/bin.js || pnpm build; test -f apps/cli/dist/bin.js",
             "timeout": 120000,
             "blocking": true
           },

--- a/apps/cli/src/commands/claude-init.ts
+++ b/apps/cli/src/commands/claude-init.ts
@@ -299,10 +299,22 @@ export async function claudeInit(args: string[] = []): Promise<void> {
     blocking: boolean;
   }> = [];
   if (isLocal) {
-    // In the agentguard dev repo, auto-build if dist is missing
+    // In the agentguard dev repo, ensure deps are linked and CLI is built.
+    // Use .modules.yaml as the pnpm install sentinel — written only after both
+    // the content-addressed store AND the symlink phase succeed (#1341).
+    // --force avoids the interactive "remove & reinstall" prompt in non-TTY envs.
     sessionStartHooks.push({
       type: 'command',
-      command: `test -f apps/cli/dist/bin.js || pnpm build`,
+      command: `test -f node_modules/.modules.yaml || pnpm install --force`,
+      timeout: 120000,
+      blocking: true,
+    });
+    // Verify the binary actually landed in THIS worktree after build.
+    // Turbo cache hits can replay to a different worktree path; the trailing
+    // `; test -f` turns that silent pass into a visible failure (#1322).
+    sessionStartHooks.push({
+      type: 'command',
+      command: `test -f apps/cli/dist/bin.js || pnpm build; test -f apps/cli/dist/bin.js`,
       timeout: 120000,
       blocking: true,
     });

--- a/apps/cli/tests/cli-claude-init.test.ts
+++ b/apps/cli/tests/cli-claude-init.test.ts
@@ -127,7 +127,7 @@ describe('claudeInit', () => {
     expect(written.hooks.SessionStart[0].hooks[1].command).toContain('status');
   });
 
-  it('installs SessionStart build + persona check + status hooks in local dev repo', async () => {
+  it('installs SessionStart install + build + persona check + status hooks in local dev repo', async () => {
     // Simulate being in the agentguard dev repo (apps/cli/src/bin.ts exists)
     vi.mocked(existsSync).mockImplementation((p: unknown) => {
       const path = String(p);
@@ -139,16 +139,22 @@ describe('claudeInit', () => {
 
     const written = writtenSettings();
     expect(written.hooks.SessionStart).toHaveLength(1);
-    expect(written.hooks.SessionStart[0].hooks).toHaveLength(3);
-    // Build hook first
-    expect(written.hooks.SessionStart[0].hooks[0].command).toContain('pnpm build');
+    expect(written.hooks.SessionStart[0].hooks).toHaveLength(4);
+    // Install check first — uses .modules.yaml sentinel (#1341)
+    expect(written.hooks.SessionStart[0].hooks[0].command).toContain('.modules.yaml');
+    expect(written.hooks.SessionStart[0].hooks[0].command).toContain('pnpm install');
     expect(written.hooks.SessionStart[0].hooks[0].blocking).toBe(true);
     expect(written.hooks.SessionStart[0].hooks[0].timeout).toBe(120000);
-    // Persona check second
-    expect(written.hooks.SessionStart[0].hooks[1].command).toContain('session-persona-check');
-    // Status hook third — in dev repo, uses local binary directly (no bash wrapper)
-    expect(written.hooks.SessionStart[0].hooks[2].command).toContain('status');
-    expect(written.hooks.SessionStart[0].hooks[2].command).toContain('apps/cli/dist/bin.js');
+    // Build hook second — trailing test verifies binary landed here (#1322)
+    expect(written.hooks.SessionStart[0].hooks[1].command).toContain('pnpm build');
+    expect(written.hooks.SessionStart[0].hooks[1].command).toContain('apps/cli/dist/bin.js');
+    expect(written.hooks.SessionStart[0].hooks[1].blocking).toBe(true);
+    expect(written.hooks.SessionStart[0].hooks[1].timeout).toBe(120000);
+    // Persona check third
+    expect(written.hooks.SessionStart[0].hooks[2].command).toContain('session-persona-check');
+    // Status hook fourth — in dev repo, uses local binary directly (no bash wrapper)
+    expect(written.hooks.SessionStart[0].hooks[3].command).toContain('status');
+    expect(written.hooks.SessionStart[0].hooks[3].command).toContain('apps/cli/dist/bin.js');
   });
 
   it('detects already-configured hook in PreToolUse and warns', async () => {


### PR DESCRIPTION
## Summary

- **#1341 — pnpm install skips on partial store**: `test -d node_modules` passes whenever the `.pnpm/` content-addressed store exists, even if symlinking never completed. Replaced with `test -f node_modules/.modules.yaml` (pnpm's post-link sentinel) + switched to `--force` to avoid the interactive prompt that hangs non-TTY agents.
- **#1322 — build hook exits 0 when Turbo writes to wrong path**: `test -f … || pnpm build` exits 0 even when a Turbo cache-hit replays outputs to a different worktree path. Added a trailing `; test -f apps/cli/dist/bin.js` so the hook fails visibly instead of silently passing.

Both changes applied to:
- `.claude/settings.json` (live config for the dev repo)
- `apps/cli/src/commands/claude-init.ts` (`--local` generator so new `claude-init` runs produce hardened hooks)
- `apps/cli/tests/cli-claude-init.test.ts` (updated to reflect 4-hook sequence)

## Test plan
- [x] `tests/bootstrap-detection.test.ts` — all 65 tests pass
- [x] `tests/cli-claude-init.test.ts` — all 40 tests pass (updated assertions)
- [x] Full CLI test suite: 796 passing, 38 pre-existing failures (no regressions introduced)
- [x] Reproduces #1341: `test -f node_modules/.modules.yaml` correctly fails when store is partial
- [x] Reproduces #1322: trailing `; test -f` exits 1 when binary is absent after build

Closes #1341
Closes #1322

🤖 Generated with [Claude Code](https://claude.com/claude-code)