### PR TITLE
fix(deps): patch path-to-regexp and brace-expansion Dependabot alerts (#1449)

### DIFF
--- a/.agentguard/squads/kernel/state.json
+++ b/.agentguard/squads/kernel/state.json
@@ -9,7 +9,7 @@
     "senior": {
       "issue": 1449,
       "title": "chore: triage Dependabot security alerts (path-to-regexp x2, brace-expansion)",
-      "status": "unassigned",
+      "status": "implementing",
       "note": "P2 security. path-to-regexp ReDoS HIGH (transitive via commander/express). brace-expansion DoS MEDIUM. Update transitive deps. Check if pnpm overrides or direct dep upgrades are needed."
     },
     "secondary": {
@@ -72,5 +72,5 @@
   ],
   "lastEmRun": "2026-03-30T12:10:00Z",
   "lastQaRun": "2026-03-30T18:52:00.000Z",
-  "updatedAt": "2026-03-30T18:52:00.000Z"
+  "updatedAt": "2026-03-30T21:10:00.000Z"
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,9 @@
   },
   "pnpm": {
     "overrides": {
-      "flatted": ">=3.4.1"
+      "flatted": ">=3.4.1",
+      "path-to-regexp": ">=8.4.0",
+      "brace-expansion": ">=5.0.5"
     }
   },
   "author": "jpleva91",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,8 @@ settings:
 
 overrides:
   flatted: '>=3.4.1'
+  path-to-regexp: '>=8.4.0'
+  brace-expansion: '>=5.0.5'
 
 importers:
 
@@ -923,8 +925,8 @@ packages:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
 
-  brace-expansion@5.0.4:
-    resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
 
   buffer@5.7.1:
@@ -1508,8 +1510,8 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
-  path-to-regexp@8.3.0:
-    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
+  path-to-regexp@8.4.0:
+    resolution: {integrity: sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -2424,7 +2426,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@5.0.4:
+  brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.4
 
@@ -2918,7 +2920,7 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.4
+      brace-expansion: 5.0.5
 
   minimist@1.2.8: {}
 
@@ -2977,7 +2979,7 @@ snapshots:
 
   path-key@3.1.1: {}
 
-  path-to-regexp@8.3.0: {}
+  path-to-regexp@8.4.0: {}
 
   pathe@2.0.3: {}
 
@@ -3111,7 +3113,7 @@ snapshots:
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
-      path-to-regexp: 8.3.0
+      path-to-regexp: 8.4.0
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
## Summary

- Closes #1449
- Adds `pnpm.overrides` for `path-to-regexp >=8.4.0` and `brace-expansion >=5.0.5` in root `package.json`, following the existing pattern used for `flatted`
- `pnpm audit` now reports **0 vulnerabilities**

## Vulnerabilities Resolved

| Advisory | Package | Severity | Was | Fixed at |
|----------|---------|----------|-----|---------|
| GHSA-27v5-c462-wpq7 | path-to-regexp | HIGH | 8.3.0 | ≥8.4.0 |
| GHSA-j3q9-mxjg-w52f | path-to-regexp | HIGH | 8.3.0 | ≥8.4.0 |
| GHSA-f886-m6hf-6m8v | brace-expansion | MEDIUM | 5.0.4 | ≥5.0.5 |

Both packages are **transitive only**:
- `path-to-regexp` pulled in by `router@2.2.0` (used by express)
- `brace-expansion` pulled in by `minimatch@10.2.4`

Neither has a direct entry in any workspace `package.json`, so `pnpm.overrides` is the correct fix (same mechanism already used for `flatted`).

## Test plan

- [x] `pnpm audit` → 0 vulnerabilities
- [x] `pnpm build` → 18/18 tasks passing
- [x] `pnpm test` → 4693/4693 passing, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)