### PR TITLE
fix(bootstrap): fall back to main worktree binary when local binary fails (closes #1376)

### DIFF
--- a/scripts/claude-hook-wrapper.sh
+++ b/scripts/claude-hook-wrapper.sh
@@ -23,6 +23,20 @@ elif command -v agentguard &>/dev/null; then
   AGENTGUARD_BIN="agentguard"
 fi
 
+# Probe the local binary — in git worktrees, apps/cli/dist/bin.js may exist but
+# crash with ERR_MODULE_NOT_FOUND because node_modules is only in the main workspace.
+# (Node ESM resolves packages relative to the binary path; worktrees don't have
+# their own node_modules.) Fall back to the main worktree binary if probe fails (#1376).
+if [ -n "$AGENTGUARD_BIN" ] && ! $AGENTGUARD_BIN --version >/dev/null 2>&1; then
+  _MAIN_ROOT="$(git worktree list --porcelain 2>/dev/null | sed -n '1s/^worktree //p')"
+  if [ -n "$_MAIN_ROOT" ] && [ -f "$_MAIN_ROOT/apps/cli/dist/bin.js" ]; then
+    AGENTGUARD_BIN="node $_MAIN_ROOT/apps/cli/dist/bin.js"
+  else
+    # No fallback available — clear so bootstrap exemption handles the action
+    AGENTGUARD_BIN=""
+  fi
+fi
+
 # BOOTSTRAP EXEMPTION (AgentGuardHQ/agentguard#995):
 # When the kernel binary is missing, allow bootstrap commands (install/build)
 # and read-only tools through so the agent can self-bootstrap.


### PR DESCRIPTION
## Summary

- Adds a silent `--version` probe to `scripts/claude-hook-wrapper.sh` after `AGENTGUARD_BIN` is set
- If the probe fails (ERR_MODULE_NOT_FOUND in git worktrees), resolves the main worktree path via `git worktree list --porcelain` and uses that binary instead
- If no fallback is available, clears `AGENTGUARD_BIN` so the bootstrap exemption handler runs (fail-safe)

## Root cause

In git worktrees, `apps/cli/dist/bin.js` may exist (from a prior build or stale artifact) but crash at startup. Node ESM resolves `@red-codes/storage` relative to the binary path — and worktrees don't have their own `node_modules`. The only `node_modules` lives in the main workspace.

Before this fix: the wrapper found the binary, skipped the bootstrap exemption path, then the binary crashed → governance **silently broken** for all tool calls in the worktree.

After this fix: probe fails → main worktree binary used → governance fully operational.

## Test

```bash
# Reproduces the bug (returns "FAIL"):
node /path/to/.worktrees/foo/apps/cli/dist/bin.js --version

# Fallback target (returns "agentguard v2.10.3"):
node /path/to/agent-guard/apps/cli/dist/bin.js --version
```

All 949 CLI tests pass.

## Test plan

- [x] Confirmed worktree local binary fails with ERR_MODULE_NOT_FOUND
- [x] Confirmed main worktree binary returns `agentguard v2.10.3` cleanly
- [x] `git worktree list --porcelain | sed -n '1s/^worktree //p'` correctly resolves main root
- [x] All 949 existing CLI tests pass (vitest, 3.08s)
- [ ] Manually tested: this exact session — governance now operating via main worktree binary

Closes #1376

🤖 Generated with [Claude Code](https://claude.com/claude-code)