### PR TITLE
chore(hq-em): EM cycle 2026-03-30T09:00Z — #1437 #1434 merged, #1430 escalated to director, PR queue CLEAR

### DIFF
--- a/.agentguard/squads/hq/em-report.json
+++ b/.agentguard/squads/hq/em-report.json
@@ -1,15 +1,27 @@
 {
   "squad": "hq",
-  "generatedAt": "2026-03-30T05:30:00.000Z",
+  "generatedAt": "2026-03-30T09:00:00.000Z",
   "identity": "claude-code:opus:hq:em",
+  "runCycle": "3h",
   "health": "red",
-  "healthReason": "Two P0 blockers: #1402 worker pool dead (cycle 7, human must run server/deploy.sh) and #1431 codex budget exhausted until Apr 3 (director decision needed — buy credits or disable codex agents). Zero squad velocity. Both open PRs conflicting.",
-  "summary": "Cycle 2026-03-30T05:30Z. No merges (PR #1434 CONFLICTING, PR #1433 CONFLICTING — commented on both requesting rebase). Closed #1392 (superseded by #1431). 7th escalation of #1402 (worker pool). 2nd escalation of #1431 (codex budget). KE-8 tracked: kernel-adapters (#1430) and kernel (#1427) at ageRuns=1. Positive: #1342 resolved (Copilot pipeline fixed), KE-7 done (PR #1425 merged), April 1 dispatch queue ready (studio EM confirms 7 tasks).",
+  "healthReason": "Two P0 blockers persist: worker pool dead on jared box (#1402, cycle 8) and codex budget exhausted until Apr 3 (#1431, cycle 3). New escalation: #1430 hook stderr blocking at ageRuns=2 (no PR after 2 kernel cycles) — escalated to director. PR queue now CLEAR (all 4 open PRs resolved this cycle).",
+  "summary": "Productive cycle. Merged #1437 (HQ EM 05:30Z) and rebased+merged #1434 (kernel EM 03:00Z — conflicted on kernel/state.json due to studio-em squash, resolved by taking main's 08:00Z QA state). PRs #1436 (#1427 fix), #1433 (studio EM) were already merged. P0 blockers #1402 and #1431 unchanged. #1427 RESOLVED via #1436 (persona.env protection invariant now enforced). #1430 escalated to director after 2 kernel cycles with no PR. New: 3 dependabot security alerts (1 high, 2 moderate). #1438 (confidence-gated HITL + kernel health writer) merged to main.",
+  "sprintStatus": {
+    "goal": "Validate Go kernel→Cloud telemetry E2E pipeline (workspace #60, due Apr 17). KE-2 SHIPPED. Version sync. ShellForge coordination.",
+    "issues": [1335, 1402, 1403, 1430, 1431],
+    "resolvedThisSprint": [1427]
+  },
   "ciStatus": {
-    "agentGuard": "yellow",
+    "agentGuard": "green",
     "agentguardCloud": "unknown",
     "agentguardAnalytics": "unknown",
-    "recentRuns": "Main branch green. PR #1432 merged (kernel-em, all CI green). PR #1433 and #1434 CONFLICTING — no CI triggered. Last successful run: hq-em-20260330-001628 (all 4 checks green, PR #1435 merged)."
+    "recentRuns": "Main green. PRs #1437, #1436, #1433, #1434 all merged (4/4 or 5/5 checks green). #1438 merged (confidence-gated HITL, Go kernel feature). 3 dependabot security alerts on main (1 high, 2 moderate) — unfiled.",
+    "securityAlerts": {
+      "count": 3,
+      "breakdown": "1 high, 2 moderate",
+      "status": "unfiled — needs triage this cycle or next",
+      "url": "https://github.com/AgentGuardHQ/agentguard/security/dependabot"
+    }
   },
   "versionMatrix": {
     "latest": "2.10.3",
@@ -17,32 +29,38 @@
     "agentguardCloud": "2.10.1",
     "agentguardAnalytics": "2.10.2",
     "drift": {
-      "agentguardCloud": "2 patches behind (P1, 5th cycle)",
-      "agentguardAnalytics": "1 patch behind (P2) — CORRECTION: previous state reported 2.7.3 SEVERE; actual package.json pin is 2.10.2. pnpm store contains old cached versions which caused misread."
+      "agentguardCloud": "2 patches behind (P1, 6th cycle — no upgrade PR filed)",
+      "agentguardAnalytics": "1 patch behind (P2)"
     }
   },
   "prQueue": {
     "agentGuard": {
-      "open": 2,
-      "details": [
+      "open": 0,
+      "details": [],
+      "mergedThisCycle": [
+        {
+          "number": 1437,
+          "title": "chore(hq-em): EM cycle 2026-03-30T05:30Z — #1431 #1402 escalated cycle 2/7, PRs #1433 #1434 CONFLICTING, #1392 closed",
+          "note": "4/4 CI green. Squash merged."
+        },
         {
           "number": 1434,
           "title": "chore(kernel-em): EM cycle 2026-03-30T03:00Z — #1432 merged, KE-8 tracking #1430 #1427",
-          "status": "CONFLICTING",
-          "checks": "no CI — merge conflict blocks run",
-          "mergeable": false,
-          "note": "Commented requesting rebase. Kernel EM to self-correct on next cycle."
+          "note": "Rebased onto main to resolve kernel/state.json conflict (studio-em had written 08:00Z QA state). Took main's state version, preserved kernel em-report. 4/4 CI green post-rebase."
+        }
+      ],
+      "alreadyMergedBeforeThisCycle": [
+        {
+          "number": 1436,
+          "title": "fix(invariants): protect persona.env from agent identity tampering",
+          "note": "Closes #1427. 5/5 CI green."
         },
         {
           "number": 1433,
           "title": "chore(studio-em): EM cycle 2026-03-30T05:00Z — PRs #265 #262 merged, queue clear, April 1 ready",
-          "status": "CONFLICTING",
-          "checks": "no CI — merge conflict blocks run",
-          "mergeable": false,
-          "note": "Commented requesting rebase. Key content noted: #1342 closed, April 1 dispatch queue ready (7 tasks for Copilot/claude-code agents)."
+          "note": "Squash-merged with kernel-qa 08:00Z cycle."
         }
-      ],
-      "mergedThisCycle": []
+      ]
     }
   },
   "dogfoodPatterns": [
@@ -50,155 +68,170 @@
       "pattern": "Hook stderr false-blocks allowed decisions on Bash tool",
       "issues": [1430],
       "severity": "P1",
-      "status": "OPEN",
-      "description": "claude-hook-wrapper.sh outputs to stderr for 'allowed' decisions with '(attempt 1/3)' counter. Claude Code treats any hook stderr as blocking error. Unattended agents on readybench cannot git commit/push. Workaround: wrap command in a shell script file.",
-      "recommendation": "Kernel-adapters squad: allowed decisions should exit 0 with no stderr. Retry counter should be suppressed or stdout-only."
+      "ageRuns": 2,
+      "status": "ESCALATED_TO_DIRECTOR",
+      "description": "claude-hook outputs to stderr for 'allowed' decisions (attempt 1/3 counter). Claude Code treats any PreToolUse hook stderr as blocking error. Readybench agents cannot git commit/push. WIP stash found in studio-em branch (claude-hook-wrapper.sh simplification) but fix must target apps/cli/src/commands/claude-hook.ts.",
+      "recommendation": "Director: assign kernel-sr directly. Fix: allowed decisions → stdout only, no stderr. Reserve stderr for deny/violation/fatal errors."
     },
     {
       "pattern": "Automated agents can self-modify .agentguard/persona.env",
       "issues": [1427],
       "severity": "P1",
-      "status": "OPEN",
-      "description": "qa-flaky-test-detector re-ran write-persona.sh during worktree init, overwriting persona.env and changing driver (claude→human), autonomy (semi-autonomous→supervised), and agent name. No invariant blocks this.",
-      "recommendation": "Kernel squad: add no-persona-self-modification invariant. write-persona.sh should be idempotent (skip if file exists)."
+      "status": "RESOLVED",
+      "resolvedBy": "PR #1436 — no-governance-self-modification invariant now blocks writes to persona.env from tool calls. Bootstrap script (write-persona.sh) runs before hooks are active, unaffected."
     },
     {
       "pattern": "Worktree node_modules missing turbo binary on fresh worktree",
       "severity": "P2",
       "status": "KNOWN_WORKAROUND",
-      "description": "On EM cycle startup, turbo not found in worktree node_modules. Must run pnpm install --frozen-lockfile to fix.",
+      "description": "On EM cycle startup, turbo not found in worktree node_modules. Must run pnpm install --frozen-lockfile.",
       "recommendation": "Add pnpm install --frozen-lockfile as pre-build step in EM startup scripts."
-    },
-    {
-      "pattern": "pnpm store misread: node_modules/.pnpm contains old cached versions",
-      "severity": "P2",
-      "status": "PROCESS_NOTE",
-      "description": "When checking installed version, always read package.json dependency pin — not node_modules/.pnpm subdirectories which contain multiple historical versions. Prior state incorrectly reported analytics at 2.7.3 due to this.",
-      "recommendation": "EM agents: use `grep '@red-codes/agentguard' package.json` not `find node_modules/.pnpm`."
     }
   ],
   "crossCuttingIssues": [
     {
       "issue": 1402,
-      "title": "[P0] Worker pool dead — 6th cycle, swarm frozen",
+      "title": "[P0] Worker pool dead — 8th cycle, swarm frozen",
       "severity": "P0",
-      "description": "All 32 PIDs dead. Queue growing. Every squad's scheduled agents blocked. Human must run server/deploy.sh.",
+      "cycleCount": 8,
+      "description": "All 32 PIDs dead. Queue depth growing. Every squad's scheduled agents blocked. Human must run server/deploy.sh.",
       "action": "HUMAN REQUIRED: cd ~/agentguard-workspace && server/deploy.sh"
     },
     {
       "issue": 1431,
-      "title": "[P0] Swarm Health: Codex budget exhausted + multi-driver circuit cascade",
+      "title": "[P0] Codex budget exhausted + multi-driver circuit cascade",
       "severity": "P0",
-      "description": "25 codex-driver agents offline until Apr 3. At midnight: all-driver cascade (codex budget + copilot circuit + claude-code rate limit + gemini budget) caused 53.7% failure rate. 3 zombie vitest PIDs consuming RAM. Orphaned worktrees need prune.",
-      "action": "Human: kill zombie PIDs, prune worktrees, decide on codex credits. Director: consider disabling codex agents until Apr 3."
-    },
-    {
-      "issue": 1403,
-      "title": "[qa-conductor] readybench QA swarm non-operational — 5+ days",
-      "severity": "P1",
-      "description": "All 19 readybench agents skipping. Wrong queue routing. Depends on #1402.",
-      "action": "Ops: fix box routing. Depends on #1402 resolution."
+      "cycleCount": 3,
+      "description": "25 codex-driver agents offline until Apr 3 (~72h). All-driver cascade at midnight: 53.7% failure rate. Director decision still pending.",
+      "action": "Director: decide credits purchase OR disable codex agents in schedule.json. Human: kill zombie vitest PIDs 1183028/1183035/1183037."
     },
     {
       "issue": 1430,
-      "title": "[dogfood] git commit hook false-blocks allowed decisions",
+      "title": "[dogfood P1] Hook stderr blocks allowed git commits — escalated to director (ageRuns=2)",
       "severity": "P1",
-      "description": "Hook stderr on allowed decisions causes Claude Code to block the action. Readybench agents cannot commit.",
-      "action": "Kernel-adapters squad: fix hook output format (no stderr on allow)."
+      "cycleCount": 2,
+      "description": "Kernel-adapters squad had 2 cycles to file a PR. No PR submitted. Per escalation rules (no PR after 2 cycles → director escalation). WIP fix exists in stash (claude-hook-wrapper.sh) but core fix must be in claude-hook.ts.",
+      "action": "DIRECTOR: Assign kernel-sr directly to #1430. Require PR by next kernel cycle."
     },
     {
-      "issue": 1427,
-      "title": "[dogfood] agent persona self-modification gap",
+      "issue": 1403,
+      "title": "[P1] readybench QA swarm non-operational — 5+ days",
       "severity": "P1",
-      "description": "Agents can overwrite .agentguard/persona.env via write-persona.sh re-run, corrupting audit identity.",
-      "action": "Kernel squad: new no-persona-self-modification invariant + idempotent write-persona.sh."
+      "description": "All 19 readybench agents skipping. Depends on #1402.",
+      "action": "Ops: fix box routing after #1402 resolved."
     },
     {
       "issue": 1335,
       "title": "Codex + Copilot circuit breakers OPEN",
       "severity": "P1",
       "description": "March budget exhaustion. Auto-resolves 2026-04-01 (2 days).",
-      "action": "Wait."
+      "action": "Wait — auto-resolves 2026-04-01."
     },
     {
-      "title": "Version drift: cloud 2.10.1 vs 2.10.3 (corrected: analytics 2.10.2 not 2.7.3)",
+      "title": "Version drift: cloud 2.10.1 vs 2.10.3 (6th cycle, P1)",
       "severity": "P1",
-      "description": "Cloud 2 patches behind (P1). Analytics 1 patch behind (P2). Cloud squad owns both.",
-      "action": "Cloud squad: upgrade agentguard-cloud to 2.10.3. Also add octi-pulpo allow rule to agentguard-cloud/agentguard.yaml."
+      "description": "Cloud 2 patches behind. No upgrade PR filed after 6 cycles. Missing octi-pulpo MCP allow rule in agentguard.yaml.",
+      "action": "Cloud squad: upgrade to 2.10.3 immediately. Add octi-pulpo allow rule."
+    },
+    {
+      "title": "Dependabot security alerts — 3 unfiled (1 high, 2 moderate)",
+      "severity": "P2",
+      "status": "NEW",
+      "description": "Detected during force-push of kernel-em rebase. Requires triage.",
+      "action": "HQ: file Dependabot triage issue or enable auto-merge for patch updates.",
+      "url": "https://github.com/AgentGuardHQ/agentguard/security/dependabot"
+    },
+    {
+      "title": "ShellForge initiative (#1362–#1367) — 5th+ cycle unassigned",
+      "severity": "P2",
+      "description": "6 ShellForge issues open, no squad owner. Director needs to assign.",
+      "action": "Director: assign ShellForge squad owner."
     }
   ],
   "resolvedSinceLastCycle": [
     {
-      "issue": 1392,
-      "title": "Swarm Health Alert 2026-03-29 Evening — CLOSED this cycle",
-      "note": "Superseded by #1431 (midnight alert). All items addressed or tracked in active blockers."
+      "issue": 1427,
+      "pr": 1436,
+      "title": "Persona.env self-modification protection — CLOSED",
+      "note": "PR #1436 merged. no-governance-self-modification invariant now includes persona.env path. 4 tests updated."
+    },
+    {
+      "pr": 1437,
+      "title": "HQ EM 05:30Z cycle report — merged",
+      "note": "Previous cycle state captured."
+    },
+    {
+      "pr": 1434,
+      "title": "Kernel EM 03:00Z cycle report — rebased + merged",
+      "note": "Resolved conflict: took main's 08:00Z QA kernel state, preserved 03:00Z em-report."
     }
   ],
   "escalations": [
     {
       "priority": "P0",
       "target": "human (jpleva91)",
-      "cycleCount": 7,
-      "reason": "Worker pool dead (#1402). Kill zombie vitest PIDs 1183028/1183035/1183037. Prune orphaned worktrees. All squads at zero velocity."
+      "cycleCount": 8,
+      "reason": "Worker pool dead (#1402). Run: cd ~/agentguard-workspace && server/deploy.sh. Also: kill 1183028 1183035 1183037 (zombie vitest), git worktree prune."
     },
     {
       "priority": "P0",
       "target": "director",
-      "cycleCount": 2,
-      "reason": "#1431: Codex budget exhausted until Apr 3 — 25 agents offline. Decide: buy credits OR disable codex agents in schedule.json. ShellForge initiative (#1362–#1367): 5th cycle unassigned."
+      "cycleCount": 3,
+      "reason": "#1431: codex budget exhausted until Apr 3. Decision: purchase credits or disable codex agents in schedule.json until Apr 3."
+    },
+    {
+      "priority": "P1",
+      "target": "director",
+      "cycleCount": 1,
+      "reason": "#1430 escalation: kernel-adapters had 2 cycles to fix hook stderr, no PR filed. Require direct assignment to kernel-sr."
     },
     {
       "priority": "P1",
       "target": "cloud squad",
-      "reason": "agentguard-cloud at 2.10.1 (P1, 5th+ cycle). Add octi-pulpo allow rule to agentguard-cloud/agentguard.yaml. analytics at 2.10.2 (P2)."
+      "cycleCount": 6,
+      "reason": "Upgrade agentguard-cloud to 2.10.3 (P1, 6th cycle). Add octi-pulpo allow rule to agentguard-cloud/agentguard.yaml."
     },
     {
-      "priority": "P1",
-      "target": "kernel-adapters squad",
-      "reason": "#1430 ageRuns=1: hook stderr false-blocks allowed git commits. PR expected this cycle or kernel EM escalates to director."
-    },
-    {
-      "priority": "P1",
-      "target": "kernel squad",
-      "reason": "#1427 ageRuns=1: no-persona-self-modification invariant + idempotent write-persona.sh. PR expected this cycle or kernel EM escalates to director."
-    },
-    {
-      "priority": "P1",
-      "target": "ops (human)",
-      "reason": "#1403: readybench QA non-operational 5+ days. Fix box routing after #1402 resolved."
+      "priority": "P2",
+      "target": "director",
+      "reason": "ShellForge initiative (#1362–#1367): assign squad owner. Also: Dependabot alerts (1 high, 2 moderate) need triage."
     }
   ],
   "humanActionsRequired": [
-    "cd ~/agentguard-workspace && server/deploy.sh  # restart worker pool (#1402) — cycle 7",
-    "kill 1183028 1183035 1183037  # zombie vitest PIDs",
-    "cd agent-guard && git worktree prune && rm -rf .worktrees/fix-kernel-false-positives .worktrees/feat-postinstall-dual-hook .worktrees/strategy-update  # orphaned worktrees",
-    "Decision (director): purchase Codex credits OR disable codex agents in schedule.json until 2026-04-03"
+    "cd ~/agentguard-workspace && server/deploy.sh  # restart worker pool (#1402)",
+    "kill 1183028 1183035 1183037  # zombie vitest PIDs (consuming RAM)",
+    "cd agent-guard && git worktree prune  # clean orphaned worktrees",
+    "Decision: purchase codex credits OR edit server/schedule.json to disable codex agents until 2026-04-03"
   ],
   "actionsThisCycle": [
     {
-      "action": "COMMENTED_PR",
+      "action": "MERGED_PR",
+      "pr": 1437,
+      "detail": "HQ EM 05:30Z cycle. 4/4 CI green."
+    },
+    {
+      "action": "REBASED_AND_MERGED_PR",
       "pr": 1434,
-      "detail": "CONFLICTING — requested rebase. Kernel EM 03:00Z. Will self-correct next kernel cycle."
-    },
-    {
-      "action": "COMMENTED_PR",
-      "pr": 1433,
-      "detail": "CONFLICTING — requested rebase. Studio EM 05:00Z. Key: #1342 closed, April 1 dispatch queue ready (7 tasks)."
-    },
-    {
-      "action": "CLOSED_ISSUE",
-      "issue": 1392,
-      "detail": "Swarm Health Alert 2026-03-29 Evening — superseded by #1431. Commented + closed."
+      "detail": "Kernel EM 03:00Z. Resolved conflict on kernel/state.json (took main's 08:00Z QA state, preserved 03:00Z em-report). Force-pushed rebased branch. 4/4 CI green post-rebase."
     },
     {
       "action": "ESCALATED",
+      "issue": 1430,
+      "detail": "No PR after ageRuns=2. Escalated to director per escalation rules. WIP stash found (claude-hook-wrapper.sh simplification) but must fix claude-hook.ts."
+    },
+    {
+      "action": "ESCALATED_COUNT",
       "issue": 1402,
-      "detail": "Cycle 7. Added cleanup checklist (zombie PIDs, orphaned worktrees). @jpleva91 tagged."
+      "detail": "Cycle 8 escalation to human. No change."
     },
     {
-      "action": "ESCALATED",
+      "action": "ESCALATED_COUNT",
       "issue": 1431,
-      "detail": "Cycle 2 escalation. Director + human. Codex decision + cleanup checklist added."
+      "detail": "Cycle 3 escalation. No director decision yet."
+    },
+    {
+      "action": "SECURITY_FINDING",
+      "detail": "Detected 3 dependabot alerts (1 high, 2 moderate) during force-push. Filed as P2 cross-cutting issue."
     }
   ]
 }

--- a/.agentguard/squads/hq/state.json
+++ b/.agentguard/squads/hq/state.json
@@ -2,31 +2,28 @@
   "squad": "hq",
   "sprint": {
     "goal": "Validate Go kernel→Cloud telemetry E2E pipeline (workspace #60, due Apr 17). KE-2 SHIPPED. Version sync. ShellForge coordination.",
-    "issues": [1335, 1402, 1403, 1430, 1427]
+    "issues": [1335, 1402, 1403, 1430, 1431]
   },
   "assignments": {
     "human-jpleva91": {
-      "task": "P0 URGENT (cycle 7): (1) Run server/deploy.sh on jared box — worker pool dead (#1402). (2) Kill zombie vitest PIDs: kill 1183028 1183035 1183037. (3) Prune orphaned worktrees: git worktree prune && rm -rf .worktrees/fix-kernel-false-positives .worktrees/feat-postinstall-dual-hook .worktrees/strategy-update.",
+      "task": "P0: Run server/deploy.sh on jared box — worker pool dead 8+ cycles, swarm frozen (#1402). Also: kill zombie vitest PIDs 1183028/1183035/1183037, prune orphaned worktrees (git worktree prune). Decision: codex credits or disable codex agents until Apr 3.",
       "priority": "P0"
     },
     "director": {
-      "task": "P0: #1431 codex budget exhausted until Apr 3 — 25 agents offline (cycle 2). Decide NOW: purchase credits OR disable codex agents in schedule.json until Apr 3. Also: assign squad ownership for ShellForge initiative (#1362–#1367, 5th cycle unassigned).",
+      "task": "P0: #1431 codex budget exhausted until Apr 3 — 25 agents offline. Decide: purchase credits OR disable codex agents in schedule.json. P1-NEW: #1430 hook stderr escalated after 2 cycles without PR — assign kernel-sr directly. P2: assign ShellForge squad owner (#1362–#1367). Triage 3 dependabot security alerts (1 high, 2 moderate).",
       "priority": "P0"
     },
     "cloud-squad": {
-      "task": "P1: Upgrade agentguard-cloud to 2.10.3. Add octi-pulpo allow rule to agentguard-cloud/agentguard.yaml (mcp.call:octi-pulpo). Note: analytics version corrected to 2.10.2 (was misread as 2.7.3 — only 1 patch behind, P2).",
+      "task": "P1: Upgrade agentguard-cloud to 2.10.3 (6th cycle behind — 2 patches). Add octi-pulpo allow rule to agentguard-cloud/agentguard.yaml (mcp.call:octi-pulpo).",
       "priority": "P1"
     },
     "kernel-adapters-squad": {
-      "task": "P1: #1430 — hook stdout/stderr bug: allowed decisions must not output to stderr (causes Claude Code to block the action). Fix claude-hook-wrapper.sh: exit 0 with no stderr for allow decisions. Suppress or move (attempt N/3) counter to stdout. ageRuns=1 — PR expected this cycle or director escalation.",
-      "priority": "P1"
-    },
-    "kernel-squad": {
-      "task": "P1: #1427 — Add no-persona-self-modification invariant: block file.write to .agentguard/persona.env from non-human drivers. Also make write-persona.sh idempotent (skip if persona.env already exists). #1432 merged. ageRuns=1 — PR expected this cycle or director escalation.",
-      "priority": "P1"
+      "task": "P1: #1430 — hook stdout/stderr bug: allowed decisions must not output to stderr. Fix apps/cli/src/commands/claude-hook.ts: route allow-path messages to stdout; reserve stderr for deny/violation/errors. ESCALATED to director after ageRuns=2. WIP stash in agent-guard on studio-em branch (claude-hook-wrapper.sh simplification) available for reference.",
+      "priority": "P1",
+      "ageRuns": 2
     },
     "ops": {
-      "task": "#1403: readybench QA swarm non-operational 5+ days — wrong queue routing, bench-devs-platform not found on jared host. Depends on #1402 + box routing fix.",
+      "task": "#1403: readybench QA swarm non-operational 5+ days — wrong queue routing. Depends on #1402 resolution.",
       "priority": "P1"
     }
   },
@@ -47,60 +44,62 @@
       "task": "no-governance-self-modification blocks read-only SQLite analytics queries (#1408)",
       "priority": "P1",
       "resolvedAt": "2026-03-29T20:40:00.000Z",
-      "note": "PR #1418 merged by kernel squad (KE-6). LOCKDOWN risk eliminated."
+      "note": "PR #1418 merged by kernel squad (KE-6)."
     },
     "ke6-no-self-approve": {
       "task": "KE-6: no-self-approve-pr invariant (#909)",
       "priority": "P1",
       "resolvedAt": "2026-03-29T22:40:00.000Z",
-      "note": "PR #1414 merged. Kernel squad KE-6 complete. KE-7 started."
+      "note": "PR #1414 merged. KE-7 started."
     },
     "copilot-event-pipeline-1342": {
       "task": "Copilot event pipeline 0 events — conference demo gap (#1342)",
       "priority": "P1",
       "resolvedAt": "2026-03-30T02:40:00.000Z",
-      "note": "PR #1429 merged (studio-sr). Root cause: Copilot quota exhaustion tripped circuit breaker. Agents fail over to claude-code with wrong driver tag. Issue #1342 closed. Auto-resolves Apr 1 on budget reset."
+      "note": "PR #1429 merged (studio-sr). Root cause: Copilot quota exhaustion tripped circuit breaker. Auto-resolves Apr 1."
     },
     "cross-repo-blast-radius-1425": {
-      "task": "PR #1425 (cross-repo-blast-radius, broken vitest symlink — kernel squad to fix)",
+      "task": "PR #1425 (cross-repo-blast-radius — session-level aggregate file cap)",
       "priority": "P1",
       "resolvedAt": "2026-03-30T00:00:00.000Z",
-      "note": "PR #1425 merged (feat(invariants): cross-repo-blast-radius — session-level aggregate file cap). KE-7 item complete."
-    },
-    "site-em-1421": {
-      "task": "PR #1421 CONFLICTING (site EM — needs rebase)",
-      "priority": "P2",
-      "resolvedAt": "2026-03-30T00:40:00.000Z",
-      "note": "PR #1421 merged: chore(site-em): EM cycle 2026-03-30T00:40Z — stat drift fixed, --tests-count flag added."
+      "note": "PR #1425 merged. KE-7 item complete."
     },
     "analytics-version-drift-severe": {
       "task": "Analytics version drift SEVERE 2.7.3 (cloud squad)",
       "priority": "P1",
       "resolvedAt": "2026-03-30T02:40:00.000Z",
-      "note": "CORRECTION: analytics package.json pin is 2.10.2, not 2.7.3. Prior state misread pnpm store (.pnpm subdirectory contains old cached versions). Only 1 patch behind — downgraded to P2. Cloud squad: only agentguard-cloud upgrade (2.10.1→2.10.3) remains P1."
+      "note": "CORRECTION: analytics package.json pin is 2.10.2, not 2.7.3. Prior state misread pnpm store. Only 1 patch behind — downgraded to P2."
     },
-    "swarm-health-alert-1392": {
-      "task": "Swarm Health Alert — 2026-03-29 (Evening) (#1392)",
-      "priority": "P2",
-      "resolvedAt": "2026-03-30T05:30:00.000Z",
-      "note": "Closed this cycle — superseded by #1431 (midnight alert). All P0/P1 items from evening alert addressed or tracked in active blockers."
+    "persona-env-protection-1427": {
+      "task": "#1427 — persona.env not protected by no-governance-self-modification invariant",
+      "priority": "P1",
+      "resolvedAt": "2026-03-30T09:00:00.000Z",
+      "note": "PR #1436 merged (fix(invariants): protect persona.env from agent identity tampering). 5/5 CI green. KE-8 item 1 of 2 complete."
     }
   },
   "blockers": [
     {
       "issue": 1402,
-      "description": "P0: Worker pool dead on jared box. 7+ cycles, swarm frozen. All 32 PIDs dead. Human must run server/deploy.sh.",
+      "description": "P0: Worker pool dead on jared box. 8+ cycles, swarm frozen. All 32 PIDs dead. Human must run server/deploy.sh.",
       "escalatedTo": "human (jpleva91)",
       "firstSeen": "2026-03-29T19:00:00.000Z",
-      "escalatedAt": "2026-03-30T05:30:00.000Z",
-      "escalationCount": 7
+      "escalatedAt": "2026-03-30T09:00:00.000Z",
+      "escalationCount": 8
     },
     {
       "issue": 1431,
-      "description": "P0: Codex budget exhausted until Apr 3. 25 agents offline. 53.7% failure rate. Director must decide: buy credits OR disable codex agents until Apr 3.",
-      "escalatedTo": "director + human (jpleva91)",
+      "description": "P0: Codex budget exhausted until Apr 3. 25 agents offline. All-driver circuit cascade at midnight: 53.7% failure rate. Also: 3 zombie vitest PIDs + orphaned worktrees need human cleanup.",
+      "escalatedTo": "human + director",
       "firstSeen": "2026-03-30T00:02:00.000Z",
-      "escalatedAt": "2026-03-30T05:30:00.000Z",
+      "escalatedAt": "2026-03-30T09:00:00.000Z",
+      "escalationCount": 3
+    },
+    {
+      "issue": 1430,
+      "description": "P1 dogfood: git commit Bash hook false-blocks allowed decisions on readybench. Hook stderr triggers Claude Code review mode. ageRuns=2 — ESCALATED TO DIRECTOR. WIP stash available (claude-hook-wrapper.sh simplification, studio-em branch).",
+      "escalatedTo": "director (kernel-adapters had 2 cycles, no PR)",
+      "firstSeen": "2026-03-29T23:03:00.000Z",
+      "escalatedAt": "2026-03-30T09:00:00.000Z",
       "escalationCount": 2
     },
     {
@@ -108,20 +107,6 @@
       "description": "P1: readybench QA swarm non-operational 5+ days. All 19 agents skipping. Depends on #1402.",
       "escalatedTo": "ops",
       "firstSeen": "2026-03-25T00:00:00.000Z"
-    },
-    {
-      "issue": 1430,
-      "description": "P1 dogfood: git commit Bash hook false-blocks allowed decisions on readybench. Hook stderr triggers Claude Code review mode.",
-      "escalatedTo": "kernel-adapters-squad",
-      "firstSeen": "2026-03-29T23:03:00.000Z",
-      "escalatedAt": "2026-03-30T02:40:00.000Z"
-    },
-    {
-      "issue": 1427,
-      "description": "P1 dogfood: agents can self-modify .agentguard/persona.env via write-persona.sh re-run. Corrupts driver attribution and audit identity.",
-      "escalatedTo": "kernel-squad",
-      "firstSeen": "2026-03-29T21:16:00.000Z",
-      "escalatedAt": "2026-03-30T02:40:00.000Z"
     },
     {
       "issue": 1335,
@@ -132,11 +117,11 @@
     }
   ],
   "prQueue": {
-    "open": 2,
-    "reviewed": 2,
+    "open": 0,
+    "reviewed": 0,
     "mergeable": 0,
-    "mergedThisCycle": 0,
-    "notes": "PR #1434 (kernel EM 03:00Z) CONFLICTING — commented requesting rebase. PR #1433 (studio EM 05:00Z) CONFLICTING — commented requesting rebase. Note: studio EM confirmed #1342 closed, April 1 dispatch queue ready (7 tasks)."
+    "mergedThisCycle": 2,
+    "notes": "Queue CLEAR. PR #1437 (HQ EM 05:30Z) merged. PR #1434 (kernel EM 03:00Z) rebased to resolve kernel/state.json conflict, then merged. PRs #1436 and #1433 already merged before this cycle."
   },
-  "updatedAt": "2026-03-30T05:30:00.000Z"
+  "updatedAt": "2026-03-30T09:00:00.000Z"
 }


### PR DESCRIPTION
## Summary

- **PR #1437** (HQ EM 05:30Z) merged — 4/4 CI green
- **PR #1434** (kernel EM 03:00Z) rebased onto main (resolved `kernel/state.json` conflict from studio-em squash containing 08:00Z QA data), then merged 4/4 CI green
- **PR queue CLEAR** — 0 open PRs after this cycle (PRs #1436 and #1433 already merged before this cycle started)
- **#1427 RESOLVED** — PR #1436 merged; `no-governance-self-modification` invariant now blocks writes to `persona.env` inside governed sessions
- **#1430 ESCALATED TO DIRECTOR** — kernel-adapters had 2 cycles (ageRuns=2), no PR filed; WIP stash found in agent-guard studio-em branch (`claude-hook-wrapper.sh` simplification) but core fix must target `apps/cli/src/commands/claude-hook.ts`
- **#1402** P0 worker pool: cycle 8 escalation — human action still required (`server/deploy.sh`)
- **#1431** P0 codex budget: cycle 3 escalation — director decision pending (credits vs disable)
- **New findings**: 3 Dependabot security alerts (1 high, 2 moderate) detected; `#1438` confidence-gated HITL + kernel health writer merged to main (Go kernel feature)
- **Cross-repo**: cloud 2.10.1 (P1, 6th cycle, no upgrade PR), analytics 2.10.2 (P2), cloud missing octi-pulpo MCP allow rule

## Health: 🔴 RED

Two P0 blockers still active. #1430 escalated to director. PR queue cleared.

## Actions Required

| Priority | Target | Action |
|----------|--------|--------|
| P0 | human (jpleva91) | `cd ~/agentguard-workspace && server/deploy.sh` (#1402) |
| P0 | director | Decide: codex credits OR disable agents until Apr 3 (#1431) |
| P1 | director | Assign kernel-sr directly to #1430 (hook stderr, ageRuns=2) |
| P1 | cloud squad | Upgrade to 2.10.3, add octi-pulpo MCP rule (6th cycle) |
| P2 | director | Assign ShellForge owner; triage 3 Dependabot alerts |

## Test plan

- [ ] Verify state.json and em-report.json diffs look correct (09:00Z timestamps)
- [ ] Confirm PR #1437 merged, PR #1434 rebased + merged, PRs #1436 and #1433 previously merged
- [ ] Confirm #1427 in resolved section, #1430 escalation noted with ageRuns=2
- [ ] Confirm security alerts documented in em-report

🤖 Generated with [Claude Code](https://claude.com/claude-code)