### PR TITLE
feat: user capture funnel — early-access CTA, cloud signup nudge, telemetry guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ AI coding agents (Claude Code, Codex CLI, GitHub Copilot CLI, Google Gemini CLI,
 > Every deny, every escalation, every code review — visible in real time.
 > **[Watch the live swarm &rarr;](https://agentguard-cloud-office-sim.vercel.app)**
 
+## Early Access
+
+**Get notified about v3.0, security updates, and team features:**
+
+> **[Join early access →](https://agentguard-cloud-dashboard.vercel.app/onboarding)** — Cloud waitlist, v3.0 announcements
+> **[GitHub Discussions →](https://github.com/AgentGuardHQ/agentguard/discussions)** — ask questions, share your setup
+
 ## Get Started
 
 ```bash

--- a/apps/cli/src/commands/claude-init.ts
+++ b/apps/cli/src/commands/claude-init.ts
@@ -991,11 +991,15 @@ function showProtectionSummary(
     );
   }
   process.stderr.write(`\n  ${DIM}ℹ Claude Desktop support coming soon.${RESET}\n`);
-  process.stderr.write(`\n  ${BOLD}☁  Get team governance & telemetry:${RESET}\n`);
-  process.stderr.write(
-    `  ${FG.cyan}https://agentguard-cloud-dashboard.vercel.app/onboarding${RESET}\n`
-  );
-  process.stderr.write(`  ${DIM}  or run: agentguard cloud signup${RESET}\n`);
+  if (process.env.AGENTGUARD_TELEMETRY !== 'off') {
+    process.stderr.write(`\n  ${BOLD}☁  Get team governance & telemetry:${RESET}\n`);
+    process.stderr.write(
+      `  ${FG.cyan}https://agentguard-cloud-dashboard.vercel.app/onboarding${RESET}\n`
+    );
+    process.stderr.write(`  ${DIM}  or run: agentguard cloud signup${RESET}\n\n`);
+    process.stderr.write(`  ${DIM}Get notified about v3.0 and security updates:${RESET}\n`);
+    process.stderr.write(`  ${FG.cyan}→ https://agentguard.dev/early-access${RESET}\n`);
+  }
   process.stderr.write('\n');
 }
 

--- a/apps/cli/src/commands/guard.ts
+++ b/apps/cli/src/commands/guard.ts
@@ -155,6 +155,12 @@ export async function guard(_args: string[], options: GuardOptions = {}): Promis
         '\n  \x1b[2mAgentGuard sends anonymous usage data to help improve the product.\n' +
           '  Run `agentguard telemetry off` to disable.\x1b[0m\n\n'
       );
+      // First-run capture nudge — suppressed when telemetry is disabled
+      if (telemetryMode !== 'off') {
+        process.stderr.write(
+          '\x1b[2m  → Connect to governance dashboard: agentguard cloud signup\x1b[0m\n\n'
+        );
+      }
       const { saveIdentity: save, generateIdentity: gen } =
         await import('@red-codes/telemetry-client');
       const updated = identity ?? gen('anonymous');


### PR DESCRIPTION
Closes #1307

## Implementation Summary

**What changed:**
- **README.md**: Added prominent "Early Access" section with CTA links before the `## Get Started` installation block, so users who bounce early still see the join link
- **`claude-init.ts`**: Wrapped the Cloud signup block in `showProtectionSummary` with a `AGENTGUARD_TELEMETRY !== 'off'` guard; added `https://agentguard.dev/early-access` URL for v3.0 notifications
- **`guard.ts`**: Added a one-time first-run capture nudge (`→ Connect to governance dashboard: agentguard cloud signup`) inside the existing `!identity.noticed` block, suppressed when `telemetryMode === 'off'`; persisted via the same `noticed` flag already used for the telemetry notice

**How to verify:**
1. `npm install -g @red-codes/agentguard && agentguard claude-init` — success output should show the early-access URL and cloud signup line (unless `AGENTGUARD_TELEMETRY=off`)
2. `AGENTGUARD_TELEMETRY=off agentguard claude-init` — cloud/early-access block should be absent
3. Delete `~/.agentguard/identity.json`, then `agentguard guard --dry-run` — first run shows `→ Connect to governance dashboard: agentguard cloud signup`
4. Run again — nudge does not repeat
5. Check README.md — "Early Access" section appears before the `npm install` block

**Out of scope (not addressed):**
- GitHub Discussions repo setting (requires repo admin, not a code change)

**Tier C scope check:**
- Files changed: 3 (limit: 5)
- Lines changed: ~22 (limit: 300)
- Breaking changes: None

---
*Tier C implementation by copilot-cli — AgentGuard three-tier governance*