### PR TITLE
fix(invariants): no-governance-self-modification false positive on agentguard.db reads (#1408)

### DIFF
--- a/packages/invariants/src/definitions.ts
+++ b/packages/invariants/src/definitions.ts
@@ -1232,6 +1232,9 @@ export const DEFAULT_INVARIANTS: AgentGuardInvariant[] = [
         '.agentguard/budget-config',
         '.agentguard/queue.txt',
         '.agentguard/metrics',
+        // Audit database — operational data produced by the runtime, not governance config.
+        // Analytics and monitoring agents need to query it (read-only SQLite probes). Closes #1408.
+        '.agentguard/agentguard.db',
         'em-report.json',
         '.agentguard-identity',
         '.agentguard-root-session',

--- a/packages/invariants/tests/invariant-definitions.test.ts
+++ b/packages/invariants/tests/invariant-definitions.test.ts
@@ -1505,6 +1505,46 @@ describe('no-governance-self-modification', () => {
     const result = inv.check({ currentCommand: heredocCmd });
     expect(result.holds).toBe(false);
   });
+
+  // Acceptance tests for #1408: read-only SQLite probe of agentguard.db
+  // The audit database is operational data produced by the runtime — not governance config.
+  // Analytics and monitoring agents must be able to query it without triggering this invariant.
+  it('holds when currentTarget is the governance audit DB (operational state, not config)', () => {
+    const result = inv.check({ currentTarget: '.agentguard/agentguard.db' });
+    expect(result.holds).toBe(true);
+  });
+
+  it('holds when shell command is a read-only SQLite probe of agentguard.db', () => {
+    const result = inv.check({
+      currentCommand: "python3 -c \"import sqlite3; conn = sqlite3.connect('.agentguard/agentguard.db'); print(conn.execute('SELECT count(*) FROM events').fetchone())\"",
+    });
+    expect(result.holds).toBe(true);
+  });
+
+  it('holds when shell command queries agentguard.db via path prefix (analytics worktree pattern)', () => {
+    const result = inv.check({
+      currentCommand: "python3 -c \"import sqlite3; conn = sqlite3.connect('agent-guard/.agentguard/agentguard.db'); ...\"",
+    });
+    expect(result.holds).toBe(true);
+  });
+
+  it('holds when sqlite3 CLI reads agentguard.db schema', () => {
+    const result = inv.check({
+      currentCommand: 'sqlite3 .agentguard/agentguard.db .tables',
+    });
+    expect(result.holds).toBe(true);
+  });
+
+  it('holds when modifiedFiles contains only agentguard.db (kernel writes audit trail)', () => {
+    const result = inv.check({ modifiedFiles: ['.agentguard/agentguard.db'] });
+    expect(result.holds).toBe(true);
+  });
+
+  it('still fails when command modifies .agentguard/ without touching the audit DB', () => {
+    // Only the audit DB path is exempt — other .agentguard/ writes are still blocked
+    const result = inv.check({ currentCommand: 'cp /tmp/policy-override.yaml .agentguard/custom-policy.yaml' });
+    expect(result.holds).toBe(false);
+  });
 });
 
 describe('lockfile-integrity', () => {


### PR DESCRIPTION
## Summary

Closes #1408 — fixes a false positive in `no-governance-self-modification` that blocked analytics and monitoring agents from querying the governance audit database.

**Root cause**: `OPERATIONAL_STATE_PATTERNS` did not include `agentguard.db`, so any command referencing `.agentguard/agentguard.db` triggered `commandViolation` — even read-only SQLite probes.

**Fix**: Add `.agentguard/agentguard.db` to `OPERATIONAL_STATE_PATTERNS`. The audit DB is operational data produced by the runtime, not governance configuration. It belongs alongside existing exempted paths (`squads/`, `swarm-state`, `persona.env`, etc.).

## Changes

| File | Change |
|------|--------|
| `packages/invariants/src/definitions.ts` | Add `.agentguard/agentguard.db` to `OPERATIONAL_STATE_PATTERNS` |
| `packages/invariants/tests/invariant-definitions.test.ts` | 6 new acceptance tests for #1408 |

## Invariant Behavior After Fix

- **Allows**: `currentTarget: .agentguard/agentguard.db` (e.g. kernel writing audit trail)
- **Allows**: Shell commands referencing `agentguard.db` (e.g. `python3 -c "... sqlite3.connect('.agentguard/agentguard.db') ..."`)
- **Allows**: `sqlite3 .agentguard/agentguard.db .tables` (read-only schema probe)
- **Still blocks**: Commands modifying other `.agentguard/` paths (events, custom-policy.yaml, etc.)
- **Still blocks**: Any `agentguard.yaml` / `policies/` write

## Impact

Without this fix, the analytics-invariant-researcher agent hit the following cascade:
1. Read-only DB probe blocked (attempt 1)
2. Retry blocked (attempt 2)
3. Third attempt → `denial-retry-escalation` → **LOCKDOWN** — disproportionate for a SELECT query

## Test Results

```
@red-codes/invariants: 608/608 passing (+6 new)
@red-codes/kernel:     935/935 passing
```

## Test plan

- [x] `currentTarget: .agentguard/agentguard.db` → holds (kernel writes are allowed)
- [x] Python sqlite3 read probe → holds
- [x] Python sqlite3 probe via `agent-guard/` path prefix → holds
- [x] `sqlite3 .agentguard/agentguard.db .tables` CLI → holds
- [x] `modifiedFiles: ['.agentguard/agentguard.db']` → holds
- [x] Commands modifying `.agentguard/custom-policy.yaml` (no DB ref) → still fails
- [x] All 935 kernel tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)