### PR TITLE
fix(bootstrap): strip rtk prefix before bootstrap allowlist matching

### DIFF
--- a/scripts/claude-hook-wrapper.sh
+++ b/scripts/claude-hook-wrapper.sh
@@ -32,6 +32,12 @@ if [ -z "$AGENTGUARD_BIN" ]; then
   HOOK_PAYLOAD="$(cat)"
   BOOTSTRAP_SAFE=0
 
+  # Normalize rtk-prefixed commands: global CLAUDE.md instructs agents to prefix
+  # all commands with 'rtk', but the bootstrap allowlist uses bare command patterns.
+  # Strip the leading 'rtk ' from the JSON "command" value before matching
+  # (AgentGuardHQ/agent-guard#1347).
+  HOOK_PAYLOAD=$(echo "$HOOK_PAYLOAD" | sed 's/"command":"rtk /"command":"/g')
+
   # Check if this is a bootstrap-safe Bash command (install/build)
   case "$HOOK_PAYLOAD" in
     *'"command":"pnpm install'* ) BOOTSTRAP_SAFE=1 ;;


### PR DESCRIPTION
Closes #1347

## Implementation Summary

**What changed:**
- Added a single `sed` normalization step in `scripts/claude-hook-wrapper.sh` that strips a leading `rtk ` from the JSON `"command"` value before the bootstrap allowlist `case` statement runs
- All 12 existing bootstrap patterns (pnpm install, pnpm build, npm ci, etc.) now automatically match `rtk`-prefixed variants — no duplication
- Read-only tool exemptions (Read, Glob, Grep, etc.) are unaffected — they match on `tool_name`, not `command`
- Piped commands (`rtk pnpm install | tail -5`) remain correctly blocked by the chaining security check that runs after the case match
- Added an inline comment linking to this issue explaining the normalization rationale

**How to verify:**
1. Simulate a hook payload with `rtk` prefix: `echo '{"tool_name":"Bash","command":"rtk pnpm install --force"}' | bash scripts/claude-hook-wrapper.sh` — should output the bootstrap-allow JSON (not a block)
2. Same with bare command `pnpm install --force` — should still work (regression check)
3. `echo '{"tool_name":"Bash","command":"rtk git status"}' | bash scripts/claude-hook-wrapper.sh` — should still be blocked (not a bootstrap command)
4. Piped: `echo '{"tool_name":"Bash","command":"rtk pnpm install | tail -5"}' | bash scripts/claude-hook-wrapper.sh` — should be blocked by chaining guard

**Tier C scope check:**
- Files changed: 1 (limit: 5)
- Lines changed: ~6 (limit: 300)
- Breaking changes: None

---
*Tier C implementation by copilot-cli — AgentGuard three-tier governance*