### PR TITLE
refactor: rebrand Cata → Clawta

### DIFF
--- a/.github/workflows/clawta-dispatch.yml
+++ b/.github/workflows/clawta-dispatch.yml
@@ -1,10 +1,10 @@
-name: Cata Agent Dispatch
+name: Clawta Agent Dispatch
 on:
   repository_dispatch:
     types: [octi-pulpo-dispatch]
 
 jobs:
-  cata-agent:
+  clawta-agent:
     runs-on: ubuntu-latest
     if: |
       github.event.client_payload.type == 'evolve' ||
@@ -19,39 +19,39 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download Cata binary
+      - name: Download Clawta binary
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "Task ID:   ${TASK_ID}"
           echo "Type:      ${TASK_TYPE}"
           echo "Priority:  ${TASK_PRIORITY}"
-          gh release download --repo AgentGuardHQ/cata \
-            --pattern "cata-linux-amd64" \
-            --output cata \
-            --clobber || echo "WARN: cata release not yet published"
-          chmod +x cata 2>/dev/null || true
+          gh release download --repo AgentGuardHQ/clawta \
+            --pattern "clawta-linux-amd64" \
+            --output clawta \
+            --clobber || echo "WARN: clawta release not yet published"
+          chmod +x clawta 2>/dev/null || true
 
       - name: Configure git identity
         run: |
           git config --global user.email "octi-pulpo@agentguardhq.com"
           git config --global user.name "Octi Pulpo Bot"
 
-      - name: Run Cata agent
+      - name: Run Clawta agent
         env:
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ ! -f ./cata ]; then
-            echo "ERROR: cata binary not available"
+          if [ ! -f ./clawta ]; then
+            echo "ERROR: clawta binary not available"
             exit 1
           fi
-          ./cata run \
+          ./clawta run \
             --provider deepseek \
             --model deepseek-chat \
             --max-turns 100 \
             "${TASK_PROMPT}" \
-            || echo "WARN: cata exited non-zero for task ${TASK_ID}"
+            || echo "WARN: clawta exited non-zero for task ${TASK_ID}"
 
       - name: Report outcome
         if: always()


### PR DESCRIPTION
Renames dispatch workflow and all Cata references to Clawta.