### PR TITLE
fix: update clawta-dispatch.yml refs from AgentGuardHQ to chitinhq

### DIFF
--- a/.github/workflows/clawta-dispatch.yml
+++ b/.github/workflows/clawta-dispatch.yml
@@ -26,7 +26,7 @@ jobs:
           echo "Task ID:   ${TASK_ID}"
           echo "Type:      ${TASK_TYPE}"
           echo "Priority:  ${TASK_PRIORITY}"
-          gh release download --repo AgentGuardHQ/clawta \
+          gh release download --repo chitinhq/clawta \
             --pattern "clawta-linux-amd64" \
             --output clawta \
             --clobber || echo "WARN: clawta release not yet published"
@@ -34,7 +34,7 @@ jobs:
 
       - name: Configure git identity
         run: |
-          git config --global user.email "octi-pulpo@agentguardhq.com"
+          git config --global user.email "octi-pulpo@chitinhq.com"
           git config --global user.name "Octi Pulpo Bot"
 
       - name: Run Clawta agent


### PR DESCRIPTION
## Summary
- Update binary download repo: `AgentGuardHQ/clawta` → `chitinhq/clawta`
- Update bot email: `octi-pulpo@agentguardhq.com` → `octi-pulpo@chitinhq.com`

Part of the org rebrand from AgentGuardHQ to chitinhq. Without this fix, the GH Actions dispatch workflow downloads from a redirected (stale) repo URL.

## Test plan
- [ ] Verify `clawta-dispatch.yml` workflow triggers on `repository_dispatch`
- [ ] Confirm binary download resolves from `chitinhq/clawta`

🤖 Generated with [Claude Code](https://claude.com/claude-code)