### PR TITLE
feat(init): change default enforcement mode from guide to monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ echo '{"tool":"Bash","command":"git push origin main"}' | agentguard guard --dry
 Non-interactive setup (CI or scripted installs):
 
 ```bash
-agentguard claude-init --mode guide --pack essentials
+agentguard claude-init --mode monitor --pack essentials
 ```
 
 > **Join the waitlist** — get cloud governance, team dashboards, and real-time telemetry:
@@ -131,7 +131,7 @@ Drop `agentguard.yaml` in your repo root. It's picked up automatically.
 ### Minimal policy
 
 ```yaml
-mode: guide        # monitor | educate | guide | enforce
+mode: monitor      # monitor | educate | guide | enforce
 pack: essentials   # curated invariant profile
 
 rules:
@@ -155,7 +155,7 @@ Four enforcement modes control how AgentGuard responds to policy violations:
 Set the mode globally and override per-invariant:
 
 ```yaml
-mode: guide                  # global default
+mode: monitor                # global default
 
 invariants:
   no-secret-exposure: enforce   # always block secrets (hardcoded)
@@ -405,7 +405,7 @@ The Go kernel includes: action normalization with AST-based shell parsing, polic
 # Setup (interactive wizard)
 agentguard claude-init                    # Interactive wizard: mode + pack → creates policy + hooks
 agentguard claude-init --global           # Install hooks globally (~/.claude/settings.json)
-agentguard claude-init --mode guide --pack essentials  # Non-interactive setup
+agentguard claude-init --mode monitor --pack essentials  # Non-interactive setup
 agentguard copilot-init                   # Set up GitHub Copilot CLI hook integration
 agentguard deepagents-init                # Set up DeepAgents (.deepagents/agentguard_middleware.py) middleware
 agentguard init --template strict         # Scaffold policy from a template

--- a/agentguard.yaml
+++ b/agentguard.yaml
@@ -5,12 +5,12 @@ id: default-policy
 name: Default Safety Policy
 description: Baseline safety rules for AI coding agents
 
-# Enforcement mode: guide | educate | monitor | enforce
-#   guide   — block dangerous actions with corrective suggestions (recommended)
+# Enforcement mode: monitor | educate | guide | enforce
+#   monitor — log threats, don't block (default — visibility first)
 #   educate — allow actions but teach correct patterns
-#   monitor — log threats, don't block
+#   guide   — block dangerous actions with corrective suggestions
 #   enforce — block dangerous actions, no suggestions
-mode: guide
+mode: monitor
 
 # Agent identity: defaults to .agentguard-identity file (created by claude-init).
 # For CI/cron agents, set AGENTGUARD_AGENT_NAME env var to override.

--- a/apps/cli/src/commands/claude-init.ts
+++ b/apps/cli/src/commands/claude-init.ts
@@ -191,27 +191,27 @@ export async function claudeInit(args: string[] = []): Promise<void> {
   const packArgIdx = args.findIndex((a) => a === '--pack');
   const packArg = packArgIdx !== -1 ? args[packArgIdx + 1] : undefined;
 
-  let selectedMode: EnforcementMode = 'guide';
+  let selectedMode: EnforcementMode = 'monitor';
   let selectedPack: string | undefined = 'essentials';
 
-  const VALID_MODES: EnforcementMode[] = ['guide', 'educate', 'monitor', 'enforce'];
+  const VALID_MODES: EnforcementMode[] = ['monitor', 'educate', 'guide', 'enforce'];
 
   if (modeArg) {
     selectedMode = VALID_MODES.includes(modeArg as EnforcementMode)
       ? (modeArg as EnforcementMode)
-      : 'guide';
+      : 'monitor';
   } else if (process.stdin.isTTY && !isRefresh) {
     const modeChoice = await promptChoice(
       'Start in which mode?',
       [
-        `Guide ${DIM}— block dangerous actions with corrective suggestions (recommended)${RESET}`,
+        `Monitor ${DIM}— log threats, don't block (default — visibility first)${RESET}`,
         `Educate ${DIM}— allow actions but teach correct patterns${RESET}`,
-        `Monitor ${DIM}— log threats, don't block${RESET}`,
+        `Guide ${DIM}— block dangerous actions with corrective suggestions${RESET}`,
         `Enforce ${DIM}— block dangerous actions, no suggestions${RESET}`,
       ],
       0
     );
-    const modeMap: EnforcementMode[] = ['guide', 'educate', 'monitor', 'enforce'];
+    const modeMap: EnforcementMode[] = ['monitor', 'educate', 'guide', 'enforce'];
     selectedMode = modeMap[modeChoice];
   }
 
@@ -678,10 +678,10 @@ id: default-policy
 name: Default Safety Policy
 description: Baseline safety rules for AI coding agents
 
-# Enforcement mode: guide | educate | monitor | enforce
-#   guide   — block dangerous actions with corrective suggestions (recommended)
+# Enforcement mode: monitor | educate | guide | enforce
+#   monitor — log threats, don't block (default — visibility first)
 #   educate — allow actions but teach correct patterns
-#   monitor — log threats, don't block
+#   guide   — block dangerous actions with corrective suggestions
 #   enforce — block dangerous actions, no suggestions
 mode: ${mode}
 
@@ -859,7 +859,7 @@ const POLICY_CANDIDATES = [
 ];
 
 function generateStarterPolicy(
-  mode: EnforcementMode = 'guide',
+  mode: EnforcementMode = 'monitor',
   pack?: string,
   forceOverwrite = false
 ): boolean {
@@ -885,7 +885,7 @@ function showProtectionSummary(
   _policyGenerated: boolean,
   rtkStatus?: { available: boolean; version?: string },
   isGlobal?: boolean,
-  mode: EnforcementMode = 'guide'
+  mode: EnforcementMode = 'monitor'
 ): void {
   process.stderr.write('\n');
   process.stderr.write(`  ${FG.green}${BOLD}AgentGuard is active.${RESET}\n\n`);
@@ -959,13 +959,13 @@ function showProtectionSummary(
   process.stderr.write(`  ${BOLD}Next steps:${RESET}\n`);
   if (mode === 'monitor') {
     process.stderr.write(
-      `  ${DIM}1. Start a Claude Code session — warnings appear in your terminal${RESET}\n`
+      `  ${DIM}1. Start a Claude Code session — violations are logged, nothing is blocked${RESET}\n`
     );
     process.stderr.write(
       `  ${DIM}2. Run ${FG.cyan}aguard inspect --last${RESET}${DIM} to review the audit trail${RESET}\n`
     );
     process.stderr.write(
-      `  ${DIM}3. Edit ${FG.cyan}agentguard.yaml${RESET}${DIM} → set ${FG.cyan}mode: guide${RESET}${DIM} when ready to block with suggestions${RESET}\n`
+      `  ${DIM}3. When ready to enforce: set ${FG.cyan}mode: guide${RESET}${DIM} (or ${FG.cyan}educate${RESET}${DIM} / ${FG.cyan}enforce${RESET}${DIM}) in agentguard.yaml${RESET}\n`
     );
   } else if (mode === 'educate') {
     process.stderr.write(
@@ -975,7 +975,7 @@ function showProtectionSummary(
       `  ${DIM}2. Run ${FG.cyan}aguard inspect --last${RESET}${DIM} to review the audit trail${RESET}\n`
     );
     process.stderr.write(
-      `  ${DIM}3. Edit ${FG.cyan}agentguard.yaml${RESET}${DIM} → set ${FG.cyan}mode: guide${RESET}${DIM} when ready to block with suggestions${RESET}\n`
+      `  ${DIM}3. When ready to block: set ${FG.cyan}mode: guide${RESET}${DIM} or ${FG.cyan}mode: enforce${RESET}${DIM} in agentguard.yaml${RESET}\n`
     );
   } else {
     process.stderr.write(

--- a/apps/cli/src/commands/codex-init.ts
+++ b/apps/cli/src/commands/codex-init.ts
@@ -56,11 +56,11 @@ export async function codexInit(args: string[] = []): Promise<void> {
   // Parse --mode flag for enforcement mode
   const modeArgIdx = args.findIndex((a) => a === '--mode');
   const modeArg = modeArgIdx !== -1 ? args[modeArgIdx + 1] : undefined;
-  const VALID_MODES: EnforcementMode[] = ['guide', 'educate', 'monitor', 'enforce'];
+  const VALID_MODES: EnforcementMode[] = ['monitor', 'educate', 'guide', 'enforce'];
   const selectedMode: EnforcementMode =
     modeArg && VALID_MODES.includes(modeArg as EnforcementMode)
       ? (modeArg as EnforcementMode)
-      : 'guide';
+      : 'monitor';
 
   // Codex CLI hooks location:
   // Repo-level: .codex/hooks.json
@@ -220,10 +220,10 @@ name: Default Safety Policy
 description: Baseline safety rules for AI coding agents
 severity: 4
 
-# Enforcement mode: guide | educate | monitor | enforce
-#   guide   — block dangerous actions with corrective suggestions (recommended)
+# Enforcement mode: monitor | educate | guide | enforce
+#   monitor — log threats, don't block (default — visibility first)
 #   educate — allow actions but teach correct patterns
-#   monitor — log threats, don't block
+#   guide   — block dangerous actions with corrective suggestions
 #   enforce — block dangerous actions, no suggestions
 mode: ${mode}
 
@@ -295,7 +295,7 @@ const POLICY_CANDIDATES = [
   '.agentguard.yml',
 ];
 
-function generateStarterPolicy(mode: EnforcementMode = 'guide'): boolean {
+function generateStarterPolicy(mode: EnforcementMode = 'monitor'): boolean {
   const repoRoot = resolveMainRepoRoot();
   for (const candidate of POLICY_CANDIDATES) {
     if (existsSync(join(repoRoot, candidate))) {
@@ -311,7 +311,7 @@ function generateStarterPolicy(mode: EnforcementMode = 'guide'): boolean {
   return true;
 }
 
-function showProtectionSummary(policyGenerated: boolean, mode: EnforcementMode = 'guide'): void {
+function showProtectionSummary(policyGenerated: boolean, mode: EnforcementMode = 'monitor'): void {
   process.stderr.write('\n');
   process.stderr.write(`  ${FG.green}${BOLD}AgentGuard is active for Codex CLI.${RESET}\n\n`);
 

--- a/apps/cli/src/commands/copilot-init.ts
+++ b/apps/cli/src/commands/copilot-init.ts
@@ -59,11 +59,11 @@ export async function copilotInit(args: string[] = []): Promise<void> {
   // Parse --mode flag for enforcement mode
   const modeArgIdx = args.findIndex((a) => a === '--mode');
   const modeArg = modeArgIdx !== -1 ? args[modeArgIdx + 1] : undefined;
-  const VALID_MODES: EnforcementMode[] = ['guide', 'educate', 'monitor', 'enforce'];
+  const VALID_MODES: EnforcementMode[] = ['monitor', 'educate', 'guide', 'enforce'];
   const selectedMode: EnforcementMode =
     modeArg && VALID_MODES.includes(modeArg as EnforcementMode)
       ? (modeArg as EnforcementMode)
-      : 'guide';
+      : 'monitor';
 
   // Copilot CLI hooks location:
   // Repo-level: .github/hooks/hooks.json
@@ -213,10 +213,10 @@ name: Default Safety Policy
 description: Baseline safety rules for AI coding agents
 severity: 4
 
-# Enforcement mode: guide | educate | monitor | enforce
-#   guide   — block dangerous actions with corrective suggestions (recommended)
+# Enforcement mode: monitor | educate | guide | enforce
+#   monitor — log threats, don't block (default — visibility first)
 #   educate — allow actions but teach correct patterns
-#   monitor — log threats, don't block
+#   guide   — block dangerous actions with corrective suggestions
 #   enforce — block dangerous actions, no suggestions
 mode: ${mode}
 
@@ -288,7 +288,7 @@ const POLICY_CANDIDATES = [
   '.agentguard.yml',
 ];
 
-function generateStarterPolicy(mode: EnforcementMode = 'guide'): boolean {
+function generateStarterPolicy(mode: EnforcementMode = 'monitor'): boolean {
   const repoRoot = resolveMainRepoRoot();
   for (const candidate of POLICY_CANDIDATES) {
     if (existsSync(join(repoRoot, candidate))) {
@@ -304,7 +304,7 @@ function generateStarterPolicy(mode: EnforcementMode = 'guide'): boolean {
   return true;
 }
 
-function showProtectionSummary(policyGenerated: boolean, mode: EnforcementMode = 'guide'): void {
+function showProtectionSummary(policyGenerated: boolean, mode: EnforcementMode = 'monitor'): void {
   process.stderr.write('\n');
   process.stderr.write(`  ${FG.green}${BOLD}AgentGuard is active for Copilot CLI.${RESET}\n\n`);
 

--- a/apps/cli/src/commands/gemini-init.ts
+++ b/apps/cli/src/commands/gemini-init.ts
@@ -56,11 +56,11 @@ export async function geminiInit(args: string[] = []): Promise<void> {
   // Parse --mode flag for enforcement mode
   const modeArgIdx = args.findIndex((a) => a === '--mode');
   const modeArg = modeArgIdx !== -1 ? args[modeArgIdx + 1] : undefined;
-  const VALID_MODES: EnforcementMode[] = ['guide', 'educate', 'monitor', 'enforce'];
+  const VALID_MODES: EnforcementMode[] = ['monitor', 'educate', 'guide', 'enforce'];
   const selectedMode: EnforcementMode =
     modeArg && VALID_MODES.includes(modeArg as EnforcementMode)
       ? (modeArg as EnforcementMode)
-      : 'guide';
+      : 'monitor';
 
   // Gemini CLI hooks location:
   // Repo-level: .gemini/settings.json
@@ -220,10 +220,10 @@ name: Default Safety Policy
 description: Baseline safety rules for AI coding agents
 severity: 4
 
-# Enforcement mode: guide | educate | monitor | enforce
-#   guide   — block dangerous actions with corrective suggestions (recommended)
+# Enforcement mode: monitor | educate | guide | enforce
+#   monitor — log threats, don't block (default — visibility first)
 #   educate — allow actions but teach correct patterns
-#   monitor — log threats, don't block
+#   guide   — block dangerous actions with corrective suggestions
 #   enforce — block dangerous actions, no suggestions
 mode: ${mode}
 
@@ -295,7 +295,7 @@ const POLICY_CANDIDATES = [
   '.agentguard.yml',
 ];
 
-function generateStarterPolicy(mode: EnforcementMode = 'guide'): boolean {
+function generateStarterPolicy(mode: EnforcementMode = 'monitor'): boolean {
   const repoRoot = resolveMainRepoRoot();
   for (const candidate of POLICY_CANDIDATES) {
     if (existsSync(join(repoRoot, candidate))) {
@@ -311,7 +311,7 @@ function generateStarterPolicy(mode: EnforcementMode = 'guide'): boolean {
   return true;
 }
 
-function showProtectionSummary(policyGenerated: boolean, mode: EnforcementMode = 'guide'): void {
+function showProtectionSummary(policyGenerated: boolean, mode: EnforcementMode = 'monitor'): void {
   process.stderr.write('\n');
   process.stderr.write(`  ${FG.green}${BOLD}AgentGuard is active for Gemini CLI.${RESET}\n\n`);
 

--- a/apps/cli/tests/cli-claude-init.test.ts
+++ b/apps/cli/tests/cli-claude-init.test.ts
@@ -476,7 +476,7 @@ describe('claudeInit', () => {
     await claudeInit([]);
 
     expect(process.stderr.write).toHaveBeenCalledWith(
-      expect.stringContaining('Guiding')
+      expect.stringContaining('Monitoring for')
     );
     expect(process.stderr.write).toHaveBeenCalledWith(
       expect.stringContaining('AgentGuard is active')


### PR DESCRIPTION
## Summary

- **Default mode: `guide` → `monitor`** across all init commands (`claude-init`, `codex-init`, `copilot-init`, `gemini-init`) — new installs start with visibility, not enforcement
- **Wizard reordered**: Monitor appears first with `(default — visibility first)` label; upgrade path is monitor → educate → guide → enforce
- **Starter `agentguard.yaml`**: `mode: monitor` so the committed policy file also reflects the new default
- **README quick-start**: examples updated from `--mode guide` to `--mode monitor`
- **Next-steps messaging**: monitor mode now says "when ready to enforce: set mode: guide / educate / enforce" — shows the full upgrade ladder

## Motivation

At 4000+ weekly npm downloads, first-time users who hit an unexpected guide-mode block tend to uninstall. At swarm scale (100+ agents), guide mode causes cascading false positives (self-mod invariant blocking state writes). The value prop is *see what your agents are doing* first, *stop what they shouldn't* second.

Closes #1359

## Test plan

- [x] `pnpm test --filter=@red-codes/agentguard` — 949 tests pass (updated `cli-claude-init.test.ts` assertion from `'Guiding'` → `'Monitoring for'`)
- [x] `pnpm test --filter=@red-codes/kernel` — 935 tests pass
- [x] `pnpm test --filter=@red-codes/policy` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)