### PR TITLE
docs: sync invariant count to 26 across all documentation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -51,7 +51,7 @@ packages/
 ├── core/          @red-codes/core — Shared utilities (types, actions, hash, execution-log)
 ├── events/        @red-codes/events — Canonical event model (schema, bus, store)
 ├── policy/        @red-codes/policy — Policy system (composer, evaluator, loaders, pack loader)
-├── invariants/    @red-codes/invariants — Invariant system (24 built-in definitions, checker)
+├── invariants/    @red-codes/invariants — Invariant system (26 built-in definitions, checker)
 ├── invariant-data-protection/ @red-codes/invariant-data-protection — Data protection invariant plugin
 ├── matchers/      @red-codes/matchers — Structured matchers (Aho-Corasick, globs, hash sets)
 ├── kernel/        @red-codes/kernel — Governed action kernel (orchestrate, normalize, decide, escalate)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,7 +229,7 @@ The kernel loop is the core of AgentGuard. Every agent action passes through it:
 1. Agent proposes action (Claude Code tool call → `RawAgentAction`)
 2. AAB normalizes intent (tool → action type, detect git/destructive commands)
 3. Policy evaluator matches rules (deny/allow with scopes, branches, limits)
-4. Invariant checker verifies system state (25 defaults)
+4. Invariant checker verifies system state (26 defaults)
 5. If allowed: execute via adapter (file/shell/git handlers)
 6. Emit lifecycle events: `ACTION_REQUESTED` → `ACTION_ALLOWED/DENIED` → `ACTION_EXECUTED/FAILED`
 7. Sink all events to SQLite for audit trail

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Install in 30 seconds. Your agents can't break what matters.</p>
 
 ---
 
-AI coding agents (Claude Code, Codex CLI, GitHub Copilot CLI, Google Gemini CLI, OpenCode, Goose, and more) run autonomously — writing files, executing commands, pushing code. AgentGuard prevents them from doing catastrophic things: no accidental pushes to main, no credential leaks, no runaway destructive loops. 24 built-in safety checks, zero config required.
+AI coding agents (Claude Code, Codex CLI, GitHub Copilot CLI, Google Gemini CLI, OpenCode, Goose, and more) run autonomously — writing files, executing commands, pushing code. AgentGuard prevents them from doing catastrophic things: no accidental pushes to main, no credential leaks, no runaway destructive loops. 26 built-in safety checks, zero config required.
 
 **For individuals:** stop your AI from wrecking your machine or repo.
 **For teams:** run fleets of agents safely at scale, with audit trails that pass compliance.
@@ -57,7 +57,7 @@ The `claude-init` wizard walks you through setup interactively:
 
   Enable a policy pack?
     ❯ 1) essentials — secrets, force push, protected branches, credentials
-      2) strict — all 24 invariants enforced
+      2) strict — all 26 invariants enforced
       3) none — monitor only, configure later
 ```
 
@@ -117,7 +117,7 @@ Identity consists of a **role** (`developer`, `reviewer`, `ops`, `security`, `ci
 | Capability | Details |
 |------------|---------|
 | **Policy enforcement** | YAML rules with deny / allow / escalate — drop `agentguard.yaml` in your repo |
-| **24 built-in invariants** | Secret exposure, protected branches, blast radius, path traversal, CI/CD config, package script injection, and more |
+| **26 built-in invariants** | Secret exposure, protected branches, blast radius, path traversal, CI/CD config, package script injection, and more |
 | **48 event kinds** | Full lifecycle telemetry: `ActionRequested → ActionAllowed/Denied → ActionExecuted` |
 | **Real-time cloud dashboard** | Telemetry streams to your team dashboard; opt-in, anonymous by default |
 | **Multi-tenant** | Team workspaces, GitHub/Google OAuth, SSO-ready |
@@ -306,7 +306,7 @@ rules:
 
 ## Built-in Invariants
 
-24 safety invariants run on every action evaluation:
+26 safety invariants run on every action evaluation:
 
 | Invariant | Severity | What it blocks |
 |-----------|----------|----------------|
@@ -344,7 +344,7 @@ Agent tool call
 AgentGuard Kernel
   1. Normalize   — map tool call to canonical action type
   2. Evaluate    — match policy rules (deny / allow / escalate)
-  3. Check       — run 24 built-in invariants
+  3. Check       — run 26 built-in invariants
   4. Execute     — run action via adapter (file, shell, git)
   5. Emit        — 48 event kinds → SQLite audit trail + cloud telemetry
 ```
@@ -388,7 +388,7 @@ For teams running agent fleets, governance becomes invisible. Agents get 8% more
 
 **Zero-dependency deployment** — the Go kernel is a single static binary. No `node_modules`, no `pnpm install`, no bootstrap deadlocks. Drop it in a worktree and it works. This is critical for CI/CD and fleet scenarios where agents spin up fresh environments.
 
-The Go kernel includes: action normalization with AST-based shell parsing, policy evaluation, 24 invariants, escalation state machine, blast radius engine, telemetry shipper (stdout/file/HTTP), and a control plane signals API. It ships automatically via `npm install` — a postinstall script downloads the prebuilt binary for your platform.
+The Go kernel includes: action normalization with AST-based shell parsing, policy evaluation, 26 invariants, escalation state machine, blast radius engine, telemetry shipper (stdout/file/HTTP), and a control plane signals API. It ships automatically via `npm install` — a postinstall script downloads the prebuilt binary for your platform.
 
 ## For Teams and Enterprise
 
@@ -489,7 +489,7 @@ extends:
 | `engineering-standards` | Balanced dev-friendly guardrails: test-before-push, format checks, safe deps |
 | `ci-safe` | Strict CI/CD pipeline protection |
 | `enterprise` | Full enterprise governance |
-| `strict` | Maximum restriction — all 24 invariants enforced |
+| `strict` | Maximum restriction — all 26 invariants enforced |
 | `open-source` | OSS contribution-friendly defaults |
 
 ## Community & Updates

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,7 +27,7 @@ AgentGuard is the **Execution Control Plane for autonomous AI agents** — the i
 | Governed action kernel (41 action types, 10 classes) | Implemented | Production |
 | Action Authorization Boundary (AAB) | Implemented | Bypass vectors closed (3 fixed in v2.4.0) |
 | Policy evaluator (YAML/JSON, composition, packs) | Implemented | Production |
-| 24 built-in invariants | Implemented | Production |
+| 26 built-in invariants | Implemented | Production |
 | Canonical event model (48 event kinds) | Implemented | Production |
 | Pre-execution simulation engine (3 simulators) | Implemented | Production |
 | Blast radius computation | Implemented | Production |

--- a/docs/agentguard.md
+++ b/docs/agentguard.md
@@ -47,7 +47,7 @@ action    emit PolicyDenied
 
 ### Invariant Monitoring
 
-Invariants are conditions that must always hold true. AgentGuard monitors these continuously, not just at action boundaries. There are 24 built-in invariants covering secrets exposure, force push, protected branches, package script injection, blast radius, test-before-push, lockfile integrity, CI/CD config modification, permission escalation, governance self-modification, container config modification, environment variable modification, network egress, destructive migrations, transitive effect analysis, IDE socket access, commit scope, script execution tracking, no-verify bypass, and more.
+Invariants are conditions that must always hold true. AgentGuard monitors these continuously, not just at action boundaries. There are 26 built-in invariants covering secrets exposure, force push, protected branches, package script injection, blast radius, test-before-push, lockfile integrity, CI/CD config modification, permission escalation, governance self-modification, container config modification, environment variable modification, network egress, destructive migrations, transitive effect analysis, IDE socket access, commit scope, script execution tracking, no-verify bypass, no-self-approve-pr, cross-repo-blast-radius, and more.
 
 **Example invariants:**
 - No secrets or credentials in committed files (`no-secret-exposure`)
@@ -209,7 +209,7 @@ AgentGuard is **implemented and operational**. The governed action kernel connec
 | Component | File | Status |
 |-----------|------|--------|
 | Invariant checker | `packages/invariants/src/checker.ts` | Complete |
-| 24 built-in invariants | `packages/invariants/src/definitions.ts` | Complete |
+| 26 built-in invariants | `packages/invariants/src/definitions.ts` | Complete |
 | Evidence pack generation | `agentguard/evidence/pack.ts` | Complete |
 
 ### Execution Adapters
@@ -282,7 +282,7 @@ packages/
 │   └── yaml-loader.ts         # YAML policy loader
 ├── invariants/src/
 │   ├── checker.ts             # Invariant evaluation engine
-│   └── definitions.ts         # 24 built-in invariants
+│   └── definitions.ts         # 26 built-in invariants
 ├── adapters/src/
 │   ├── file.ts                # File operations (fs)
 │   ├── shell.ts               # Shell execution (child_process)

--- a/docs/autonomous-sdlc-architecture.md
+++ b/docs/autonomous-sdlc-architecture.md
@@ -728,7 +728,7 @@ CI
 |-----------|--------|----------|
 | Action type normalization (AAB) | Exists | `src/kernel/aab.ts` |
 | Policy evaluation | Exists | `src/policy/evaluator.ts` |
-| 24 invariant checks | Exists | `packages/invariants/src/definitions.ts` |
+| 26 invariant checks | Exists | `packages/invariants/src/definitions.ts` |
 | Escalation monitor (4 levels) | Exists | `src/kernel/monitor.ts` |
 | JSONL event persistence | Exists | `src/events/jsonl.ts` |
 | GovernanceDecisionRecord | Exists | `src/kernel/decisions/` |

--- a/docs/autonomous-sdlc-methodology.md
+++ b/docs/autonomous-sdlc-methodology.md
@@ -7,7 +7,7 @@ AgentGuard — a 70,000-line, 20-package governed action runtime — was built i
 **Key metrics:**
 - 33,668 lines of production TypeScript, 39,160 lines of tests
 - 20 workspace packages, 3 applications (CLI, VS Code extension, telemetry server)
-- 142 test files, 24 invariants, 47 event kinds, 41 action types
+- 142 test files, 26 invariants, 47 event kinds, 41 action types
 - Equivalent to 240 story points / 6-8 months of traditional senior engineering
 - Delivered in <2 weeks by one person with an autonomous agent swarm
 

--- a/docs/hook-architecture.md
+++ b/docs/hook-architecture.md
@@ -119,7 +119,7 @@ AAB normalization (Bash → shell.exec or git.push, Write → file.write, etc.)
   ↓
 Policy evaluation (match rules from agentguard.yaml)
   ↓
-Invariant checks (24 built-in safety checks)
+Invariant checks (26 built-in safety checks)
   ↓
 Decision: ALLOW or DENY
   ↓

--- a/docs/owasp-agentic-top10-coverage.md
+++ b/docs/owasp-agentic-top10-coverage.md
@@ -1,6 +1,6 @@
 # OWASP Agentic Top 10 Coverage — AgentGuard
 
-> Audit date: 2026-03-25 | AgentGuard kernel: 24 invariants, 41 action types, 95+ command patterns
+> Audit date: 2026-03-25 | AgentGuard kernel: 26 invariants, 41 action types, 95+ command patterns
 
 ## Coverage Summary
 
@@ -220,7 +220,7 @@
 |----------|-----------|------------------------|
 | Prompt Injection | Moderate (detect + block destructive) | Claimed 10/10 |
 | Insecure Tool Impl | Strong (typed actions, adapters) | Claimed 10/10 |
-| Excessive Agency | Strong (24 invariants, escalation) | Claimed 10/10 |
+| Excessive Agency | Strong (26 invariants, escalation) | Claimed 10/10 |
 | Insecure Output | Weak (PII/secret detection only) | Claimed 10/10 |
 | Inadequate Sandboxing | Minimal (no OS isolation) | Claimed 10/10 |
 | Implicit Trust | Strong (crypto trust chain) | Claimed 10/10 |

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -258,7 +258,7 @@ rules:
 
 ### 3. Invariant Plugins
 
-Invariant plugins add custom safety checks evaluated before every action. AgentGuard ships 24 built-in invariants; plugins extend this with domain-specific checks.
+Invariant plugins add custom safety checks evaluated before every action. AgentGuard ships 26 built-in invariants; plugins extend this with domain-specific checks.
 
 **Integration point:** `packages/invariants/src/` — implement the `AgentGuardInvariant` interface.
 

--- a/docs/roadmap-overview.md
+++ b/docs/roadmap-overview.md
@@ -25,7 +25,7 @@ AgentGuard is the **mandatory execution control plane for AI agents** — the ru
 | Governed action kernel (41 action types, 10 classes) | Implemented | Production |
 | Action Authorization Boundary (AAB) | Implemented | Bypass vectors closed (3 fixed in v2.4.0) |
 | Policy evaluator (YAML/JSON, composition, packs) | Implemented | Production |
-| 24 built-in invariants | Implemented | Production |
+| 26 built-in invariants | Implemented | Production |
 | Canonical event model (47 event kinds) | Implemented | Production |
 | Pre-execution simulation engine (3 simulators) | Implemented | Production |
 | Blast radius computation | Implemented | Production |

--- a/docs/unified-architecture.md
+++ b/docs/unified-architecture.md
@@ -36,7 +36,7 @@ The system has one architectural spine: the **canonical event model**. All syste
          │  1. ACTION_REQUESTED event                          │
          │  2. AAB normalizes intent                           │
          │  3. Policy evaluation (match → allow/deny)          │
-         │  4. Invariant checking (6 default invariants)       │
+         │  4. Invariant checking (26 default invariants)      │
          │  5. Evidence pack generation                        │
          │  6. If allowed: execute via adapter                 │
          │  7. ACTION_ALLOWED/DENIED + ACTION_EXECUTED/FAILED  │
@@ -79,7 +79,7 @@ Agent proposes action (RawAgentAction)
     │
     ▼ Engine.evaluate() → EngineDecision
     │   ├── Policy evaluator: match rules, check deny/allow
-    │   ├── Invariant checker: 6 defaults + custom invariants
+    │   ├── Invariant checker: 26 defaults + custom invariants
     │   └── Evidence pack: structured audit record
     │
     ▼ Monitor.process() → MonitorDecision


### PR DESCRIPTION
## What drifted

The invariant count drifted across 12 documentation files. The source of truth (`packages/invariants/src/definitions.ts`) contains **26 named invariants**, but docs referenced three different stale values:

| Stale count | Files |
|-------------|-------|
| **6** | `docs/unified-architecture.md` (early architectural sketch, never updated) |
| **24** | README.md, ARCHITECTURE.md, ROADMAP.md, and 7 docs/*.md files |
| **25** | CLAUDE.md (single occurrence in kernel loop description) |

The two invariants added since the last doc update:
- `No Self-Approve PR` — agents cannot approve their own pull requests
- `Cross-Repo Blast Radius` — limits destructive reach across repository boundaries

## Files changed

- `README.md` — 7 occurrences (marketing copy, feature table, invariant list, CLI reference, Go kernel description, pack table)
- `CLAUDE.md` — 1 occurrence (kernel loop step 4)
- `ARCHITECTURE.md` — 1 occurrence (package description)
- `ROADMAP.md` — 1 occurrence (feature status table)
- `docs/agentguard.md` — 3 occurrences
- `docs/autonomous-sdlc-architecture.md` — 1 occurrence
- `docs/autonomous-sdlc-methodology.md` — 1 occurrence
- `docs/hook-architecture.md` — 1 occurrence
- `docs/owasp-agentic-top10-coverage.md` — 2 occurrences
- `docs/plugin-api.md` — 1 occurrence
- `docs/roadmap-overview.md` — 1 occurrence
- `docs/unified-architecture.md` — 2 occurrences

## Verification

Count verified against source: `grep -c "name:.*'" packages/invariants/src/definitions.ts` → **26**

No source code, tests, or CI/CD modified — documentation only.

---
*Created by copilot-docs-sync — AgentGuard Copilot swarm*