### PR TITLE
fix(aab): remove docker stop from destructive patterns

### DIFF
--- a/packages/core/src/data/destructive-patterns.json
+++ b/packages/core/src/data/destructive-patterns.json
@@ -31,7 +31,6 @@
   { "pattern": "\\bpip\\s+uninstall\\b", "description": "Uninstall Python package", "riskLevel": "high", "category": "package" },
   { "pattern": "\\biptables\\s+-F\\b", "description": "Flush all firewall rules", "riskLevel": "critical", "category": "network" },
   { "pattern": "\\bufw\\s+disable\\b", "description": "Disable firewall", "riskLevel": "critical", "category": "network" },
-  { "pattern": "\\bdocker\\s+stop\\b", "description": "Stop Docker container", "riskLevel": "high", "category": "container" },
   { "pattern": "\\bdocker\\s+volume\\s+rm\\b", "description": "Remove Docker volume (data loss)", "riskLevel": "critical", "category": "container" },
   { "pattern": "\\bdocker\\s+volume\\s+prune\\b", "description": "Prune all unused Docker volumes", "riskLevel": "critical", "category": "container" },
   { "pattern": "\\bdocker\\s+network\\s+rm\\b", "description": "Remove Docker network", "riskLevel": "high", "category": "container" },

--- a/packages/kernel/tests/agentguard-aab.test.ts
+++ b/packages/kernel/tests/agentguard-aab.test.ts
@@ -221,8 +221,8 @@ describe('agentguard/core/aab', () => {
     });
 
     // Expanded container/orchestration patterns
-    it('detects docker stop', () => {
-      expect(isDestructiveCommand('docker stop my-container')).toBe(true);
+    it('does not flag docker stop as destructive (reversible — container can be restarted, no data lost)', () => {
+      expect(isDestructiveCommand('docker stop my-container')).toBe(false);
     });
 
     it('detects docker volume rm', () => {
@@ -961,11 +961,9 @@ describe('agentguard/core/aab', () => {
           severity: 3,
         },
       ];
-      const result = authorize(
-        { tool: 'Bash', command: 'rm -rf /tmp/test' },
-        policies,
-        { defaultDeny: true }
-      );
+      const result = authorize({ tool: 'Bash', command: 'rm -rf /tmp/test' }, policies, {
+        defaultDeny: true,
+      });
       expect(result.result.allowed).toBe(true);
       expect(result.result.reason).toBe('Allow everything');
     });
@@ -979,21 +977,17 @@ describe('agentguard/core/aab', () => {
           severity: 3,
         },
       ];
-      const result = authorize(
-        { tool: 'Bash', command: 'rm -rf /tmp/test' },
-        policies,
-        { defaultDeny: true }
-      );
+      const result = authorize({ tool: 'Bash', command: 'rm -rf /tmp/test' }, policies, {
+        defaultDeny: true,
+      });
       expect(result.result.allowed).toBe(false);
       expect(result.result.reason).toContain('Destructive command detected');
     });
 
     it('destructive commands denied when no policies loaded (#1253)', () => {
-      const result = authorize(
-        { tool: 'Bash', command: 'dd if=/dev/zero of=/dev/sda' },
-        [],
-        { defaultDeny: false }
-      );
+      const result = authorize({ tool: 'Bash', command: 'dd if=/dev/zero of=/dev/sda' }, [], {
+        defaultDeny: false,
+      });
       expect(result.result.allowed).toBe(false);
       expect(result.result.reason).toContain('Destructive command detected');
     });
@@ -1010,11 +1004,9 @@ describe('agentguard/core/aab', () => {
           severity: 3,
         },
       ];
-      const result = authorize(
-        { tool: 'Bash', command: 'rm -rf /tmp/test' },
-        policies,
-        { defaultDeny: true }
-      );
+      const result = authorize({ tool: 'Bash', command: 'rm -rf /tmp/test' }, policies, {
+        defaultDeny: true,
+      });
       // Deny rule fires first (shell.exec matches), so even though destructive
       // check would also deny, the policy deny takes effect in the evaluator.
       // But the destructive gate still returns deny because the evaluator denied.
@@ -1113,10 +1105,7 @@ describe('agentguard/core/aab', () => {
           severity: 5,
         },
       ];
-      const result = authorize(
-        { tool: 'Bash', command: 'git push --force origin main' },
-        policies
-      );
+      const result = authorize({ tool: 'Bash', command: 'git push --force origin main' }, policies);
       expect(result.result.allowed).toBe(false);
       expect(result.result.reason).toContain('protected branch');
     });
@@ -1310,7 +1299,9 @@ describe('agentguard/core/aab', () => {
 
     it('only strips a single wrapper prefix', () => {
       // Nested wrappers: only the outermost is stripped
-      expect(stripCommandWrappers('rtk time git push origin main')).toBe('time git push origin main');
+      expect(stripCommandWrappers('rtk time git push origin main')).toBe(
+        'time git push origin main'
+      );
     });
 
     it('does not strip strace (multi-token flags handled by \\b patterns)', () => {


### PR DESCRIPTION
Closes #1398

## Implementation Summary

**What changed:**
- Removed `docker stop` from `destructive-patterns.json` — stopping a container sends SIGTERM/SIGKILL to the container process but leaves the container record and all data intact. It is fully reversible (`docker start`). Classifying it as destructive blocks legitimate QA teardown workflows.
- Updated test: changed `detects docker stop` → `does not flag docker stop as destructive` with `toBe(false)`. The test description documents *why* (reversibility + no data loss) to inform future maintainers.
- `docker rm`, `docker kill`, and all volume/prune variants remain in patterns — they have greater destructive potential.

**How to verify:**
1. Run `pnpm test --filter=@red-codes/kernel` — all 193 kernel tests should pass
2. Confirm `docker stop bench-devs-test-db` no longer triggers "Destructive command detected" in a governed session
3. Confirm `docker rm`, `docker volume rm`, `docker system prune` still block as expected

**Tier C scope check:**
- Files changed: 2 (limit: 5)
- Lines changed: ~3 (limit: 300)
- Breaking changes: None

---
*Tier C implementation by copilot-cli — AgentGuard three-tier governance*