### PR TITLE
fix(invariants): exempt read-only commands from script-execution-tracking

### DIFF
--- a/packages/invariants/src/definitions.ts
+++ b/packages/invariants/src/definitions.ts
@@ -274,6 +274,7 @@ const READ_ONLY_CMDS: string[] = [
   'cat',
   'head',
   'tail',
+  'less',
   'find',
   'grep',
   'rg',
@@ -1834,6 +1835,16 @@ export const DEFAULT_INVARIANTS: AgentGuardInvariant[] = [
           holds: true,
           expected: 'Shell commands must not execute session-written scripts',
           actual: 'No command available',
+        };
+      }
+
+      // Read-only commands (cat, grep, head, tail, etc.) cannot execute scripts — skip
+      const baseCmd = extractBaseCommand(command);
+      if (READ_ONLY_CMDS.includes(baseCmd) && !hasFileRedirect(command)) {
+        return {
+          holds: true,
+          expected: 'Shell commands must not execute session-written scripts',
+          actual: 'Read-only shell command cannot execute scripts',
         };
       }
 

--- a/packages/invariants/tests/transitive-effect-analysis.test.ts
+++ b/packages/invariants/tests/transitive-effect-analysis.test.ts
@@ -711,4 +711,36 @@ describe('script-execution-tracking', () => {
     expect(result.holds).toBe(false);
     expect(result.actual).toContain('exploit.cjs');
   });
+
+  it('holds for cat on a session-written .py file — read-only, not execution (#1475)', () => {
+    const result = inv.check({
+      currentActionType: 'shell.exec',
+      currentCommand: 'cat /path/to/config.py',
+      sessionWrittenFiles: ['config.py'],
+    });
+    expect(result.holds).toBe(true);
+    expect(result.actual).toContain('Read-only shell command');
+  });
+
+  it('holds for head/tail/wc on session-written scripts — read-only (#1475)', () => {
+    for (const cmd of ['head', 'tail', 'wc', 'less', 'grep']) {
+      const result = inv.check({
+        currentActionType: 'shell.exec',
+        currentCommand: `${cmd} exploit.py`,
+        sessionWrittenFiles: ['exploit.py'],
+      });
+      expect(result.holds).toBe(true);
+    }
+  });
+
+  it('does not exempt cat when it has a file redirect (#1475)', () => {
+    const result = inv.check({
+      currentActionType: 'shell.exec',
+      currentCommand: 'cat exploit.py > /tmp/out.sh',
+      sessionWrittenFiles: ['exploit.py'],
+    });
+    // cat + output redirect is not read-only — hasFileRedirect returns true,
+    // so the exemption is skipped and the invariant still fires.
+    expect(result.holds).toBe(false);
+  });
 });


### PR DESCRIPTION
Closes #1475

## Implementation Summary

**What changed:**
- Added `READ_ONLY_CMDS` early-return guard to the `script-execution-tracking` invariant — the same pattern already used in all other write-guard invariants (5 locations). Commands like `cat`, `grep`, `head`, `tail`, `wc`, `less` cannot execute scripts, so they should be exempt.
- Added `less` to `READ_ONLY_CMDS` (it was missing; `less` is a read-only pager with no write capability).
- Added 3 regression tests: `cat` on session-written `.py` file, loop over `head/tail/wc/less/grep`, and verification that `cat` + file redirect still triggers the invariant.

**Root cause:** The `script-execution-tracking` invariant at line 1808 was the only write-guard invariant missing the standard `extractBaseCommand` → `READ_ONLY_CMDS.includes` → early return pattern. It would match any command containing the basename of a session-written script file, regardless of whether the command was actually executing it.

**How to verify:**
1. `pnpm test --filter=@red-codes/invariants` — 636 tests pass
2. Manually: set `sessionWrittenFiles: ['config.py']`, check `cat /path/to/config.py` → `holds: true`

**Tier C scope check:**
- Files changed: 2 (limit: 5)
- Lines changed: ~43 (limit: 300)
- Breaking changes: None (false positive fix — more permissive for read-only commands)

---
*Tier C implementation by copilot-cli — AgentGuard three-tier governance*