### PR TITLE
fix(site): update invariant count 25→26 and shellforge patterns 87→93

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -5,11 +5,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="google-site-verification" content="OeJuCct5Y8LRHQB95DkF5Y9hwUvZIvtYrpKy16x3o28" />
   <title>AgentGuard — Run AI Agents Without Fear</title>
-  <meta name="description" content="AgentGuard — default-deny governance for AI coding agents. 25 invariants, four enforcement modes, tamper-evident audit trail. Install in 30 seconds.">
+  <meta name="description" content="AgentGuard — default-deny governance for AI coding agents. 26 invariants, four enforcement modes, tamper-evident audit trail. Install in 30 seconds.">
 
   <!-- OpenGraph -->
   <meta property="og:title" content="AgentGuard — Run AI Agents Without Fear">
-  <meta property="og:description" content="Default-deny governance for AI coding agents. 25 invariants, four enforcement modes (monitor, educate, guide, enforce), tamper-evident audit trail. Install in 30 seconds.">
+  <meta property="og:description" content="Default-deny governance for AI coding agents. 26 invariants, four enforcement modes (monitor, educate, guide, enforce), tamper-evident audit trail. Install in 30 seconds.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://agentguardhq.github.io/agentguard/">
   <meta property="og:image" content="https://agentguardhq.github.io/agentguard/og-image.png">
@@ -28,7 +28,7 @@
     "name": "AgentGuard",
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "Windows, macOS, Linux",
-    "description": "AgentGuard — default-deny governance for AI coding agents. 25 invariants, four enforcement modes, tamper-evident audit trail.",
+    "description": "AgentGuard — default-deny governance for AI coding agents. 26 invariants, four enforcement modes, tamper-evident audit trail.",
     "url": "https://agentguardhq.github.io/agentguard/",
     "offers": {
       "@type": "Offer",
@@ -433,7 +433,7 @@
             Run AI Agents <span class="text-cta">Without Fear</span>
           </h1>
           <p class="text-muted text-lg leading-relaxed mb-8 max-w-xl">
-            Your AI agents can't push to main, leak credentials, or destroy your repo. 25 built-in safety checks block catastrophic actions before they execute. Install in 30 seconds. Sleep at night.
+            Your AI agents can't push to main, leak credentials, or destroy your repo. 26 built-in safety checks block catastrophic actions before they execute. Install in 30 seconds. Sleep at night.
           </p>
           <div class="flex flex-wrap gap-4">
             <a href="#quickstart" class="bg-cta hover:bg-cta-dark text-bg font-semibold px-6 py-3 rounded-lg transition-colors text-sm inline-flex items-center gap-2 cursor-pointer">
@@ -490,7 +490,7 @@
             <div class="text-muted text-sm mt-1">Action Types</div>
           </div>
           <div class="reveal">
-            <div class="font-mono font-bold text-3xl sm:text-4xl text-text counter" data-target="25">0</div>
+            <div class="font-mono font-bold text-3xl sm:text-4xl text-text counter" data-target="26">0</div>
             <div class="text-muted text-sm mt-1">Invariants</div>
           </div>
           <div class="reveal">
@@ -537,7 +537,7 @@
               <svg class="w-5 h-5 text-info" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><polyline points="9 12 11 14 15 10"/></svg>
             </div>
             <h3 class="font-mono font-semibold text-text mb-2">Production-Grade Kernel</h3>
-            <p class="text-muted text-sm leading-relaxed">Sub-millisecond evaluation latency. 25 invariants, 93 destructive patterns, tamper-evident audit chain. The reference monitor architecture enterprises require for autonomous agent deployment.</p>
+            <p class="text-muted text-sm leading-relaxed">Sub-millisecond evaluation latency. 26 invariants, 93 destructive patterns, tamper-evident audit chain. The reference monitor architecture enterprises require for autonomous agent deployment.</p>
           </div>
         </div>
       </div>
@@ -567,7 +567,7 @@
               <p class="text-text">&nbsp;</p>
               <p class="text-cta">$ aguard guard --policy agentguard.yaml</p>
               <p class="text-muted">&nbsp;&nbsp;AgentGuard Runtime Active</p>
-              <p class="text-muted">&nbsp;&nbsp;policy: agentguard.yaml | invariants: 25 | patterns: 93</p>
+              <p class="text-muted">&nbsp;&nbsp;policy: agentguard.yaml | invariants: 26 | patterns: 93</p>
               <p class="text-text">&nbsp;</p>
               <p class="text-cta">&nbsp;&nbsp;✓ file.write  src/auth/service.ts</p>
               <p class="text-cta">&nbsp;&nbsp;✓ test.run    vitest (4,394 passed)</p>
@@ -722,7 +722,7 @@
             </li>
             <li class="flex items-start gap-3">
               <svg class="w-5 h-5 text-cta mt-0.5 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
-              <span>25 built-in invariants + 93 destructive patterns detected <strong class="text-text">automatically</strong></span>
+              <span>26 built-in invariants + 93 destructive patterns detected <strong class="text-text">automatically</strong></span>
             </li>
             <li class="flex items-start gap-3">
               <svg class="w-5 h-5 text-cta mt-0.5 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
@@ -2365,7 +2365,7 @@ rules:
       // ---- Terminal Typing Animation ----
       var terminalLines = [
         { text: '  AgentGuard Runtime Active', cls: 'text-cta', delay: 0 },
-        { text: '  policy: agentguard.yaml | invariants: 25 | patterns: 93', cls: 'text-muted', delay: 0 },
+        { text: '  policy: agentguard.yaml | invariants: 26 | patterns: 93', cls: 'text-muted', delay: 0 },
         { text: '', cls: '', delay: 300 },
         { text: '  \u2713 file.write  src/auth/service.ts', cls: 'text-cta', delay: 0 },
         { text: '  \u2713 shell.exec  npm test', cls: 'text-cta', delay: 0 },

--- a/site/shellforge.html
+++ b/site/shellforge.html
@@ -326,7 +326,7 @@
               <span class="font-mono text-xs font-bold px-2 py-1 rounded bg-cta/10 text-cta">GOVERN</span>
               <h3 class="font-mono font-semibold text-text">AgentGuard</h3>
             </div>
-            <p class="text-muted text-sm leading-relaxed">Policy enforcement on every action — allow, deny, or correct. 22 built-in invariants, 87 destructive patterns, tamper-evident audit trail. The enforcement boundary agents cannot bypass.</p>
+            <p class="text-muted text-sm leading-relaxed">Policy enforcement on every action — allow, deny, or correct. 26 built-in invariants, 93 destructive patterns, tamper-evident audit trail. The enforcement boundary agents cannot bypass.</p>
             <div class="mt-4 font-mono text-xs text-muted bg-bg rounded-lg p-3">
               <div class="text-danger">[DENIED] git push --force</div>
               <div class="text-cta">[ALLOWED] file.write src/</div>
@@ -439,8 +439,8 @@
               <div class="flex items-start gap-3">
                 <svg class="w-5 h-5 text-cta mt-0.5 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
                 <div>
-                  <div class="font-semibold text-text text-sm">22 built-in invariants</div>
-                  <div class="text-muted text-sm">Secret exposure, protected branches, blast radius, test-before-push, lockfile integrity and 17 more — active by default.</div>
+                  <div class="font-semibold text-text text-sm">26 built-in invariants</div>
+                  <div class="text-muted text-sm">Secret exposure, protected branches, blast radius, test-before-push, lockfile integrity and 21 more — active by default.</div>
                 </div>
               </div>
               <div class="flex items-start gap-3">


### PR DESCRIPTION
## Summary

- **index.html**: invariant count updated from 25 → 26 across all 9 occurrences (meta description, og:description, JSON-LD schema, hero copy, stats counter `data-target`, two feature card mentions, terminal demo HTML, and JS animation string)
- **shellforge.html**: invariant count 22 → 26 and destructive patterns 87 → 93 (two occurrences — feature card prose and spec table)

## Root cause

Two new invariants were merged since the last site update:
- `No Self-Approve PR`
- `Cross-Repo Blast Radius`

shellforge.html was significantly behind, reflecting an even older baseline (22 invariants / 87 patterns).

## Verification

Counts confirmed against source of truth:
- `packages/invariants/src/definitions.ts` → 26 `name:` entries
- `packages/core/src/data/destructive-patterns.json` → 93 patterns

## Test plan

- [ ] Verify `grep "25 invariant\|22 built\|87 destructive" site/*.html` returns no matches
- [ ] Spot-check stats bar counter on index.html animates to 26
- [ ] Confirm shellforge.html feature card reads "26 built-in invariants, 93 destructive patterns"

🤖 Generated with [Claude Code](https://claude.com/claude-code)