### PR TITLE
fix(site): sync swarm section — 139 agents, 5 governed drivers

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -1685,17 +1685,17 @@ rules:
       <div class="max-w-7xl mx-auto px-6">
         <div class="text-center mb-6 reveal">
           <h2 id="swarm-heading" class="font-mono font-bold text-3xl sm:text-4xl mb-4">Agent Swarm</h2>
-          <p class="text-muted text-lg max-w-2xl mx-auto">Deploy a coordinated team of governed AI agents. 120 agents across 4 governed drivers, each with dedicated skills, schedules, and governance policies.</p>
+          <p class="text-muted text-lg max-w-2xl mx-auto">Deploy a coordinated team of governed AI agents. 139 agents across 5 governed drivers, each with dedicated skills, schedules, and governance policies.</p>
         </div>
 
         <!-- Stats -->
         <div class="flex justify-center gap-8 mb-14 reveal">
           <div class="text-center">
-            <span class="block font-mono font-bold text-2xl text-cta">120</span>
+            <span class="block font-mono font-bold text-2xl text-cta">139</span>
             <span class="text-muted text-xs uppercase tracking-wider">Agents</span>
           </div>
           <div class="text-center">
-            <span class="block font-mono font-bold text-2xl text-cta">4</span>
+            <span class="block font-mono font-bold text-2xl text-cta">5</span>
             <span class="text-muted text-xs uppercase tracking-wider">Drivers</span>
           </div>
           <div class="text-center">


### PR DESCRIPTION
## Summary

- **139 agents** (was 120) — synced to current production swarm count per issue #1387 proof points
- **5 Drivers** (was 4) — Goose (Block) shipped as 5th governed driver (MCP extension model, `agentguard goose-init`)

## Root cause

Both values are `<span>` hardcoded stats in the Agent Swarm section — outside the `data-target` pattern that `check-site-stats.sh` monitors. Gap noted for future coverage.

## Drivers now counted

| Driver | Integration | Command |
|--------|------------|---------|
| Claude Code | Hook (PreToolUse/PostToolUse) | `agentguard claude-init` |
| Copilot CLI | Hook | `agentguard copilot-init` |
| Codex CLI | Hook | `agentguard codex-init` |
| Gemini CLI | Hook | `agentguard gemini-init` |
| Goose (Block) | MCP extension | `agentguard goose-init` |

## Test plan

- [x] `bash scripts/check-site-stats.sh` passes (all 13 checks green)
- [x] Swarm section reflects correct counts on visual review

🤖 Generated by marketing-em (claude-code:opus:marketing:em) | 2026-03-29T21:30Z