### PR TITLE
docs: add MCP Governance Gateway documentation

### DIFF
--- a/.agentguard/director-report.json
+++ b/.agentguard/director-report.json
@@ -1,148 +1,270 @@
 {
-  "runAt": "2026-03-28T21:00:00.000Z",
+  "runAt": "2026-03-30T22:30:00.000Z",
   "runType": "evening",
-  "overallHealth": "yellow",
-  "healthReason": "No squads red. P0 CI regression resolved (PRs #1160, #1168). 3 PRs mergeable and awaiting review. QA agents still broken (P1, deferred to April 1). Budget exhaustion auto-resolves April 1. Stale state files across kernel and HQ need EM refresh.",
+  "overallHealth": "red",
+  "healthReason": "4 squads RED (cloud, hq, qa, analytics). Worker pool dead 11 cycles (#1402) — thundering herd risk < 24h with April 1 budget resets. 69.5% agent failure rate (#1452). Cloud squad 5 days stale with 74.3% systemic failures. QA non-operational 5+ days. v3.0-gate (#1306) 12 cycles unassigned, 5 days to conference deadline. Marketing conference content RED. Escalation threshold (2+ RED) exceeded — human escalation MANDATORY.",
+  "escalationToHuman": {
+    "triggered": true,
+    "reason": "4 squads RED (threshold: 2). Worker pool dead 11 cycles with April 1 thundering herd imminent.",
+    "immediateActions": [
+      "P0 CRITICAL (HOURS): Run server/deploy.sh on jared box (#1402) BEFORE April 1 budget resets. Dead pool + 60+ queued items + circuit breaker auto-clear = thundering herd.",
+      "P0 CRITICAL: Kill 26 zombie vitest processes (~3.3GB RAM) per #1452: ps aux | grep 'cloud-qa-257589|cloud-sr-1428111|tier-c-copilot-implementer-1127453' | grep vitest | awk '{print $2}' | xargs kill",
+      "P0 CRITICAL: Prune 3 stuck worktrees: git worktree prune && rm -rf .worktrees/marketing-em-3815251 .worktrees/octi-pulpo-sr-3847600 .worktrees/octi-pulpo-qa-3847601",
+      "P0 STRATEGIC: Assign kernel #1306 (v3.0-gate default-deny) TODAY — 12 cycles unassigned, conference demo depends on it, 5 days to April 4 deadline.",
+      "P0: Review and merge cloud#532 (agent fleet overview page) — last unmet success criterion for conference gate.",
+      "P0: Assign #228 (Agent 365 Q&A brief) — 10+ cycles unowned, conference dependent.",
+      "P1: Fix agentguard#1477 (telemetry.agentguard.dev unreachable default URL) before next release — silent event loss for users without .env override.",
+      "P1: Review agentguard#1476 (better-sqlite3 bindings) — add postinstall script or prebuilt binary.",
+      "P1: Read #1462 governance report — 5 HIGH systemic issues including 99.9% sessions lacking agent identity."
+    ]
+  },
   "squads": {
     "kernel": {
-      "health": "yellow",
-      "summary": "P0 CI regression RESOLVED — PRs #1160 (test regressions) and #1168 (SQLite fallback, closes #1148) merged. PR #1153 (heredoc fix) rebased and merged. State.json blocker is stale — EM should clear it. PR #969 still awaiting review (CI green). Go kernel work (#955, #957) not yet started.",
-      "staleState": true,
+      "health": "green",
+      "summary": "KE-9 sprint active (security maintenance + new invariant design). 4693/4693 tests passing (+44 new tests this cycle). 2 PRs merged today (#1448 claude-hook stderr fix, #1453 docs sync). #1449 security deps patched (PR #1469 merged). No blockers.",
+      "staleState": false,
       "actionItems": [
-        "EM: clear stale P0 CI blocker from state.json",
-        "EM: review and merge PR #969 (claude-init binary path fix)",
-        "Senior: resume Go kernel hook path (#955, #957)"
+        "Continue KE-9: #1384 browser governance invariants (design work), #1385 irreversible action detection",
+        "From #1462: fix gh CLI false positive in destructive command scanner, investigate no-secret-exposure dormancy, fix session-to-agent attribution join",
+        "Merge PR #1480 when CI passes (read-only command exemption for script-execution-tracking)"
       ]
     },
     "studio": {
       "health": "yellow",
-      "summary": "Guitar Jam Partner architecture merged (#153 closed). PR #176 open (DPP onboarding checklist). March budget exhausted — auto-resets April 1. Junior issues #165-169 queued for April 1.",
+      "summary": "Budget-blocked until April 1. 7 items queued for dispatch (Guitar Jam #165-169, market research #203, QA validation #233). E2E telemetry gate VERIFIED (workspace#273) — 372k cloud events confirmed, 3 bugs filed. PR #1479 (telemetry results) CI green, mergeable.",
       "staleState": false,
       "actionItems": [
-        "EM: review and merge PR #176 (docs only)",
-        "April 1: retrigger broken QA agents (qa-regression-analyzer, qa-test-architect)"
+        "Merge PR #1479 (telemetry gate results, CI 4/4 green)",
+        "April 1: dispatch 7 queued items once budgets reset",
+        "Monitor thundering herd risk — coordinate with #1402 resolution"
       ]
     },
     "cloud": {
-      "health": "yellow",
-      "summary": "PR #472 (outcome filter) listed as ready-to-merge in agentguard-cloud. Version pinned at 2.8.0, 4 versions behind current 2.8.4 (HQ blocker B2). Deployment-gate UI due Apr 15.",
+      "health": "red",
+      "summary": "5 DAYS STALE — no sprint goal, no assignments, no EM activity since March 25. HQ reports 74.3% systemic exit=1 failures (9th cycle). Still running old agentguard version (needs 2.10.3 upgrade). cloud#532 (agent fleet page) awaiting human review with all checks passing.",
       "staleState": true,
+      "staleDays": 5,
       "actionItems": [
-        "Merge PR #472 in agentguard-cloud",
-        "Upgrade @red-codes/agentguard from 2.8.0 → 2.8.4 (P2)"
+        "FORCE-ASSIGN: Cloud EM must update state.json and set sprint goal within 24h",
+        "P0: Upgrade agentguard-cloud to 2.10.3 — likely root cause of 74.3% failure rate",
+        "P0: Add octi-pulpo allow rule to agentguard-cloud/agentguard.yaml",
+        "P0: Human review cloud#532 (agent fleet overview page)"
       ]
     },
     "hq": {
-      "health": "yellow",
-      "summary": "Both blockers resolved: B1 (#1153 merged), B2 still open (cloud version pin). 2 stale EM report PRs (#1150, #1151) should be closed. Cross-repo triage active.",
-      "staleState": true,
+      "health": "red",
+      "summary": "Most active squad (updated 21:00Z today) but managing 5 P0 blockers. Worker pool dead 11 cycles (#1402), codex budget exhausted (#1431), 69.5% agent failure rate (#1452), governance report reveals 5 HIGH systemic issues (#1462). PR #1455 (marketing-em) CONFLICTING — 2nd rebase request. New EM cycle PR pending.",
+      "staleState": false,
       "actionItems": [
-        "EM: close stale PRs #1150 and #1151 (superseded by #1170)",
-        "EM: clear resolved blocker B1 from state.json",
-        "Assign cloud-squad to upgrade agentguard-cloud to 2.8.4"
+        "Continue escalating #1402 (worker pool) — director now force-escalating to human",
+        "Codex budget (#1431): auto-resolves April 3. No purchase needed — accept degraded capacity.",
+        "Close PR #1455 (marketing-em, conflicting) and create fresh PR",
+        "Route #1462 kernel tasks to kernel-squad, hq-ops tasks to ops"
       ]
     },
     "analytics": {
-      "health": "yellow",
-      "summary": "ETL hardening and cost tracking in progress. Waiting on kernel Goose adapter for ShellForge event ingestion. PR #31 merged in agentguard-analytics (pipeline error isolation).",
-      "staleState": false,
+      "health": "red",
+      "summary": "NO STATE FILE EXISTS — squad is completely dark. Cannot assess sprint progress, blockers, or health. Last director report (March 28) said ETL hardening in progress with no blockers.",
+      "staleState": true,
+      "staleDays": "unknown",
       "actionItems": [
-        "Continue ETL hardening — no blockers"
+        "FORCE-ASSIGN: Analytics EM must create state.json and report status within 24h",
+        "Verify ETL pipeline health and ShellForge event ingestion status"
       ]
     },
     "qa": {
-      "health": "yellow",
-      "summary": "qa-regression-analyzer and qa-test-architect both timing out at 1800s on bench-devs-platform (0% success). Budget-silenced until April 1.",
-      "staleState": false,
+      "health": "red",
+      "summary": "5 DAYS STALE — empty sprint goal, no assignments. 0/18 QA agents operational (QA conductor RED day 5+). Blocked on #1402 (worker pool dead) and bench-devs-platform path missing on readybench worker.",
+      "staleState": true,
+      "staleDays": 5,
       "actionItems": [
-        "April 1: retrigger agents with increased timeout or chunked processing",
-        "Escalate to human if still failing after retrigger"
+        "Depends on #1402 resolution first",
+        "April 1: retrigger QA agents once worker pool is restored",
+        "Implement manual QA gate for conference-labeled PRs (Option C from #274)"
       ]
     },
     "design": {
       "health": "yellow",
-      "summary": "Deployment-gate UX wireframes in progress (supports cloud squad, due Apr 15). No blockers.",
-      "staleState": false,
-      "actionItems": []
+      "summary": "5 days stale but low-activity squad. Last report indicated deployment-gate UX wireframes in progress (due Apr 15). No blockers.",
+      "staleState": true,
+      "staleDays": 5,
+      "actionItems": [
+        "EM: refresh state.json with current wireframe progress"
+      ]
     },
     "marketing": {
-      "health": "yellow",
-      "summary": "ShellForge launch content pipeline active. Demo video (#893) blocked on built CLI + real governance demo. Content accuracy flag: site references '21 invariants' but actual count differs.",
+      "health": "red",
+      "summary": "#1387 containment post: 4 cycles with no draft — ESCALATED to Jared. OWASP blog corrected and publish-ready (awaiting LinkedIn). Conference at risk: #1382 talk outline not started (16 days to April 15), #1379 Meta demo not started (6 days to April 5 red line). #1444 marketing site rebrand added (P0, depends on #1443 design system).",
       "staleState": false,
       "actionItems": [
-        "Verify invariant count on site (CLAUDE.md says 24, ROADMAP says 22, site may say 21)",
-        "Provide marketing with built CLI for demo video recording"
+        "ESCALATED: #1387 containment post — Jared must own or kill",
+        "URGENT: #1379 Meta demo — 6 days to red line, no engineering started",
+        "Publish OWASP blog post on LinkedIn (corrections applied)",
+        "Start #1382 conference talk outline (16 days remain)"
       ]
     },
     "site": {
       "health": "green",
-      "summary": "Sprint delivered. ShellForge product page merged (#1157). v3.0 messaging live. Monitoring deploy-pages CI.",
+      "summary": "All stat checks passing after drift fixes (26 invariants, 92 patterns, 43 action types, 48 event kinds, 4649 tests, 35 CLI commands). Monitoring for drift as v2.10 work lands.",
       "staleState": false,
       "actionItems": []
+    },
+    "octi-pulpo": {
+      "health": "yellow",
+      "summary": "Budget-aware dispatch sprint. No blockers reported. State file lacks timestamp and health field — needs EM attention. Cloud-side allow rule still pending (#1410 merged OSS-side).",
+      "staleState": false,
+      "actionItems": [
+        "EM: add updatedAt and health fields to state.json",
+        "Coordinate with cloud squad on allow rule addition"
+      ]
     }
   },
   "crossSquadBlockers": [
     {
       "id": "XB1",
-      "severity": "P2",
-      "description": "agentguard-cloud pinned at @red-codes/agentguard 2.8.0 — 4 versions behind 2.8.4. Risks E2E telemetry pipeline accuracy.",
-      "squads": ["cloud", "hq"],
-      "owner": "cloud-squad",
-      "deadline": "2026-04-03",
-      "status": "open"
+      "severity": "P0",
+      "description": "Worker pool dead on jared box (#1402) — cascades to QA swarm (#1403), studio QA validation, conference readiness. 11 cycles unresolved. April 1 thundering herd imminent.",
+      "squads": ["hq", "qa", "studio"],
+      "owner": "human (jpleva91)",
+      "deadline": "2026-03-31",
+      "status": "FORCE-ESCALATED",
+      "note": "Persisted across 2 director runs. Force-assigning per escalation rules."
     },
     {
       "id": "XB2",
-      "severity": "P1",
-      "description": "ShellForge critical path blocked on kernel Goose adapter — cascades to MCP server, QA bench, cloud telemetry, analytics ETL.",
-      "squads": ["kernel", "cloud", "analytics", "qa"],
-      "owner": "kernel-senior",
-      "deadline": "2026-04-10",
-      "status": "open",
-      "note": "Kernel must finish Go kernel hook path (#955, #957) first, then Goose adapter."
+      "severity": "P0",
+      "description": "Cloud squad 5 days stale + 74.3% systemic exit=1 failures. Needs 2.10.3 upgrade. Blocks telemetry pipeline accuracy, agent fleet dashboard, conference demo.",
+      "squads": ["cloud", "hq", "studio"],
+      "owner": "cloud-em (FORCE-ASSIGNED)",
+      "deadline": "2026-04-01",
+      "status": "FORCE-ASSIGNED",
+      "note": "Cloud EM has been unresponsive 5 days. If no update by April 1, escalate to human."
     },
     {
       "id": "XB3",
+      "severity": "P0",
+      "description": "v3.0-gate default-deny (#1306) — 12 cycles unassigned. Conference demo depends on this. Core product thesis.",
+      "squads": ["kernel"],
+      "owner": "UNASSIGNED — human must assign",
+      "deadline": "2026-04-04",
+      "status": "FORCE-ESCALATED",
+      "note": "12 cycles unassigned triggers force-assign rule. Human must decide owner TODAY."
+    },
+    {
+      "id": "XB4",
+      "severity": "P0",
+      "description": "69.5% agent failure rate (#1452) — 26 zombie vitest processes (~3.3GB RAM), 3 stuck worktrees. System resource exhaustion on jared box.",
+      "squads": ["hq", "cloud", "qa"],
+      "owner": "human (jpleva91)",
+      "deadline": "2026-03-31",
+      "status": "FORCE-ESCALATED"
+    },
+    {
+      "id": "XB5",
       "severity": "P1",
-      "description": "QA agents (qa-regression-analyzer, qa-test-architect) 0% on bench — blocks QA reliability target of 80%+.",
-      "squads": ["qa", "studio"],
-      "owner": "qa-em",
+      "description": "Codex budget exhausted (#1431) until April 3. 25+ agents offline. Director decision: accept degraded capacity (no purchase needed — auto-resolves in 3 days).",
+      "squads": ["hq"],
+      "owner": "director",
       "deadline": "2026-04-03",
-      "status": "deferred_to_april_1"
+      "status": "ACCEPTED — auto-resolves",
+      "note": "Director decision: do NOT purchase credits. 3-day degraded capacity is acceptable."
+    },
+    {
+      "id": "XB6",
+      "severity": "P1",
+      "description": "QA non-operational 5+ days (0/18 agents). Depends on XB1 (#1402). Manual QA gate recommended for conference PRs.",
+      "squads": ["qa", "studio"],
+      "owner": "qa-em + human",
+      "deadline": "2026-04-05",
+      "status": "blocked_on_XB1"
+    },
+    {
+      "id": "XB7",
+      "severity": "P1",
+      "description": "Telemetry default URL broken (#1477) — silent event loss for users without .env override. Must fix before next release.",
+      "squads": ["kernel", "studio"],
+      "owner": "kernel-squad",
+      "deadline": "next release",
+      "status": "open"
+    },
+    {
+      "id": "XB8",
+      "severity": "P1",
+      "description": "Marketing conference content RED — #1387 4 cycles no draft, #1379 Meta demo 6 days to red line, #1382 talk outline 16 days.",
+      "squads": ["marketing"],
+      "owner": "human (jpleva91)",
+      "deadline": "2026-04-05",
+      "status": "ESCALATED"
     }
   ],
   "prQueue": {
     "mergeableNow": [
-      {"repo": "agent-guard", "pr": 1178, "title": "fix(adapters): map Copilot CLI meta-tools to known action types", "ci": "5/5 green"},
-      {"repo": "agent-guard", "pr": 1179, "title": "chore(roadmap): triage backlog + sync roadmap to v2.8.4", "ci": "5/5 green"},
-      {"repo": "agent-guard", "pr": 1183, "title": "test: add tests for cli/commands/trust", "ci": "5/5 green"}
+      {"repo": "agent-guard", "pr": 1479, "title": "chore(squad): studio E2E telemetry gate verified — workspace#273", "ci": "4/4 green"}
     ],
-    "staleToClose": [
-      {"repo": "agent-guard", "pr": 1150, "title": "chore(studio): EM report (stale)", "reason": "superseded by newer EM runs"},
-      {"repo": "agent-guard", "pr": 1151, "title": "chore(hq): EM report (CI failing)", "reason": "superseded by #1170"}
+    "ciPending": [
+      {"repo": "agent-guard", "pr": 1480, "title": "fix(invariants): exempt read-only commands from script-execution-tracking", "ci": "0/4 passed — awaiting CI"}
+    ],
+    "conflicting": [
+      {"repo": "agent-guard", "pr": 1455, "title": "chore(marketing-em): EM cycle 2026-03-30T20:00Z", "ci": "failing — conflicts", "action": "Close and recreate"}
+    ],
+    "crossRepo": [
+      {"repo": "agentguard-cloud", "pr": 532, "title": "feat(dashboard): agent fleet overview page", "ci": "8/8 critical passed", "action": "NEEDS HUMAN REVIEW"},
+      {"repo": "agentguard-workspace", "pr": 269, "title": "feat(swarm): add 5 new agents", "ci": "org-chart fix pushed, awaiting CI green", "action": "Merge when green"}
     ]
   },
   "strategicAlignment": {
-    "status": "aligned",
-    "notes": "All squads aligned with ROADMAP Phase 6 (Reference Monitor Hardening) and ShellForge critical path. No drift detected. Kernel Go kernel work is the primary strategic dependency — needs to unblock before ShellForge E2E pipeline completes."
+    "status": "at_risk",
+    "notes": "3 strategic risks: (1) v3.0-gate (#1306) unassigned 12 cycles — this IS the product thesis (default-deny governance) and the conference demo depends on it. (2) Cloud squad stale 5 days — telemetry pipeline and dashboard are critical for conference. (3) Marketing conference content pipeline RED — Meta demo, talk outline, containment post all behind schedule. Kernel squad is the bright spot — green, productive, aligned with roadmap."
   },
   "resolvedSinceLastRun": [
-    "P0 CI regression — fixed by PRs #1160 (test regressions) and #1168 (SQLite fallback)",
-    "P1 PR #1153 heredoc false-positive — rebased and merged (2026-03-28T03:38)",
-    "Site ShellForge page delivered — PR #1157 merged",
-    "Analytics pipeline error isolation — PR #31 merged in agentguard-analytics"
+    "KE-8 COMPLETE: #1427 (persona.env protection, PR #1436) and #1430 (claude-hook stderr fix, PR #1448) both merged",
+    "Security deps patched: PR #1469 merged (path-to-regexp, brace-expansion)",
+    "Enforcement posture display shipped: PR #1466 merged",
+    "User capture funnel shipped: PR #1466 (early-access CTA, cloud signup nudge)",
+    "Copilot event pipeline fixed: PR #1429 merged (was 0 events)",
+    "Telemetry E2E gate verified: 372k cloud events confirmed, deny flow working",
+    "Site stat drift fixed: 7 occurrences corrected across site",
+    "Docs synced: invariant count updated to 26 across all documentation (#1453)",
+    "+44 new tests (adapters: 299→343 from #1451, invariants: 624→633 from #1436)"
   ],
-  "escalations": [],
+  "directorDecisions": [
+    {
+      "id": "DD1",
+      "decision": "Codex budget (#1431): accept 3-day degraded capacity. Do NOT purchase credits. Auto-resolves April 3.",
+      "rationale": "Cost-benefit: 3 days of reduced throughput is acceptable vs purchasing credits for a budget that resets automatically."
+    },
+    {
+      "id": "DD2",
+      "decision": "Force-escalate #1402 (worker pool) to human. This is the 2nd director run where this blocker persists — per escalation rules, force-assigning with deadline.",
+      "rationale": "11 cycles unresolved. Cascades to 3 squads. April 1 thundering herd risk is the most dangerous near-term threat."
+    },
+    {
+      "id": "DD3",
+      "decision": "Force-assign cloud EM to update state.json and upgrade to 2.10.3 within 24h. If no response, escalate to human.",
+      "rationale": "5 days stale is unacceptable. 74.3% failure rate is likely caused by version mismatch."
+    },
+    {
+      "id": "DD4",
+      "decision": "Force-escalate #1306 (v3.0-gate) to human for immediate assignment. 12 cycles unassigned crosses all thresholds.",
+      "rationale": "This is the product's core thesis and the conference demo keystone. Cannot remain unassigned."
+    }
+  ],
   "dogfood": {
     "issues": [],
-    "notes": "No governance issues encountered during this director run. Dogfood reporting guide not found at claude/shared/dogfood-reporting.md — file may have been moved or not yet created in this repo."
+    "notes": "Dogfood reporting guide (claude/shared/dogfood-reporting.md) not found in this repo. No governance issues encountered during director run — all file reads and state analysis completed without AgentGuard intervention."
   },
+  "nextRun": "2026-03-31T10:00:00.000Z",
   "nextActions": [
-    "Kernel EM: clear stale P0 blocker, review PR #969, resume Go kernel work",
-    "HQ EM: close stale PRs #1150/#1151, update state.json blockers",
-    "Cloud squad: merge PR #472 in agentguard-cloud, upgrade to 2.8.4",
-    "All EMs: review and merge PRs #1178, #1179, #1183 (all CI green)",
-    "QA EM: April 1 — retrigger broken agents with increased timeout",
-    "Marketing: verify invariant count accuracy on site"
+    "HUMAN P0 (HOURS): Run server/deploy.sh BEFORE April 1 budget resets (#1402)",
+    "HUMAN P0: Kill zombie vitest processes and prune stuck worktrees (#1452)",
+    "HUMAN P0: Assign #1306 (v3.0-gate default-deny) TODAY",
+    "HUMAN P0: Review cloud#532 (agent fleet page)",
+    "HUMAN P0: Assign #228 (Agent 365 Q&A brief)",
+    "CLOUD EM: Update state.json, set sprint goal, upgrade to 2.10.3 — deadline 24h",
+    "ANALYTICS EM: Create state.json — squad is completely dark",
+    "KERNEL: Merge PR #1479 (telemetry gate, CI green). Merge PR #1480 when CI passes.",
+    "KERNEL: Fix #1477 (telemetry default URL) before next release",
+    "MARKETING: #1379 Meta demo — 6 days to red line. Start engineering NOW.",
+    "QA: Implement manual gate for conference PRs (Option C) while waiting for #1402"
   ]
 }

--- a/.agentguard/director-report.json
+++ b/.agentguard/director-report.json
@@ -1,121 +1,145 @@
 {
-  "runAt": "2026-03-30T22:30:00.000Z",
-  "runType": "evening",
+  "runAt": "2026-03-31T00:00:00.000Z",
+  "runType": "night-followup",
+  "priorRun": "2026-03-30T22:30:00.000Z",
   "overallHealth": "red",
-  "healthReason": "4 squads RED (cloud, hq, qa, analytics). Worker pool dead 11 cycles (#1402) — thundering herd risk < 24h with April 1 budget resets. 69.5% agent failure rate (#1452). Cloud squad 5 days stale with 74.3% systemic failures. QA non-operational 5+ days. v3.0-gate (#1306) 12 cycles unassigned, 5 days to conference deadline. Marketing conference content RED. Escalation threshold (2+ RED) exceeded — human escalation MANDATORY.",
+  "healthReason": "3+ squads RED (cloud, qa, marketing; hq borderline RED managing 5 P0 blockers). Worker pool dead 11+ cycles (#1402) — thundering herd risk in <24h with April 1 budget resets. 69.5% agent failure rate (#1452). Cloud squad 6 days stale with 74.3% systemic failures. QA non-operational 5+ days. Marketing conference content pipeline RED (#1387, #1379, #1382). No human action on any P0 since evening run. Escalation threshold (2+ RED) exceeded — human escalation MANDATORY.",
+  "deltaSinceLastRun": {
+    "prsMergedToMain": [
+      {"pr": 1479, "title": "chore(squad): studio senior E2E telemetry gate — workspace#273 completed", "note": "Was 'mergeable now' in evening report. MERGED."},
+      {"pr": 1475, "title": "fix(invariants): exempt read-only commands from script-execution-tracking (closes #1475)", "note": "Was 'CI pending' as PR #1480 in evening report. MERGED."}
+    ],
+    "humanActionsCompleted": [],
+    "newSquadData": [
+      "Octi-pulpo: rich workspace-level state shows 22+ items completed this sprint, 370 tests passing, build green. Healthiest squad in the swarm.",
+      "Shellforge: state shows PR #89 (25 tests) awaiting human review, all P0/P1 bugs fixed, transitioning to P2 bug sweep."
+    ],
+    "escalationsRemaining": "ALL P0 escalations from evening run remain unaddressed. #1402 (worker pool), #1306 (v3.0-gate 12 cycles), #1452 (zombie processes), #228 (Agent365 Q&A), cloud#532 (fleet page review)."
+  },
   "escalationToHuman": {
     "triggered": true,
-    "reason": "4 squads RED (threshold: 2). Worker pool dead 11 cycles with April 1 thundering herd imminent.",
+    "reason": "3+ squads RED (threshold: 2). All P0 escalations from evening run unresolved. April 1 thundering herd imminent (<24h).",
     "immediateActions": [
-      "P0 CRITICAL (HOURS): Run server/deploy.sh on jared box (#1402) BEFORE April 1 budget resets. Dead pool + 60+ queued items + circuit breaker auto-clear = thundering herd.",
+      "P0 CRITICAL (HOURS): Run server/deploy.sh on jared box (#1402) BEFORE April 1 budget resets. Dead pool + 60+ queued items + circuit breaker auto-clear = thundering herd. SINGLE MOST IMPORTANT ACTION.",
       "P0 CRITICAL: Kill 26 zombie vitest processes (~3.3GB RAM) per #1452: ps aux | grep 'cloud-qa-257589|cloud-sr-1428111|tier-c-copilot-implementer-1127453' | grep vitest | awk '{print $2}' | xargs kill",
       "P0 CRITICAL: Prune 3 stuck worktrees: git worktree prune && rm -rf .worktrees/marketing-em-3815251 .worktrees/octi-pulpo-sr-3847600 .worktrees/octi-pulpo-qa-3847601",
       "P0 STRATEGIC: Assign kernel #1306 (v3.0-gate default-deny) TODAY — 12 cycles unassigned, conference demo depends on it, 5 days to April 4 deadline.",
-      "P0: Review and merge cloud#532 (agent fleet overview page) — last unmet success criterion for conference gate.",
+      "P0: Review and merge cloud#532 (agent fleet overview page) — last unmet conference gate criterion.",
       "P0: Assign #228 (Agent 365 Q&A brief) — 10+ cycles unowned, conference dependent.",
-      "P1: Fix agentguard#1477 (telemetry.agentguard.dev unreachable default URL) before next release — silent event loss for users without .env override.",
-      "P1: Review agentguard#1476 (better-sqlite3 bindings) — add postinstall script or prebuilt binary.",
-      "P1: Read #1462 governance report — 5 HIGH systemic issues including 99.9% sessions lacking agent identity."
+      "P1: Fix agentguard#1477 (telemetry.agentguard.dev unreachable default URL) before next release.",
+      "P1: Review shellforge PR #89 (25 tests, test coverage baseline) — blocking shellforge P2 bug sweep.",
+      "P1: Read governance report #1462 — 5 HIGH systemic issues including 99.9% sessions lacking agent identity.",
+      "P1: Publish OWASP blog to LinkedIn (fix line 27: '41' → '43' action types first)."
     ]
   },
   "squads": {
     "kernel": {
       "health": "green",
-      "summary": "KE-9 sprint active (security maintenance + new invariant design). 4693/4693 tests passing (+44 new tests this cycle). 2 PRs merged today (#1448 claude-hook stderr fix, #1453 docs sync). #1449 security deps patched (PR #1469 merged). No blockers.",
-      "staleState": false,
+      "updated": "2026-03-30T21:10:00.000Z",
+      "stale": false,
+      "summary": "KE-9 sprint active (security maintenance + new invariant design). 4693/4693 tests passing (+44 new this cycle). #1449 security deps PATCHED (PR #1469). PR #1475 merged (read-only command exemption). 0 open PRs. No blockers.",
       "actionItems": [
-        "Continue KE-9: #1384 browser governance invariants (design work), #1385 irreversible action detection",
-        "From #1462: fix gh CLI false positive in destructive command scanner, investigate no-secret-exposure dormancy, fix session-to-agent attribution join",
-        "Merge PR #1480 when CI passes (read-only command exemption for script-execution-tracking)"
+        "Continue KE-9: #1384 browser governance invariants, #1385 irreversible action detection",
+        "From #1462: fix gh CLI false positive, investigate no-secret-exposure dormancy, fix session-to-agent join",
+        "Fix #1477 (telemetry default URL) before next release"
       ]
     },
     "studio": {
       "health": "yellow",
-      "summary": "Budget-blocked until April 1. 7 items queued for dispatch (Guitar Jam #165-169, market research #203, QA validation #233). E2E telemetry gate VERIFIED (workspace#273) — 372k cloud events confirmed, 3 bugs filed. PR #1479 (telemetry results) CI green, mergeable.",
-      "staleState": false,
+      "updated": "2026-03-30T10:45:00.000Z",
+      "stale": false,
+      "summary": "Budget-blocked until April 1. 7 items queued for dispatch. E2E telemetry gate VERIFIED — PR #1479 MERGED. 372k cloud events confirmed, 3 bugs filed. PR #269 (5 new agents) awaiting CI green.",
       "actionItems": [
-        "Merge PR #1479 (telemetry gate results, CI 4/4 green)",
         "April 1: dispatch 7 queued items once budgets reset",
-        "Monitor thundering herd risk — coordinate with #1402 resolution"
+        "Monitor thundering herd risk — coordinate with #1402",
+        "Merge workspace#269 when CI green"
       ]
     },
     "cloud": {
       "health": "red",
-      "summary": "5 DAYS STALE — no sprint goal, no assignments, no EM activity since March 25. HQ reports 74.3% systemic exit=1 failures (9th cycle). Still running old agentguard version (needs 2.10.3 upgrade). cloud#532 (agent fleet page) awaiting human review with all checks passing.",
-      "staleState": true,
-      "staleDays": 5,
+      "updated": "2026-03-25T00:00:00.000Z",
+      "stale": true,
+      "staleDays": 6,
+      "summary": "6 DAYS STALE — no sprint goal, no assignments, no EM activity since March 25. 74.3% systemic exit=1 failures (9th cycle per HQ). Running outdated agentguard version. cloud#532 (fleet page) awaiting human review.",
       "actionItems": [
-        "FORCE-ASSIGN: Cloud EM must update state.json and set sprint goal within 24h",
-        "P0: Upgrade agentguard-cloud to 2.10.3 — likely root cause of 74.3% failure rate",
-        "P0: Add octi-pulpo allow rule to agentguard-cloud/agentguard.yaml",
-        "P0: Human review cloud#532 (agent fleet overview page)"
+        "FORCE-ASSIGN: Cloud EM must update state.json — deadline 2026-03-31T12:00Z",
+        "P0: Upgrade agentguard-cloud to 2.10.3",
+        "P0: Add octi-pulpo allow rule to agentguard.yaml",
+        "If no EM response by deadline → escalate to human"
       ]
     },
     "hq": {
-      "health": "red",
-      "summary": "Most active squad (updated 21:00Z today) but managing 5 P0 blockers. Worker pool dead 11 cycles (#1402), codex budget exhausted (#1431), 69.5% agent failure rate (#1452), governance report reveals 5 HIGH systemic issues (#1462). PR #1455 (marketing-em) CONFLICTING — 2nd rebase request. New EM cycle PR pending.",
-      "staleState": false,
+      "health": "yellow",
+      "updated": "2026-03-30T21:00:00.000Z",
+      "stale": false,
+      "summary": "Most active squad — managing 5 P0 blockers across swarm. #1402 worker pool (11 cycles), #1431 codex budget (auto-resolves Apr 3), #1452 failure rate, #1462 governance report. PR #1455 CONFLICTING.",
       "actionItems": [
-        "Continue escalating #1402 (worker pool) — director now force-escalating to human",
-        "Codex budget (#1431): auto-resolves April 3. No purchase needed — accept degraded capacity.",
-        "Close PR #1455 (marketing-em, conflicting) and create fresh PR",
-        "Route #1462 kernel tasks to kernel-squad, hq-ops tasks to ops"
-      ]
-    },
-    "analytics": {
-      "health": "red",
-      "summary": "NO STATE FILE EXISTS — squad is completely dark. Cannot assess sprint progress, blockers, or health. Last director report (March 28) said ETL hardening in progress with no blockers.",
-      "staleState": true,
-      "staleDays": "unknown",
-      "actionItems": [
-        "FORCE-ASSIGN: Analytics EM must create state.json and report status within 24h",
-        "Verify ETL pipeline health and ShellForge event ingestion status"
+        "#1402: FORCE-ESCALATED to human — cascade root cause",
+        "#1431: ACCEPTED — auto-resolves April 3",
+        "Close #1455, create fresh PR",
+        "Route #1462 tasks to kernel-squad and ops"
       ]
     },
     "qa": {
       "health": "red",
-      "summary": "5 DAYS STALE — empty sprint goal, no assignments. 0/18 QA agents operational (QA conductor RED day 5+). Blocked on #1402 (worker pool dead) and bench-devs-platform path missing on readybench worker.",
-      "staleState": true,
-      "staleDays": 5,
+      "updated": "2026-03-25T06:20:02.274Z",
+      "stale": true,
+      "staleDays": 6,
+      "summary": "6 DAYS STALE — 0/18 QA agents operational. Root cause: #1402 (worker pool dead) + missing bench-devs-platform path.",
       "actionItems": [
         "Depends on #1402 resolution first",
-        "April 1: retrigger QA agents once worker pool is restored",
-        "Implement manual QA gate for conference-labeled PRs (Option C from #274)"
+        "April 1: retrigger once worker pool + budgets restored",
+        "Implement manual QA gate for conference PRs"
+      ]
+    },
+    "octi-pulpo": {
+      "health": "green",
+      "updated": "2026-03-30T08:45:00.000Z",
+      "stale": false,
+      "summary": "THRIVING — highest-velocity squad. 22+ items shipped this sprint: budget-aware dispatch, GitHub write-back, sprint management, Slack integration, vector search, self-heal brain. 370 tests passing. PR queue 1/3 (QA tests). Only 1 active P1: wire BudgetStore into main.go (2 lines).",
+      "actionItems": [
+        "Wire BudgetStore into main.go (P1, assigned to octi-pulpo-sr)",
+        "Merge PR #93 (QA tests) when reviewed"
+      ]
+    },
+    "shellforge": {
+      "health": "yellow",
+      "updated": "2026-03-30T06:10:00.000Z",
+      "stale": false,
+      "summary": "All P0/P1 bugs fixed. PR #89 (25 tests, closes #68 + #66) awaiting human review — blocking P2 bug sweep. 6 PRs merged today. No dev-agent — EM authors fixes directly.",
+      "actionItems": [
+        "Human: review and merge PR #89",
+        "If merged: pick #51 or #52 for next fix",
+        "Dogfood run (#76): unblocked, needs RunPod trigger"
       ]
     },
     "design": {
       "health": "yellow",
-      "summary": "5 days stale but low-activity squad. Last report indicated deployment-gate UX wireframes in progress (due Apr 15). No blockers.",
-      "staleState": true,
-      "staleDays": 5,
+      "updated": "2026-03-25T00:00:00.000Z",
+      "stale": true,
+      "staleDays": 6,
+      "summary": "Dormant — empty sprint goal. Prior context: deployment-gate UX wireframes (due April 15).",
       "actionItems": [
-        "EM: refresh state.json with current wireframe progress"
-      ]
-    },
-    "marketing": {
-      "health": "red",
-      "summary": "#1387 containment post: 4 cycles with no draft — ESCALATED to Jared. OWASP blog corrected and publish-ready (awaiting LinkedIn). Conference at risk: #1382 talk outline not started (16 days to April 15), #1379 Meta demo not started (6 days to April 5 red line). #1444 marketing site rebrand added (P0, depends on #1443 design system).",
-      "staleState": false,
-      "actionItems": [
-        "ESCALATED: #1387 containment post — Jared must own or kill",
-        "URGENT: #1379 Meta demo — 6 days to red line, no engineering started",
-        "Publish OWASP blog post on LinkedIn (corrections applied)",
-        "Start #1382 conference talk outline (16 days remain)"
+        "EM: refresh state.json with wireframe progress"
       ]
     },
     "site": {
       "health": "green",
-      "summary": "All stat checks passing after drift fixes (26 invariants, 92 patterns, 43 action types, 48 event kinds, 4649 tests, 35 CLI commands). Monitoring for drift as v2.10 work lands.",
-      "staleState": false,
+      "updated": "2026-03-30T06:09:00.000Z",
+      "stale": false,
+      "summary": "All stat checks passing. Monitoring for drift as v2.10 work lands. 2 PRs merged this cycle.",
       "actionItems": []
     },
-    "octi-pulpo": {
-      "health": "yellow",
-      "summary": "Budget-aware dispatch sprint. No blockers reported. State file lacks timestamp and health field — needs EM attention. Cloud-side allow rule still pending (#1410 merged OSS-side).",
-      "staleState": false,
+    "marketing": {
+      "health": "red",
+      "updated": "2026-03-29T22:05:00.000Z",
+      "stale": false,
+      "summary": "#1387 containment post: 4 cycles, NO DRAFT — ESCALATED to Jared. #1382 talk outline: not started (16 days). #1379 Meta demo: not started (6 days to red line). OWASP blog ready for LinkedIn (fix '41' → '43').",
       "actionItems": [
-        "EM: add updatedAt and health fields to state.json",
-        "Coordinate with cloud squad on allow rule addition"
+        "ESCALATED: Jared must own or kill #1387",
+        "URGENT: #1379 Meta demo — 6 days to red line, start engineering NOW",
+        "#1382 conference talk outline — 16 days to Phase 2 gate",
+        "Publish OWASP blog (fix action type count first)"
       ]
     }
   },
@@ -123,56 +147,55 @@
     {
       "id": "XB1",
       "severity": "P0",
-      "description": "Worker pool dead on jared box (#1402) — cascades to QA swarm (#1403), studio QA validation, conference readiness. 11 cycles unresolved. April 1 thundering herd imminent.",
+      "description": "Worker pool dead on jared box (#1402) — cascades to QA, studio, conference readiness. 11+ cycles. April 1 thundering herd imminent.",
       "squads": ["hq", "qa", "studio"],
       "owner": "human (jpleva91)",
       "deadline": "2026-03-31",
-      "status": "FORCE-ESCALATED",
-      "note": "Persisted across 2 director runs. Force-assigning per escalation rules."
+      "status": "FORCE-ESCALATED — persisted 2 director runs",
+      "persistedDirectorRuns": 2
     },
     {
       "id": "XB2",
       "severity": "P0",
-      "description": "Cloud squad 5 days stale + 74.3% systemic exit=1 failures. Needs 2.10.3 upgrade. Blocks telemetry pipeline accuracy, agent fleet dashboard, conference demo.",
+      "description": "Cloud squad 6 days stale + 74.3% systemic failures. Needs 2.10.3 upgrade.",
       "squads": ["cloud", "hq", "studio"],
-      "owner": "cloud-em (FORCE-ASSIGNED)",
-      "deadline": "2026-04-01",
-      "status": "FORCE-ASSIGNED",
-      "note": "Cloud EM has been unresponsive 5 days. If no update by April 1, escalate to human."
+      "owner": "cloud-em (FORCE-ASSIGNED, deadline 2026-03-31T12:00Z)",
+      "deadline": "2026-03-31",
+      "status": "FORCE-ASSIGNED — escalate to human if no response by 12:00Z",
+      "persistedDirectorRuns": 2
     },
     {
       "id": "XB3",
       "severity": "P0",
-      "description": "v3.0-gate default-deny (#1306) — 12 cycles unassigned. Conference demo depends on this. Core product thesis.",
+      "description": "v3.0-gate default-deny (#1306) — 12 cycles unassigned. Conference demo keystone.",
       "squads": ["kernel"],
-      "owner": "UNASSIGNED — human must assign",
+      "owner": "UNASSIGNED — human must assign TODAY",
       "deadline": "2026-04-04",
-      "status": "FORCE-ESCALATED",
-      "note": "12 cycles unassigned triggers force-assign rule. Human must decide owner TODAY."
+      "status": "FORCE-ESCALATED — persisted 2 director runs",
+      "persistedDirectorRuns": 2
     },
     {
       "id": "XB4",
       "severity": "P0",
-      "description": "69.5% agent failure rate (#1452) — 26 zombie vitest processes (~3.3GB RAM), 3 stuck worktrees. System resource exhaustion on jared box.",
+      "description": "69.5% agent failure rate (#1452) — 26 zombie vitest, 3 stuck worktrees, ~3.3GB RAM waste.",
       "squads": ["hq", "cloud", "qa"],
       "owner": "human (jpleva91)",
       "deadline": "2026-03-31",
-      "status": "FORCE-ESCALATED"
+      "status": "FORCE-ESCALATED — persisted 2 director runs",
+      "persistedDirectorRuns": 2
     },
     {
       "id": "XB5",
       "severity": "P1",
-      "description": "Codex budget exhausted (#1431) until April 3. 25+ agents offline. Director decision: accept degraded capacity (no purchase needed — auto-resolves in 3 days).",
+      "description": "Codex budget exhausted (#1431) until April 3. 25+ agents offline.",
       "squads": ["hq"],
       "owner": "director",
-      "deadline": "2026-04-03",
-      "status": "ACCEPTED — auto-resolves",
-      "note": "Director decision: do NOT purchase credits. 3-day degraded capacity is acceptable."
+      "status": "ACCEPTED — auto-resolves April 3"
     },
     {
       "id": "XB6",
       "severity": "P1",
-      "description": "QA non-operational 5+ days (0/18 agents). Depends on XB1 (#1402). Manual QA gate recommended for conference PRs.",
+      "description": "QA non-operational 5+ days (0/18 agents). Depends on XB1.",
       "squads": ["qa", "studio"],
       "owner": "qa-em + human",
       "deadline": "2026-04-05",
@@ -181,90 +204,80 @@
     {
       "id": "XB7",
       "severity": "P1",
-      "description": "Telemetry default URL broken (#1477) — silent event loss for users without .env override. Must fix before next release.",
+      "description": "Telemetry default URL broken (#1477) — silent event loss for new installs.",
       "squads": ["kernel", "studio"],
       "owner": "kernel-squad",
-      "deadline": "next release",
       "status": "open"
     },
     {
       "id": "XB8",
       "severity": "P1",
-      "description": "Marketing conference content RED — #1387 4 cycles no draft, #1379 Meta demo 6 days to red line, #1382 talk outline 16 days.",
+      "description": "Marketing conference content RED — #1387 escalated, #1379 6 days to red line, #1382 16 days.",
       "squads": ["marketing"],
       "owner": "human (jpleva91)",
       "deadline": "2026-04-05",
       "status": "ESCALATED"
+    },
+    {
+      "id": "XB9",
+      "severity": "P1",
+      "description": "Shellforge PR #89 (25 tests) blocking P2 bug sweep. Human review needed.",
+      "squads": ["shellforge"],
+      "owner": "human",
+      "status": "open — 1 EM cycle persisted"
     }
   ],
-  "prQueue": {
-    "mergeableNow": [
-      {"repo": "agent-guard", "pr": 1479, "title": "chore(squad): studio E2E telemetry gate verified — workspace#273", "ci": "4/4 green"}
-    ],
-    "ciPending": [
-      {"repo": "agent-guard", "pr": 1480, "title": "fix(invariants): exempt read-only commands from script-execution-tracking", "ci": "0/4 passed — awaiting CI"}
-    ],
-    "conflicting": [
-      {"repo": "agent-guard", "pr": 1455, "title": "chore(marketing-em): EM cycle 2026-03-30T20:00Z", "ci": "failing — conflicts", "action": "Close and recreate"}
-    ],
-    "crossRepo": [
-      {"repo": "agentguard-cloud", "pr": 532, "title": "feat(dashboard): agent fleet overview page", "ci": "8/8 critical passed", "action": "NEEDS HUMAN REVIEW"},
-      {"repo": "agentguard-workspace", "pr": 269, "title": "feat(swarm): add 5 new agents", "ci": "org-chart fix pushed, awaiting CI green", "action": "Merge when green"}
-    ]
-  },
   "strategicAlignment": {
     "status": "at_risk",
-    "notes": "3 strategic risks: (1) v3.0-gate (#1306) unassigned 12 cycles — this IS the product thesis (default-deny governance) and the conference demo depends on it. (2) Cloud squad stale 5 days — telemetry pipeline and dashboard are critical for conference. (3) Marketing conference content pipeline RED — Meta demo, talk outline, containment post all behind schedule. Kernel squad is the bright spot — green, productive, aligned with roadmap."
+    "phase1Deadline": "2026-04-17",
+    "daysRemaining": 17,
+    "conferenceDate": "2026-05-06",
+    "conferenceDaysRemaining": 36,
+    "notes": [
+      "Kernel: GREEN, aligned. KE-9 security + invariant work supports demo. 4693 tests.",
+      "Octi-pulpo: GREEN, exceeding expectations. Platform coordination infra ahead of schedule.",
+      "Studio: YELLOW, blocked by external deps. Well-organized April 1 dispatch queue. AT RISK due to thundering herd.",
+      "Cloud: RED, stale 6 days. 74.3% failures undermine dashboard demo. Critical path.",
+      "Marketing: RED. Conference content pipeline stalled — 3 deliverables behind.",
+      "QA: RED. No safety net for conference PRs.",
+      "v3.0-gate (#1306): THE strategic keystone — 12 cycles unassigned. Conference demo incomplete without it."
+    ]
   },
-  "resolvedSinceLastRun": [
-    "KE-8 COMPLETE: #1427 (persona.env protection, PR #1436) and #1430 (claude-hook stderr fix, PR #1448) both merged",
-    "Security deps patched: PR #1469 merged (path-to-regexp, brace-expansion)",
-    "Enforcement posture display shipped: PR #1466 merged",
-    "User capture funnel shipped: PR #1466 (early-access CTA, cloud signup nudge)",
-    "Copilot event pipeline fixed: PR #1429 merged (was 0 events)",
-    "Telemetry E2E gate verified: 372k cloud events confirmed, deny flow working",
-    "Site stat drift fixed: 7 occurrences corrected across site",
-    "Docs synced: invariant count updated to 26 across all documentation (#1453)",
-    "+44 new tests (adapters: 299→343 from #1451, invariants: 624→633 from #1436)"
-  ],
   "directorDecisions": [
     {
       "id": "DD1",
-      "decision": "Codex budget (#1431): accept 3-day degraded capacity. Do NOT purchase credits. Auto-resolves April 3.",
-      "rationale": "Cost-benefit: 3 days of reduced throughput is acceptable vs purchasing credits for a budget that resets automatically."
+      "decision": "Codex budget (#1431): accept degraded capacity. No purchase. Auto-resolves April 3.",
+      "status": "standing"
     },
     {
       "id": "DD2",
-      "decision": "Force-escalate #1402 (worker pool) to human. This is the 2nd director run where this blocker persists — per escalation rules, force-assigning with deadline.",
-      "rationale": "11 cycles unresolved. Cascades to 3 squads. April 1 thundering herd risk is the most dangerous near-term threat."
+      "decision": "Force-escalate #1402 (worker pool) to human — 2nd director run persisted. MANDATORY before April 1.",
+      "status": "ACTIVE"
     },
     {
       "id": "DD3",
-      "decision": "Force-assign cloud EM to update state.json and upgrade to 2.10.3 within 24h. If no response, escalate to human.",
-      "rationale": "5 days stale is unacceptable. 74.3% failure rate is likely caused by version mismatch."
+      "decision": "Force-assign cloud EM — deadline 2026-03-31T12:00Z. If no response, escalate to human.",
+      "status": "ACTIVE"
     },
     {
       "id": "DD4",
-      "decision": "Force-escalate #1306 (v3.0-gate) to human for immediate assignment. 12 cycles unassigned crosses all thresholds.",
-      "rationale": "This is the product's core thesis and the conference demo keystone. Cannot remain unassigned."
+      "decision": "Force-escalate #1306 (v3.0-gate) to human for immediate assignment.",
+      "status": "ACTIVE"
+    },
+    {
+      "id": "DD5",
+      "decision": "Shellforge squad acknowledged as 10th squad — included in all future reports.",
+      "status": "NEW"
+    },
+    {
+      "id": "DD6",
+      "decision": "Octi-pulpo health upgraded from YELLOW to GREEN based on workspace-level state.",
+      "status": "NEW"
     }
   ],
   "dogfood": {
     "issues": [],
-    "notes": "Dogfood reporting guide (claude/shared/dogfood-reporting.md) not found in this repo. No governance issues encountered during director run — all file reads and state analysis completed without AgentGuard intervention."
+    "notes": "No AgentGuard governance issues encountered during this director run."
   },
-  "nextRun": "2026-03-31T10:00:00.000Z",
-  "nextActions": [
-    "HUMAN P0 (HOURS): Run server/deploy.sh BEFORE April 1 budget resets (#1402)",
-    "HUMAN P0: Kill zombie vitest processes and prune stuck worktrees (#1452)",
-    "HUMAN P0: Assign #1306 (v3.0-gate default-deny) TODAY",
-    "HUMAN P0: Review cloud#532 (agent fleet page)",
-    "HUMAN P0: Assign #228 (Agent 365 Q&A brief)",
-    "CLOUD EM: Update state.json, set sprint goal, upgrade to 2.10.3 — deadline 24h",
-    "ANALYTICS EM: Create state.json — squad is completely dark",
-    "KERNEL: Merge PR #1479 (telemetry gate, CI green). Merge PR #1480 when CI passes.",
-    "KERNEL: Fix #1477 (telemetry default URL) before next release",
-    "MARKETING: #1379 Meta demo — 6 days to red line. Start engineering NOW.",
-    "QA: Implement manual gate for conference PRs (Option C) while waiting for #1402"
-  ]
+  "nextRun": "2026-03-31T10:00:00.000Z"
 }

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Identity consists of a **role** (`developer`, `reviewer`, `ops`, `security`, `ci
 | **Agent SDK** | Programmatic governance for custom integrations and RunManifest-driven workflows |
 | **Agent identity** | Declare agent role + driver for governance telemetry — automatic prompt or CLI flag |
 | **Pre-push hooks** | Branch protection enforcement via git pre-push hooks, configured from agentguard.yaml |
+| **Three enforcement surfaces** | Hook mode (CLI adapters), embedded mode (Go library), and gateway mode (MCP-to-MCP proxy) |
 | **Works with** | Claude Code, Codex CLI, GitHub Copilot CLI, Google Gemini CLI, OpenCode, Goose (Block), any MCP client |
 
 ## Policy Format (YAML)
@@ -347,16 +348,22 @@ rules:
 ## Architecture
 
 ```
-Agent tool call
-      │
-      ▼
-AgentGuard Kernel
-  1. Normalize   — map tool call to canonical action type
-  2. Evaluate    — match policy rules (deny / allow / escalate)
-  3. Check       — run 26 built-in invariants
-  4. Execute     — run action via adapter (file, shell, git)
-  5. Emit        — 48 event kinds → SQLite audit trail + cloud telemetry
+┌─── Hook Mode ────────────┐  ┌─── Embedded Mode ─────┐  ┌─── Gateway Mode ──────────────┐
+│ Claude Code / Copilot /  │  │ ShellForge imports     │  │ Agent ──SSE──▶ Gateway ──▶     │
+│ Codex / Gemini / Goose   │  │ kernel as Go library   │  │ MCP tool servers (filesystem,  │
+│ call kernel per tool use │  │                        │  │ GitHub, DB, etc.)              │
+└──────────┬───────────────┘  └──────────┬─────────────┘  └──────────┬─────────────────────┘
+           │                             │                           │
+           ▼                             ▼                           ▼
+                          AgentGuard Go Kernel
+                1. Normalize   — map tool call to canonical action type
+                2. Evaluate    — match policy rules (deny / allow / escalate)
+                3. Check       — run 26 built-in invariants
+                4. Execute     — run action via adapter (file, shell, git)
+                5. Emit        — 48 event kinds → SQLite audit trail + cloud telemetry
 ```
+
+All three modes share the same kernel, the same 26 invariants, and the same YAML policy format.
 
 **Storage:** SQLite audit trail at `.agentguard/`. Every decision is recorded and verifiable.
 
@@ -401,6 +408,65 @@ The Go kernel includes: action normalization with AST-based shell parsing, polic
 
 **Confidence-gated HITL** — the Go kernel computes a 0.0–1.0 confidence score from four weighted signals (action risk tier, retry count, escalation state, blast radius). When the score falls below threshold, the kernel emits a `PauseRequested` event and presents a CLI prompt (`y/n`, auto-deny on timeout) before proceeding. This gives human operators a targeted, low-friction approval gate for actions the kernel considers ambiguous — without blocking the entire agent session.
 
+### Three Enforcement Surfaces
+
+AgentGuard enforces governance through three deployment modes. Use whichever fits your integration:
+
+| Mode | How it works | Best for |
+|------|-------------|----------|
+| **Hook mode** | CLI adapters (Claude Code, Copilot, Codex, Gemini, Goose) call the kernel on every tool use | Individual developers and teams using supported CLI agents |
+| **Embedded mode** | Import the Go kernel as a library in your own orchestrator | Custom agent frameworks (e.g., ShellForge) |
+| **Gateway mode** | MCP-to-MCP proxy sits between any agent and any MCP tool server | Any MCP-compatible agent — zero code changes required |
+
+### MCP Governance Gateway
+
+The gateway is an MCP-to-MCP proxy that intercepts every tool call between an agent and its MCP tool servers. Point your agent at the gateway instead of the tool server — governance is applied transparently.
+
+```
+Agent ──SSE──▶ AgentGuard Gateway ──▶ Upstream MCP Tool Server(s)
+                     │
+                     ▼
+              Go Kernel (26 invariants + policy eval)
+              Session governance (blast radius, velocity, budget)
+```
+
+**Key capabilities:**
+- Proxies multiple upstream MCP tool servers simultaneously
+- Evaluates every tool call through the full Go kernel (26 invariants + policy evaluation)
+- Session-level governance: cumulative blast radius, action velocity, runaway detection, budget tracking, denial density
+- Zero code changes for agents — just change the MCP endpoint URL
+
+**Quick start:**
+
+```bash
+agentguard gateway start                 # Start the gateway (reads agentguard-gateway.yaml)
+agentguard gateway status                # Check gateway health and upstream connections
+```
+
+**Configuration** (`agentguard-gateway.yaml`):
+
+```yaml
+listen:
+  host: 127.0.0.1
+  port: 4100
+  transport: sse
+
+upstreams:
+  - name: filesystem
+    url: http://localhost:3100/sse
+  - name: github
+    url: http://localhost:3200/sse
+
+policy: agentguard.yaml       # Same policy format as hook/embedded mode
+
+session:
+  blastRadiusLimit: 50        # Cumulative files across all tool calls
+  actionVelocityWindow: 60s   # Rate limiting window
+  budgetMaxDollars: 5.00      # Per-session spend cap
+```
+
+Agents connect to `http://127.0.0.1:4100/sse` and see a unified tool catalog from all upstreams — with every call governed.
+
 ## For Teams and Enterprise
 
 | Feature | Details |
@@ -426,6 +492,10 @@ agentguard gemini-init                    # Set up Google Gemini CLI hook integr
 agentguard goose-init                     # Set up Goose (Block) CLI integration
 agentguard init --template strict         # Scaffold policy from a template
 agentguard status                         # Show governance status
+
+# Gateway (MCP-to-MCP proxy)
+agentguard gateway start                  # Start the MCP governance gateway
+agentguard gateway status                 # Check gateway health and upstream connections
 
 # Runtime
 agentguard guard                          # Start governed action runtime

--- a/docs/unified-architecture.md
+++ b/docs/unified-architecture.md
@@ -8,25 +8,53 @@ AgentGuard is a **governed action runtime**. The Action is the primary unit of c
 
 The system has one architectural spine: the **canonical event model**. All system activity becomes events. The kernel produces governance events. Subscribers (TUI renderer, JSONL sink, CLI inspect) consume them.
 
+## Enforcement Surfaces
+
+AgentGuard provides three ways to integrate the governance kernel:
+
+| Mode | Integration | Use case |
+|------|------------|----------|
+| **Hook mode** | CLI adapters call the kernel per tool use (PreToolUse/PostToolUse) | Claude Code, Copilot, Codex, Gemini, Goose |
+| **Embedded mode** | Import the Go kernel as a library | Custom orchestrators (e.g., ShellForge) |
+| **Gateway mode** | MCP-to-MCP proxy intercepts tool calls over SSE | Any MCP-compatible agent — zero code changes |
+
+All three modes share the same kernel, the same 26 invariants, and the same YAML policy format.
+
+### Gateway Mode
+
+The MCP Governance Gateway is an MCP-to-MCP proxy (`go/internal/gateway/`). It listens on SSE for agent connections, proxies multiple upstream MCP tool servers simultaneously, and evaluates every tool call through the Go kernel. The gateway adds session-level governance: cumulative blast radius, action velocity, runaway detection, budget tracking, and denial density.
+
+```
+Agent ──SSE──▶ AgentGuard Gateway ──▶ Upstream MCP Tool Server(s)
+                     │
+                     ▼
+              Go Kernel (26 invariants + policy eval)
+              Session governance (blast radius, velocity, budget)
+```
+
+Configuration via `agentguard-gateway.yaml`. CLI: `agentguard gateway start` / `agentguard gateway status`.
+
 ## System Model
 
 ```
 ┌──────────────────────────────────────────────────────────────────┐
 │                        Event Sources                             │
 │                                                                  │
-│  Claude Code Hooks        Agent Tool Calls      CI Systems       │
-│  ├── PreToolUse           ├── file.write        ├── pipeline     │
-│  ├── PostToolUse          ├── git.commit         ├── build       │
-│  └── (future hooks)       ├── git.push          └── deploy      │
-│                           └── shell.exec                         │
+│  CLI Hook Adapters        Embedded (Go lib)     MCP Gateway      │
+│  ├── Claude Code          ├── ShellForge        ├── SSE listener │
+│  ├── Copilot CLI          └── Custom agents     ├── MCP proxy    │
+│  ├── Codex CLI                                  └── Upstream     │
+│  ├── Gemini CLI                                    tool servers  │
+│  └── Goose                                                       │
 └──────────────────┬───────────────────┬───────────────┬───────────┘
                    │                   │               │
                    ▼                   ▼               ▼
          ┌─────────────────────────────────────────────────────┐
-         │              Claude Code Adapter                     │
+         │           Adapter / Normalization Layer              │
          │                                                     │
          │  Normalize tool calls → RawAgentAction              │
-         │  Implementation: packages/adapters/src/claude-code.ts │
+         │  Hook adapters: packages/adapters/src/              │
+         │  Gateway proxy: go/internal/gateway/                │
          └──────────────────────┬──────────────────────────────┘
                                 │
                                 ▼
@@ -42,18 +70,19 @@ The system has one architectural spine: the **canonical event model**. All syste
          │  7. ACTION_ALLOWED/DENIED + ACTION_EXECUTED/FAILED  │
          │  8. Escalation tracking (monitor)                   │
          │                                                     │
-         │  Implementation: packages/kernel/src/kernel.ts               │
+         │  Implementation: packages/kernel/src/kernel.ts      │
+         │  Go kernel: go/internal/kernel/                     │
          └──────────────────────┬──────────────────────────────┘
                                 │
                ┌────────────────┼────────────────┐
                │                │                │
                ▼                ▼                ▼
      ┌─────────────┐  ┌─────────────┐  ┌─────────────┐
-     │ TUI Renderer │  │ JSONL Sink   │  │  EventBus   │
+     │ TUI Renderer │  │ SQLite Sink  │  │  EventBus   │
      │              │  │              │  │             │
      │ Terminal     │  │ .agentguard/ │  │ Pub/sub     │
-     │ action       │  │ events/      │  │ broadcast   │
-     │ stream       │  │ <runId>.jsonl│  │             │
+     │ action       │  │ audit trail  │  │ broadcast   │
+     │ stream       │  │              │  │             │
      └──────────────┘  └──────────────┘  └──────┬──────┘
                                                 │
                                                 ▼
@@ -62,6 +91,7 @@ The system has one architectural spine: the **canonical event model**. All syste
                                     │                   │
                                     │  CLI inspect      │
                                     │  CLI events       │
+                                    │  Cloud telemetry  │
                                     └───────────────────┘
 ```
 
@@ -147,7 +177,7 @@ Pure domain logic with no environment dependencies.
 
 1. **Single event schema.** The kernel and all consumers use the same canonical event format.
 
-2. **Kernel as single mediation point.** All agent actions pass through the kernel. No bypass.
+2. **Kernel as single mediation point.** All agent actions pass through the kernel — whether via hook adapter, embedded library, or MCP gateway. No bypass.
 
 3. **Independent operation.** The kernel operates independently. Subscribers connect through the canonical event model.
 


### PR DESCRIPTION
## Summary

- Add **Gateway Mode** section to README — documents the MCP-to-MCP proxy that intercepts tool calls between any agent and any MCP tool server
- Update **Architecture** diagram to show all three enforcement surfaces (hook, embedded, gateway) sharing the same kernel
- Add `gateway start` / `gateway status` to the **CLI Reference**
- Add `agentguard-gateway.yaml` config example
- Update `docs/unified-architecture.md` with new Enforcement Surfaces section and refreshed System Model diagram

## Test plan

- [ ] Verify README renders correctly on GitHub (diagrams, tables, code blocks)
- [ ] Verify `docs/unified-architecture.md` renders correctly
- [ ] Confirm no broken links in the Links table

🤖 Generated with [Claude Code](https://claude.com/claude-code)