### PR TITLE
docs: sync documentation with codebase state (26 invariants, 43 action types)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -51,7 +51,7 @@ packages/
 ├── core/          @red-codes/core — Shared utilities (types, actions, hash, execution-log)
 ├── events/        @red-codes/events — Canonical event model (schema, bus, store)
 ├── policy/        @red-codes/policy — Policy system (composer, evaluator, loaders, pack loader)
-├── invariants/    @red-codes/invariants — Invariant system (24 built-in definitions, checker)
+├── invariants/    @red-codes/invariants — Invariant system (26 built-in definitions, checker)
 ├── invariant-data-protection/ @red-codes/invariant-data-protection — Data protection invariant plugin
 ├── matchers/      @red-codes/matchers — Structured matchers (Aho-Corasick, globs, hash sets)
 ├── kernel/        @red-codes/kernel — Governed action kernel (orchestrate, normalize, decide, escalate)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,9 +43,9 @@ This is a **pnpm monorepo** orchestrated by **Turbo**. Workspace packages live i
 packages/
 ├── core/src/                   # @red-codes/core — Shared utilities
 │   ├── types.ts                # Shared TypeScript type definitions (includes RunManifest)
-│   ├── actions.ts              # 41 canonical action types across 10 classes
+│   ├── actions.ts              # 43 canonical action types across 10 classes
 │   ├── governance-data.ts      # Governance data loader (typed access to shared JSON data)
-│   ├── data/                   # JSON governance data (actions, blast-radius, destructive-patterns, escalation, git-action-patterns, invariant-patterns, tool-action-map)
+│   ├── data/                   # JSON governance data (actions, blast-radius, destructive-patterns, escalation, git-action-patterns, github-action-patterns, invariant-patterns, tool-action-map)
 │   ├── hash.ts                 # Content hashing utilities
 │   ├── crypto-hash.ts          # Cryptographic hashing (SHA-256)
 │   ├── rtk.ts                  # RTK token optimization integration
@@ -110,7 +110,9 @@ packages/
 │   ├── registry.ts             # Adapter registry (action class → handler)
 │   ├── file.ts, shell.ts, git.ts  # Action handlers
 │   ├── claude-code.ts          # Claude Code hook adapter
+│   ├── codex-cli.ts            # Codex CLI hook adapter
 │   ├── copilot-cli.ts          # Copilot CLI hook adapter
+│   ├── gemini-cli.ts           # Gemini CLI hook adapter
 │   └── hook-integrity.ts       # Hook integrity verification
 ├── plugins/src/                # @red-codes/plugins — Plugin ecosystem
 │   ├── discovery.ts            # Plugin discovery mechanism
@@ -229,7 +231,7 @@ The kernel loop is the core of AgentGuard. Every agent action passes through it:
 1. Agent proposes action (Claude Code tool call → `RawAgentAction`)
 2. AAB normalizes intent (tool → action type, detect git/destructive commands)
 3. Policy evaluator matches rules (deny/allow with scopes, branches, limits)
-4. Invariant checker verifies system state (25 defaults)
+4. Invariant checker verifies system state (26 defaults)
 5. If allowed: execute via adapter (file/shell/git handlers)
 6. Emit lifecycle events: `ACTION_REQUESTED` → `ACTION_ALLOWED/DENIED` → `ACTION_EXECUTED/FAILED`
 7. Sink all events to SQLite for audit trail
@@ -320,9 +322,10 @@ The canonical event model is the architectural spine. Event kinds defined in `pa
 - **Intent Drift**: `IntentDriftDetected`
 - **Capability Validation**: `CapabilityValidated`
 - **Environmental Enforcement**: `IdeSocketAccessBlocked`
+- **Command Audit**: `UnknownCommandWarn`
 
 ### Action Classes & Types
-41 canonical action types across 10 classes, defined in `packages/core/src/actions.ts`:
+43 canonical action types across 10 classes, defined in `packages/core/src/actions.ts`:
 - **file**: `file.read`, `file.write`, `file.delete`, `file.move`
 - **test**: `test.run`, `test.run.unit`, `test.run.integration`
 - **git**: `git.diff`, `git.commit`, `git.push`, `git.force-push`, `git.branch.create`, `git.branch.delete`, `git.checkout`, `git.reset`, `git.merge`, `git.worktree.add`, `git.worktree.remove`, `git.worktree.list`
@@ -331,7 +334,7 @@ The canonical event model is the architectural spine. Event kinds defined in `pa
 - **http**: `http.request`
 - **deploy**: `deploy.trigger`
 - **infra**: `infra.apply`, `infra.destroy`
-- **github**: `github.pr.list`, `github.pr.create`, `github.pr.merge`, `github.pr.close`, `github.pr.view`, `github.pr.checks`, `github.issue.list`, `github.issue.create`, `github.issue.close`, `github.release.create`, `github.run.list`, `github.run.view`, `github.api`
+- **github**: `github.pr.list`, `github.pr.create`, `github.pr.merge`, `github.pr.close`, `github.pr.view`, `github.pr.checks`, `github.pr.approve`, `github.pr.review`, `github.issue.list`, `github.issue.create`, `github.issue.close`, `github.release.create`, `github.run.list`, `github.run.view`, `github.api`
 - **mcp**: `mcp.call`
 
 ### Build & Module System

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Install in 30 seconds. Your agents can't break what matters.</p>
 
 ---
 
-AI coding agents (Claude Code, Codex CLI, GitHub Copilot CLI, Google Gemini CLI, OpenCode, Goose, and more) run autonomously — writing files, executing commands, pushing code. AgentGuard prevents them from doing catastrophic things: no accidental pushes to main, no credential leaks, no runaway destructive loops. 24 built-in safety checks, zero config required.
+AI coding agents (Claude Code, Codex CLI, GitHub Copilot CLI, Google Gemini CLI, OpenCode, Goose, and more) run autonomously — writing files, executing commands, pushing code. AgentGuard prevents them from doing catastrophic things: no accidental pushes to main, no credential leaks, no runaway destructive loops. 26 built-in safety checks, zero config required.
 
 **For individuals:** stop your AI from wrecking your machine or repo.
 **For teams:** run fleets of agents safely at scale, with audit trails that pass compliance.
@@ -57,7 +57,7 @@ The `claude-init` wizard walks you through setup interactively:
 
   Enable a policy pack?
     ❯ 1) essentials — secrets, force push, protected branches, credentials
-      2) strict — all 24 invariants enforced
+      2) strict — all 26 invariants enforced
       3) none — monitor only, configure later
 ```
 
@@ -117,7 +117,7 @@ Identity consists of a **role** (`developer`, `reviewer`, `ops`, `security`, `ci
 | Capability | Details |
 |------------|---------|
 | **Policy enforcement** | YAML rules with deny / allow / escalate — drop `agentguard.yaml` in your repo |
-| **24 built-in invariants** | Secret exposure, protected branches, blast radius, path traversal, CI/CD config, package script injection, and more |
+| **26 built-in invariants** | Secret exposure, protected branches, blast radius, path traversal, CI/CD config, package script injection, and more |
 | **48 event kinds** | Full lifecycle telemetry: `ActionRequested → ActionAllowed/Denied → ActionExecuted` |
 | **Real-time cloud dashboard** | Telemetry streams to your team dashboard; opt-in, anonymous by default |
 | **Multi-tenant** | Team workspaces, GitHub/Google OAuth, SSO-ready |
@@ -289,7 +289,7 @@ rules:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `action` | `string \| string[]` | Action type(s): `file.read`, `git.push`, `shell.exec`, `mcp.call`, etc. (41 types across 10 classes) |
+| `action` | `string \| string[]` | Action type(s): `file.read`, `git.push`, `shell.exec`, `mcp.call`, etc. (43 types across 10 classes) |
 | `effect` | `string` | `deny` or `allow` |
 | `target` | `string` | Glob pattern for file paths or command patterns |
 | `branches` | `string[]` | Git branch names this rule applies to |
@@ -306,7 +306,7 @@ rules:
 
 ## Built-in Invariants
 
-24 safety invariants run on every action evaluation:
+26 safety invariants run on every action evaluation:
 
 | Invariant | Severity | What it blocks |
 |-----------|----------|----------------|
@@ -334,6 +334,8 @@ rules:
 | `recursive-operation-guard` | Low | `find -exec`, `xargs` with write/delete |
 | `lockfile-integrity` | Low | `package.json` changes without lockfile sync |
 | `no-verify-bypass` | High | `git push/commit --no-verify` — prevents skipping pre-push/pre-commit hooks |
+| `no-self-approve-pr` | Critical | Agents merging or approving PRs they authored — enforces separation of duties in multi-agent swarms |
+| `cross-repo-blast-radius` | High | Caps cumulative unique files written across all repos in a session (default: 50 files) |
 
 ## Architecture
 
@@ -344,7 +346,7 @@ Agent tool call
 AgentGuard Kernel
   1. Normalize   — map tool call to canonical action type
   2. Evaluate    — match policy rules (deny / allow / escalate)
-  3. Check       — run 24 built-in invariants
+  3. Check       — run 26 built-in invariants
   4. Execute     — run action via adapter (file, shell, git)
   5. Emit        — 48 event kinds → SQLite audit trail + cloud telemetry
 ```
@@ -388,7 +390,7 @@ For teams running agent fleets, governance becomes invisible. Agents get 8% more
 
 **Zero-dependency deployment** — the Go kernel is a single static binary. No `node_modules`, no `pnpm install`, no bootstrap deadlocks. Drop it in a worktree and it works. This is critical for CI/CD and fleet scenarios where agents spin up fresh environments.
 
-The Go kernel includes: action normalization with AST-based shell parsing, policy evaluation, 24 invariants, escalation state machine, blast radius engine, telemetry shipper (stdout/file/HTTP), and a control plane signals API. It ships automatically via `npm install` — a postinstall script downloads the prebuilt binary for your platform.
+The Go kernel includes: action normalization with AST-based shell parsing, policy evaluation, 26 invariants, escalation state machine, blast radius engine, telemetry shipper (stdout/file/HTTP), and a control plane signals API. It ships automatically via `npm install` — a postinstall script downloads the prebuilt binary for your platform.
 
 ## For Teams and Enterprise
 
@@ -489,7 +491,7 @@ extends:
 | `engineering-standards` | Balanced dev-friendly guardrails: test-before-push, format checks, safe deps |
 | `ci-safe` | Strict CI/CD pipeline protection |
 | `enterprise` | Full enterprise governance |
-| `strict` | Maximum restriction — all 24 invariants enforced |
+| `strict` | Maximum restriction — all 26 invariants enforced |
 | `open-source` | OSS contribution-friendly defaults |
 
 ## Community & Updates

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,10 +24,10 @@ AgentGuard is the **Execution Control Plane for autonomous AI agents** — the i
 
 | Component | Status | Maturity |
 |-----------|--------|----------|
-| Governed action kernel (41 action types, 10 classes) | Implemented | Production |
+| Governed action kernel (43 action types, 10 classes) | Implemented | Production |
 | Action Authorization Boundary (AAB) | Implemented | Bypass vectors closed (3 fixed in v2.4.0) |
 | Policy evaluator (YAML/JSON, composition, packs) | Implemented | Production |
-| 24 built-in invariants | Implemented | Production |
+| 26 built-in invariants | Implemented | Production |
 | Canonical event model (48 event kinds) | Implemented | Production |
 | Pre-execution simulation engine (3 simulators) | Implemented | Production |
 | Blast radius computation | Implemented | Production |


### PR DESCRIPTION
## Summary

Automated documentation sync detected drift between the codebase and docs.

- **Invariant count drift**: All docs referenced 24 invariants but codebase has **26** (`no-self-approve-pr` and `cross-repo-blast-radius` were added but never reflected in README/ARCHITECTURE/ROADMAP/CLAUDE.md)
- **Action type count drift**: Docs said 41 types but codebase has **43** (`github.pr.approve` and `github.pr.review` added in actions.json)
- **README invariant table**: Missing 2 rows for the new invariants
- **Event kind drift**: `UnknownCommandWarn` (48th event kind) missing from CLAUDE.md event model listing
- **Adapter tree drift**: `codex-cli.ts` and `gemini-cli.ts` missing from CLAUDE.md project structure tree (they ARE listed in Package Layout text — tree was inconsistent)
- **Data dir drift**: `github-action-patterns.json` missing from CLAUDE.md data directory file listing
- **Kernel step count drift**: CLAUDE.md kernel loop step 4 said "25 defaults" → 26

## Changes

- `README.md` — 24→26 invariants (×5 occurrences), 41→43 action types (×1), added `no-self-approve-pr` and `cross-repo-blast-radius` rows to invariant table
- `ARCHITECTURE.md` — 24→26 built-in definitions
- `ROADMAP.md` — 41→43 action types in current state table; 24→26 invariants in current state table
- `CLAUDE.md` — 41→43 action types (×2); added `UnknownCommandWarn` event kind; added `codex-cli.ts` and `gemini-cli.ts` to adapters tree; added `github-action-patterns` to data dir listing; added `github.pr.approve` and `github.pr.review` to github action types list; 25→26 kernel defaults

## Document Contradictions Flagged

1. **ROADMAP.md line 68** claims `deepagents.ts` adapter was "Shipped v2.8.1" but `packages/adapters/src/` does not contain `deepagents.ts` and `apps/cli/src/commands/` has no `deepagents-hook.ts` or `deepagents-init.ts`. This may be a reverted feature or cloud-only component — not corrected here (requires human judgment).

2. **ROADMAP.md line 46** references "46 event kinds mapped" as a historical v2.3.0 ship note, while the current count is 48. This is a historical record and has been left as-is.

## Source

Auto-generated by the **Scheduled Docs Sync** skill (`documentation-maintainer-agent`, identity: `claude-code:opus:ops`).

---
*Run: 2026-03-30T06:05:01Z*